### PR TITLE
generalized dice loss (for good)

### DIFF
--- a/src/backends/caffe/caffelib.h
+++ b/src/backends/caffe/caffelib.h
@@ -202,8 +202,10 @@ namespace dd
     private:
       void update_protofile_classes(caffe::NetParameter &net_param);
 
-      void update_protofiles_dice_deeplab_vgg16(caffe::NetParameter &net_param, caffe::NetParameter &deploy_net_param);
-      void update_protofiles_dice_unet(caffe::NetParameter &net_param, caffe::NetParameter &deploy_net_param);
+      void update_protofiles_dice_one_hot(caffe::NetParameter &net_param, std::string loss, int nclasses);
+
+      void update_protofiles_dice_deeplab_vgg16(caffe::NetParameter &net_param, caffe::NetParameter &deploy_net_param, std::string loss, int ignore_label);
+      void update_protofiles_dice_unet(caffe::NetParameter &net_param, caffe::NetParameter &deploy_net_param, std::string loss, int ignore_label);
 
       void update_protofile_imageDataLayer(caffe::NetParameter &net_param);
 
@@ -216,6 +218,7 @@ namespace dd
 
       int find_index_layer_by_type(caffe::NetParameter &net_param, std::string type);
       int find_index_layer_by_name(caffe::NetParameter &net_param, std::string name);
+      caffe::LayerParameter* find_layer_by_type(caffe::NetParameter &net_param, std::string type);
 
 
       void fix_batch_size(const APIData &ad,

--- a/tests/ut-caffe-mlp.cc
+++ b/tests/ut-caffe-mlp.cc
@@ -610,7 +610,8 @@ TEST(caffelib, configure_deeplabvgg16_diceloss)
 {
   APIData ad;
   ad.add("template","deeplab_vgg16");
-  ad.add("loss","dice");
+  ad.add("loss","dice_weighted");
+  ad.add("ignore_label",0);
   ad.add("templates","../templates/caffe");
   ad.add("repository","./");
   ad.add("nclasses",2);


### PR DESCRIPTION
works with new custom caffe

add ability tu use generalized dice (F1) loss for image segmentation, multilabel and optionally weighted
can be given an "ignore_label"

option to mllib:
```
"loss": "dice"
"loss": "dice_multiclass"
"loss": "dice_weighted"
```

this option, used with "template":"deeplab_vgg16" or "template":"unet" and "segmentation":true (input parameter) generates corresponding architectures with dice loss
mllib option ignore_label is also usable

-  service creation
```
curl -X PUT "http://localhost:8080/services/imageserv" -d '{
       "mllib":"caffe",
       "description":"image segmentation service",
       "type":"supervised",
       "parameters":{
         "input":{                              
           "segmentation": true, "connector":"image", "db":false
         },                                     
         "mllib":{
           "loss":"dice_multiclass", "nclasses": 150,"template":"deeplab_vgg16"                                        
         }                      
       },       
       "model":{                           
         "templates":"../templates/caffe/",
         "repository":"/data1/infantes/models/test/"
       }}'
```
- train
```
curl -X POST "http://localhost:8080/train" -d '{
       "service":"imageserv",
       "async":true,
       "parameters":{
         "mllib":{
           "gpu":true,
            "resume":false,
           "net":{
             "batch_size":4,"test_batch_size":2
           },
           "solver":{
             "test_interval":1000,"snapshot":1000,
             "iterations":70000,
             "base_lr":0.0001,
             "solver_type":"RMSPROP"
           },
            "distort":{"all_effects":true,"prob":0.5}
         },
         "input":{
           "connector": "image",
           "width":480,
           "height":480,
           "db": false
         },
         "output":{
           "measure":["acc", "meaniou"]
         }
       },
       "data":["/data1/segmentation/mitparsing/data_480x480/train.txt", "/data1/segmentation/mitparsing/data_480x480/val_shuf50.txt"]
}'
```