### PR TITLE
Add USE_HDF5 flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,13 +71,15 @@ set(eigen_archive_hash "50812b426b7c")
 include_directories("${EIGEN3_INCLUDE_DIR}")
 
 # hdf5
-if (RPI3)
-  set(HDF5_LIB /usr/lib/arm-linux-gnueabihf/hdf5/serial)
-else()
-  set(HDF5_LIB /usr/lib/x86_64-linux-gnu/hdf5/serial)
+if (USE_HDF5)
+  if (RPI3)
+    set(HDF5_LIB /usr/lib/arm-linux-gnueabihf/hdf5/serial)
+  else()
+    set(HDF5_LIB /usr/lib/x86_64-linux-gnu/hdf5/serial)
+  endif()
+  set (HDF5_INCLUDE /usr/include/hdf5/serial)
+  include_directories(${HDF5_INCLUDE})
 endif()
-set (HDF5_INCLUDE /usr/include/hdf5/serial)
-include_directories(${HDF5_INCLUDE})
 
 # dependency on Boost
 find_package(Boost 1.54 REQUIRED COMPONENTS filesystem thread system iostreams)
@@ -371,24 +373,41 @@ else()
     BUILD_IN_SOURCE 1
     )
 
-  if (JETSON)
-    set(HDF5_LIB /usr/lib/aarch64-linux-gnu/hdf5/serial)
-  elseif (RPI3)
-    set(HDF5_LIB /usr/lib/arm-linux-gnueabihf/hdf5/serial)
-  else()
-    set(HDF5_LIB /usr/lib/x86_64-linux-gnu/hdf5/serial)
+  if (USE_HDF5)
+    if (JETSON)
+      set(HDF5_LIB /usr/lib/aarch64-linux-gnu/hdf5/serial)
+    elseif (RPI3)
+      set(HDF5_LIB /usr/lib/arm-linux-gnueabihf/hdf5/serial)
+    else()
+      set(HDF5_LIB /usr/lib/x86_64-linux-gnu/hdf5/serial)
+    endif()
   endif()
-  if (CUDA_FOUND)
-    set(CAFFE_INC_DIR ${CMAKE_BINARY_DIR}/caffe_dd/src/caffe_dd/include ${CMAKE_BINARY_DIR}/caffe_dd/src/caffe_dd/build/src ${CUDA_INCLUDE_DIRS} ${PROTOBUF_INCLUDE_DIR})
-    set(CAFFE_LIB_DIR ${CMAKE_BINARY_DIR}/caffe_dd/src/caffe_dd/build/lib ${CMAKE_BINARY_DIR}/caffe_dd/src/caffe_dd/build/src ${HDF5_LIB} ${PROTOBUF_LIB_DIR})
+
+  if (USE_HDF5)
+    if (CUDA_FOUND)
+      set(CAFFE_INC_DIR ${CMAKE_BINARY_DIR}/caffe_dd/src/caffe_dd/include ${CMAKE_BINARY_DIR}/caffe_dd/src/caffe_dd/build/src ${CUDA_INCLUDE_DIRS} ${PROTOBUF_INCLUDE_DIR})
+      set(CAFFE_LIB_DIR ${CMAKE_BINARY_DIR}/caffe_dd/src/caffe_dd/build/lib ${CMAKE_BINARY_DIR}/caffe_dd/src/caffe_dd/build/src ${HDF5_LIB} ${PROTOBUF_LIB_DIR})
+    else()
+      set(CAFFE_INC_DIR ${CMAKE_BINARY_DIR}/caffe_dd/src/caffe_dd/include ${CMAKE_BINARY_DIR}/caffe_dd/src/caffe_dd/build/src /usr/include/hdf5/serial ${PROTOBUF_INCLUDE_DIR})
+      set(CAFFE_LIB_DIR $ENV{HOME}/lib ${CMAKE_BINARY_DIR}/caffe_dd/src/caffe_dd/build/lib ${CMAKE_BINARY_DIR}/caffe_dd/src/caffe_dd/build/src ${HDF5_LIB} ${PROTOBUF_LIB_DIR})
+    endif()
   else()
