### PR TITLE
timeseries minor fixes

### DIFF
--- a/src/backends/caffe/caffeinputconns.cc
+++ b/src/backends/caffe/caffeinputconns.cc
@@ -1512,7 +1512,7 @@ namespace dd
     return 0;
   }
 
-  int DDCCsvTS::read_dir(const std::string &dir, bool is_test_data)
+  int DDCCsvTS::read_dir(const std::string &dir, bool is_test_data, bool update_bounds)
   {
     // first recursive list csv files
     std::unordered_set<std::string> allfiles;
@@ -1523,11 +1523,15 @@ namespace dd
     if (!_cifc)
       return -1;
 
-    if (_cifc->_scale && (_cifc->_min_vals.empty() || _cifc->_max_vals.empty() ))
+    if (update_bounds && _cifc->_scale && (_cifc->_min_vals.empty() || _cifc->_max_vals.empty() ))
       {
+        std::unordered_set<std::string> reallyallfiles;
+        ret = fileops::list_directory(_cifc->_csv_test_fname, true, false, true, reallyallfiles);
+        reallyallfiles.insert(allfiles.begin(), allfiles.end());
+
         std::vector<double> min_vals = _cifc->_min_vals;
         std::vector<double> max_vals = _cifc->_max_vals;
-        for (auto fname : allfiles)
+        for (auto fname : reallyallfiles)
           {
             std::pair<std::vector<double>,std::vector<double>> mm = _cifc->get_min_max_vals(fname);
             if (min_vals.empty())
@@ -1824,8 +1828,8 @@ namespace dd
     DDCCsvTS ddccsvts;
     ddccsvts._cifc = this;
     ddccsvts._adconf = ad_input;
-    ddccsvts.read_dir(_csv_fname);
-    ddccsvts.read_dir(_csv_test_fname,true);
+    ddccsvts.read_dir(_csv_fname,false,true);
+    ddccsvts.read_dir(_csv_test_fname,true,false);
 
 
     _txn->Commit();

--- a/src/backends/caffe/caffeinputconns.h
+++ b/src/backends/caffe/caffeinputconns.h
@@ -810,7 +810,7 @@ namespace dd
     int read_file(const std::string &fname, bool is_test_data=false);
     int read_db(const std::string &fname);
     int read_mem(const std::string &content);
-    int read_dir(const std::string &dir, bool is_test_data=false);
+    int read_dir(const std::string &dir, bool is_test_data=false, bool update_bounds = true);
 
     DDCsvTS _ddcsvts;
     CSVTSCaffeInputFileConn *_cifc = nullptr;

--- a/src/backends/caffe/caffelib.cc
+++ b/src/backends/caffe/caffelib.cc
@@ -2596,10 +2596,15 @@ namespace dd
                            else
                              {
                                double res = results[slot]->data_at(loc);
-                               double max = ic->_max_vals[ic->_label_pos[k]];
-                               double min = ic->_min_vals[ic->_label_pos[k]];
-                               double unscaled_res = res * (max - min) + min;
-                               predictions.push_back(unscaled_res);
+                               if (!ic->_dont_scale_labels)
+                                 {
+                                   double max = ic->_max_vals[ic->_label_pos[k]];
+                                   double min = ic->_min_vals[ic->_label_pos[k]];
+                                   if (ic->_scale_between_minus1_and_1)
+                                     res +=  0.5;
+                                   res = res * (max -min) + min;
+                                 }
+                               predictions.push_back(res);
                              }
                          }
                        APIData ts;

--- a/src/backends/ncnn/ncnninputconns.h
+++ b/src/backends/ncnn/ncnninputconns.h
@@ -195,10 +195,15 @@ namespace dd
 
       double unscale_res(double res, int k)
       {
+        if (_dont_scale_labels)
+          return res;
         if (_min_vals.empty() || _max_vals.empty())
           return res;
         double min = _min_vals[_label_pos[k]];
-        return res * (_max_vals[_label_pos[k]]- min) + min;
+        if (_scale_between_minus1_and_1)
+          return (res+0.5) * (_max_vals[_label_pos[k]]- min) + min;
+        else
+          return res * (_max_vals[_label_pos[k]]- min) + min;
       }
 
 

--- a/src/csvinputfileconn.cc
+++ b/src/csvinputfileconn.cc
@@ -351,7 +351,7 @@ namespace dd
 	{
          find_min_max(csv_file);
 	}
-      
+
       // read data
       while(std::getline(csv_file,hline))
 	{
@@ -422,7 +422,7 @@ namespace dd
 	  _logger->info("data split test size={} / remaining data size={}",_csvdata_test.size(),_csvdata.size());
 	}
       if (!_ignored_columns.empty() || !_categoricals.empty())
-	update_columns();
+        update_columns();
   }
   
 }

