### PR TITLE
Added support for softmax temperature scaling through API.

### DIFF
--- a/src/backends/caffe/caffelib.h
+++ b/src/backends/caffe/caffelib.h
@@ -193,6 +193,12 @@ namespace dd
 				const int &ignore_label,
 				const int &timesteps);
 
+      /**
+       * \brief updates the softmax temperature
+       * @param mllib apidata object
+       */
+      void update_deploy_protofile_softmax(const APIData &ad);
+      
     private:
       void update_protofile_classes(caffe::NetParameter &net_param);
 


### PR DESCRIPTION
New parameter is `scaling_temperature` a service creation ('PUT /predict').

This is to be used with our [libtscaling](https://github.com/jolibrain/libtscaling) for model automatic calibration.