### PR TITLE
Added 'status:true' parameter to API GET /info calls 

### DIFF
--- a/src/commandlinejsonapi.cc
+++ b/src/commandlinejsonapi.cc
@@ -60,7 +60,7 @@ namespace dd
       }
     if (FLAGS_info)
       {
-	std::string janswer = jrender(info());
+	std::string janswer = jrender(info(""));
 	std::cout << janswer << std::endl;
       }
     if (!FLAGS_service_name.empty())

--- a/src/httpjsonapi.cc
+++ b/src/httpjsonapi.cc
@@ -338,7 +338,8 @@ public:
       {
 	if (rscs.at(0) == _rsc_info)
 	  {
-	    fillup_response(response,_hja->info(),access_log,code,tstart,accept_encoding);
+	    std::string jstr = dd::uri_query_to_json(req_query);
+	    fillup_response(response,_hja->info(jstr),access_log,code,tstart,accept_encoding);
 	  }
 	else if (rscs.at(0) == _rsc_services)
 	  {

--- a/src/jsonapi.h
+++ b/src/jsonapi.h
@@ -88,7 +88,7 @@ namespace dd
 
     // resources
     // return a JSON document for every API call
-    JDoc info() const;
+    JDoc info(const std::string &jstr) const;
     JDoc service_create(const std::string &sname, const std::string &jstr);
     JDoc service_status(const std::string &sname);
     JDoc service_delete(const std::string &sname,
@@ -112,14 +112,15 @@ namespace dd
   class visitor_info : public mapbox::util::static_visitor<APIData>
   {
   public:
-    visitor_info() {}
+    visitor_info(const bool &status):_status(status) {}
     ~visitor_info() {}
 
     template<typename T>
       APIData operator() (T &mllib)
       {
-	return mllib.info();
+	return mllib.info(_status);
       }
+    bool _status = false;
   };
 
   /**

--- a/src/mllibstrategy.h
+++ b/src/mllibstrategy.h
@@ -170,7 +170,7 @@ namespace dd
      * \brief collect current measures history into a data object
      * 
      */
-    void collect_measures_history(APIData &ad)
+    void collect_measures_history(APIData &ad) const
     {
       APIData meas_hist;
       std::lock_guard<std::mutex> lock(_meas_per_iter_mutex);
@@ -217,7 +217,7 @@ namespace dd
      * @param meas measure name
      * @return current value of measure
      */
-    double get_meas(const std::string &meas)
+    double get_meas(const std::string &meas) const
     {
       std::lock_guard<std::mutex> lock(_meas_mutex);
       auto hit = _meas.find(meas);
@@ -230,7 +230,7 @@ namespace dd
      * \brief collect current measures into a data object
      * @param ad data object to hold the measures
      */
-    void collect_measures(APIData &ad)
+    void collect_measures(APIData &ad) const
     {
       APIData meas;
       std::lock_guard<std::mutex> lock(_meas_mutex);
@@ -247,7 +247,7 @@ namespace dd
      * \brief render estimated remaining time
      * @param ad data object to hold the estimate
      */
-    void est_remain_time(APIData &out)
+    void est_remain_time(APIData &out) const
     {
       APIData meas = out.getobj("measure");
       if (meas.has("remain_time")){    
@@ -265,7 +265,6 @@ namespace dd
     TInputConnectorStrategy _inputc; /**< input connector strategy for channeling data in. */
     TOutputConnectorStrategy _outputc; /**< output connector strategy for passing results back to API. */
 
-    bool _has_train = false; /**< whether training is available. */
     bool _has_predict = true; /**< whether prediction is available. */
 
     TMLModel _mlmodel; /**< statistical model template. */
@@ -282,8 +281,8 @@ namespace dd
     std::shared_ptr<spdlog::logger> _logger; /**< mllib logger. */
     
   protected:
-    std::mutex _meas_per_iter_mutex; /**< mutex over measures history. */
-    std::mutex _meas_mutex; /** mutex around current measures. */
+    mutable std::mutex _meas_per_iter_mutex; /**< mutex over measures history. */
+    mutable std::mutex _meas_mutex; /** mutex around current measures. */
   };  
   
 }

--- a/tests/ut-caffeapi.cc
+++ b/tests/ut-caffeapi.cc
@@ -65,7 +65,7 @@ static std::string iterations_sflare = "2000";
 static std::string iterations_camvid = "2";
 #endif
 
-static std::string gpuid = "0"; // change as needed
+static std::string gpuid = "2"; // change as needed
 
 TEST(caffeapi,service_train)
 {

--- a/tests/ut-jsonapi.cc
+++ b/tests/ut-jsonapi.cc
@@ -51,7 +51,7 @@ TEST(jsonapi,service_delete)
   jstr = "{\"clear\":\"mem\"}";
   std::string jdelstr = japi.jrender(japi.service_delete(sname,jstr));
   ASSERT_EQ(ok_str,jdelstr);
-  std::string jinfostr = japi.jrender(japi.info());
+  std::string jinfostr = japi.jrender(japi.info(""));
   JDoc jd;
   jd.Parse(jinfostr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
@@ -119,7 +119,7 @@ TEST(jsonapi,info)
   ASSERT_EQ(created_str,joutstr);
 
   // info
-  std::string jinfostr = japi.jrender(japi.info());
+  std::string jinfostr = japi.jrender(japi.info(""));
   //std::cout << "jinfostr=" << jinfostr << std::endl;
   JDoc jd;
   jd.Parse(jinfostr.c_str());


### PR DESCRIPTION
This is allows the instant retrieval of a wider range of information over all active services:
- training status
- input sizes
- model repository, ...