### PR TITLE
Regularize bad bbox to the boundaries of the image

### DIFF
--- a/src/backends/caffe/caffelib.cc
+++ b/src/backends/caffe/caffelib.cc
@@ -2408,21 +2408,20 @@ namespace dd
 			outr += det_size;
 			if (detection[2] < confidence_threshold)
 			  continue;
-			probs.push_back(detection[2]);
-			cats.push_back(this->_mlmodel.get_hcorresp(detection[1]));
+                        probs.push_back(detection[2]);
+                        cats.push_back(this->_mlmodel.get_hcorresp(detection[1]));
 			APIData ad_bbox;
-			bool skip = false;
 			for (int d=3;d<7;d++)
 			  {
-			    if (detection[d] < 0 || detection[d] > 1)
+			    if (detection[d] < 0 )
 			      {
-				this->_logger->error("skipping invalid bbox");
-				skip = true;
-				break;
-			      }
+                                detection[d] = 0;
+                             }
+                            else if (detection[d] > 1)
+			      {
+                                detection[d] = 1
+                             }
 			  }
-			if (skip)
-			  continue; // does not record this bbox
 			ad_bbox.add("xmin",detection[3]*cols);
 			ad_bbox.add("ymax",detection[4]*rows);
 			ad_bbox.add("xmax",detection[5]*cols);


### PR DESCRIPTION
Instead of removing bad bbox, this PR regularizes the size of the bbox to the boundaries of the image.
This can be usefull when an object is not completly present in the image (the bounding box might exceed the size of the image)