--- a/src/csvinputfileconn.h
+++ b/src/csvinputfileconn.h
@@ -222,34 +222,35 @@ namespace dd
     {
       auto lit = _columns.begin();
       for (int j=0;j<(int)vals.size();j++)
-	{
-	  bool j_is_id = (_columns.empty() || _id.empty()) ? false : (*lit) == _id;
-	  if (j_is_id)
-	    {
-	      ++lit;
-	      continue;
-	    }
-	  bool equal_bounds = (_max_vals.at(j) == _min_vals.at(j));
-	  if (equal_bounds)
-	    {
-	      ++lit;
-	      continue;
-	    }
-         if (_dont_scale_labels)
-           {
-             bool j_is_label = false;
-             if (!_columns.empty() && std::find(_label_pos.begin(),_label_pos.end(),j)!=_label_pos.end())
-               j_is_label = true;
-             if (j_is_label)
-               {
-                 ++lit;
-                 continue;
-               }
-           }
-	  
-	  vals.at(j) = (vals.at(j) - _min_vals.at(j)) / (_max_vals.at(j) - _min_vals.at(j));
-	  ++lit;
-	}
+        {
+          bool j_is_id = (_columns.empty() || _id.empty()) ? false : (*lit) == _id;
+          if (j_is_id)
+            {
+              ++lit;
+              continue;
+            }
+          bool equal_bounds = (_max_vals.at(j) == _min_vals.at(j));
+          if (equal_bounds)
+            {
+              ++lit;
+              continue;
+            }
+          if (_dont_scale_labels)
+            {
+              bool j_is_label = false;
+              if (!_columns.empty() && std::find(_label_pos.begin(),_label_pos.end(),j)!=_label_pos.end())
+                j_is_label = true;
+              if (j_is_label)
+                {
+                  ++lit;
+                  continue;
+                }
+            }
+          vals.at(j) = (vals.at(j) - _min_vals.at(j)) / (_max_vals.at(j) - _min_vals.at(j));
+          if (_scale_between_minus1_and_1)
+            vals.at(j) = vals.at(j)-0.5;
+          ++lit;
+        }
     }
 
     void read_scale_vals(const APIData &ad_input)
@@ -561,6 +562,7 @@ namespace dd
     std::string _id;
     bool _scale = false; /**< whether to scale all data between 0 and 1 */
     bool _dont_scale_labels = true; // original csv input conn do not scale labels, while it is needed for csv timeseries
+    bool _scale_between_minus1_and_1 = false;
     std::vector<double> _min_vals; /**< upper bound used for auto-scaling data */
     std::vector<double> _max_vals; /**< lower bound used for auto-scaling data */
     std::unordered_map<std::string,CCategorical> _categoricals; /**< auto-converted categorical variables */

--- a/src/csvtsinputfileconn.h
+++ b/src/csvtsinputfileconn.h
@@ -43,7 +43,8 @@ namespace dd
     int read_file(const std::string &fname, bool is_test_data = false);
     int read_db(const std::string &fname);
     int read_mem(const std::string &content);
-    int read_dir(const std::string &dir, bool is_test_data = false, bool allow_read_test = true);
+    int read_dir(const std::string &dir, bool is_test_data = false, bool allow_read_test = true,
+                 bool update_bounds = true);
 
     DDCsv _ddcsv;
     CSVTSInputFileConn *_cifc = nullptr;
@@ -59,7 +60,11 @@ namespace dd
 
 
   CSVTSInputFileConn()
-    :CSVInputFileConn() {}
+    :CSVInputFileConn()
+      {
+        this->_dont_scale_labels = false;
+        this->_scale_between_minus1_and_1 = true;
+      }
 
     ~CSVTSInputFileConn() {}
 
