### PR TITLE
expose overlap_threshold for tests in detection tasks

### DIFF
--- a/src/backends/caffe/caffelib.h
+++ b/src/backends/caffe/caffelib.h
@@ -214,6 +214,11 @@ namespace dd
        * @param mllib apidata object
        */
       bool update_timesteps(int timesteps);
+
+      /**
+         update detection evaluation layer 's threshold if asked for
+       */
+      bool update_bbox_overlap_threshold(caffe::Net<float> *net, float t);
       
     private:
       void update_protofile_classes(caffe::NetParameter &net_param);


### PR DESCRIPTION
overlap_threshold is a hard threshold over intersection ratio of bboxes. computed bboxes that do not overlap ground truth bboxes more than these ratio are completely discarded.

overlap ratio is IoU (intersection over union):
intersection_size / (bbox1_size + bbox2_size - intersection_size)
see for instance  https://www.pyimagesearch.com/2016/11/07/intersection-over-union-iou-for-object-detection/
1.0 is perfect match
0.0 is complete miss (null intersection)

example usage : 
curl -X POST 'http://localhost:8080/predict' -d '{
"service":"detection_service",
"parameters":{
"output":{
"measure":"map"
"overlap_threshold" : 0.7
},
"data":["test_data"]
}'