### PR TITLE
dice fix

### DIFF
--- a/src/backends/caffe/caffelib.cc
+++ b/src/backends/caffe/caffelib.cc
@@ -207,7 +207,7 @@ namespace dd
 	caffe::ReadProtoFromTextFile(dest_net,&net_param); //TODO: catch parsing error (returns bool true on success)
 	caffe::ReadProtoFromTextFile(dest_deploy_net,&deploy_net_param);
 
-    if (this->_loss == "dice"  || _loss == "dice_multiclass" || _loss == "dice_weighted")
+       if (this->_loss.compare(0, 4, "dice",0,4) == 0)
       // dice loss!!
       {
         int ignore_label = -1;

--- a/src/backends/caffe/caffelib.cc
+++ b/src/backends/caffe/caffelib.cc
@@ -3193,6 +3193,10 @@ namespace dd
       dclp->set_generalization(caffe::DiceCoefLossParameter::MULTICLASS);
     else if (loss == "dice_weighted")
       dclp->set_generalization(caffe::DiceCoefLossParameter::MULTICLASS_WEIGHTED);
+    // else if (loss == "dice_weighted_batch")
+    //   dclp->set_generalization(caffe::DiceCoefLossParameter::MULTICLASS_WEIGHTED);
+    // else if (loss == "dice_weighted_all")
+    //   dclp->set_generalization(caffe::DiceCoefLossParameter::MULTICLASS_WEIGHTED);
 
 
     // now work on deploy.txt

--- a/src/backends/caffe/caffelib.cc
+++ b/src/backends/caffe/caffelib.cc
@@ -3124,6 +3124,7 @@ namespace dd
     caffe::LayerParameter* mvn_param = insert_layer_before(net_param, softml_pos++);
     *mvn_param->mutable_name() = "normalization";
     *mvn_param->mutable_type() = "MVN";
+    mvn_param->mutable_mvn_param()->set_across_channels(true);
     mvn_param->add_bottom(logits);
     mvn_param->add_top(logits_norm);
 
@@ -3205,6 +3206,7 @@ namespace dd
     mvn_param = insert_layer_before(deploy_net_param, final_interp_pos++);
     *mvn_param->mutable_name() = "normalization";
     *mvn_param->mutable_type() = "MVN";
+    mvn_param->mutable_mvn_param()->set_across_channels(true);
     mvn_param->add_bottom(logits);
     mvn_param->add_top(logits_norm);
 
@@ -3257,6 +3259,7 @@ namespace dd
     caffe::LayerParameter* mvn_param = insert_layer_before(net_param, softml_pos++);
     *mvn_param->mutable_name() = "normalization";
     *mvn_param->mutable_type() = "MVN";
+    mvn_param->mutable_mvn_param()->set_across_channels(true);
     mvn_param->add_bottom(logits);
     mvn_param->add_top(logits_norm);
 
@@ -3325,6 +3328,7 @@ namespace dd
     mvn_param = insert_layer_before(deploy_net_param, final_pred++);
     *mvn_param->mutable_name() = "normalization";
     *mvn_param->mutable_type() = "MVN";
+    mvn_param->mutable_mvn_param()->set_across_channels(true);
     mvn_param->add_bottom(logits);
     mvn_param->add_top(logits_norm);
 

--- a/src/supervisedoutputconnector.h
+++ b/src/supervisedoutputconnector.h
@@ -906,15 +906,15 @@ namespace dd
 
 	      // mean acc over classes
 	      double c_total_targ = static_cast<double>((dtarg.array() == c).count());
-	      if (c_sum == 0 || c_total_targ == 0)
-		{}
+	      if (/* c_sum == 0 || */ c_total_targ == 0)
+               {
+               }
 	      else
 		{
 		  double accc = c_sum / c_total_targ;
 		  mean_acc[c] += accc;
 		  mean_acc_bs[c]++;
-
-        }
+              }
 
            // mean intersection over union
 	      double c_false_neg = static_cast<double>((ddiffc.array() == -2-c).count());
@@ -944,6 +944,7 @@ namespace dd
 	  meaniou += mean_iou[c];
 	}
       clacc = mean_acc;
+
       // corner case where prediction is wrong
       if (c_nclasses > 0) {
         meanacc /= static_cast<double>(c_nclasses);


### PR DESCRIPTION
normalize correctly in case of multiclass
mvn normalization is now done across channels (added at prototxt generation for both deeplab and unet)

weighted version  ok, also support class_weight

api: 
`"loss" = "dice"`     or `dice_multiclass` or `dice_weighted_batch` or `dice_weighted_all`

also honors "class_weights" in inputconnector 
also honors ignore_label (use with caution)

needs caffe_dice fix branch (to be merged) 