### PR TITLE
ncnn timeseries for predictions 

### DIFF
--- a/src/backends/ncnn/ncnninputconns.h
+++ b/src/backends/ncnn/ncnninputconns.h
@@ -23,6 +23,7 @@
 #define NCNNINPUTCONNS_H
 
 #include "imginputfileconn.h"
+#include "csvtsinputfileconn.h"
 
 // NCNN
 #include "net.h"
@@ -32,8 +33,21 @@ namespace dd
     class NCNNInputInterface
     {
     public:
-        NCNNInputInterface() {}
-        ~NCNNInputInterface() {}
+      NCNNInputInterface() {}
+      NCNNInputInterface(const NCNNInputInterface &i)
+      {
+        _timeseries_lengths = i._timeseries_lengths;
+        _continuation = i._continuation;
+        _ntargets = i._ntargets;
+      }
+
+      ~NCNNInputInterface() {}
+
+      double unscale_res(double res, int nout);
+
+      std::vector<int> _timeseries_lengths;
+      bool _continuation = false;
+      int _ntargets;
     };
 
     class ImgNCNNInputFileConn : public ImgInputFileConn, public NCNNInputInterface
@@ -73,17 +87,128 @@ namespace dd
                 throw;
             }
             cv::Mat bgr = this->_images.at(0);
+            _height = bgr.rows;
+            _width = bgr.cols;
 
             _in = ncnn::Mat::from_pixels(bgr.data, ncnn::Mat::PIXEL_BGR, bgr.cols, bgr.rows);
             _in.substract_mean_normalize(&_mean[0], 0);
 	    _ids.push_back(this->_uris.at(0));
         }
 
-        public:
-            ncnn::Mat _in;
-            ncnn::Mat _out;
-	    std::vector<std::string> _ids; /**< input ids (e.g. image ids) */
+      double unscale_res(double res, int nout) {return 0 * res * nout;}
+
+    public:
+      ncnn::Mat _in;
+      ncnn::Mat _out;
+      std::vector<std::string> _ids; /**< input ids (e.g. image ids) */
     };
+
+    class CSVTSNCNNInputFileConn : public CSVTSInputFileConn, public NCNNInputInterface
+    {
+    public:
+        CSVTSNCNNInputFileConn()
+            :CSVTSInputFileConn() {}
+        CSVTSNCNNInputFileConn(const CSVTSNCNNInputFileConn &i)
+            :CSVTSInputFileConn(i),NCNNInputInterface(i) {}
+        ~CSVTSNCNNInputFileConn() {}
+
+        // for API info only
+        int width() const
+        {
+            return _width;
+        }
+
+        // for API info only
+        int height() const
+        {
+            return _height;
+        }
+
+        void init(const APIData &ad)
+        {
+            CSVTSInputFileConn::init(ad);
+            if (ad.has("continuation"))
+              _continuation= ad.get("continuation").get<bool>();
+        }
+
+        void transform(const APIData &ad)
+        {
+            try
+            {
+                CSVTSInputFileConn::transform(ad);
+            }
+            catch(const std::exception& e)
+            {
+                throw;
+            }
+
+            APIData ad_input = ad.getobj("parameters").getobj("input");
+            if (ad_input.has("continuation"))
+              _continuation= ad_input.get("continuation").get<bool>();
+
+            //  data should be is in this->_csvtsdata
+            int nseries = this->_csvtsdata.size();
+            _height = 0;
+            _width = this->_csvtsdata[0][0]._v.size() + 1;
+
+            for (int i =0; i< nseries; ++i)
+              {
+                int l = this->_csvtsdata[i].size();
+                _timeseries_lengths.push_back(l);
+                _height += l;
+              }
+            // Mat(w,h)
+            _in.create(_width,_height);
+
+            int mati = 0;
+
+            //only inputs are put into _in
+            _ntargets = this->_label_pos.size();
+            std::vector<int> input_pos;
+            for (int i =0; i<_width-1; ++i)
+              if (std::find(this->_label_pos.begin(),this->_label_pos.end(),i)
+                  == this->_label_pos.end())
+                input_pos.push_back(i);
+
+            for (unsigned int si = 0; si<this->_csvtsdata.size(); ++si)
+              {
+                if (_continuation)
+                  _in[mati++] = 1;
+                else
+                  _in[mati++] = 0;
+                for (int di = 0; di < _ntargets; ++di)
+                  _in[mati++] = 0;
+                for (unsigned int di : input_pos)
+                  _in[mati++] = this->_csvtsdata[si][0]._v[di];
+                for (unsigned int ti=1; ti < this->_csvtsdata[si].size(); ++ti)
+                  {
+                    _in[mati++] = 1;
+                    for (int di = 0; di < _ntargets; ++di)
+                      _in[mati++] = 0;
+                    for (unsigned int di : input_pos)
+                      _in[mati++] = this->_csvtsdata[si][ti]._v[di];
+                  }
+              }
+            _ids.push_back(this->_uris.at(0));
+        }
+
+      double unscale_res(double res, int k)
+      {
+        if (_min_vals.empty() || _max_vals.empty())
+          return res;
+        double min = _min_vals[_label_pos[k]];
+        return res * (_max_vals[_label_pos[k]]- min) + min;
+      }
+
+
+    public:
+      ncnn::Mat _in;
+      ncnn::Mat _out;
+      int _height;
+      int _width;
+      std::vector<std::string> _ids; /**< input ids (e.g. image ids) */
+    };
+
 }
 
 #endif