-    set(CAFFE_INC_DIR ${CMAKE_BINARY_DIR}/caffe_dd/src/caffe_dd/include ${CMAKE_BINARY_DIR}/caffe_dd/src/caffe_dd/build/src /usr/include/hdf5/serial ${PROTOBUF_INCLUDE_DIR})
-    set(CAFFE_LIB_DIR $ENV{HOME}/lib ${CMAKE_BINARY_DIR}/caffe_dd/src/caffe_dd/build/lib ${CMAKE_BINARY_DIR}/caffe_dd/src/caffe_dd/build/src ${HDF5_LIB} ${PROTOBUF_LIB_DIR})
+    if (CUDA_FOUND)
+      set(CAFFE_INC_DIR ${CMAKE_BINARY_DIR}/caffe_dd/src/caffe_dd/include ${CMAKE_BINARY_DIR}/caffe_dd/src/caffe_dd/build/src ${CUDA_INCLUDE_DIRS} ${PROTOBUF_INCLUDE_DIR})
+      set(CAFFE_LIB_DIR ${CMAKE_BINARY_DIR}/caffe_dd/src/caffe_dd/build/lib ${CMAKE_BINARY_DIR}/caffe_dd/src/caffe_dd/build/src ${PROTOBUF_LIB_DIR})
+    else()
+      set(CAFFE_INC_DIR ${CMAKE_BINARY_DIR}/caffe_dd/src/caffe_dd/include ${CMAKE_BINARY_DIR}/caffe_dd/src/caffe_dd/build/src ${PROTOBUF_INCLUDE_DIR})
+      set(CAFFE_LIB_DIR $ENV{HOME}/lib ${CMAKE_BINARY_DIR}/caffe_dd/src/caffe_dd/build/lib ${CMAKE_BINARY_DIR}/caffe_dd/src/caffe_dd/build/src ${PROTOBUF_LIB_DIR})
+    endif()
   endif()
 endif()
 
 # Caffe dependencies
-set(CAFFE_LIB_DEPS -lleveldb -lsnappy -llmdb -lhdf5_hl -lhdf5 -lopenblas -lcaffe -lprotobuf)
+if (USE_HDF5)
+  set(CAFFE_LIB_DEPS -lleveldb -lsnappy -llmdb -lhdf5_hl -lhdf5 -lopenblas -lcaffe -lprotobuf)
+else()
+  set(CAFFE_LIB_DEPS -lleveldb -lsnappy -llmdb -lopenblas -lcaffe -lprotobuf)
+endif()
 
 if (USE_TF)
   add_dependencies(caffe_dd tensorflow_cc)
@@ -479,14 +498,25 @@ set(COMMON_LINK_DIRS
   ${XGBOOST_LIB_DIR}
   ${TSNE_LIB_DIR}
   ${DLIB_LIB_DIR})
-set(COMMON_LINK_LIBS
-  ddetect ${CUDA_LIB_DEPS} glog gflags ${OpenCV_LIBS} curlpp curl hdf5_cpp ${Boost_LIBRARIES}
-  ${CAFFE_LIB_DEPS}
-  ${CAFFE2_LIB_DEPS}
-  ${TF_LIB_DEPS}
-  ${XGBOOST_LIB_DEPS}
-  ${TSNE_LIB_DEPS}
-  ${DLIB_LIB_DEPS})
+if (USE_HDF5)
+  set(COMMON_LINK_LIBS
+    ddetect ${CUDA_LIB_DEPS} glog gflags ${OpenCV_LIBS} curlpp curl hdf5_cpp ${Boost_LIBRARIES}
+    ${CAFFE_LIB_DEPS}
+    ${CAFFE2_LIB_DEPS}
+    ${TF_LIB_DEPS}
+    ${XGBOOST_LIB_DEPS}
+    ${TSNE_LIB_DEPS}
+    ${DLIB_LIB_DEPS})
+else()
+  set(COMMON_LINK_LIBS
+    ddetect ${CUDA_LIB_DEPS} glog gflags ${OpenCV_LIBS} curlpp curl ${Boost_LIBRARIES}
+    ${CAFFE_LIB_DEPS}
+    ${CAFFE2_LIB_DEPS}
+    ${TF_LIB_DEPS}
+    ${XGBOOST_LIB_DEPS}
+    ${TSNE_LIB_DEPS}
+    ${DLIB_LIB_DEPS})
+endif()
 set(HTTP_LINK_LIBS cppnetlib-uri crypto ssl)
 
 add_subdirectory(main)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,6 @@ include(ExternalProject)
 
 set (deepdetect_VERSION_MAJOR 0)
 set (deepdetect_VERSION_MINOR 1)
-set (HDF5_LIB /usr/lib/x86_64-linux-gnu/hdf5/serial)
 
 # options
 OPTION(BUILD_TESTS "Should the tests be built")
@@ -72,7 +71,11 @@ set(eigen_archive_hash "50812b426b7c")
 include_directories("${EIGEN3_INCLUDE_DIR}")
 
 # hdf5
-set (HDF5_LIB /usr/lib/x86_64-linux-gnu/hdf5/serial)
+if (RPI3)
+  set(HDF5_LIB /usr/lib/arm-linux-gnueabihf/hdf5/serial)
+else()
+  set(HDF5_LIB /usr/lib/x86_64-linux-gnu/hdf5/serial)
+endif()
 set (HDF5_INCLUDE /usr/include/hdf5/serial)
 include_directories(${HDF5_INCLUDE})
 
@@ -346,6 +349,10 @@ else()
     set(CAFFE_DD_CONFIG_FILE Makefile.config.cpu)
   endif()
 