@@ -67,19 +72,25 @@ namespace dd
     : CSVInputFileConn(i), _csvtsdata(i._csvtsdata),
       _csvtsdata_test(i._csvtsdata_test)
         {
-          this->_dont_scale_labels = false;
+          this->_scale_between_minus1_and_1 = i._scale_between_minus1_and_1;
+          this->_dont_scale_labels = i._dont_scale_labels;
+          this->_min_vals = i._min_vals;
+          this->_max_vals = i._max_vals;
         }
 
-
+    void init(const APIData &ad)
+    {
+      fillup_parameters(ad);
+    }
 
     void fillup_parameters(const APIData &ad_input)
     {
       if (ad_input.has("scale") && ad_input.get("scale").get<bool>())
         {
           _scale = true;
-          deserialize_bounds();
         }
       CSVInputFileConn::fillup_parameters(ad_input);
+      deserialize_bounds();
     }
 
     void shuffle_data(std::vector<std::vector<CSVline>> cvstsdata);
@@ -102,7 +113,7 @@ namespace dd
     }
 
     // read min max values, return false if not present
-    bool deserialize_bounds();
+    bool deserialize_bounds(bool force = false);
     void serialize_bounds();
 
     /*   std::string s = "Boost,\"C++ Libraries\""; */
@@ -124,7 +135,7 @@ namespace dd
     std::vector<std::vector<CSVline>> _csvtsdata_test;
     std::vector<std::string> _fnames;
 
-
+    int _boundsprecision = 15;
   };
 }
 

--- a/src/generators/net_caffe.cc
+++ b/src/generators/net_caffe.cc
@@ -83,10 +83,10 @@ namespace dd
     bool autoencoder = false;
     if (ad_mllib.has("autoencoder"))
       autoencoder = ad_mllib.get("autoencoder").get<bool>();
-    int width = inputc.width();
-    int height = inputc.height();
-    int channels = inputc.channels();
-    int batch_size = inputc.batch_size();
+    int width = inputc.width() > 0 ? inputc.width() : 1;
+    int height = inputc.height() > 0 ? inputc.height() : 1;
+    int channels = inputc.channels() > 0 ? inputc.channels() : 1;
+    int batch_size = inputc.batch_size() > 0 ? inputc.batch_size() : 1;
     bool flat1dconv = inputc._flat1dconv; // whether the model uses 1d-conv (e.g. character-level convnet for text)
     
     // train net

--- a/src/generators/net_caffe_recurrent.h
+++ b/src/generators/net_caffe_recurrent.h
@@ -41,7 +41,7 @@ namespace dd
     ~NetLayersCaffeRecurrent() {}
 
     void add_basic_block(caffe::NetParameter *net_param,
-                         const std::string &bottom_seq,
+                         const std::vector<std::string> &bottom_seq,
                          const std::string &bottom_cont,
                          const std::string &top,
                          const int &num_output,
@@ -66,7 +66,7 @@ namespace dd
                     std::string inputs_name,
                     std::string cont_seq);
 
-    void add_flatten(caffe::NetParameter *net_params,
+    void add_flatten(caffe::NetParameter *net_params, std::string name,
                      std::string bottom, std::string top, int axis);
 
 
@@ -74,7 +74,7 @@ namespace dd
 
     void add_affine(caffe::NetParameter *net_params,
                     std::string name,
-                    std::string bottom,
+                    const std::vector<std::string> &bottom,
                     std::string top,
                     const std::string weight_filler,
                     const std::string bias_filler,


### PR DESCRIPTION
- do not write default dim values in prototxt (as they are negative, this write overflowed values into prototxt), necessary to debug workflow including editing prototxt by hand (normal / platform workflow is not affected)
- get back old commit from some lost branch that computes min and max from all files including test files, and not only train files + small fix on this part
- do not read bounds for auto unscale at every predict, but only at service init
- scale values between -0.5 and 0.5 instead of 0 and 1, as LSTM sensitive part is around 0
- add residual style LSTM:   in service creation, parameters.mllib.residual = true (false by default) adds every possible short connexion, resnet-style. Unclear if this helps for derivatives, as it was designed for. 