### PR TITLE
Fix to history subsampling.

### DIFF
--- a/src/mllibstrategy.h
+++ b/src/mllibstrategy.h
@@ -188,7 +188,7 @@ namespace dd
     {
       std::vector<double> sub_hist;
       sub_hist.reserve(npoints);
-      int rpoints = std::ceil(hist.size() / npoints);
+      int rpoints = std::ceil(hist.size() / npoints) + 1;
       for (size_t i=0;i<hist.size();i+=rpoints)
 	sub_hist.push_back(hist.at(i));
       return sub_hist;
@@ -207,9 +207,9 @@ namespace dd
       auto hit = _meas_per_iter.begin();
       while(hit!=_meas_per_iter.end())
 	{
-	  if (npoints > 0 && (*hit).second.size() > npoints)
+	  if (npoints > 0 && (int)(*hit).second.size() > npoints)
 	    meas_hist.add((*hit).first+"_hist",subsample_hist((*hit).second,npoints));
-	  meas_hist.add((*hit).first+"_hist",(*hit).second);
+	  else meas_hist.add((*hit).first+"_hist",(*hit).second);
 	  ++hit;
 	}
       ad.add("measure_hist",meas_hist);

--- a/src/mlservice.h
+++ b/src/mlservice.h
@@ -312,7 +312,7 @@ namespace dd
 	      this->est_remain_time(out);
 	      std::chrono::time_point<std::chrono::system_clock> trun = std::chrono::system_clock::now();
 	      out.add("time",std::chrono::duration_cast<std::chrono::seconds>(trun-(*hit).second._tstart).count());
-	      if (ad_params_out.has("measure_hist") && ad_params_out.get("measure_hist").get<bool>())
+	      if (ad_params_out.has("max_hist_points") || (ad_params_out.has("measure_hist") && ad_params_out.get("measure_hist").get<bool>()))
 		{
 		  if (ad_params_out.has("max_hist_points"))
 		    this->collect_measures_history(out,ad_params_out.get("max_hist_points").get<int>());
@@ -352,7 +352,7 @@ namespace dd
 	      out.add("model",jmrepo);
 	      std::chrono::time_point<std::chrono::system_clock> trun = std::chrono::system_clock::now();
 	      out.add("time",std::chrono::duration_cast<std::chrono::seconds>(trun-(*hit).second._tstart).count());
-	      if (ad_params_out.has("measure_hist") && ad_params_out.get("measure_hist").get<bool>())
+	      if (ad_params_out.has("max_hist_points") || (ad_params_out.has("measure_hist") && ad_params_out.get("measure_hist").get<bool>()))
 		{
 		  if (ad_params_out.has("max_hist_points"))
 		    this->collect_measures_history(out,ad_params_out.get("max_hist_points").get<int>());

--- a/tests/ut-httpapi.cc
+++ b/tests/ut-httpapi.cc
@@ -34,7 +34,7 @@ std::string serv = "myserv";
 std::string serv_put = "{\"mllib\":\"caffe\",\"description\":\"example classification service\",\"type\":\"supervised\",\"parameters\":{\"input\":{\"connector\":\"csv\"},\"mllib\":{\"template\":\"mlp\",\"nclasses\":2,\"layers\":[50,50,50],\"activation\":\"PReLU\"}},\"model\":{\"templates\":\"../templates/caffe/\",\"repository\":\".\"}}";
 
 #ifndef CPU_ONLY
-static std::string iterations_mnist = "250";
+static std::string iterations_mnist = "10000";
 #else
 static std::string iterations_mnist = "10";
 #endif
@@ -170,7 +170,7 @@ TEST(httpjsonapi,train)
   ASSERT_TRUE(d.HasMember("body"));
   ASSERT_TRUE(d["body"].HasMember("measure"));
 #ifndef CPU_ONLY
-  ASSERT_EQ(249,d["body"]["measure"]["iteration"].GetDouble());
+  ASSERT_EQ(9999,d["body"]["measure"]["iteration"].GetDouble());
 #else
   ASSERT_EQ(9,d["body"]["measure"]["iteration"].GetDouble());
 #endif
@@ -214,7 +214,7 @@ TEST(httpjsonapi,train)
   bool running = true;
   while(running)
     {
-      httpclient::get_call(luri+"/train?service="+serv+"&job=1&timeout=1&parameters.output.measure_hist=true&parameters.output.max_hist_points=100","GET",code,jstr);
+      httpclient::get_call(luri+"/train?service="+serv+"&job=1&timeout=1&parameters.output.max_hist_points=100","GET",code,jstr);
       running = jstr.find("running") != std::string::npos;
       if (running)
 	{
@@ -236,7 +236,7 @@ TEST(httpjsonapi,train)
 	  ASSERT_TRUE(jd2["body"]["measure"].HasMember("iteration"));
 	  ASSERT_TRUE(jd2["body"]["measure"]["iteration"].GetDouble() >= 0);
 	  ASSERT_TRUE(jd2["body"].HasMember("measure_hist"));
-	  ASSERT_TRUE(100 <= jd2["body"]["measure_hist"]["train_loss"].Size());
+	  ASSERT_TRUE(100 >= jd2["body"]["measure_hist"]["train_loss_hist"].Size());
 	}
       else ASSERT_TRUE(jstr.find("finished")!=std::string::npos);
     }


### PR DESCRIPTION
At the moment, limiting the number of measure history points is only available by using the single parameter alone `parameters.output.max_hist_points=1000` (with any value) on a `GET /train` call. This automatically activates `parameters.output.measure_hist=true` that at the moment cannot be passed concurrently.