--- a/src/backends/ncnn/ncnnlib.h
+++ b/src/backends/ncnn/ncnnlib.h
@@ -53,11 +53,13 @@ namespace dd
     public:
         ncnn::Net *_net = nullptr;
         int _nclasses = 0;
+        bool _timeserie =  false;
     private:
         static ncnn::UnlockedPoolAllocator _blob_pool_allocator;
         static ncnn::PoolAllocator _workspace_pool_allocator;
     protected:
         int _threads = 1;
+    int _old_height = -1;
     };
 }
 

--- a/src/csvinputfileconn.cc
+++ b/src/csvinputfileconn.cc
@@ -83,6 +83,7 @@ namespace dd
 	else _cifc->add_train_csvline(std::to_string(_cifc->_csvdata.size()+1),vals);
 	++l;
       }
+    _cifc->update_columns();
     return 0;
   }
 

--- a/src/jsonapi.cc
+++ b/src/jsonapi.cc
@@ -509,6 +509,8 @@ namespace dd
     {
       if (input == "image")
         add_service(sname, std::move(MLService<NCNNLib,ImgNCNNInputFileConn,SupervisedOutput,NCNNModel>(sname,ncnnmodel,description)), ad);
+      else if (input == "csv_ts" || input == "csvts")
+        add_service(sname,std::move(MLService<NCNNLib,CSVTSNCNNInputFileConn,SupervisedOutput,NCNNModel>(sname,ncnnmodel,description)),ad);
       else return dd_input_connector_not_found_1004();
       if (JsonAPI::store_json_blob(ncnnmodel._repo, jstr))
         _logger->error("couldn't write {} file in model repository {}", JsonAPI::_json_blob_fname, ncnnmodel._repo);

--- a/src/services.h
+++ b/src/services.h
@@ -113,6 +113,7 @@ namespace dd
     #if defined(USE_CAFFE) || defined(USE_CAFFE2) || defined(USE_TF) || defined(USE_DLIB) || defined(USE_XGBOOST) || defined(USE_TSNE)
     ,
     #endif
+    MLService<NCNNLib,CSVTSNCNNInputFileConn,SupervisedOutput,NCNNModel>,
     MLService<NCNNLib,ImgNCNNInputFileConn,SupervisedOutput,NCNNModel>
 #endif
     > mls_variant_type;


### PR DESCRIPTION

- input + output of timeseries for ncnnlib 
- add templates instanciations for ncnn timeseries
- correclty format input and output for timeseries
- add continuation option for ncnn timeseries, so that it can use saved internal state of lstm

- example for service instanciation : 
```
curl -X PUT "http://10.10.77.61:8080/services/dd_valve" -d '{
{"mllib":"ncnn", "description":"dd valve timeserie simulator",
    "type":"supervised",
    "parameters":{
         "input":{
              "connector":"csvts", "db": false,
              "label" : ["PRV.port_b.p","PRV.der_alpha.u","PRV.der_alpha.y"],
              "ignore": ["time"] },
         "mllib":{ "regression":true  }  },
    "model":{ "repository":"/home/infantes/ncnn_ts/model/"  }}'
```

- example for prediction: 
```
curl -X POST "http://10.10.77.61:8080/predict" -d '{
{"service":"dd_valve",
      "parameters":{
         "input":{
              "connector":"csvts", "db": false,
                "timesteps":1,
                "separator":";",
                "scale":true,
                "continuation":true},         "output": {},
          "mllib":{"net":{"test_batch_size":1}}},
          "data":["time;PRV.monitoring.inlet.m_flow;PRV.monitoring.inlet.p;PRV.monitoring.inlet.T;domain.SAP;PRV.SENSLINE.p;PRV.port_b.p;PRV.der_alpha.u;PRV.der_alpha.y","0.0;9.317033900850000e-01;4.599366323670000e+05;4.731500000000000e+02;1.013250000000000e+05;2.388701844060000e+05;0.0;0.0;0.0"]}}'
```