### PR TITLE
Retrieve files from subdirectories of class directories

### DIFF
--- a/src/backends/caffe/caffeinputconns.cc
+++ b/src/backends/caffe/caffeinputconns.cc
@@ -119,7 +119,7 @@ namespace dd
 
     // list directories in dataset train folder
     std::unordered_set<std::string> subdirs;
-    if (fileops::list_directory(rfolders.at(0),false,true,subdirs))
+    if (fileops::list_directory(rfolders.at(0),false,true,false,subdirs))
       throw InputConnectorBadParamException("failed reading image train data directory " + rfolders.at(0));
 
     // list files and classes, possibly shuffle / split them
@@ -131,7 +131,7 @@ namespace dd
     while(uit!=subdirs.end())
       {
 	std::unordered_set<std::string> subdir_files;
-	if (fileops::list_directory((*uit),true,false,subdir_files))
+	if (fileops::list_directory((*uit),true,false,true,subdir_files))
 	  throw InputConnectorBadParamException("failed reading image train data sub-directory " + (*uit));
 	std::string cls = dd_utils::split((*uit),'/').back();
 	hcorresp.insert(std::pair<int,std::string>(cl,cls));
@@ -183,7 +183,7 @@ namespace dd
       {
 	// list directories in dataset test folder
 	std::unordered_set<std::string> test_subdirs;
-	if (fileops::list_directory(rfolders.at(1),false,true,test_subdirs))
+	if (fileops::list_directory(rfolders.at(1),false,true,false,test_subdirs))
 	  throw InputConnectorBadParamException("failed reading image test data directory " + rfolders.at(1));
 
 	// list files and classes, possibly shuffle / split them
@@ -192,7 +192,7 @@ namespace dd
 	while(uit!=test_subdirs.end())
 	  {
 	    std::unordered_set<std::string> subdir_files;
-	    if (fileops::list_directory((*uit),true,false,subdir_files))
+	    if (fileops::list_directory((*uit),true,false,true,subdir_files))
 	      throw InputConnectorBadParamException("failed reading image test data sub-directory " + (*uit));
 	    std::string cls = dd_utils::split((*uit),'/').back();
 	    if ((hcit=hcorresp_r.find(cls))==hcorresp_r.end())

--- a/src/backends/caffe/caffemodel.cc
+++ b/src/backends/caffe/caffemodel.cc
@@ -66,7 +66,7 @@ namespace dd
     static std::string meanf = "mean.binaryproto";
     this->_repo = repo;
     std::unordered_set<std::string> lfiles;
-    int e = fileops::list_directory(repo,true,false,lfiles);
+    int e = fileops::list_directory(repo,true,false,false,lfiles);
     if (e != 0)
       {
 	logger->error("error reading or listing caffe models in repository {}",repo);
@@ -159,7 +159,7 @@ namespace dd
 	  }
 	else logger->info("sucessfully copied best model file {}",best_caffemodel);
 	std::unordered_set<std::string> lfiles;
-	fileops::list_directory(source_repo,true,false,lfiles);
+	fileops::list_directory(source_repo,true,false,false,lfiles);
 	auto hit = lfiles.begin();
 	while(hit!=lfiles.end())
 	  {

--- a/src/backends/caffe2/caffe2inputimg.cc
+++ b/src/backends/caffe2/caffe2inputimg.cc
@@ -268,7 +268,7 @@ namespace dd {
 					   bool is_reversed) {
 
     std::unordered_set<std::string> subdirs;
-    if (fileops::list_directory(root, false, true, subdirs)) {
+    if (fileops::list_directory(root, false, true, false, subdirs)) {
       std::string msg("Failed reading image data directory " + root);
       _logger->error(msg);
       throw InputConnectorBadParamException(msg);
@@ -279,7 +279,7 @@ namespace dd {
     for (const std::string &dir : subdirs) {
 
       std::unordered_set<std::string> subdir_files;
-      if (fileops::list_directory(dir, true, false, subdir_files)) {
+      if (fileops::list_directory(dir, true, false, true, subdir_files)) {
 	std::string msg("Failed reading image data sub-directory " + dir);
 	_logger->error(msg);
 	throw InputConnectorBadParamException(msg);

--- a/src/backends/caffe2/caffe2model.cc
+++ b/src/backends/caffe2/caffe2model.cc
@@ -67,7 +67,7 @@ namespace dd {
 
     // List available files
     std::unordered_set<std::string> lfiles;
-    if (fileops::list_directory(_repo, true, false, lfiles)) {
+    if (fileops::list_directory(_repo, true, false, false, lfiles)) {
       std::string msg("error reading or listing Caffe2 models in repository " + _repo);
       logger->error(msg);
       throw MLLibBadParamException(msg);

--- a/src/backends/dlib/dlibmodel.cc
+++ b/src/backends/dlib/dlibmodel.cc
@@ -37,7 +37,7 @@ namespace dd {
         std::string modelName = ".dat";
         this->_repo = repo;
         std::unordered_set<std::string> lfiles;
-        int e = fileops::list_directory(repo, true, false, lfiles);
+        int e = fileops::list_directory(repo, true, false, false, lfiles);
         if (e != 0) {
             logger->error("error reading or listing dlib models in repository {}", repo);
             return 1;

--- a/src/backends/tf/tfmodel.cc
+++ b/src/backends/tf/tfmodel.cc
@@ -41,7 +41,7 @@ namespace dd
     std::string labelFile = ".txt";
     this->_repo = repo;
     std::unordered_set<std::string> lfiles;
-  	int e = fileops::list_directory(repo,true,false,lfiles);
+  	int e = fileops::list_directory(repo,true,false, false, lfiles);
     if (e != 0)
       {
 	logger->error("error reading or listing tensorflow models in repository {}",repo);

--- a/src/backends/xgb/xgbmodel.cc
+++ b/src/backends/xgb/xgbmodel.cc
@@ -40,7 +40,7 @@ namespace dd
     static std::string weights = ".model";
     static std::string corresp = "corresp";
     std::unordered_set<std::string> lfiles;
-    int e = fileops::list_directory(_repo,true,false,lfiles);
+    int e = fileops::list_directory(_repo,true,false,false,lfiles);
     if (e != 0)
       {
 	logger->error("error reading or listing XGBoost models in repository {}",_repo);

--- a/src/imginputfileconn.h
+++ b/src/imginputfileconn.h
@@ -206,7 +206,7 @@ namespace dd
     {
       // list directories in dir
       std::unordered_set<std::string> subdirs;
-      if (fileops::list_directory(dir,false,true,subdirs))
+      if (fileops::list_directory(dir,false,true,false,subdirs))
 	throw InputConnectorBadParamException("failed reading text subdirectories in data directory " + dir);
       _logger->info("imginputfileconn: list subdirs size={}",subdirs.size());
       
@@ -220,7 +220,7 @@ namespace dd
 	  while(uit!=subdirs.end())
 	    {
 	      std::unordered_set<std::string> subdir_files;
-	      if (fileops::list_directory((*uit),true,false,subdir_files))
+	      if (fileops::list_directory((*uit),true,false,true,subdir_files))
 		throw InputConnectorBadParamException("failed reading image data sub-directory " + (*uit));
 	      auto fit = subdir_files.begin();
 	      while(fit!=subdir_files.end()) // XXX: re-iterating the file is not optimal
@@ -235,7 +235,7 @@ namespace dd
       else
 	{
 	  std::unordered_set<std::string> test_files;
-	  fileops::list_directory(dir,true,false,test_files);
+	  fileops::list_directory(dir,true,false,false,test_files);
 	  auto fit = test_files.begin();
 	  while(fit!=test_files.end())
 	    {

--- a/src/txtinputfileconn.cc
+++ b/src/txtinputfileconn.cc
@@ -68,7 +68,7 @@ namespace dd
 
     // list directories in dir
     std::unordered_set<std::string> subdirs;
-    if (fileops::list_directory(dir,false,true,subdirs))
+    if (fileops::list_directory(dir,false,true,false,subdirs))
       throw InputConnectorBadParamException("failed reading text subdirectories in data directory " + dir);
     _logger->info("txtinputfileconn: list subdirs size={}",subdirs.size());
     
@@ -102,7 +102,7 @@ namespace dd
 	while(uit!=subdirs.end())
 	  {
 	    std::unordered_set<std::string> subdir_files;
-	    if (fileops::list_directory((*uit),true,false,subdir_files))
+	    if (fileops::list_directory((*uit),true,false,true,subdir_files))
 	      throw InputConnectorBadParamException("failed reading text data sub-directory " + (*uit));
 	    std::string cls = dd_utils::split((*uit),'/').back();
 	    if (!test_dir)
@@ -138,7 +138,7 @@ namespace dd
     else
       {
 	std::unordered_set<std::string> test_files;
-	fileops::list_directory(dir,true,false,test_files);
+	fileops::list_directory(dir,true,false,false,test_files);
 	auto fit = test_files.begin();
 	while(fit!=test_files.end())
 	  {

--- a/src/utils/fileops.hpp
+++ b/src/utils/fileops.hpp
@@ -98,25 +98,28 @@ namespace dd
     }
 
     static int list_directory(const std::string &repo,
-			      const bool &files,
-			      const bool &dirs,
-			      std::unordered_set<std::string> &lfiles)
+                              const bool &files,
+                              const bool &dirs,
+                              const bool &sub_files,
+                              std::unordered_set<std::string> &lfiles)
     {
       DIR *dir;
       struct dirent *ent;
       if ((dir = opendir(repo.c_str())) != NULL) {
-	while ((ent = readdir(dir)) != NULL) {
-	  if ((files && (ent->d_type == DT_REG || ent->d_type == DT_LNK))
-	      || (dirs && (ent->d_type == DT_DIR || ent->d_type == DT_LNK) && ent->d_name[0] != '.'))
-	    lfiles.insert(std::string(repo) + "/" + std::string(ent->d_name));
-	}
-	closedir(dir);
-	return 0;
-      } 
-      else 
-	{
-	  return 1;
-	}
+        while ((ent = readdir(dir)) != NULL) {
+          if ((files && (ent->d_type == DT_REG || ent->d_type == DT_LNK))
+              || (dirs && (ent->d_type == DT_DIR || ent->d_type == DT_LNK) && ent->d_name[0] != '.'))
+            lfiles.insert(std::string(repo) + "/" + std::string(ent->d_name));
+          if (sub_files && (ent->d_type == DT_DIR || ent->d_type == DT_LNK) && ent->d_name[0] != '.')
+            list_directory(std::string(repo) + "/" + std::string(ent->d_name),files,dirs,sub_files,lfiles);
+        }
+        closedir(dir);
+        return 0;
+      }
+      else
+        {
+          return 1;
+        }
     }
 
     // remove everything, including first level directories within directory


### PR DESCRIPTION
In case of a large datasets it might be difficult to have several thousands of images in one folder. This PR makes it possible to have sub-directories in classes folder.

For instance for a binary classification on images with two labels *1* and *0*.
Now we can create sub-directories in those directories to have less  elements in folders.

Before the tree must be like the following
```
data
|-- 1
|   |-- image_1
|   |-- image_2
|   `-- etc.
|-- 0
|   |-- image_1
|   |-- image_2
|   `--  etc.
```

Now it's possible to have the following
```
data
|-- 1
|   |-- split_1
|   |  |-- image_1
|   |  `-- image_2
|   |-- split_2
|   |  |-- image_3
|   |  `-- image_4
|   `-- split_etc
|-- 0
|   |-- split_1
|   |  |-- image_1
|   |  `-- image_2
|   |-- split_2
|   |  |-- image_3
|   |  `-- image_4
|   `-- split_etc
```