### PR TITLE
Support for fasttext neural architecture

### DIFF
--- a/src/caffeinputconns.h
+++ b/src/caffeinputconns.h
@@ -538,6 +538,8 @@ namespace dd
     {
       if (_characters)
 	return 1;
+      if (_embed)
+	return _sequence;
       if (_channels > 0)
 	return _channels;
       return feature_size();
@@ -594,6 +596,11 @@ namespace dd
       APIData ad_input = ad_param.getobj("input");
       if (ad_input.has("db") && ad_input.get("db").get<bool>())
 	_db = true;
+      if (ad_input.has("embedding") && ad_input.get("embedding").get<bool>())
+	{
+	  std::cerr << "Using sequence=" << _sequence << " with embedding\n";
+	  _embed = true;
+	}
       
       // transform to one-hot vector datum
       if (_train && _db)
@@ -724,6 +731,8 @@ namespace dd
 	int datum_channels;
 	if (_characters)
 	  datum_channels = 1;
+	else if (_embed)
+	  datum_channels = _sequence;
 	else datum_channels = _vocab.size(); // XXX: may be very large
 	datum.set_channels(datum_channels);
        	datum.set_height(1);
@@ -732,16 +741,37 @@ namespace dd
 	if (!_characters)
 	  {
 	    std::unordered_map<std::string,Word>::const_iterator wit;
-	    for (int i=0;i<datum_channels;i++) // XXX: expected to be slow
-	      datum.add_float_data(0.0);
-	    tbe->reset();
-	    while(tbe->has_elt())
+	    if (!_embed)
 	      {
-		std::string key;
-		double val;
-		tbe->get_next_elt(key,val);
-		if ((wit = _vocab.find(key))!=_vocab.end())
-		  datum.set_float_data(_vocab[key]._pos,static_cast<float>(val));
+		for (int i=0;i<datum_channels;i++) // XXX: expected to be slow
+		  datum.add_float_data(0.0);
+		tbe->reset();
+		while(tbe->has_elt())
+		  {
+		    std::string key;
+		    double val;
+		    tbe->get_next_elt(key,val);
+		    if ((wit = _vocab.find(key))!=_vocab.end())
+		      datum.set_float_data(_vocab[key]._pos,static_cast<float>(val));
+		  }
+	      }
+	    else
+	      {
+		tbe->reset();
+		int i = 0;
+		while(tbe->has_elt())
+		  {
+		    std::string key;
+		    double val;
+		    tbe->get_next_elt(key,val);
+		    if ((wit = _vocab.find(key))!=_vocab.end())
+		      datum.add_float_data(static_cast<float>(_vocab[key]._pos));
+		    ++i;
+		    if (i == _sequence) // tmp limit on sequence length
+		      break;
+		  }
+		while (datum.float_data_size() < _sequence)
+		  datum.add_float_data(0.0);
 	      }
 	  }
 	else // character-level features
@@ -813,6 +843,7 @@ namespace dd
     std::string _dbfullname = "train.lmdb";
     std::string _test_dbfullname = "test.lmdb";
     int _channels = 0;
+    bool _embed = false; /**< whether model is using an input embedding layer. */
   };
 
   /**

--- a/src/caffelib.h
+++ b/src/caffelib.h
@@ -76,6 +76,7 @@ namespace dd
 				       const bool &sparse,
 				       const int &targets,
 				       const int &cnclasses,
+				       const TInputConnectorStrategy &inputc,
 				       caffe::NetParameter &net_param,
 				       caffe::NetParameter &deploy_net_param);
 

--- a/templates/caffe/fasttext/deploy.prototxt
+++ b/templates/caffe/fasttext/deploy.prototxt
@@ -1,0 +1,89 @@
+name: "fasttext"
+layer {
+  name: "inputl"
+  type: "MemoryData"
+  top: "data"
+  top: "label"
+  memory_data_param {
+    batch_size: 1000
+    channels: 100
+    height: 1
+    width: 1
+  }
+}
+layer {
+  name: "ip0"
+  type: "Embed"
+  bottom: "data"
+  top: "ip0"
+  embed_param {
+    num_output: 10
+    input_dim: 28494
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+    }
+  }
+}
+layer {
+  name: "re1"
+  type: "Reshape"
+  bottom: "ip0"
+  top: "ip0r"
+  reshape_param {
+    shape {
+      dim: 0
+      dim: 1
+      dim: 100
+      dim: -1
+    }
+  }
+}
+layer {
+  name: "p1"
+  type: "Pooling"
+  bottom: "ip0r"
+  top: "p1"
+  pooling_param {
+    pool: AVE
+    kernel_h: 100
+    kernel_w: 1
+    stride_h: 1
+    stride_w: 1
+  }
+}
+layer {
+  name: "re2"
+  type: "Reshape"
+  bottom: "p1"
+  top: "p1r"
+  reshape_param {
+    shape {
+      dim: 0
+      dim: -1
+    }
+  }
+}
+layer {
+  name: "ip3"
+  type: "InnerProduct"
+  bottom: "p1r"
+  top: "ip3"
+  inner_product_param {
+    num_output: 4
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+    }
+  }
+}
+layer {
+  name: "loss"
+  type: "Softmax"
+  bottom: "ip3"
+  top: "losst"
+}

--- a/templates/caffe/fasttext/fasttext.prototxt
+++ b/templates/caffe/fasttext/fasttext.prototxt
@@ -1,0 +1,120 @@
+name: "fasttext"
+layer {
+  name: "inputl"
+  type: "MemoryData"
+  top: "data"
+  top: "label"
+  include {
+    phase: TRAIN
+  }
+  memory_data_param {
+    batch_size: 1000
+    channels: 100
+    height: 1
+    width: 1
+  }
+}
+layer {
+  name: "inputlt"
+  type: "MemoryData"
+  top: "data"
+  top: "label"
+  include {
+    phase: TEST
+  }
+  memory_data_param {
+    batch_size: 1000
+    channels: 100
+    height: 1
+    width: 1
+  }
+}
+layer {
+  name: "ip0"
+  type: "Embed"
+  bottom: "data"
+  top: "ip0"
+  embed_param {
+    num_output: 10
+    input_dim: 28494
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+    }
+  }
+}
+layer {
+  name: "re1"
+  type: "Reshape"
+  bottom: "ip0"
+  top: "ip0r"
+  reshape_param {
+    shape {
+      dim: 0
+      dim: 1
+      dim: 100
+      dim: -1
+    }
+  }
+}
+layer {
+  name: "p1"
+  type: "Pooling"
+  bottom: "ip0r"
+  top: "p1"
+  pooling_param {
+    pool: AVE
+    kernel_h: 100
+    kernel_w: 1
+    stride_h: 1
+    stride_w: 1
+  }
+}
+layer {
+  name: "re2"
+  type: "Reshape"
+  bottom: "p1"
+  top: "p1r"
+  reshape_param {
+    shape {
+      dim: 0
+      dim: -1
+    }
+  }
+}
+layer {
+  name: "ip3"
+  type: "InnerProduct"
+  bottom: "p1r"
+  top: "ip3"
+  inner_product_param {
+    num_output: 4
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+    }
+  }
+}
+layer {
+  name: "losst"
+  type: "Softmax"
+  bottom: "ip3"
+  top: "losst"
+  include {
+    phase: TEST
+  }
+}
+layer {
+  name: "loss"
+  type: "SoftmaxWithLoss"
+  bottom: "ip3"
+  bottom: "label"
+  top: "loss"
+  include {
+    phase: TRAIN
+  }
+}

--- a/templates/caffe/fasttext/fasttext_solver.prototxt
+++ b/templates/caffe/fasttext/fasttext_solver.prototxt
@@ -1,0 +1,17 @@
+net: "fasttext.prototxt"
+test_iter: 1
+test_interval: 100
+base_lr: 0.1
+momentum: 0.9
+#weight_decay: 0.00001
+lr_policy: "fixed"
+#weight_decay: 0.0005
+#lr_policy: "inv"
+#gamma: 0.0001
+#power: 0.75
+display: 100
+max_iter: 400000
+snapshot: 400000
+snapshot_prefix: "fasttext"
+solver_mode: CPU
+random_seed: 0

--- a/tests/ut-caffe-mlp.cc
+++ b/tests/ut-caffe-mlp.cc
@@ -52,7 +52,7 @@ TEST(caffelib,configure_mlp_template_1)
   ad.add("activation","prelu");
   ad.add("dropout",0.6);
   
-  CaffeLib<CSVCaffeInputFileConn,SupervisedOutput,CaffeModel>::configure_mlp_template(ad,false,false,0,nclasses,net_param,deploy_net_param);
+  CaffeLib<CSVCaffeInputFileConn,SupervisedOutput,CaffeModel>::configure_mlp_template(ad,false,false,0,nclasses,CSVCaffeInputFileConn(),net_param,deploy_net_param);
 
   caffe::WriteProtoToTextFile(net_param,onet_file);
   caffe::WriteProtoToTextFile(deploy_net_param,donet_file);
@@ -101,7 +101,7 @@ TEST(caffelib,configure_mlp_template_sparse_1)
   ad.add("dropout",0.6);
   ad.add("sparse",true);
   
-  CaffeLib<CSVCaffeInputFileConn,SupervisedOutput,CaffeModel>::configure_mlp_template(ad,false,true,0,nclasses,net_param,deploy_net_param);
+  CaffeLib<CSVCaffeInputFileConn,SupervisedOutput,CaffeModel>::configure_mlp_template(ad,false,true,0,nclasses,CSVCaffeInputFileConn(),net_param,deploy_net_param);
 
   caffe::WriteProtoToTextFile(net_param,onet_file);
   caffe::WriteProtoToTextFile(deploy_net_param,donet_file);
@@ -156,7 +156,7 @@ TEST(caffelib,configure_mlp_template_1_db)
   ad.add("dropout",0.2);
   ad.add("db",true);
   
-  CaffeLib<CSVCaffeInputFileConn,SupervisedOutput,CaffeModel>::configure_mlp_template(ad,false,false,0,nclasses,net_param,deploy_net_param);
+  CaffeLib<CSVCaffeInputFileConn,SupervisedOutput,CaffeModel>::configure_mlp_template(ad,false,false,0,nclasses,CSVCaffeInputFileConn(),net_param,deploy_net_param);
 
   caffe::WriteProtoToTextFile(net_param,onet_file);
   caffe::WriteProtoToTextFile(deploy_net_param,donet_file);
@@ -208,7 +208,7 @@ TEST(caffelib,configure_mlp_template_n)
   ad.add("activation","prelu");
   ad.add("dropout",0.6);
   
-  CaffeLib<CSVCaffeInputFileConn,SupervisedOutput,CaffeModel>::configure_mlp_template(ad,false,false,0,nclasses,net_param,deploy_net_param);
+  CaffeLib<CSVCaffeInputFileConn,SupervisedOutput,CaffeModel>::configure_mlp_template(ad,false,false,0,nclasses,CSVCaffeInputFileConn(),net_param,deploy_net_param);
 
   caffe::WriteProtoToTextFile(net_param,onet_file);
   caffe::WriteProtoToTextFile(deploy_net_param,donet_file);
@@ -264,7 +264,7 @@ TEST(caffelib,configure_mlp_template_n_mt)
   ad.add("activation","prelu");
   ad.add("dropout",0.6);
   
-  CaffeLib<CSVCaffeInputFileConn,SupervisedOutput,CaffeModel>::configure_mlp_template(ad,false,false,targets,nclasses,net_param,deploy_net_param);
+  CaffeLib<CSVCaffeInputFileConn,SupervisedOutput,CaffeModel>::configure_mlp_template(ad,false,false,targets,nclasses,CSVCaffeInputFileConn(),net_param,deploy_net_param);
 
   caffe::WriteProtoToTextFile(net_param,onet_file);
   caffe::WriteProtoToTextFile(deploy_net_param,donet_file);


### PR DESCRIPTION
From FAIR article https://arxiv.org/abs/1607.01759
This PR requires PR #174, and the template is not usable as such. At the moment needs to be modified for every use-case. I am putting it here so that interested users can try it out.

Example on the AGNews dataset:
- service creation:

```
curl -X PUT "http://localhost:8080/services/fasttext" -d "{\"mllib\":\"caffe\",\"description\":\"newsgroup classification service\",\"type\":\"supervised\",\"parameters\":{\"input\":{\"connector\":\"txt\",\"sequence\":100,\"sentences\":true},\"mllib\":{\"gpu\":true,\"nclasses\":4}},\"model\":{\"repository\":\"/path/to/models/fasttext/\"}}"
```
- training:

```
curl -X POST "http://localhost:8080/train" -d "{\"service\":\"fasttext\",\"async\":true,\"parameters\":{\"mllib\":{\"gpu\":true,\"solver\":{\"iterations\":100000,\"test_interval\":5000,\"base_lr\":0.01,\"solver_type\":\"SGD\",\"lr_policy\":\"step\",\"gamma\":0.1,\"stepsize\":100000},\"net\":{\"batch_size\":512}},\"input\":{\"sequence\":100,\"embedding\":true,\"shuffle\":true,\"test_split\":0.1,\"min_count\":5,\"min_word_length\":2,\"count\":false},\"output\":{\"measure\":[\"mcll\",\"f1\"]}},\"data\":[\"/path/to/agnews_data\"]}"
```

This should yield ~90% F1 and ACC.

Details:
- `sequence`: max number of words taken into account in a document. It's good practice to try to fit it near the true max or mean sequence number, otherwise much of the data is padded with zeros
- `embedding`: required in `mllib` at service creation then into `input` connector at training time

-`sentences`: see API, this should be used when your data are one sample per line in file
