### PR TITLE
Dice loss api

### DIFF
--- a/src/backends/caffe/caffelib.cc
+++ b/src/backends/caffe/caffelib.cc
@@ -61,6 +61,7 @@ namespace dd
     _autoencoder = cl._autoencoder;
     cl._net = nullptr;
     _crop_size = cl._crop_size;
+    _loss = cl._loss;
   }
 
   template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
@@ -187,34 +188,150 @@ namespace dd
 	caffe::ReadProtoFromTextFile(dest_deploy_net,&deploy_net_param);
 
 
-    if (this->_loss == 1 || this->_loss == 2 || this->_loss == 3)
+    if (this->_loss == 1)
       // dice loss!!
       {
-        int k = net_param.layer_size();
-        for (int l=k-1;l>0;l--)
+        if (net_param.name().compare("deeplab_vgg16")==0)
           {
-            caffe::LayerParameter *lparam = net_param.mutable_layer(l);
-            if (lparam->type() == "SoftmaxWithLoss")
-              {
-                lparam->set_type("DiceCoefLoss");
-                if (lparam->has_softmax_param())
-                  lparam->clear_softmax_param();
-                caffe::DiceCoefLossParameter* dclp = lparam->mutable_dice_coef_loss_param();
-                switch (this->_loss)
-                  {
-                  case 1:
-                    dclp->set_generalization(caffe::DiceCoefLossParameter::NONE);
-                    break;
-                  // case 2:
-                  //   dclp->set_generalization(caffe::DiceCoefLossParameter::BINARY);
-                  //   break;
-                  // case 3:
-                  //   dclp->set_generalization(caffe::DiceCoefLossParameter::BINARY_WEIGHTED);
-                  //   break;
-                  }
-                break;
-              }
-	      }
+            caffe::LayerParameter *shrink_param = find_layer_by_name(net_param,"label_shrink");
+            shrink_param->add_include();
+            caffe::NetStateRule *nsr = shrink_param->mutable_include(0);
+            nsr->set_phase(caffe::TRAIN);
+
+            int softml_pos = find_index_layer_by_type(net_param,"SoftmaxWithLoss");
+
+            std::string logits_from_loss = net_param.layer(softml_pos).bottom(0);
+            std::string agg_output = logits_from_loss + "_agg";
+            std::string sigmoid_output = agg_output + "_norm";
+
+            caffe::LayerParameter* conv_param = insert_layer_before(net_param, softml_pos++);
+            *conv_param->mutable_name() = "linear_aggregation";
+            *conv_param->mutable_type() = "Convolution";
+            conv_param->add_bottom(logits_from_loss);
+            conv_param->add_top(agg_output);
+            caffe::ConvolutionParameter* conv_param_param = conv_param->mutable_convolution_param();
+            conv_param_param->set_num_output(1);
+            conv_param_param->set_axis(1);
+            conv_param_param->add_kernel_size(1);
+
+            caffe::FillerParameter* filler_param = conv_param_param->mutable_weight_filler();
+            filler_param->set_std(0.01);
+            filler_param->set_type("gaussian");
+
+
+
+
+            caffe::LayerParameter* sigmoid_loss_param = insert_layer_before(net_param, softml_pos++);
+            sigmoid_loss_param->set_name("agg_norm");
+            sigmoid_loss_param->set_type("Sigmoid");
+            sigmoid_loss_param->add_bottom(agg_output);
+            sigmoid_loss_param->add_top(sigmoid_output);
+            sigmoid_loss_param->add_include();
+            nsr = sigmoid_loss_param->mutable_include(0);
+            nsr->set_phase(caffe::TRAIN);
+
+
+            // first new loss
+            caffe::LayerParameter *lossparam = net_param.mutable_layer(softml_pos);
+            *lossparam->mutable_type() = "DiceCoefLoss";
+            *lossparam->mutable_bottom(0) = sigmoid_output;
+            caffe::DiceCoefLossParameter* dclp = lossparam->mutable_dice_coef_loss_param();
+            dclp->set_generalization(caffe::DiceCoefLossParameter::NONE);
+
+            caffe::LayerParameter* final_interp_param = find_layer_by_name(net_param,"final_interp");
+            *final_interp_param->mutable_bottom(0) = agg_output;
+
+            caffe::LayerParameter* probt_param = find_layer_by_name(net_param, "probt");
+            *probt_param->mutable_type() = "Sigmoid";
+
+
+            // now work on deploy.txt
+            int final_interp_pos = find_index_layer_by_type(deploy_net_param, "Interp");
+            final_interp_param = deploy_net_param.mutable_layer(final_interp_pos);
+            *final_interp_param->mutable_bottom(0) = agg_output;
+
+            conv_param = insert_layer_before(deploy_net_param, final_interp_pos);
+            *conv_param->mutable_name() = "linear_aggregation";
+            *conv_param->mutable_type() = "Convolution";
+            conv_param->add_bottom(logits_from_loss);
+            conv_param->add_top(agg_output);
+            conv_param_param = conv_param->mutable_convolution_param();
+            conv_param_param->set_num_output(1);
+            conv_param_param->set_axis(1);
+            conv_param_param->add_kernel_size(1);
+            filler_param = conv_param_param->mutable_weight_filler();
+            filler_param->set_std(0.01);
+            filler_param->set_type("gaussian");
+
+
+            probt_param = find_layer_by_name(deploy_net_param, "probt");
+            *probt_param->mutable_type() = "Sigmoid";
+          }
+        else if (net_param.name().compare("unet") == 0)
+          {
+            int softml_pos = find_index_layer_by_type(net_param,"SoftmaxWithLoss");
+
+            std::string logits_from_loss = net_param.layer(softml_pos).bottom(0);
+            std::string agg_output = logits_from_loss + "_agg";
+            std::string sigmoid_output = agg_output + "_norm";
+
+            caffe::LayerParameter* conv_param = insert_layer_before(net_param, softml_pos++);
+            *conv_param->mutable_name() = "linear_aggregation";
+            *conv_param->mutable_type() = "Convolution";
+            conv_param->add_bottom(logits_from_loss);
+            conv_param->add_top(agg_output);
+            caffe::ConvolutionParameter* conv_param_param = conv_param->mutable_convolution_param();
+            conv_param_param->set_num_output(1);
+            conv_param_param->set_axis(1);
+            conv_param_param->add_kernel_size(1);
+
+            caffe::FillerParameter* filler_param = conv_param_param->mutable_weight_filler();
+            filler_param->set_std(0.01);
+            filler_param->set_type("gaussian");
+
+            caffe::LayerParameter* sigmoid_loss_param = insert_layer_before(net_param, softml_pos++);
+            sigmoid_loss_param->set_name("agg_norm");
+            sigmoid_loss_param->set_type("Sigmoid");
+            sigmoid_loss_param->add_bottom(agg_output);
+            sigmoid_loss_param->add_top(sigmoid_output);
+            sigmoid_loss_param->add_include();
+            caffe::NetStateRule *nsr = sigmoid_loss_param->mutable_include(0);
+            nsr->set_phase(caffe::TRAIN);
+
+            // first new loss
+            caffe::LayerParameter *lossparam = net_param.mutable_layer(softml_pos);
+            lossparam->clear_softmax_param();
+            *lossparam->mutable_type() = "DiceCoefLoss";
+            *lossparam->mutable_bottom(0) = sigmoid_output;
+            caffe::DiceCoefLossParameter* dclp = lossparam->mutable_dice_coef_loss_param();
+            dclp->set_generalization(caffe::DiceCoefLossParameter::NONE);
+
+            caffe::LayerParameter* probt_param = find_layer_by_name(net_param, "probt");
+            *probt_param->mutable_type() = "Sigmoid";
+            *probt_param->mutable_bottom(0) = agg_output;
+
+
+            int final_pred = find_index_layer_by_name(deploy_net_param, "pred");
+
+            conv_param = insert_layer_before(deploy_net_param, final_pred);
+            *conv_param->mutable_name() = "linear_aggregation";
+            *conv_param->mutable_type() = "Convolution";
+            conv_param->add_bottom(logits_from_loss);
+            conv_param->add_top(agg_output);
+            conv_param_param = conv_param->mutable_convolution_param();
+            conv_param_param->set_num_output(1);
+            conv_param_param->set_axis(1);
+            conv_param_param->add_kernel_size(1);
+            filler_param = conv_param_param->mutable_weight_filler();
+            filler_param->set_std(0.01);
+            filler_param->set_type("gaussian");
+
+
+            probt_param = find_layer_by_name(deploy_net_param, "pred");
+            *probt_param->mutable_type() = "Sigmoid";
+            *probt_param->mutable_bottom(0) = agg_output;
+
+          }
 
       }
 
