### PR TITLE
Measure history subsampling

### DIFF
--- a/src/mlservice.h
+++ b/src/mlservice.h
@@ -313,7 +313,11 @@ namespace dd
 	      std::chrono::time_point<std::chrono::system_clock> trun = std::chrono::system_clock::now();
 	      out.add("time",std::chrono::duration_cast<std::chrono::seconds>(trun-(*hit).second._tstart).count());
 	      if (ad_params_out.has("measure_hist") && ad_params_out.get("measure_hist").get<bool>())
-		this->collect_measures_history(out);
+		{
+		  if (ad_params_out.has("max_hist_points"))
+		    this->collect_measures_history(out,ad_params_out.get("max_hist_points").get<int>());
+		  else this->collect_measures_history(out);
+		}
 	    }
 	  else if (status == std::future_status::ready)
 	    {
@@ -349,7 +353,11 @@ namespace dd
 	      std::chrono::time_point<std::chrono::system_clock> trun = std::chrono::system_clock::now();
 	      out.add("time",std::chrono::duration_cast<std::chrono::seconds>(trun-(*hit).second._tstart).count());
 	      if (ad_params_out.has("measure_hist") && ad_params_out.get("measure_hist").get<bool>())
-		this->collect_measures_history(out);
+		{
+		  if (ad_params_out.has("max_hist_points"))
+		    this->collect_measures_history(out,ad_params_out.get("max_hist_points").get<int>());
+		  else this->collect_measures_history(out);
+		}
 	      _training_jobs.erase(hit);
 	    }
 	  return 0;

--- a/tests/ut-httpapi.cc
+++ b/tests/ut-httpapi.cc
@@ -236,7 +236,7 @@ TEST(httpjsonapi,train)
 	  ASSERT_TRUE(jd2["body"]["measure"].HasMember("iteration"));
 	  ASSERT_TRUE(jd2["body"]["measure"]["iteration"].GetDouble() >= 0);
 	  ASSERT_TRUE(jd2["body"].HasMember("measure_hist"));
-	  ASSERT_TRUE(100 <= jd2["body"].["measure_hist"]["train_loss"].Size());
+	  ASSERT_TRUE(100 <= jd2["body"]["measure_hist"]["train_loss"].Size());
 	}
       else ASSERT_TRUE(jstr.find("finished")!=std::string::npos);
     }

--- a/tests/ut-httpapi.cc
+++ b/tests/ut-httpapi.cc
@@ -214,7 +214,7 @@ TEST(httpjsonapi,train)
   bool running = true;
   while(running)
     {
-      httpclient::get_call(luri+"/train?service="+serv+"&job=1&timeout=1&parameters.output.measure_hist=true","GET",code,jstr);
+      httpclient::get_call(luri+"/train?service="+serv+"&job=1&timeout=1&parameters.output.measure_hist=true&parameters.output.max_hist_points=100","GET",code,jstr);
       running = jstr.find("running") != std::string::npos;
       if (running)
 	{
@@ -236,6 +236,7 @@ TEST(httpjsonapi,train)
 	  ASSERT_TRUE(jd2["body"]["measure"].HasMember("iteration"));
 	  ASSERT_TRUE(jd2["body"]["measure"]["iteration"].GetDouble() >= 0);
 	  ASSERT_TRUE(jd2["body"].HasMember("measure_hist"));
+	  ASSERT_TRUE(100 <= jd2["body"].["measure_hist"]["train_loss"].Size());
 	}
       else ASSERT_TRUE(jstr.find("finished")!=std::string::npos);
     }


### PR DESCRIPTION
Added `max_hist_point` parameter as the maximum number of measured points to be returned. Full history is subsampled.