### PR TITLE
Pinning spdlog to v0.17.0 for Travis

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -53,6 +53,7 @@ if [ "$TRAVIS_OS_NAME" = 'linux' ]; then
         ##################
         # Not available on 14.04 trusty via package
 	git clone https://github.com/gabime/spdlog.git
+	cd spdlog && git checkout v0.17.0 && cd ..
 	sudo cp -r spdlog/include/spdlog /usr/include/
 	
         if [ "$BUILD_CUDA" = 'true' ]; then


### PR DESCRIPTION
Travis builds use Ubuntu 14.04 and require cloning spdlog. Current up-to-date version seems to be breaking some elements, pinning it to last stable release 0.17.0.