### PR TITLE
Eucl fix

### DIFF
--- a/src/backends/caffe/caffelib.cc
+++ b/src/backends/caffe/caffelib.cc
@@ -1577,7 +1577,7 @@ namespace dd
 	      slot = 0; // flatten output
            else if (_regression && _ntargets == 1 && typeid(inputc) == typeid(CSVCaffeInputFileConn))
              {
-               slot = findOutputSlotNumberByBlobName(net, "ip_loss");
+               slot = findOutputSlotNumberByBlobName(net, "ip_losst");
              }
 
 

--- a/src/backends/caffe/caffelib.cc
+++ b/src/backends/caffe/caffelib.cc
@@ -1406,6 +1406,12 @@ namespace dd
     ad_res.add("train_loss",this->get_meas("train_loss"));
     APIData ad_out = ad.getobj("parameters").getobj("output");
 
+    if (ad.getobj("parameters").getobj("mllib").has("ignore_value"))
+      {
+        double ignore_value = ad.getobj("parameters").getobj("mllib").get("ignore_value").get<double>();
+        ad_res.add("ignore_value", ignore_value);
+      }
+
     if (ad_out.has("measure"))
       {
 	float mean_loss = 0.0;
@@ -1569,6 +1575,12 @@ namespace dd
 	      slot--;
 	    else if (_autoencoder && typeid(inputc) == typeid(ImgCaffeInputFileConn))
 	      slot = 0; // flatten output
+           else if (_regression && _ntargets == 1 && typeid(inputc) == typeid(CSVCaffeInputFileConn))
+             {
+               slot = findOutputSlotNumberByBlobName(net, "ip_loss");
+             }
+
+
 	    int scount = lresults[slot]->count();
 	    int scperel = scount / dv_size;
 
@@ -3399,6 +3411,35 @@ namespace dd
       }
 
   }
+
+
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
+  int CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::findOutputSlotNumberByBlobName(const caffe::Net<float> *net,
+                                     const std::string blob_name)
+  {
+    const std::vector<std::string> blob_names = net->blob_names();
+    const std::vector<int> output_blob_indices = net->output_blob_indices();
+    for (int i =0; i<net->num_outputs(); ++i)
+      {
+        if (blob_names[output_blob_indices[i]] == blob_name)
+          return i;
+      }
+    return -1;
+  }
+
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
+  Blob<float>* CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::findOutputBlobByName(const caffe::Net<float> *net, const std::string blob_name)
+  {
+    const std::vector<std::string> blob_names = net->blob_names();
+    const std::vector<int> output_blob_indices = net->output_blob_indices();
+    for (int i =0; i<net->num_outputs(); ++i)
+      {
+        if (blob_names[output_blob_indices[i]] == blob_name)
+          net->output_blobs().at(i);
+      }
+    return nullptr;
+  }
+
 
 
   template class CaffeLib<ImgCaffeInputFileConn,SupervisedOutput,CaffeModel>;

--- a/src/backends/caffe/caffelib.h
+++ b/src/backends/caffe/caffelib.h
@@ -252,6 +252,14 @@ namespace dd
       void save_if_best(APIData &meas_out, boost::shared_ptr<caffe::Solver<float>>solver,
                         bool already_snapshoted);
 
+      int findOutputSlotNumberByBlobName(const caffe::Net<float> *net,
+                                     const std::string blob_name);
+
+      Blob<float>* findOutputBlobByName(const caffe::Net<float> *net,
+                                        const std::string blob_name);
+
+
+
     public:
       caffe::Net<float> *_net = nullptr; /**< neural net. */
       bool _gpu = false; /**< whether to use GPU. */

--- a/src/generators/net_caffe_mlp.cc
+++ b/src/generators/net_caffe_mlp.cc
@@ -90,7 +90,6 @@ namespace dd
     if (regression)
       {
 	add_euclidean_loss(this->_net_params,bottom,"label","losst",ntargets);
-	add_euclidean_loss(this->_net_params,bottom,"","loss",ntargets,true);
 	add_euclidean_loss(this->_dnet_params,bottom,"","loss",ntargets,true);
       }
     else if (autoencoder) //TODO: sigmoid crossentropy would be only for integer-type targets...

--- a/src/supervisedoutputconnector.h
+++ b/src/supervisedoutputconnector.h
@@ -1529,6 +1529,12 @@ namespace dd
     {
       double eucl = 0.0;
       int batch_size = ad.get("batch_size").get<int>();
+      bool has_ignore = ad.has("ignore_value");
+
+      double ignore_value = -10000;
+      if (has_ignore)
+        ignore_value = ad.get("ignore_value").get<double>();
+
       for (int i=0;i<batch_size;i++)
 	{
 	  APIData bad = ad.getobj(std::to_string(i));
@@ -1537,18 +1543,24 @@ namespace dd
 	  if (predictions.size() > 1)
 	    target = bad.get("target").get<std::vector<double>>();
 	  else target.push_back(bad.get("target").get<double>());
+         double leucl = 0;
 	  for (size_t i=0;i<target.size();i++)
-	    if (thres >= 0)
+           {
+             if (has_ignore && target.at(i) == ignore_value)
+               continue;
+             double diff = predictions.at(i)-target.at(i);
+             if (thres >= 0 )
+               {
+                 if (fabs(diff) >= thres)
+                   leucl += diff*diff;
+               }
+             else
 	      {
-		if (target.at(i) >thres)
-		  eucl += (predictions.at(i)-target.at(i))*(predictions.at(i)-target.at(i));
+               leucl += diff*diff;
 	      }
-	    else
-	      {
-		if (target.at(i) >=0)
-		  eucl += (predictions.at(i)-target.at(i))*(predictions.at(i)-target.at(i));
-	      }
-	}
+           }
+         eucl += sqrt(leucl);
+       }
       return eucl / static_cast<double>(batch_size);
     }
     


### PR DESCRIPTION
this branch includes various fixes
- in euclidean metric: do not discard <0 values (was introduced for multisoftlabel case in order to discard targets with value -1)
- introduce ignore_value param to mllib parameters in order to not to take into account some target values (ie -1 in multisoftlabel case)
- clean up mlp net generation (was creating to fc layers, one for test one for train, but phases were not set )
- add search of ouput blob by name, in order to begin to stop messes with slot number, used it for csv + regression + 1 output