@@ -386,6 +503,68 @@ namespace dd
     if (this->_mlmodel.read_from_repository(this->_mlmodel._repo,this->_logger))
       throw MLLibBadParamException("error reading or listing Caffe models in repository " + this->_mlmodel._repo);
   }
+
+
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
+  caffe::LayerParameter*
+  CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::insert_layer_before(caffe::NetParameter &net_param, int layer_number)
+  {
+    
+    net_param.add_layer();
+
+    for (int i=net_param.layer_size()-1; i>layer_number; --i)
+      {
+        caffe::LayerParameter *lparam = net_param.mutable_layer(i);
+        *lparam = net_param.layer(i-1);
+      }
+    net_param.mutable_layer(layer_number)->Clear();
+    return  net_param.mutable_layer(layer_number);
+  }
+
+
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
+  caffe::LayerParameter*
+  CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::find_layer_by_name(caffe::NetParameter &net_param, std::string name)
+  {
+    int k = net_param.layer_size();
+    for (int l=k-1;l>0;l--)
+      {
+        caffe::LayerParameter *lparam = net_param.mutable_layer(l);
+        if (lparam->name().compare(name) == 0)
+          return net_param.mutable_layer(l);
+      }
+    return NULL;
+  }
+
+
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
+  int
+  CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::find_index_layer_by_type(caffe::NetParameter &net_param, std::string type)
+  {
+    int k = net_param.layer_size();
+    for (int l=k-1;l>0;l--)
+      {
+        caffe::LayerParameter *lparam = net_param.mutable_layer(l);
+        if (lparam->type() == type)
+          return l;
+      }
+    return -1;
+  }
+
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
+  int
+  CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::find_index_layer_by_name(caffe::NetParameter &net_param, std::string name)
+  {
+    int k = net_param.layer_size();
+    for (int l=k-1;l>0;l--)
+      {
+        caffe::LayerParameter *lparam = net_param.mutable_layer(l);
+        if (lparam->name() == name)
+          return l;
+      }
+    return -1;
+  }
+
 
   template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
   void CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::configure_noise_and_distort(const APIData &ad,
@@ -614,9 +793,11 @@ namespace dd
         if (ad.get("loss").get<std::string>().compare("dice")==0)
           {
             if (this->_inputc._segmentation)
-              _loss = 1;
+              {
+                _loss = 1;
+              }
             else
-              throw MLLibBadParamException("asked for dice loss without segmentation");
+              throw MLLibBadParamException("asked for vanilla dice loss without segmentation");
           }
         // else if (ad.get("loss").get<std::string>().compare("dice_binary")==0)
         //   {
@@ -1146,7 +1327,7 @@ namespace dd
 	  nout = _ntargets;
 	if (_autoencoder)
 	  nout = inputc.channels();
-	ad_res.add("nclasses",_nclasses);
+    ad_res.add("nclasses",_nclasses);
 	inputc.reset_dv_test();
 	while(true)
 	  {
@@ -1305,15 +1486,31 @@ namespace dd
 			    double target = dv_float_data.at(j).at(l);
 			    double best_prob = -1.0;
 			    double best_cat = -1.0;
-			    for (int k=0;k<nout;k++)
-			      {
-				double prob = lresults[slot]->cpu_data()[l+(nout*j+k)*dv_float_data.at(j).size()];
-				if (prob >= best_prob)
-				  {
-				    best_prob = prob;
-				    best_cat = k;
-				  }
-			      }
+                if (lresults[slot]->shape(1) != 1)
+                  {
+                    for (int k=0;k<nout;k++)
+                      {
+                        double prob = lresults[slot]->cpu_data()[l+(nout*j+k)*dv_float_data.at(j).size()];
+                        if (prob >= best_prob)
+                          {
+                            best_prob = prob;
+                            best_cat = k;
+                          }
+                      }
+                  }
+                else
+                  {
+                    // in case of dice loss + deeplab_vgg16, predictions are at pos 0
+                    double res = lresults[slot]->cpu_data()[l+j*dv_float_data.at(j).size()];
+                    if (res > 0.5)
+                      {
+                        best_cat = 1;
+                      }
+                    else
+                      {
+                        best_cat = 0;
+                      }
+                  }
 			    preds.push_back(best_cat);
 			    targets.push_back(target);
 			  }
@@ -1627,15 +1824,26 @@ namespace dd
 		      {
 			double max_prob = -1.0;
 			double best_cat = -1.0;
-			for (int k=0;k<nclasses;k++)
-			  {
-			    double prob = results[slot]->cpu_data()[(j*nclasses+k)*imgsize+i];
-			    if (prob > max_prob)
-			      {
-				max_prob = prob;
-				best_cat = static_cast<double>(k);
-			      }
-			  }
+            if (results[slot]->shape(1) != 1)
+              {
+                for (int k=0;k<nclasses;k++)
+                  {
+                    double prob = results[slot]->cpu_data()[(j*nclasses+k)*imgsize+i];
+                    if (prob > max_prob)
+                      {
+                        max_prob = prob;
+                        best_cat = static_cast<double>(k);
+                      }
+                  }
+              }
+            else
+              {
+                double prob = results[slot]->cpu_data()[(j)*imgsize+i];
+                if (prob > 0.5)
+                  best_cat = 1;
+                else
+                  best_cat = 0;
+              }
 			vals.push_back(best_cat);
 		      }
 		    auto bit = inputc._imgs_size.find(uri);
@@ -2359,24 +2567,24 @@ namespace dd
 	  {
 	    if (lparam->has_convolution_param())
 	      {
-		int num_output = lparam->mutable_convolution_param()->num_output();
-		if (last_layer || num_output == 0)
-		  lparam->mutable_convolution_param()->set_num_output(_nclasses);
-		if (last_layer && num_output != 0)
-		  break;
-		else last_layer = false;
+            int num_output = lparam->mutable_convolution_param()->num_output();
+            if (_loss ==1 && lparam->name() == "linear_aggregation" && num_output == 1)
+              continue;
+            if (last_layer || num_output == 0)
+              lparam->mutable_convolution_param()->set_num_output(_nclasses);
+            if (last_layer && num_output != 0)
+              break;
+            else last_layer = false;
 	      }
 	  }
 	else if (lparam->type() == "InnerProduct" || lparam->type() == "SparseInnerProduct")
 	  {
 	    if (lparam->has_inner_product_param())
 	      {
-		if (!_regression || _ntargets == 0)
-		  {
-		    lparam->mutable_inner_product_param()->set_num_output(_nclasses);
-		  }
-		else lparam->mutable_inner_product_param()->set_num_output(_ntargets);
-		break;
+            if (!_regression || _ntargets == 0)
+                lparam->mutable_inner_product_param()->set_num_output(_nclasses);
+            else lparam->mutable_inner_product_param()->set_num_output(_ntargets);
+            break;
 	      }
 	  }
 	/*else if (lparam->type() == "DetectionOutput")

--- a/src/backends/caffe/caffelib.cc
+++ b/src/backends/caffe/caffelib.cc
@@ -286,7 +286,7 @@ namespace dd
             conv_param_param->add_kernel_size(1);
 
             caffe::FillerParameter* filler_param = conv_param_param->mutable_weight_filler();
-            filler_param->set_std(0.01);
+            filler_param->set_std(0.5);
             filler_param->set_type("gaussian");
 
             caffe::LayerParameter* sigmoid_loss_param = insert_layer_before(net_param, softml_pos++);
@@ -323,7 +323,7 @@ namespace dd
             conv_param_param->set_axis(1);
             conv_param_param->add_kernel_size(1);
             filler_param = conv_param_param->mutable_weight_filler();
-            filler_param->set_std(0.01);
+            filler_param->set_std(0.5);
             filler_param->set_type("gaussian");
 
 

--- a/src/backends/caffe/caffelib.h
+++ b/src/backends/caffe/caffelib.h
@@ -202,6 +202,12 @@ namespace dd
     private:
       void update_protofile_classes(caffe::NetParameter &net_param);
 
+      void update_protofiles_dice_deeplab_vgg16(caffe::NetParameter &net_param, caffe::NetParameter &deploy_net_param);
+      void update_protofiles_dice_unet(caffe::NetParameter &net_param, caffe::NetParameter &deploy_net_param);
+
+      void update_protofile_imageDataLayer(caffe::NetParameter &net_param);
+
+
       void update_protofile_finetune(caffe::NetParameter &net_param);
 
       caffe::LayerParameter* insert_layer_before
@@ -232,7 +238,7 @@ namespace dd
       std::vector<int> _gpuid = {0}; /**< GPU id. */
       int _nclasses = 0; /**< required, as difficult to acquire from Caffe's internals. */
       bool _regression = false; /**< whether the net acts as a regressor. */
-      int _loss = 0; /**< loss to use : 0 softmax+multinomail logistic or1: dice*/
+      std::string _loss = ""; /**< loss to use : 0 softmax+multinomail logistic or1: dice*/
       int _ntargets = 0; /**< number of classification or regression targets. */
       bool _autoencoder = false; /**< whether an autoencoder. */
       std::mutex _net_mutex; /**< mutex around net, e.g. no concurrent predict calls as net is not re-instantiated. Use batches instead. */

--- a/src/backends/caffe/caffelib.h
+++ b/src/backends/caffe/caffelib.h
@@ -204,6 +204,14 @@ namespace dd
 
       void update_protofile_finetune(caffe::NetParameter &net_param);
 
+      caffe::LayerParameter* insert_layer_before
+      (caffe::NetParameter &net_param, int layer_number);
+      caffe::LayerParameter*  find_layer_by_name(caffe::NetParameter &net_param, std::string name);
+
+      int find_index_layer_by_type(caffe::NetParameter &net_param, std::string type);
+      int find_index_layer_by_name(caffe::NetParameter &net_param, std::string name);
+
+
       void fix_batch_size(const APIData &ad,
 			  const TInputConnectorStrategy &inputc,
 			  int &user_batch_size,

--- a/src/backends/caffe/caffelib.h
+++ b/src/backends/caffe/caffelib.h
@@ -224,6 +224,7 @@ namespace dd
       std::vector<int> _gpuid = {0}; /**< GPU id. */
       int _nclasses = 0; /**< required, as difficult to acquire from Caffe's internals. */
       bool _regression = false; /**< whether the net acts as a regressor. */
+      int _loss = 0; /**< loss to use : 0 softmax+multinomail logistic or1: dice*/
       int _ntargets = 0; /**< number of classification or regression targets. */
       bool _autoencoder = false; /**< whether an autoencoder. */
       std::mutex _net_mutex; /**< mutex around net, e.g. no concurrent predict calls as net is not re-instantiated. Use batches instead. */

--- a/tests/ut-caffe-mlp.cc
+++ b/tests/ut-caffe-mlp.cc
@@ -606,6 +606,39 @@ TEST(caffelib,configure_resnet_template_n_nt)
   delete caff;
 }
 
+TEST(caffelib, configure_deeplabvgg16_diceloss)
+{
+  APIData ad;
+  ad.add("template","deeplab_vgg16");
+  ad.add("loss","dice");
+  ad.add("templates","../templates/caffe");
+  ad.add("repository","./");
+  ad.add("nclasses",2);
+  ad.add("segmentation",true);
+  CaffeLib<ImgCaffeInputFileConn,SupervisedOutput,CaffeModel> *caff = new CaffeLib<ImgCaffeInputFileConn,SupervisedOutput,CaffeModel>(CaffeModel(ad));
+  caff->_logger = spdlog::syslog_logger("UT");
+  caff->_inputc.init(ad);
+  caff->init_mllib(ad);
+  caff->instantiate_template(ad);
+  caff->_loss = 1;
+
+  caffe::NetParameter net_param, deploy_net_param;
+  bool succ = caffe::ReadProtoFromTextFile("./deeplab_vgg16.prototxt",&net_param);
+  ASSERT_TRUE(succ);
+
+  bool found = false;
+  int k = net_param.layer_size();
+
+  for (int l=k-1;l>0;l--)
+    {
+      caffe::LayerParameter *lparam = net_param.mutable_layer(l);
+      if (lparam->type() == "DiceCoefLoss")
+        found = true;
+    }
+  ASSERT_TRUE(found);
+
+}
+
 TEST(caffelib, configure_unet_diceloss)
 {
   APIData ad;
@@ -620,6 +653,7 @@ TEST(caffelib, configure_unet_diceloss)
   caff->_inputc.init(ad);
   caff->init_mllib(ad);
   caff->instantiate_template(ad);
+  caff->_loss = 1;
 
   caffe::NetParameter net_param, deploy_net_param;
   bool succ = caffe::ReadProtoFromTextFile("./unet.prototxt",&net_param);

--- a/tests/ut-caffe-mlp.cc
+++ b/tests/ut-caffe-mlp.cc
@@ -616,7 +616,7 @@ TEST(caffelib, configure_deeplabvgg16_diceloss)
   ad.add("nclasses",2);
   ad.add("segmentation",true);
   CaffeLib<ImgCaffeInputFileConn,SupervisedOutput,CaffeModel> *caff = new CaffeLib<ImgCaffeInputFileConn,SupervisedOutput,CaffeModel>(CaffeModel(ad));
-  caff->_logger = spdlog::syslog_logger("UT");
+  caff->_logger = spdlog::syslog_logger("UT-deeplab_vgg16");
   caff->_inputc.init(ad);
   caff->init_mllib(ad);
   caff->instantiate_template(ad);
@@ -649,7 +649,7 @@ TEST(caffelib, configure_unet_diceloss)
   ad.add("nclasses",2);
   ad.add("segmentation",true);
   CaffeLib<ImgCaffeInputFileConn,SupervisedOutput,CaffeModel> *caff = new CaffeLib<ImgCaffeInputFileConn,SupervisedOutput,CaffeModel>(CaffeModel(ad));
-  caff->_logger = spdlog::syslog_logger("UT");
+  caff->_logger = spdlog::syslog_logger("UT-unet");
   caff->_inputc.init(ad);
   caff->init_mllib(ad);
   caff->instantiate_template(ad);

--- a/tests/ut-caffe-mlp.cc
+++ b/tests/ut-caffe-mlp.cc
@@ -605,3 +605,35 @@ TEST(caffelib,configure_resnet_template_n_nt)
   ASSERT_EQ(276,deploy_net_param.layer_size());
   delete caff;
 }
+
+TEST(caffelib, configure_unet_diceloss)
+{
+  APIData ad;
+  ad.add("template","unet");
+  ad.add("loss","dice");
+  ad.add("templates","../templates/caffe");
+  ad.add("repository","./");
+  ad.add("nclasses",2);
+  ad.add("segmentation",true);
+  CaffeLib<ImgCaffeInputFileConn,SupervisedOutput,CaffeModel> *caff = new CaffeLib<ImgCaffeInputFileConn,SupervisedOutput,CaffeModel>(CaffeModel(ad));
+  caff->_logger = spdlog::syslog_logger("UT");
+  caff->_inputc.init(ad);
+  caff->init_mllib(ad);
+  caff->instantiate_template(ad);
+
+  caffe::NetParameter net_param, deploy_net_param;
+  bool succ = caffe::ReadProtoFromTextFile("./unet.prototxt",&net_param);
+  ASSERT_TRUE(succ);
+
+  bool found = false;
+  int k = net_param.layer_size();
+
+  for (int l=k-1;l>0;l--)
+    {
+      caffe::LayerParameter *lparam = net_param.mutable_layer(l);
+      if (lparam->type() == "DiceCoefLoss")
+        found = true;
+    }
+  ASSERT_TRUE(found);
+
+}


### PR DESCRIPTION
add api for dice losses 
- "loss":"dice"  
- "loss":"dice_binary" 
- "loss":"dice_binary_weighted"

 in `mllib` (caffelib) parameters

WARNING: only dice is implemented in caffe atm