### PR TITLE
stores full metric history into metrics.json once training job has finished

### DIFF
--- a/src/jsonapi.cc
+++ b/src/jsonapi.cc
@@ -978,7 +978,7 @@ namespace dd
     if (train_status == "finished")
       {
 	std::string mrepo = out.getobj("model").get("repository").get<std::string>();
-	if (JsonAPI::store_json_blob(mrepo,jrender(jtrain)))
+	if (JsonAPI::store_json_blob(mrepo,jrender(jtrain),"metrics.json"))
 	  _logger->error("couldn't write to {} file in model repository {}",JsonAPI::_json_blob_fname,mrepo);
       }
     return jtrain;
@@ -1049,10 +1049,15 @@ namespace dd
   }
   
   int JsonAPI::store_json_blob(const std::string &model_repo,
-			       const std::string &jstr)
+			       const std::string &jstr,
+			       const std::string &jfilename)
   {
     std::ofstream outf;
-    outf.open(model_repo + "/" + JsonAPI::_json_blob_fname,std::ofstream::out|std::ofstream::app);
+    std::string outfname = model_repo + "/";
+    if (!jfilename.empty())
+      outfname += jfilename;
+    else outfname += JsonAPI::_json_blob_fname;
+    outf.open(outfname,std::ofstream::out|std::ofstream::app);
     if (!outf.is_open())
       return 1;
     outf << jstr << std::endl;

--- a/src/jsonapi.h
+++ b/src/jsonapi.h
@@ -101,7 +101,8 @@ namespace dd
     JDoc service_train_delete(const std::string &jstr);
 
     static int store_json_blob(const std::string &model_repo,
-			       const std::string &jstr);
+			       const std::string &jstr,
+			       const std::string &jfilename="");
 
     static int store_json_config_blob(const std::string &model_repo,
 				      const std::string &jstr);

--- a/src/mlservice.h
+++ b/src/mlservice.h
@@ -353,12 +353,10 @@ namespace dd
 	      out.add("model",jmrepo);
 	      std::chrono::time_point<std::chrono::system_clock> trun = std::chrono::system_clock::now();
 	      out.add("time",std::chrono::duration_cast<std::chrono::seconds>(trun-(*hit).second._tstart).count());
-	      if (ad_params_out.has("max_hist_points") || (ad_params_out.has("measure_hist") && ad_params_out.get("measure_hist").get<bool>()))
-		{
-		  if (ad_params_out.has("max_hist_points"))
-		    this->collect_measures_history(out,ad_params_out.get("max_hist_points").get<int>());
-		  else this->collect_measures_history(out);
-		}
+	      // metrics history is force-collected when training finishes
+	      if (ad_params_out.has("max_hist_points"))
+		this->collect_measures_history(out,ad_params_out.get("max_hist_points").get<int>());
+	      else this->collect_measures_history(out);
 	      _training_jobs.erase(hit);
 	    }
 	  return 0;


### PR DESCRIPTION
This PR automates the storage of full metric history after a training job has finished.

Related to #354 

`metrics.json` is the final file stored in model directory.