### PR TITLE
Exit on failure from command line start list behavior

### DIFF
--- a/src/jsonapi.h
+++ b/src/jsonapi.h
@@ -45,7 +45,7 @@ namespace dd
      * \brief service autostart from JSON file
      * @param autostart_file JSON file with service API call and JSON body
      */
-    JDoc service_autostart(const std::string &autostart_file);
+    JDoc service_autostart(const std::string &autostart_file, const bool &no_exit_on_failure = true);
     
     /**
      * \brief error status generation


### PR DESCRIPTION
Changed behavior when running from command line so that an error will cause dede to exit by default (configurable with a command line parameter to disable this behavior). When using jsonapi otherwise, the default behavior is still to not exit on failure.

If different exit values are preferred for different cases, I can make that change.