### PR TITLE
use USE_HTTP to condionally include httpjsonapi.h, correct not defined to !defined

### DIFF
--- a/main/dede.cc
+++ b/main/dede.cc
@@ -22,7 +22,9 @@
 #include "deepdetect.h"
 #include "commandlineapi.h"
 #include "commandlinejsonapi.h"
+#ifdef USE_HTTP
 #include "httpjsonapi.h"
+#endif
 #include "imginputfileconn.h"
 #include "outputconnectorstrategy.h"
 #ifdef USE_XGBOOST

--- a/src/deepdetect.cc
+++ b/src/deepdetect.cc
@@ -22,7 +22,9 @@
 #include "deepdetect.h"
 #include "commandlineapi.h"
 #include "commandlinejsonapi.h"
+#ifdef USE_HTTP
 #include "httpjsonapi.h"
+#endif
 #include "dd_config.h"
 #include "githash.h"
 
@@ -48,7 +50,6 @@ namespace dd
 #endif
 #endif
 
-
 #ifdef USE_JSON_API
 #ifdef USE_COMMANDLINE
   template class DeepDetect<CommandLineJsonAPI>;
@@ -56,7 +57,7 @@ namespace dd
 #ifdef USE_HTTP
   template class DeepDetect<HttpJsonAPI>;
 #endif
-  #if not defined(USE_COMMANDLINE) && not defined (USE_HTTP)
+  #if !defined(USE_COMMANDLINE) && !defined(USE_HTTP)
     template class DeepDetect<JsonAPI>;
   #endif
 #endif


### PR DESCRIPTION
use USE_HTTP to condionally include httpjsonapi.h
correct not defined to !defined to get correct behavior on Windows