### PR TITLE
Fix Protobuf conflict preventing complete build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -783,7 +783,7 @@ if (USE_NCNN)
 endif()
 
 if (USE_TENSORRT)
-  if (NOT USE_CAFFE2 AND NOT USE_TF)
+  if (NOT USE_CAFFE2 AND NOT USE_TF AND NOT USE_TORCH)
     find_package(Protobuf REQUIRED)
     if (Protobuf_FOUND)
       set(PROTOBUF_INCLUDE_DIR ${Protobuf_INCLUDE_DIRS})


### PR DESCRIPTION
```
cmake -DUSE_CUDNN=ON -DUSE_SIMSEARCH=ON -DUSE_TSNE=ON -DUSE_XGBOOST=ON -DUSE_TORCH=ON -DUSE_NCNN=ON -DUSE_TENSORRT=ON -DCUDA_ARCH="-gencode arch=compute_61,code=sm_61" ..
make
```
now builds the project successfully