### PR TITLE
wrong map_# measures 

### DIFF
--- a/src/supervisedoutputconnector.h
+++ b/src/supervisedoutputconnector.h
@@ -1369,7 +1369,7 @@ namespace dd
 	}
       for (auto ap: APs)
         {
-          ap.second /= static_cast<float>(APs_count[ap.first]);
+          APs[ap.first] /= static_cast<float>(APs_count[ap.first]);
         }
      return mmAP / static_cast<double>(pos_count);;
     }


### PR DESCRIPTION
map_# measures where normalized correctly, but not put back into map used for output , due to a wrong 
 map access through iterator