### PR TITLE
enlarge recurrent template grammar + cvsts fixes

### DIFF
--- a/src/backends/caffe/caffelib.cc
+++ b/src/backends/caffe/caffelib.cc
@@ -2877,7 +2877,7 @@ namespace dd
         if (loss_scale_layer_param != NULL)
           {
             loss_scale_layer_param->mutable_scale_param()->mutable_filler()->
-              set_value(1.0/(float)_ntargets/(float)batch_size/(float)inputc._timesteps);
+              set_value(1.0/(float)_ntargets/(float)batch_size);
           }
       }
 

--- a/src/csvinputfileconn.cc
+++ b/src/csvinputfileconn.cc
@@ -83,6 +83,7 @@ namespace dd
 	else _cifc->add_train_csvline(std::to_string(_cifc->_csvdata.size()+1),vals);
 	++l;
       }
+    _cifc->update_columns();
     return 0;
   }
 

--- a/src/generators/net_caffe_recurrent.cc
+++ b/src/generators/net_caffe_recurrent.cc
@@ -38,7 +38,7 @@ namespace dd
                                                 const std::string &type,
                                                 const int id)
   {
-    std::string ctype = (type == "R" ?  "RNN" : "LSTM");
+    std::string ctype = (type == _rnn_str ?  "RNN" : "LSTM");
     caffe::LayerParameter *lparam = net_param->add_layer();
     lparam->set_type(ctype);
     lparam->set_name(ctype+std::to_string(id));
@@ -207,6 +207,11 @@ namespace dd
             r_layers.push_back(_rnn_str);
             h_sizes.push_back(std::stoi(s.substr(pos+_rnn_str.size())));
           }
+        else if ((pos=s.find(_affine_str))!= std::string::npos)
+          {
+            r_layers.push_back(_affine_str);
+            h_sizes.push_back(std::stoi(s.substr(pos+_affine_str.size())));
+          }
         else
           {
             try
@@ -295,15 +300,18 @@ namespace dd
     std::string top;
     for (unsigned int i=0; i<layers.size(); ++i)
       {
-        if (layers[i] == "R")
+        if (layers[i] == _rnn_str)
           type = "RNN";
-        else if (layers[i] == "L")
+        else if (layers[i] == _lstm_str)
           type = "LSTM";
-        else if (layers[i] == "A")
+        else if (layers[i] == _affine_str)
           type = "AFFINE";
 
         top = type+"_"+std::to_string(i);
-
+        if ((i == layers.size() -1) && osize[osize.size()-1] == ntargets)
+          top = "rnn_pred";
+        else
+          top = type+"_"+std::to_string(i);
         if (type == "AFFINE")
           {
             int isize = i==0? osize[i] : osize[i-1]; //used only for initing weights

--- a/src/generators/net_caffe_recurrent.h
+++ b/src/generators/net_caffe_recurrent.h
@@ -87,6 +87,7 @@ namespace dd
   private:
     const std::string _lstm_str = "L";
     const std::string _rnn_str = "R";
+    const std::string _affine_str = "A";
 
   };
   


### PR DESCRIPTION
now layers can be
['L50','L50','A3','L3','A3']    meaning two lstm with output size of 50, followed by an affine (inner product) layer for dimension reduction, then another LSTM layer with output size of 3 , and finally another inner product.

N B: this PR is not ready for merge, it is p-requested for jenkins 