### PR TITLE
implement fileops on WIN32 using boost::filesystem, correct includes

### DIFF
--- a/src/apistrategy.h
+++ b/src/apistrategy.h
@@ -26,6 +26,12 @@
 #include "services.h"
 #include <spdlog/spdlog.h>
 
+#ifdef USE_DD_SYSLOG
+#include <spdlog/sinks/syslog_sink.h>
+#else
+#include <spdlog/sinks/stdout_sinks.h>
+#endif
+
 namespace dd
 {
 

--- a/src/ext/rmustache/mustache.cc
+++ b/src/ext/rmustache/mustache.cc
@@ -19,6 +19,10 @@
 #include <fstream>
 #include <vector>
 
+#ifdef WIN32
+#define strcasecmp _stricmp
+#endif
+
 #include <boost/algorithm/string.hpp>
 #include <boost/foreach.hpp>
 

--- a/src/mlservice.h
+++ b/src/mlservice.h
@@ -29,6 +29,7 @@
 #include <mutex>
 //#include <shared_mutex>
 #include <boost/thread/shared_mutex.hpp>
+#include <boost/thread/lock_types.hpp>
 #include <unordered_map>
 #include <chrono>
 #include <iostream>

--- a/tests/ut-ncnnapi.cc
+++ b/tests/ut-ncnnapi.cc
@@ -23,9 +23,6 @@
 #include "jsonapi.h"
 #include <gtest/gtest.h>
 #include <stdio.h>
-#include <unistd.h>
-#include <sys/stat.h>
-#include <sys/types.h>
 #include <iostream>
 
 using namespace dd;


### PR DESCRIPTION
implement fileops on WIN32 using boost::filesystem
some function are still missing
remove useless includes in ut_nncnnapi.cc
correct some include missing or misconfigured
strcasecmp does not exist on Windows/MSVC so replace it by _stricmp