### PR TITLE
dd api for caffe warmup

### DIFF
--- a/src/backends/caffe/caffelib.cc
+++ b/src/backends/caffe/caffelib.cc
@@ -1133,6 +1133,10 @@ namespace dd
 	  solver_param.set_lr_policy(ad_solver.get("lr_policy").get<std::string>());
 	if (ad_solver.has("base_lr"))
 	  solver_param.set_base_lr(ad_solver.get("base_lr").get<double>());
+    if (ad_solver.has("warmup_lr"))
+      solver_param.set_warmup_start_lr(ad_solver.get("warmup_lr").get<double>());
+    if (ad_solver.has("warmup_iter"))
+      solver_param.set_warmup_iter(ad_solver.get("warmup_iter").get<int>());
 	if (ad_solver.has("gamma"))
 	  solver_param.set_gamma(ad_solver.get("gamma").get<double>());
 	if (ad_solver.has("stepsize"))
@@ -1409,6 +1413,8 @@ namespace dd
 	  {
 	    caffe::SGDSolver<float> *sgd_solver = static_cast<caffe::SGDSolver<float>*>(solver.get());
 	    this->_logger->info("Iteration {}, lr = {}, smoothed_loss={}",solver->iter_,sgd_solver->GetLearningRate(),this->get_meas("train_loss"));
+        if (sgd_solver->param_.warmup_iter() > 0)
+          this->_logger->info("[doing warmup (start_lr = {}, iter = {})]",solver->param_.warmup_start_lr(),solver->param_.warmup_iter());
 	  }
 	try
 	  {


### PR DESCRIPTION
add API for caffe warmup (see https://github.com/jolibrain/caffe/pull/50)
parameters.mllib.solver.warmup_lr : initial lr (lr is computed linearly from warmup_lr to base_lr between 0 and warmup_iter)
parmeters.mllib.solver.warmup_iter : number of warmup iterations

TESTED OK (against correct caffe)