+  if (RPI3)
+    set(CAFFE_DD_CONFIG_FILE Makefile.config.pi3)
+  endif()
+
   list(APPEND CAFFE_DD_CONFIGURE_COMMAND
     ln -sf ${CAFFE_DD_CONFIG_FILE} Makefile.config &&
     echo "OPENCV_VERSION:=${OPENCV_VERSION}" >> Makefile.config &&
@@ -366,6 +373,8 @@ else()
 
   if (JETSON)
     set(HDF5_LIB /usr/lib/aarch64-linux-gnu/hdf5/serial)
+  elseif (RPI3)
+    set(HDF5_LIB /usr/lib/arm-linux-gnueabihf/hdf5/serial)
   else()
     set(HDF5_LIB /usr/lib/x86_64-linux-gnu/hdf5/serial)
   endif()

--- a/src/backends/caffe/caffeinputconns.cc
+++ b/src/backends/caffe/caffeinputconns.cc
@@ -26,7 +26,9 @@
 #include "caffeinputconns.h"
 #include "utils/utils.hpp"
 #include <boost/multi_array.hpp>
+#ifdef USE_HDF5
 #include <H5Cpp.h>
+#endif // USE_HDF5
 #include <memory>
 #include "utf8.h"
 
@@ -396,6 +398,7 @@ namespace dd
   }
 
   // - fixed size in-memory arrays put down to disk at once
+	#ifdef USE_HDF5
   void ImgCaffeInputFileConn::images_to_hdf5(const std::vector<std::string> &img_lists,
 					     const std::string &dbfullname,
 					     const std::string &test_dbfullname)
@@ -647,6 +650,7 @@ namespace dd
       tlist << s << std::endl;
     tlist.close();
   }
+	#endif // USE_HDF5
 
   int ImgCaffeInputFileConn::objects_to_db(const std::vector<std::string> &filelists,
 					   const int &db_height,

--- a/src/backends/caffe/caffeinputconns.h
+++ b/src/backends/caffe/caffeinputconns.h
@@ -352,8 +352,9 @@ namespace dd
 		}
 
 	      // read images list and create dbs
-	      images_to_hdf5(_uris,_dbfullname,_test_dbfullname);
-
+				#ifdef USE_HDF5
+				images_to_hdf5(_uris,_dbfullname,_test_dbfullname);
+				#endif // USE_HDF5
 	      // enrich data object with db files location
 	      APIData dbad;
 	      dbad.add("train_db",_model_repo + "/training.txt");
@@ -466,7 +467,7 @@ namespace dd
 				      const std::string &backend,
 				      const bool &encoded,
 				      const std::string &encode_type);
-
+		#ifdef USE_HDF5
     void images_to_hdf5(const std::vector<std::string> &img_lists,
 			const std::string &traindbname,
 			const std::string &testdbname);
@@ -477,6 +478,7 @@ namespace dd
 			      std::unordered_map<uint32_t,int> &alphabet,
 			      int &max_ocr_length,
 			      const bool &train_db);
+		#endif // USE_HDF5
 
     int objects_to_db(const std::vector<std::string> &rfolders,
 		      const int &db_height,

--- a/src/backends/caffe/caffelib.cc
+++ b/src/backends/caffe/caffelib.cc
@@ -2389,6 +2389,7 @@ namespace dd
 		batch_size = user_batch_size;
 	      }
 	  }
+	#ifdef USE_HDF5
 	else if (lp->has_hdf5_data_param())
 	  {
 	    caffe::HDF5DataParameter *dp = lp->mutable_hdf5_data_param();
@@ -2408,6 +2409,7 @@ namespace dd
 	      }
 	    dp->set_image(true);
 	  }
+	#endif // USE_HDF5
 	else if (lp->has_dense_image_data_param())
 	  {
 	    caffe::DenseImageDataParameter *dp = lp->mutable_dense_image_data_param();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,7 +18,11 @@ if (GTEST_FOUND)
 
   if (USE_TF)
     add_executable(opencv_tensor opencv_tensor.cc)
-    target_link_libraries(opencv_tensor ${OpenCV_LIBS} boost_thread boost_system crypto ssl hdf5_cpp ${TF_LIB_DEPS})
+    if (USE_HDF5)
+      target_link_libraries(opencv_tensor ${OpenCV_LIBS} boost_thread boost_system crypto ssl hdf5_cpp ${TF_LIB_DEPS})
+    else()
+      target_link_libraries(opencv_tensor ${OpenCV_LIBS} boost_thread boost_system crypto ssl ${TF_LIB_DEPS})
+    endif()
   endif()
 
   add_executable(test_server test-server.cc)


### PR DESCRIPTION
USE_HDF5 flag for compilation and usage without `libhdf5`.

Note: need merging of https://github.com/jolibrain/deepdetect/pull/493 and https://github.com/jolibrain/caffe/pull/28 before.