### PR TITLE
segmentation confidence maps

### DIFF
--- a/src/backends/caffe/caffelib.h
+++ b/src/backends/caffe/caffelib.h
@@ -258,6 +258,9 @@ namespace dd
       Blob<float>* findOutputBlobByName(const caffe::Net<float> *net,
                                         const std::string blob_name);
 
+      std::vector<double> seg_resize(const std::vector<double>& vals,
+                                     const int height_net,  const int width_net,
+                                     const int height_dest, const int width_dest);
 
 
     public:

--- a/src/unsupervisedoutputconnector.h
+++ b/src/unsupervisedoutputconnector.h
@@ -30,7 +30,7 @@ namespace dd
   public:
     unsup_result(const std::string &uri,
 		 const std::vector<double> &vals,
-		 const APIData &extra=APIData())
+                 const APIData &extra=APIData())
       :_uri(uri),_vals(vals),_extra(extra) {
     }
 
@@ -115,13 +115,12 @@ namespace dd
 	  if ((hit=_vres.find(uri))==_vres.end())
 	    {
 	      _vres.insert(std::pair<std::string,int>(uri,_vvres.size()));
-	      if (ad.has("imgsize"))
-		{
-		  APIData ad_imgsize;
-		  ad_imgsize.add("imgsize",ad.getobj("imgsize"));
-		  _vvres.push_back(unsup_result(uri,vals,ad_imgsize));
-		}
-	      else _vvres.push_back(unsup_result(uri,vals));
+             APIData extra;
+             if (ad.has("imgsize"))
+               extra.add("imgsize",ad.getobj("imgsize"));
+             if (ad.has("confidences"))
+               extra.add("confidences",ad.getobj("confidences"));
+             _vvres.push_back(unsup_result(uri,vals,extra));
 	    }
 	  
 	}
@@ -231,6 +230,8 @@ namespace dd
 	  else adpred.add("vals",_vvres.at(i)._vals);
 	  if (_vvres.at(i)._extra.has("imgsize"))
 	    adpred.add("imgsize",_vvres.at(i)._extra.getobj("imgsize"));
+	  if (_vvres.at(i)._extra.has("confidences"))
+	    adpred.add("confidences",_vvres.at(i)._extra.getobj("confidences"));
 	  if (i == _vvres.size()-1)
 	    adpred.add("last",true);
 #ifdef USE_SIMSEARCH

--- a/tests/ut-caffeapi.cc
+++ b/tests/ut-caffeapi.cc
@@ -1117,6 +1117,25 @@ TEST(caffeapi,service_train_images_seg)
   ASSERT_TRUE(fabs(jd["body"]["measure"]["train_loss"].GetDouble()) > 0);
   ASSERT_TRUE(jd["body"]["measure"]["acc"].GetDouble() >= 0.0);
 
+  //predict + conf map
+  std::string jpredictstr = "{\"service\":\"" + sname + "\",\"async\":false,\"parameters\":{\"input\":{\"segmentation\":true},\"mllib\":{\"gpu\":true,\"gpuid\":"+gpuid+",\"net\":{\"batch_size\":1,\"test_batch_size\":1}},\"output\":{\"confidences\":[\"best\",\"2\"]}},\"data\":[\"" + camvid_repo + "test/0001TP_008550.png\"]}";
+  joutstr = japi.jrender(japi.service_predict(jpredictstr));
+  std::cout << "joutstr predict=" << joutstr << std::endl;
+  jd.Parse(joutstr.c_str());
+  ASSERT_TRUE(!jd.HasParseError());
+  ASSERT_EQ(200,jd["status"]["code"]);
+  ASSERT_TRUE(jd["body"]["predictions"][0].HasMember("vals"));
+  ASSERT_TRUE(jd["body"]["predictions"][0]["vals"].IsArray());
+  ASSERT_TRUE(jd["body"]["predictions"][0]["vals"].Size() == (480*480));
+  ASSERT_TRUE(jd["body"]["predictions"][0].HasMember("confidences"));
+  ASSERT_TRUE(jd["body"]["predictions"][0]["confidences"].HasMember("best"));
+  ASSERT_TRUE(jd["body"]["predictions"][0]["confidences"]["best"].IsArray());
+  ASSERT_TRUE(jd["body"]["predictions"][0]["confidences"]["best"].Size() == 480*480);
+  ASSERT_TRUE(jd["body"]["predictions"][0]["confidences"].HasMember("2"));
+  ASSERT_TRUE(jd["body"]["predictions"][0]["confidences"]["2"].IsArray());
+  ASSERT_TRUE(jd["body"]["predictions"][0]["confidences"]["2"].Size() == 480*480);
+
+
   // remove service
   jstr = "{\"clear\":\"full\"}";
   joutstr = japi.jrender(japi.service_delete(sname,jstr));


### PR DESCRIPTION
add output of confidence maps for segmentation tasks

API:
 
curl -X POST "http://localhost:8080/predict" -d "{"{\"service\": \"camvid\",\"async\":false,\"parameters\":{\"input\":{\\"segmentation\":true},\"mllib\":{\"gpu\":true,\"gpuid\":"+gpuid+",\"net\":{\"batch_size\":1,\"test_batch_size\":1}},\"output\":{\"confidences\":[\"best\",\"2\"]}},\"data\":[\"" + camvid_repo + "test/0001TP_008550.png\"]}

new option is  parameters.output.confidences, is an array of string
can take value like:
["best","2","4"]  : output confidences maps for best class (predicted value) and also for classes 2 and 4
["all"] : output confidences maps for all classes
["best","all"] : output confidences maps for best class and also for all classes 

