### PR TITLE
move init of attributes to construction instead of declaration

### DIFF
--- a/src/backends/ncnn/ncnnlib.cc
+++ b/src/backends/ncnn/ncnnlib.cc
@@ -42,7 +42,7 @@ namespace dd
   
     template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
     NCNNLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::NCNNLib(const NCNNModel &cmodel)
-        :MLLib<TInputConnectorStrategy,TOutputConnectorStrategy,NCNNModel>(cmodel)
+      :MLLib<TInputConnectorStrategy,TOutputConnectorStrategy,NCNNModel>(cmodel), _threads(1), _old_height(-1)
     {
         this->_libname = "ncnn";
         _net = new ncnn::Net();


### PR DESCRIPTION
for some reason, visual studio does not seem to init properly aatributes when their value is given at declaration and not at construction 