### PR TITLE
OpenCV GPU support with CUDA for image input resizing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ option(USE_TORCH "use libtorch backend")
 option(USE_HDF5 "use HDF5" ON)
 option(USE_CAFFE "use Caffe backend" ON)
 option(USE_TENSORRT "use TensorRT backend" OFF)
+option(USE_CUDA_CV "use CUDA with OpenCV (Requires OpenCV build for CUDA)" OFF)
 
 if (USE_CAFFE)
   add_definitions(-DUSE_CAFFE)
@@ -51,7 +52,7 @@ execute_process(
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
-set(CMAKE_CXX_FLAGS "-g -Wall -Wextra -fopenmp -O2 -fPIC -std=c++11  -DUSE_OPENCV -DUSE_LMDB")
+set(CMAKE_CXX_FLAGS "-g -Wall -Wextra -fopenmp -O2 -fPIC -std=c++11 -DUSE_OPENCV -DUSE_LMDB")
 
 if (USE_COMMAND_LINE)
   if (NOT USE_CAFFE)
@@ -441,6 +442,10 @@ endif()
 set(OPENCV_VERSION ${OpenCV_VERSION_MAJOR})
 include_directories(${OpenCV_INCLUDE_DIRS})
 message(STATUS "OpenCV ${OPENCV_VERSION} (${OpenCV_VERSION}) found (${OpenCV_CONFIG_PATH})")
+if (CUDA_FOUND AND USE_CUDA_CV)
+  message(STATUS "Using CUDA OpenCV")
+  string(APPEND CMAKE_CXX_FLAGS " -DUSE_CUDA_CV")
+endif()
 
 # customized Caffe as external project
 if (CAFFE_INC_DIR AND CAFFE_LIB_DIR)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -437,6 +437,9 @@ endif() # USE_TF
 # OpenCV
 find_package(OpenCV 3 QUIET)
 if (NOT OpenCV_FOUND)
+  find_package(OpenCV 4 QUIET)
+endif()
+if (NOT OpenCV_FOUND)
   find_package(OpenCV 2 REQUIRED)
 endif()
 set(OPENCV_VERSION ${OpenCV_VERSION_MAJOR})

--- a/src/backends/caffe/caffeinputconns.h
+++ b/src/backends/caffe/caffeinputconns.h
@@ -197,9 +197,9 @@ namespace dd
 	    }
 	  
 	  float *mean = nullptr;
-	  std::string meanfullname = _model_repo + "/" + _meanfname;
 	  if (_data_mean.count() == 0 && _has_mean_file)
 	    {
+	      std::string meanfullname = _model_repo + "/" + _meanfname;
 	      caffe::BlobProto blob_proto;
 	      caffe::ReadProtoFromBinaryFile(meanfullname.c_str(),&blob_proto);
 	      _data_mean.FromProto(blob_proto);

--- a/src/chain_actions.cc
+++ b/src/chain_actions.cc
@@ -76,7 +76,7 @@ namespace dd
 	      double ymin = bbox.get("ymin").get<double>() / orig_rows * img.rows;
 	      double xmax = bbox.get("xmax").get<double>() / orig_cols * img.cols;
 	      double ymax = bbox.get("ymax").get<double>() / orig_rows * img.rows;
-
+	      
 	      double deltax = bratio * (xmax - xmin);
 	      double deltay = bratio * (ymax - ymin);
 
@@ -84,7 +84,7 @@ namespace dd
 	      double cxmax = std::min(static_cast<double>(img.cols),xmax+deltax);
 	      double cymax = std::max(0.0,ymax-deltay);
 	      double cymin = std::min(static_cast<double>(img.rows),ymin+deltay);
-	      
+
 	      cv::Rect roi(cxmin,cymax,cxmax-cxmin,cymin-cymax);
 	      cv::Mat cropped_img = img(roi);
 

--- a/src/imginputfileconn.h
+++ b/src/imginputfileconn.h
@@ -390,7 +390,11 @@ namespace dd
       _bw(i._bw),_unchanged_data(i._unchanged_data),
       _mean(i._mean),_has_mean_scalar(i._has_mean_scalar),
       _scaled(i._scaled), _scale_min(i._scale_min), _scale_max(i._scale_max),
-      _keep_orig(i._keep_orig), _interp(i._interp), _cuda(i._cuda) {}
+      _keep_orig(i._keep_orig), _interp(i._interp)
+#ifdef USE_CUDA_CV
+      , _cuda(i._cuda)
+#endif
+      {}
     ~ImgInputFileConn() {}
 
     void init(const APIData &ad)


### PR DESCRIPTION
This PR adds OpenCV GPU support (NVidia only) for image input resizing operation. This functionality **requires an OpenCV builds with CUDA support**.

API changes
- `input.cuda` boolean to resize input images on GPU

Build flag
- `-DUSE_CUDA_CV=ON` passed to `cmake`

Results:
- Early tests on Jetson TX2 shows up to 20% speed gain on single image with large size (e.g. 4000x4000)
- Speedup may vary depending on GPU