### PR TITLE
autoload API option to prevent model from loading at service creation

### DIFF
--- a/src/backends/caffe/caffelib.h
+++ b/src/backends/caffe/caffelib.h
@@ -103,7 +103,8 @@ namespace dd
      * \brief creates neural net instance based on model
      * @return 0 if OK, 2, if missing 'deploy' file, 1 otherwise
      */
-    int create_model(const bool &test=false);
+     int create_model(const bool &test=false,
+		      const bool &autoload_model=true);
     
     /*- from mllib -*/
     /**


### PR DESCRIPTION
Sometimes, we may not want an existing model to preload at soon as the API service creation call.

This PR defines `mllib` boolean option `autoload_model`.