### PR TITLE
Services autostart via calls list in a file

### DIFF
--- a/main/dede.cc
+++ b/main/dede.cc
@@ -37,7 +37,6 @@ DEFINE_int32(jsonapi,0,"whether to use the JSON command line API (0: HTTP server
 int main(int argc, char *argv[])
 {
   google::ParseCommandLineFlags(&argc, &argv, true);
-  //::google::InitGoogleLogging(argv[0]);
 #ifdef USE_XGBOOST
   rabit::Init(argc,argv);
 #endif

--- a/src/httpjsonapi.cc
+++ b/src/httpjsonapi.cc
@@ -499,6 +499,7 @@ namespace dd
   {
     google::ParseCommandLineFlags(&argc, &argv, true);
     std::signal(SIGINT,terminate);
+    JsonAPI::boot(argc,argv);
     return start_server(FLAGS_host,FLAGS_port,FLAGS_nthreads);
   }
 

--- a/src/jsonapi.h
+++ b/src/jsonapi.h
@@ -42,6 +42,12 @@ namespace dd
     int boot(int argc, char *argv[]);
 
     /**
+     * \brief service autostart from JSON file
+     * @param autostart_file JSON file with service API call and JSON body
+     */
+    JDoc service_autostart(const std::string &autostart_file);
+    
+    /**
      * \brief error status generation
      * @param jst JSON document object
      * @param code error HTTP code


### PR DESCRIPTION
This automates the creation of services when DD server starts.

File format is as follows:

- service creation:
```
service_create;sname;JSON string
```
where `sname` is the service name and the JSON is a string without external quotes

- service prediction
```
service_predict;JSON string
``` 