### PR TITLE
skip bad bbox on Jetson nano GPU with Caffe

### DIFF
--- a/src/backends/caffe/caffelib.cc
+++ b/src/backends/caffe/caffelib.cc
@@ -2411,6 +2411,18 @@ namespace dd
 			probs.push_back(detection[2]);
 			cats.push_back(this->_mlmodel.get_hcorresp(detection[1]));
 			APIData ad_bbox;
+			bool skip = false;
+			for (int d=3;d<7;d++)
+			  {
+			    if (detection[d] < 0 || detection[d] > 1)
+			      {
+				this->_logger->error("skipping invalid bbox");
+				skip = true;
+				break;
+			      }
+			  }
+			if (skip)
+			  continue; // does not record this bbox
 			ad_bbox.add("xmin",detection[3]*cols);
 			ad_bbox.add("ymax",detection[4]*rows);
 			ad_bbox.add("xmax",detection[5]*cols);

--- a/src/backends/caffe/caffelib.cc
+++ b/src/backends/caffe/caffelib.cc
@@ -2408,8 +2408,6 @@ namespace dd
 			outr += det_size;
 			if (detection[2] < confidence_threshold)
 			  continue;
-			probs.push_back(detection[2]);
-			cats.push_back(this->_mlmodel.get_hcorresp(detection[1]));
 			APIData ad_bbox;
 			bool skip = false;
 			for (int d=3;d<7;d++)
@@ -2423,6 +2421,8 @@ namespace dd
 			  }
 			if (skip)
 			  continue; // does not record this bbox
+			probs.push_back(detection[2]);
+			cats.push_back(this->_mlmodel.get_hcorresp(detection[1]));
 			ad_bbox.add("xmin",detection[3]*cols);
 			ad_bbox.add("ymax",detection[4]*rows);
 			ad_bbox.add("xmax",detection[5]*cols);


### PR DESCRIPTION
CUDA execution of DetectionOutput Caffe layer appears to sometimes return overflows in bounding boxes output coordinates.
~~~At this stage, this is unclear why this is never happening on other GPUs, nor has it been reported by Jetson Nano customers that we know use DD, though we checked with them.~~~
This PR makes sure these bounding boxes are removed by DD.