### PR TITLE
fixed mean subtraction to image when using Caffe model without mean.binaryproto

### DIFF
--- a/src/backends/caffe/caffeinputconns.h
+++ b/src/backends/caffe/caffeinputconns.h
@@ -186,9 +186,12 @@ namespace dd
 	      throw;
 	    }
 	  float *mean = nullptr;
-	  std::string meanfullname = _model_repo + "/" + _meanfname;
-	  if (_data_mean.count() == 0 && _has_mean_file)
+	  if (this->_has_mean_scalar)
 	    {
+	    }
+	  else if (_data_mean.count() == 0 && _has_mean_file)
+	    {
+	      std::string meanfullname = _model_repo + "/" + _meanfname;
 	      caffe::BlobProto blob_proto;
 	      caffe::ReadProtoFromBinaryFile(meanfullname.c_str(),&blob_proto);
 	      _data_mean.FromProto(blob_proto);
@@ -204,10 +207,12 @@ namespace dd
 	  for (int i=0;i<(int)this->_images.size();i++)
 	    {      
 	      caffe::Datum datum;
+	      if (this->_has_mean_scalar)
+		cv::subtract(this->_mean,this->_images.at(i),this->_images.at(i));
 	      caffe::CVMatToDatum(this->_images.at(i),&datum);
 	      if (!_test_labels.empty())
 		datum.set_label(_test_labels.at(i));
-	      if (_data_mean.count() != 0)
+	      if (_data_mean.count() != 0 && !this->_has_mean_scalar)
 		{
 		  int height = datum.height();
 		  int width = datum.width();


### PR DESCRIPTION
When `mean.binaryproto` is available (e.g. model trained with DD), it is read as needed in order to remove the average pixel values from the input image. 

This PR fixes applying the mean when `mean.binaryproto` is not in the model repository and `mean` is defined in the `input` connector JSON object.