### PR TITLE
Use a std::vector instead of variable length array

### DIFF
--- a/src/supervisedoutputconnector.h
+++ b/src/supervisedoutputconnector.h
@@ -824,9 +824,9 @@ namespace dd
          if (timeserie)
            {
              // we have timeseries outputs (flattened / interleaved in preds!)
-             double max_errors[timeseries];
-             int indexes_max_error[timeseries];
-             double mean_errors[timeseries];
+             std::vector<double> max_errors(timeseries);
+             std::vector<int> indexes_max_error(timeseries);
+             std::vector<double> mean_errors(timeseries);
              double max_error;
              double mean_error;
 
@@ -844,7 +844,7 @@ namespace dd
 
              if (L1)
                {
-                 timeSeriesErrors(ad_res, timeseries, max_errors, indexes_max_error, mean_errors, max_error, mean_error, true);
+                 timeSeriesErrors(ad_res, timeseries, &max_errors[0], &indexes_max_error[0], &mean_errors[0], max_error, mean_error, true);
                  for (int i=0; i<timeseries; ++i)
                    {
                      meas_out.add("L1_max_error_" + std::to_string(i),max_errors[i]);
@@ -858,7 +858,7 @@ namespace dd
                }
              if (L2)
                {
-                 timeSeriesErrors(ad_res, timeseries, max_errors, indexes_max_error, mean_errors, max_error, mean_error, false);
+                 timeSeriesErrors(ad_res, timeseries, &max_errors[0], &indexes_max_error[0], &mean_errors[0], max_error, mean_error, false);
                  for (int i=0; i<timeseries; ++i)
                    {
                      meas_out.add("L2_max_error_" + std::to_string(i),max_errors[i]);
@@ -917,7 +917,7 @@ namespace dd
             error = error.array() * error.array();
           //          std::cout << "error: " << error << std::endl;
           dVec batchmax = error.colwise().maxCoeff();
-          int batch_max_indexes[timeseries];
+          std::vector<int> batch_max_indexes(timeseries);
           for (int j =0; j<timeseries; ++j)
               error.col(j).maxCoeff(&(batch_max_indexes[j]));
 
@@ -1751,9 +1751,10 @@ namespace dd
     
     // measure: gini coefficient
     static double comp_gini(const std::vector<double> &a, const std::vector<double> &p) {
-      struct K {double a, p;} k[a.size()];
+      struct K { double a, p; };
+      std::vector<K> k(a.size());
       for (size_t i = 0; i != a.size(); ++i) k[i] = {a[i], p[i]};
-      std::stable_sort(k, k+a.size(), [](const K &a, const K &b) {return a.p > b.p;});
+      std::stable_sort(k.begin(), k.end(), [](const K &a, const K &b) {return a.p > b.p;});
       double accPopPercSum=0, accLossPercSum=0, giniSum=0, sum=0;
       for (auto &i: a) sum += i;
       for (auto &i: k) 


### PR DESCRIPTION
Variable Length Array is a C99 feature and is not supported in C++.

g++ support c++11 AND C99 at the same time but not other compilers.

MSVC is only C90 compliant...