### PR TITLE
input image interpolation method selection via API

### DIFF
--- a/src/imginputfileconn.h
+++ b/src/imginputfileconn.h
@@ -358,7 +358,7 @@ namespace dd
       _bw(i._bw),_unchanged_data(i._unchanged_data),
       _mean(i._mean),_has_mean_scalar(i._has_mean_scalar),
       _scaled(i._scaled), _scale_min(i._scale_min), _scale_max(i._scale_max),
-      _keep_orig(i._keep_orig) {}
+      _keep_orig(i._keep_orig), _interp(i._inter) {}
     ~ImgInputFileConn() {}
 
     void init(const APIData &ad)

--- a/src/imginputfileconn.h
+++ b/src/imginputfileconn.h
@@ -358,7 +358,7 @@ namespace dd
       _bw(i._bw),_unchanged_data(i._unchanged_data),
       _mean(i._mean),_has_mean_scalar(i._has_mean_scalar),
       _scaled(i._scaled), _scale_min(i._scale_min), _scale_max(i._scale_max),
-      _keep_orig(i._keep_orig), _interp(i._inter) {}
+      _keep_orig(i._keep_orig), _interp(i._interp) {}
     ~ImgInputFileConn() {}
 
     void init(const APIData &ad)


### PR DESCRIPTION
This PR allows to control OpenCV interpolation method via the API:

```json
{
"parameter": {
  "input": {"connector":"image", "interp": "linear"}
 }
}
```
The `interp` API parameter takes values from `"linear","nearest","cubic","area","lanczos4"`. 

Fastest methods are `"nearest"` then `"linear"`, default remains `"cubic"`.