### PR TITLE
added ability to avoid index preloading

### DIFF
--- a/src/mlmodel.h
+++ b/src/mlmodel.h
@@ -99,6 +99,7 @@ namespace dd
       if (!_se)
 	{
 	  _se = new SearchEngine<AnnoySE>(dim,_repo);
+	  _se->_tse->_map_populate = _index_preload;
 	  _se->create_index();
 	}
     }
@@ -139,6 +140,7 @@ namespace dd
     
 #ifdef USE_SIMSEARCH
     SearchEngine<AnnoySE> *_se = nullptr;
+    bool _index_preload = true;
 #endif
 
   private:
@@ -147,11 +149,14 @@ namespace dd
       std::string repo =  ad.get("repository").get<std::string>();
       bool create = ad.has("create_repository") && ad.get("create_repository").get<bool>();
       bool isDir;
-      bool exists= fileops::file_exists(repo, isDir);
+      bool exists = fileops::file_exists(repo, isDir);
       if (exists && !isDir)
         throw MLLibBadParamException("file exists with same name as repository");
       if (!exists && create)
         fileops::create_dir(repo,0775);
+#ifdef USE_SIMSEARCH
+      _index_preload = ad.has("index_preload") && ad.get("index_preload").get<bool>();
+#endif
     }
   };
 }

--- a/src/simsearch.h
+++ b/src/simsearch.h
@@ -160,7 +160,7 @@ namespace dd
     const std::string _index_name = "index.ann";
     bool _saved_tree = false; /**< whether the tree has been saved. */
     bool _built_index = false; /**< whether the index has been built. */
-    const bool _map_populate = true; /**< whether to use MAP_POPULATE when mmapping the full index. */
+    bool _map_populate = true; /**< whether to use MAP_POPULATE when mmapping the full index. */
   };
   
 }


### PR DESCRIPTION
Avoid full index preloading with `index_preload` set to false, forces mmap to not use MAP_POPULATE