### PR TITLE
Automated model installation from compressed archive at service creation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -519,7 +519,7 @@ set(COMMON_LINK_DIRS
   ${DLIB_LIB_DIR})
 if (USE_HDF5)
   set(COMMON_LINK_LIBS
-    ddetect ${CUDA_LIB_DEPS} glog gflags ${OpenCV_LIBS} curlpp curl hdf5_cpp ${Boost_LIBRARIES}
+    ddetect ${CUDA_LIB_DEPS} glog gflags ${OpenCV_LIBS} curlpp curl hdf5_cpp ${Boost_LIBRARIES} archive
     ${CAFFE_LIB_DEPS}
     ${CAFFE2_LIB_DEPS}
     ${TF_LIB_DEPS}

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ Below are instructions for Ubuntu 14.04 LTS and 16.04 LTS. For other Linux and U
 
 Beware of dependencies, typically on Debian/Ubuntu Linux, do:
 ```
-sudo apt-get install build-essential libgoogle-glog-dev libgflags-dev libeigen3-dev libopencv-dev libcppnetlib-dev libboost-dev libboost-iostreams-dev libcurlpp-dev libcurl4-openssl-dev protobuf-compiler libopenblas-dev libhdf5-dev libprotobuf-dev libleveldb-dev libsnappy-dev liblmdb-dev libutfcpp-dev cmake libgoogle-perftools-dev unzip python-setuptools python-dev libspdlog-dev python-six python-enum34
+sudo apt-get install build-essential libgoogle-glog-dev libgflags-dev libeigen3-dev libopencv-dev libcppnetlib-dev libboost-dev libboost-iostreams-dev libcurlpp-dev libcurl4-openssl-dev protobuf-compiler libopenblas-dev libhdf5-dev libprotobuf-dev libleveldb-dev libsnappy-dev liblmdb-dev libutfcpp-dev cmake libgoogle-perftools-dev unzip python-setuptools python-dev libspdlog-dev python-six python-enum34 libarchive-dev
 ```
 
 #### Default build with Caffe

--- a/src/backends/caffe/caffemodel.cc
+++ b/src/backends/caffe/caffemodel.cc
@@ -29,8 +29,34 @@
 
 namespace dd
 {
+  CaffeModel::CaffeModel(const APIData &ad, APIData &adg,
+			 const std::shared_ptr<spdlog::logger> &logger)
+    :MLModel(ad,adg,logger)
+  {
+    if (ad.has("templates"))
+      this->_mlmodel_template_repo = ad.get("templates").get<std::string>();
+    else this->_mlmodel_template_repo += "caffe/"; // default
+
+    if (ad.has("def"))
+      _def = ad.get("def").get<std::string>();
+    if (ad.has("trainf"))
+      _trainf = ad.get("trainf").get<std::string>();
+    if (ad.has("weights"))
+      _weights = ad.get("weights").get<std::string>();
+    if (ad.has("corresp"))
+      _corresp = ad.get("corresp").get<std::string>();
+    if (ad.has("solver"))
+      _solver = ad.get("solver").get<std::string>();
+    if (ad.has("repository"))
+      {
+       	if (read_from_repository(ad.get("repository").get<std::string>(),spdlog::get("api")))
+	  throw MLLibBadParamException("error reading or listing Caffe models in repository " + _repo);
+      }
+    read_corresp_file();
+  }
+
   CaffeModel::CaffeModel(const APIData &ad)
-    :MLModel(ad)
+      :MLModel(ad)
   {
     if (ad.has("templates"))
       this->_mlmodel_template_repo = ad.get("templates").get<std::string>();

--- a/src/backends/caffe/caffemodel.h
+++ b/src/backends/caffe/caffemodel.h
@@ -34,6 +34,8 @@ namespace dd
   public:
   CaffeModel(): MLModel() {}
     CaffeModel(const APIData &ad);
+    CaffeModel(const APIData &ad, APIData &adg,
+	       const std::shared_ptr<spdlog::logger> &logger);
   CaffeModel(const APIData &ad, const std::string &repo)
     :MLModel(ad, repo) {}
     ~CaffeModel() {};

--- a/src/backends/caffe2/caffe2model.cc
+++ b/src/backends/caffe2/caffe2model.cc
@@ -25,8 +25,9 @@
 
 namespace dd {
 
-  Caffe2Model::Caffe2Model(const APIData &ad)
-    :MLModel()
+  Caffe2Model::Caffe2Model(const APIData &ad, APIData &adg,
+			   const std::shared_ptr<spdlog::logger> &logger)
+    :MLModel(ad, adg, logger)
   {
     std::map<std::string, std::string *> names =
       {

--- a/src/backends/caffe2/caffe2model.h
+++ b/src/backends/caffe2/caffe2model.h
@@ -33,7 +33,8 @@ namespace dd {
   class Caffe2Model : public MLModel {
   public:
     Caffe2Model():MLModel() {}
-    Caffe2Model(const APIData &ad);
+    Caffe2Model(const APIData &ad, APIData &adg,
+		const std::shared_ptr<spdlog::logger> &logger);
     Caffe2Model(const std::string &repo)
       :MLModel(repo) {}
     ~Caffe2Model() {};

--- a/src/backends/dlib/dlibmodel.cc
+++ b/src/backends/dlib/dlibmodel.cc
@@ -24,7 +24,10 @@
 #include <string>
 
 namespace dd {
-    DlibModel::DlibModel(const APIData &ad) {
+     DlibModel::DlibModel(const APIData &ad, APIData &adg,
+		       const std::shared_ptr<spdlog::logger> &logger)
+       :MLModel(ad,adg,logger)
+     {
         if (ad.has("repository")) {
             read_from_repository(ad.get("repository").get<std::string>(),
                                  spdlog::get("api")); // XXX: beware, error not caught

--- a/src/backends/dlib/dlibmodel.h
+++ b/src/backends/dlib/dlibmodel.h
@@ -32,7 +32,8 @@ namespace dd {
     public:
         DlibModel() : MLModel() {}
 
-        DlibModel(const APIData &ad);
+        DlibModel(const APIData &ad, APIData &adg,
+		  const std::shared_ptr<spdlog::logger> &logger);
 
         DlibModel(const std::string &repo)
                 : MLModel(repo) {}

--- a/src/backends/tf/tfmodel.cc
+++ b/src/backends/tf/tfmodel.cc
@@ -24,7 +24,9 @@
 #include <string>
 namespace dd
 {
-  TFModel::TFModel(const APIData &ad)
+  TFModel::TFModel(const APIData &ad, APIDat &adg,
+		   const std::shared_ptr<spdlog::logger> &logger)
+    :MLModel(ad,adg,logger)
   {
    if (ad.has("repository"))
       {

--- a/src/backends/tf/tfmodel.h
+++ b/src/backends/tf/tfmodel.h
@@ -33,7 +33,8 @@ namespace dd
   {
   public:
     TFModel():MLModel() {}
-    TFModel(const APIData &ad);
+    TFModel(const APIData &ad, APIData &adg,
+	    const std::shared_ptr<spdlog::logger> &logger);
     TFModel(const std::string &repo)
       :MLModel(repo) {}
     ~TFModel() {}

--- a/src/backends/tsne/tsnemodel.h
+++ b/src/backends/tsne/tsnemodel.h
@@ -33,8 +33,9 @@ namespace dd
   {
   public:
     TSNEModel():MLModel() {}
-    TSNEModel(const APIData &ad)
-      :MLModel()
+  TSNEModel(const APIData &ad,APIData &adg,
+	    const std::shared_ptr<spdlog::logger> &logger)
+    :MLModel(ad,adg,logger)
       {
 	if (ad.has("repository"))
 	  this->_repo = ad.get("repository").get<std::string>();

--- a/src/backends/xgb/xgbmodel.cc
+++ b/src/backends/xgb/xgbmodel.cc
@@ -26,8 +26,9 @@
 namespace dd
 {
 
-  XGBModel::XGBModel(const APIData &ad)
-    :MLModel(ad)
+  XGBModel::XGBModel(const APIData &ad, APIData &adg,
+		     const std::shared_ptr<spdlog::logger> &logger)
+    :MLModel(ad,adg,logger)
   {
     if (ad.has("repository"))
       this->_repo = ad.get("repository").get<std::string>();

--- a/src/backends/xgb/xgbmodel.h
+++ b/src/backends/xgb/xgbmodel.h
@@ -34,7 +34,8 @@ namespace dd
   {
   public:
     XGBModel():MLModel() {}
-    XGBModel(const APIData &ad);
+    XGBModel(const APIData &ad, APIData &adg,
+	     const std::shared_ptr<spdlog::logger> &logger);
     XGBModel(const std::string &repo)
       :MLModel(repo) {}
     ~XGBModel() {}

--- a/src/commandlineapi.cc
+++ b/src/commandlineapi.cc
@@ -58,6 +58,7 @@ namespace dd
 	  {
 	    APIData model_ad;
 	    model_ad.add("repository",FLAGS_model_repo);
+	    APIData adg;
 	    CaffeModel cmodel(model_ad);
 	    add_service(FLAGS_service,std::move(MLService<CaffeLib,ImgCaffeInputFileConn,SupervisedOutput,CaffeModel>(FLAGS_service,cmodel)));
 	  }
@@ -87,6 +88,7 @@ namespace dd
 	  {
 	    APIData model_ad;
 	    model_ad.add("repository",FLAGS_model_repo);
+	    APIData adg;
 	    CaffeModel cmodel(model_ad);
 	    add_service(FLAGS_service,std::move(MLService<CaffeLib,ImgCaffeInputFileConn,SupervisedOutput,CaffeModel>(FLAGS_service,cmodel)));
 	    APIData ad, out;

--- a/src/jsonapi.cc
+++ b/src/jsonapi.cc
@@ -409,7 +409,7 @@ namespace dd
       {
 	if (mllib == "caffe")
 	  {
-	    CaffeModel cmodel(ad_model);
+	    CaffeModel cmodel(ad_model,ad,_logger);
 	    if (type == "supervised")
 	      {
 		if (input == "image")
@@ -453,7 +453,7 @@ namespace dd
 #ifdef USE_CAFFE2
 
 	else if (mllib == "caffe2") {
-	  Caffe2Model c2model(ad_model);
+	  Caffe2Model c2model(ad_model,ad,_logger);
 	  if (type == "supervised") {
 
 	    if (input == "image")
@@ -489,7 +489,7 @@ namespace dd
 #ifdef USE_TF
 	else if (mllib == "tensorflow" || mllib == "tf")
 	  {
-	    TFModel tfmodel(ad_model);
+	    TFModel tfmodel(ad_model,ad,_logger);
 	    if (type == "supervised")
 	      {
 		if (input == "image")
@@ -518,7 +518,7 @@ namespace dd
 #endif
 #ifdef USE_DLIB
     else if (mllib == "dlib") {
-	    DlibModel dlibmodel(ad_model);
+            DlibModel dlibmodel(ad_model,ad,_logger);
 	    if (type == "supervised") {
 	        if (input == "image") {
 	            add_service(sname, std::move(MLService<DlibLib, ImgDlibInputFileConn, SupervisedOutput, DlibModel>(sname, dlibmodel, description)), ad);
@@ -539,7 +539,7 @@ namespace dd
 #ifdef USE_XGBOOST
 	else if (mllib == "xgboost")
 	  {
-	    XGBModel xmodel(ad_model);
+	    XGBModel xmodel(ad_model,ad,_logger);
 	    if (input == "csv")
 	      add_service(sname,std::move(MLService<XGBLib,CSVXGBInputFileConn,SupervisedOutput,XGBModel>(sname,xmodel,description)),ad);
 	    else if (input == "svm")
@@ -557,7 +557,7 @@ namespace dd
 #ifdef USE_TSNE
 	else if (mllib == "tsne")
 	  {
-	    TSNEModel tmodel(ad_model);
+	    TSNEModel tmodel(ad_model,ad,_logger);
 	    if (input == "csv")
 	      add_service(sname,std::move(MLService<TSNELib,CSVTSNEInputFileConn,UnsupervisedOutput,TSNEModel>(sname,tmodel,description)),ad);
 	    else if (input == "txt")

--- a/src/utils/fileops.hpp
+++ b/src/utils/fileops.hpp
@@ -28,6 +28,8 @@
 #include <sys/stat.h>
 #include <stdio.h>
 #include <unistd.h>
+#include <archive.h>
+#include <archive_entry.h>
 
 namespace dd
 {
@@ -223,9 +225,90 @@ namespace dd
       return 0;
     }
 
+    static int copy_uncompressed_data(struct archive *ar, struct archive *aw)
+    {
+      int r;
+      const void *buff;
+      size_t size;
+      int64_t offset;
 
-  };
-  
+      for (;;) {
+	r = archive_read_data_block(ar, &buff, &size, &offset);
+	if (r == ARCHIVE_EOF)
+	  return (ARCHIVE_OK);
+	if (r < ARCHIVE_OK)
+	  return (r);
+	r = archive_write_data_block(aw, buff, size, offset);
+	if (r < ARCHIVE_OK) {
+	  std::cerr << "archive error: " << archive_error_string(aw) << std::endl;
+	  return r;
+	}
+      }
+    }
+    
+    static int uncompress(const std::string &fc,
+			  const std::string &repo)
+    {
+      struct archive *a;
+      struct archive *ext;
+      struct archive_entry *entry;
+      int flags;
+      int r;
+
+      flags = ARCHIVE_EXTRACT_TIME;
+      //flags |= ARCHIVE_EXTRACT_PERM;
+      //flags |= ARCHIVE_EXTRACT_ACL;
+      flags |= ARCHIVE_EXTRACT_FFLAGS;
+      
+      a = archive_read_new();
+      archive_read_support_format_all(a);
+      archive_read_support_filter_all(a);
+      ext = archive_write_disk_new();
+      archive_write_disk_set_options(ext, flags);
+      archive_write_disk_set_standard_lookup(ext);
+      if ((r = archive_read_open_filename(a, fc.c_str(), 10240))) // 10240 is block_size
+	return r;
+      for (;;) {
+	r = archive_read_next_header(a, &entry);
+	if (r == ARCHIVE_EOF)
+	  break;
+	if (r < ARCHIVE_OK)
+	  std::cerr <<  "archive error: " << archive_error_string(a) << std::endl;
+	if (r < ARCHIVE_WARN) {
+	  std::cerr << "archive error, aborting\n";
+	  return 1;
+	}
+	const char * compressed_head = archive_entry_pathname(entry);
+	const std::string full_outpath = repo + "/" + compressed_head;
+	archive_entry_set_pathname(entry,full_outpath.c_str());
+	r = archive_write_header(ext, entry);
+	if (r < ARCHIVE_OK)
+	  std::cerr << "archive error: " << archive_error_string(ext) << std::endl;
+	else if (archive_entry_size(entry) > 0) {
+	  r = copy_uncompressed_data(a, ext);
+	  if (r < ARCHIVE_OK)
+	    std::cerr << "error writing uncompressed data: " << archive_error_string(ext) << std::endl;
+	  if (r < ARCHIVE_WARN) {
+	    std::cerr << "archive error, aborting\n";
+	    return 2;
+	  }
+	}
+	r = archive_write_finish_entry(ext);
+	if (r < ARCHIVE_OK)
+	  std::cerr << "error finishing uncompressed data entry: " << archive_error_string(ext) << std::endl;
+	if (r < ARCHIVE_WARN) {
+	  std::cerr << "archive error, aborting\n";
+	  return 3;
+	}
+      }
+      archive_read_close(a);
+      archive_read_free(a);
+      archive_write_close(ext);
+      archive_write_free(ext);
+
+      return 0;
+    }
+  };  
 }
 
 #endif


### PR DESCRIPTION
This PR allows the automatic loading and installation of a model as a compressed archive.

If the model directory (and thus the tarball) contains a `config.json` file with the exact JSON content of a `PUT /services` call, the model parameters are loaded automatically. 

Thus in the example below the number of classes `nclasses` and `width`/`height` parameters do not need to be specified anymore.

Note: **when the `config.json` file exists, its `parameters` object overrides the full `parameters` object specified via the API.**

* API addition
`init` parameter in `model` on `PUT /services`

Example:

- service creation:

```
curl -X PUT "http://localhost:8080/services/imageserv" -d '{ 
       "mllib":"caffe", 
       "description":"image detection service", 
       "type":"supervised", 
       "parameters":{ 
         "input":{ 
           "connector":"image" 
         }, 
         "mllib":{ 
         } 
       }, 
       "model":{ 
         "templates":"../templates/caffe/", 
         "repository":"/home/beniz/tmp/test_auto",
         "init":"/path/to/detection_600.tar.gz" 
       } 
     }' 
```

- service predict:

```
curl -X POST 'http://localhost:8080/predict' -d '{
 "service": "imageserv",
 "parameters": {
  "input": {},
  "output": {
   "confidence_threshold": 0.2,
   "bbox": true
  },
  "mllib": {
   "gpu": true
  }
 },
 "data": [
  "https://s.hdnux.com/photos/76/76/11/16507462/9/727x0.jpg"
 ]
}'
```