### PR TITLE
dede API for lookahead

### DIFF
--- a/src/backends/caffe/caffelib.cc
+++ b/src/backends/caffe/caffelib.cc
@@ -1147,6 +1147,12 @@ namespace dd
 	  solver_param.set_rms_decay(ad_solver.get("rms_decay").get<double>());
 	if (ad_solver.has("iter_size"))
 	  solver_param.set_iter_size(ad_solver.get("iter_size").get<int>());
+    if (ad_solver.has("lookahead"))
+      solver_param.set_lookahead(ad_solver.get("lookahead").get<bool>());
+    if (ad_solver.has("lookahead_steps"))
+      solver_param.set_lookahead_steps(ad_solver.get("lookahead_steps").get<int>());
+    if (ad_solver.has("lookahead_alpha"))
+      solver_param.set_lookahead_alpha(ad_solver.get("lookahead_alpha").get<double>());
 
 	if (ad_solver.has("min_lr"))
 	  solver_param.set_min_lr(ad_solver.get("min_lr").get<double>());


### PR DESCRIPTION
dede API for lookahead solver, see https://github.com/jolibrain/caffe/pull/49
train options (with default values): 
parameters.solver.lookahead : false,
parameters.solver.lookahead_steps : 6,     
parameters.solver.lookahead_alpha : 0.5

set first option to true for using 

TESTED OK (over ADAM)