### PR TITLE
Regularize bad bbox to the boundaries of the image

### DIFF
--- a/src/backends/caffe/caffelib.cc
+++ b/src/backends/caffe/caffelib.cc
@@ -2408,13 +2408,19 @@ namespace dd
 			outr += det_size;
 			if (detection[2] < confidence_threshold)
 			  continue;
+			// Fix border of bboxes
+			detection[3] = std::max(((float) detection[3]), 0.0f);
+			detection[4] = std::max(((float) detection[4]), 0.0f);
+			detection[5] = std::min(((float) detection[5]), 1.0f);
+			detection[6] = std::min(((float) detection[6]), 1.0f);
+
 			probs.push_back(detection[2]);
 			cats.push_back(this->_mlmodel.get_hcorresp(detection[1]));
 			APIData ad_bbox;
-			ad_bbox.add("xmin",detection[3]*cols);
-			ad_bbox.add("ymax",detection[4]*rows);
-			ad_bbox.add("xmax",detection[5]*cols);
-			ad_bbox.add("ymin",detection[6]*rows);
+			ad_bbox.add("xmin",detection[3]*(cols-1));
+			ad_bbox.add("ymax",detection[4]*(rows-1));
+			ad_bbox.add("xmax",detection[5]*(cols-1));
+			ad_bbox.add("ymin",detection[6]*(rows-1));
 			bboxes.push_back(ad_bbox);
 		      }
 		    if (leave)


### PR DESCRIPTION
Instead of removing bad bbox, this PR regularizes the size of the bbox to the boundaries of the image.
This can be usefull when an object is not completly present in the image (the bounding box might exceed the size of the image)