### PR TITLE
FIX: when not using DD_SYSLOG include spdlog::stdout_logger_mt

### DIFF
--- a/src/mlservice.h
+++ b/src/mlservice.h
@@ -32,6 +32,9 @@
 #include <unordered_map>
 #include <chrono>
 #include <iostream>
+#if !defined USE_DD_SYSLOG
+#include <spdlog/sinks/stdout_sinks.h>
+#endif
 
 namespace dd
 {


### PR DESCRIPTION
compile fix when not passing -DUSE_DD_SYSLOG to cmake