### PR TITLE
correctly aggregate means

### DIFF
--- a/src/supervisedoutputconnector.h
+++ b/src/supervisedoutputconnector.h
@@ -1307,14 +1307,16 @@ namespace dd
     
     static double ap(const APIData &ad)
     {
-      double mAP = 0.0;
+      double mmAP = 0.0;
       std::map<int, float> APs;
-      
+
       // extract tp, fp, labels
       APIData bad = ad.getobj("0");
       int pos_count = ad.get("pos_count").get<int>();
       for (int i=0;i<pos_count;i++)
 	{
+         // do a mean over label AP per image in test set
+         double mAP = 0.0;
 	  std::vector<APIData> vbad = bad.getv(std::to_string(i));
 	  //std::cerr << "vbad size=" << vbad.size() << std::endl;
 	  for (size_t j=0;j<vbad.size();j++)
@@ -1346,8 +1348,10 @@ namespace dd
 	      mAP += APs[label];
 	    }
 	  mAP/=static_cast<double>(vbad.size());
+         // do a mean mAP over images in test set
+         mmAP += mAP;
 	}
-      return mAP;
+      return mmAP/static_cast<double>(pos_count);
     }
     
     // measure: AUC


### PR DESCRIPTION
change aggregation of means

- the idea is to compute mean (over test images) of mean (over labels) of average precision (of bounding boxes)

- bug: the APs of one image (for every labels) were summed to previous mAP (supposedly over all images in test set) then divided by the number of labels in the current image, giving a weighted sum (the first map was divided n_test_images times, the second n_test_images -1 by the number of label of current image)

- Now the map is computed over one image (mean over labels) then summed to global mmap, and divided in the end by the number of image, so we have a mean mAP