### PR TITLE
Store metrics on disk upon every status call

### DIFF
--- a/src/jsonapi.cc
+++ b/src/jsonapi.cc
@@ -989,7 +989,7 @@ namespace dd
       }
     jtrain.AddMember("head",jhead,jtrain.GetAllocator());
     jtrain.AddMember("body",jout,jtrain.GetAllocator());
-    if (train_status == "finished")
+    if (train_status == "finished" || train_status == "running")
       {
 	std::string mrepo = out.getobj("model").get("repository").get<std::string>();
 	if (JsonAPI::store_json_blob(mrepo,jrender(jtrain),"metrics.json"))

--- a/src/mlservice.h
+++ b/src/mlservice.h
@@ -316,9 +316,10 @@ namespace dd
 	      out.add("time",std::chrono::duration_cast<std::chrono::seconds>(trun-(*hit).second._tstart).count());
 	      if (ad_params_out.has("max_hist_points") || (ad_params_out.has("measure_hist") && ad_params_out.get("measure_hist").get<bool>()))
 		{
+		  int max_hist_points = 10000; // default
 		  if (ad_params_out.has("max_hist_points"))
-		    this->collect_measures_history(out,ad_params_out.get("max_hist_points").get<int>());
-		  else this->collect_measures_history(out);
+		    max_hist_points = ad_params_out.get("max_hist_points").get<int>();
+		  this->collect_measures_history(out,max_hist_points);
 		}
 	    }
 	  else if (status == std::future_status::ready)
@@ -355,9 +356,10 @@ namespace dd
 	      std::chrono::time_point<std::chrono::system_clock> trun = std::chrono::system_clock::now();
 	      out.add("time",std::chrono::duration_cast<std::chrono::seconds>(trun-(*hit).second._tstart).count());
 	      // metrics history is force-collected when training finishes
+	      int max_hist_points = 10000; // default
 	      if (ad_params_out.has("max_hist_points"))
-		this->collect_measures_history(out,ad_params_out.get("max_hist_points").get<int>());
-	      else this->collect_measures_history(out);
+		max_hist_points = ad_params_out.get("max_hist_points").get<int>();
+	      this->collect_measures_history(out,max_hist_points);
 	      out.add("mltype",this->_mltype);
 	      out.add("sname",this->_sname);
 	      out.add("description",this->_description);


### PR DESCRIPTION
This saves `metrics.json` file upon every status call on a training job.