### PR TITLE
Plateau learning rate policy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,7 @@ else()
 	caffe_dd
 	PREFIX caffe_dd
 	INSTALL_DIR ${CMAKE_BINARY_DIR}
-	URL https://github.com/beniz/caffe/archive/master.tar.gz
+	URL https://github.com/beniz/caffe/archive/master_plateau.tar.gz
 	CONFIGURE_COMMAND ln -sf Makefile.config.gpu.cudnn Makefile.config && echo "OPENCV_VERSION:=${OPENCV_VERSION}" >> Makefile.config && make -j${N}
 	INSTALL_COMMAND ""
 	BUILD_IN_SOURCE 1
@@ -82,7 +82,7 @@ ExternalProject_Add(
 	caffe_dd
 	PREFIX caffe_dd
 	INSTALL_DIR ${CMAKE_BINARY_DIR}
-	URL https://github.com/beniz/caffe/archive/master.tar.gz
+	URL https://github.com/beniz/caffe/archive/master_plateau.tar.gz
 	CONFIGURE_COMMAND ln -sf Makefile.config.gpu Makefile.config && echo "OPENCV_VERSION:=${OPENCV_VERSION}" >> Makefile.config && make -j${N}
 	INSTALL_COMMAND ""
 	BUILD_IN_SOURCE 1
@@ -93,7 +93,7 @@ ExternalProject_Add(
       caffe_dd
       PREFIX caffe_dd
       INSTALL_DIR ${CMAKE_BINARY_DIR}
-      URL https://github.com/beniz/caffe/archive/master.tar.gz
+      URL https://github.com/beniz/caffe/archive/master_plateau.tar.gz
       CONFIGURE_COMMAND ln -sf Makefile.config.cpu Makefile.config && echo "OPENCV_VERSION:=${OPENCV_VERSION}" >> Makefile.config && make -j${N}
       INSTALL_COMMAND ""
       BUILD_IN_SOURCE 1

--- a/src/caffelib.cc
+++ b/src/caffelib.cc
@@ -1540,6 +1540,8 @@ namespace dd
 	  solver_param.set_rms_decay(ad_solver.get("rms_decay").get<double>());
 	if (ad_solver.has("iter_size"))
 	  solver_param.set_iter_size(ad_solver.get("iter_size").get<int>());
+	if (ad_solver.has("plateau_winsize"))
+	  solver_param.add_plateau_winsize(ad_solver.get("plateau_winsize").get<int>());
       }
     
     // optimize


### PR DESCRIPTION
Integration from Caffe PR https://github.com/BVLC/caffe/pull/4606
The learning rate is changed automatically when training loss reaches a plateau.

Beware, plateau is conditioned upon the training loss, not the test loss.

Works as follows:
- use `lr_policy:plateau` in `mllib.solver` with `caffe`
- set `policy_winsize` in `mllib.solver` with `caffe`: this is the minimum number of steps between two learning rate changes.
