### PR TITLE
Added input connector timeout, ref #647

### DIFF
--- a/src/backends/caffe/caffeinputconns.cc
+++ b/src/backends/caffe/caffeinputconns.cc
@@ -1361,7 +1361,7 @@ namespace dd
     if (ad_input.has("label_offset"))
     _label_offset = ad_input.get("label_offset").get<int>();*/
     
-    DataEl<DDCCsv> ddcsv;
+    DataEl<DDCCsv> ddcsv(this->_input_timeout);
     ddcsv._ctype._cifc = this;
     ddcsv._ctype._adconf = ad_input;
     ddcsv.read_element(_csv_fname,this->_logger);
@@ -2281,7 +2281,7 @@ namespace dd
     if (_uris.size() > 1)
       _svm_test_fname = _uris.at(1);
 
-    DataEl<DDSvm> ddsvm;
+    DataEl<DDSvm> ddsvm(this->_input_timeout);
     ddsvm._ctype._cifc = this;
     ddsvm._ctype._adconf = ad_input;
     ddsvm.read_element(_svm_fname,this->_logger);

--- a/src/csvinputfileconn.h
+++ b/src/csvinputfileconn.h
@@ -195,6 +195,9 @@ namespace dd
 	  for (std::string v: vcats)
 	    _categoricals.emplace(std::make_pair(v,CCategorical()));
 	}
+
+      // timeout
+      this->set_timeout(ad_input);
     }
 
     void read_categoricals(const APIData &ad_input)
@@ -366,7 +369,7 @@ namespace dd
 	  
 	  if (!_csv_fname.empty()) // when training from file
 	    {
-	      DataEl<DDCsv> ddcsv;
+	      DataEl<DDCsv> ddcsv(this->_input_timeout);
 	      ddcsv._ctype._cifc = this;
 	      ddcsv._ctype._adconf = ad_input;
 	      ddcsv.read_element(_csv_fname,this->_logger);
@@ -375,7 +378,7 @@ namespace dd
 	    {
 	      for (size_t i=uri_offset;i<_uris.size();i++)
 		{
-		  DataEl<DDCsv> ddcsv;
+		  DataEl<DDCsv> ddcsv(this->_input_timeout);
 		  ddcsv._ctype._cifc = this;
 		  ddcsv._ctype._adconf = ad_input;
 		  ddcsv.read_element(_uris.at(i),this->_logger);
@@ -406,7 +409,7 @@ namespace dd
 		}
 	      /*else if (!_categoricals.empty())
 		throw InputConnectorBadParamException("use of categoricals_mapping requires a CSV header");*/
-	      DataEl<DDCsv> ddcsv;
+	      DataEl<DDCsv> ddcsv(this->_input_timeout);
 	      ddcsv._ctype._cifc = this;
 	      ddcsv._ctype._adconf = ad_input;
 	      ddcsv.read_element(_uris.at(i),this->_logger);

--- a/src/csvtsinputfileconn.cc
+++ b/src/csvtsinputfileconn.cc
@@ -192,7 +192,7 @@ namespace dd
 
           if (!_csv_fname.empty()) // when training from file
             {
-              DataEl<DDCsvTS> ddcsvts;
+              DataEl<DDCsvTS> ddcsvts(this->_input_timeout);
               ddcsvts._ctype._cifc = this;
               ddcsvts._ctype._adconf = ad_input;
               ddcsvts.read_element(_csv_fname,this->_logger);
@@ -202,7 +202,7 @@ namespace dd
           {
             for (size_t i=uri_offset;i<_uris.size();i++)
 		{
-		  DataEl<DDCsvTS> ddcsvts;
+		  DataEl<DDCsvTS> ddcsvts(this->_input_timeout);
 		  ddcsvts._ctype._cifc = this;
 		  ddcsvts._ctype._adconf = ad_input;
 		  ddcsvts.read_element(_uris.at(i),this->_logger);
@@ -236,7 +236,7 @@ namespace dd
                 }
               /*else if (!_categoricals.empty())
                 throw InputConnectorBadParamException("use of categoricals_mapping requires a CSV header");*/
-              DataEl<DDCsvTS> ddcsvts;
+              DataEl<DDCsvTS> ddcsvts(this->_input_timeout);
               ddcsvts._ctype._cifc = this;
               ddcsvts._ctype._adconf = ad_input;
               ddcsvts.read_element(_uris.at(i),this->_logger);

--- a/src/csvtsinputfileconn.h
+++ b/src/csvtsinputfileconn.h
@@ -93,6 +93,9 @@ namespace dd
         }
       CSVInputFileConn::fillup_parameters(ad_input);
       deserialize_bounds();
+
+      // timeout
+      this->set_timeout(ad_input);
     }
 
     void shuffle_data(std::vector<std::vector<CSVline>> cvstsdata);

--- a/src/imginputfileconn.h
+++ b/src/imginputfileconn.h
@@ -420,6 +420,9 @@ namespace dd
       // image interpolation method
       if (ad.has("interp"))
 	_interp = ad.get("interp").get<std::string>();
+
+      // timeout
+      this->set_timeout(ad);
     }
     
     int feature_size() const
@@ -469,7 +472,7 @@ namespace dd
 	{
 	  bool no_img = false;
 	  std::string u = _uris.at(i);
-	  DataEl<DDImg> dimg;
+	  DataEl<DDImg> dimg(this->_input_timeout);
 	  dimg._ctype._bw = _bw;
           dimg._ctype._rgb = _rgb;
 	  dimg._ctype._unchanged_data = _unchanged_data;

--- a/src/inputconnectorstrategy.h
+++ b/src/inputconnectorstrategy.h
@@ -40,7 +40,11 @@ namespace dd
   template <class DDT> class DataEl
   {
   public:
-    DataEl() {}
+    DataEl(const int &timeout)
+      {
+	if (timeout != -1)
+	  _timeout = timeout;
+      }
     ~DataEl() {}
 
     int read_element(const std::string &uri,
@@ -58,7 +62,7 @@ namespace dd
 	  int outcode = -1;
 	  try
 	    {
-	      httpclient::get_call(uri,"GET",outcode,_content);
+	      httpclient::get_call(uri,"GET",outcode,_content,_timeout);
 	    }
 	  catch(...)
 	    {
@@ -82,6 +86,7 @@ namespace dd
     }
     
     std::string _content;
+    int _timeout = 600; // 10 mins is default
     DDT _ctype;
   };
   
@@ -121,7 +126,8 @@ namespace dd
   public:
     InputConnectorStrategy() {}
     InputConnectorStrategy(const InputConnectorStrategy &i)
-      :_model_repo(i._model_repo),_logger(i._logger) {}
+      :_model_repo(i._model_repo),_logger(i._logger),
+       _input_timeout(i._input_timeout) {}
     ~InputConnectorStrategy() {}
     
     /**
@@ -178,6 +184,12 @@ namespace dd
 	}
     }
 
+    void set_timeout(const APIData &ad)
+    {
+      if (ad.has("timeout"))
+	_input_timeout = ad.get("timeout").get<int>();
+    }
+    
     /**
      * \brief input parameters to return to user through API,
      *        especially when they have been automatically modified,
@@ -199,6 +211,8 @@ namespace dd
     std::vector<std::string> _index_uris; /**< URI to be stored in similarity search index. */
     std::string _model_repo; /**< model repository, useful when connector needs to read from saved data (e.g. vocabulary). */
     std::shared_ptr<spdlog::logger> _logger;
+
+    int _input_timeout = -1; /**< timeout on input data retrieval: -1 means using default (600sec), otherwise set via input parameters. */
   };
   
 }

--- a/src/svminputfileconn.h
+++ b/src/svminputfileconn.h
@@ -80,6 +80,9 @@ namespace dd
     {
       if (ad_input.has("test_split"))
 	_test_split = ad_input.get("test_split").get<double>();
+
+      // timeout
+      this->set_timeout(ad_input);
     }
 
     void shuffle_data(const APIData &ad)
@@ -140,7 +143,7 @@ namespace dd
 	    }
 	  if (!_svm_fname.empty()) // when training from file
 	    {
-	      DataEl<DDSvm> ddsvm;
+	      DataEl<DDSvm> ddsvm(this->_input_timeout);
 	      ddsvm._ctype._cifc = this;
 	      ddsvm._ctype._adconf = ad_input;
 	      ddsvm.read_element(_svm_fname,this->_logger);
@@ -149,7 +152,7 @@ namespace dd
 	    {
 	      for (size_t i=1;i<_uris.size();i++)
 		{
-		  DataEl<DDSvm> ddsvm;
+		  DataEl<DDSvm> ddsvm(this->_input_timeout);
 		  ddsvm._ctype._cifc = this;
 		  ddsvm._ctype._adconf = ad_input;
 		  ddsvm.read_element(_uris.at(i),this->_logger);
@@ -175,7 +178,7 @@ namespace dd
 	    {
 	      if (_uris.at(i).empty())
 		throw InputConnectorBadParamException("no data could be found for input " + std::to_string(i));
-	      DataEl<DDSvm> ddsvm;
+	      DataEl<DDSvm> ddsvm(this->_input_timeout);
 	      ddsvm._ctype._cifc = this;
 	      ddsvm._ctype._adconf = ad_input;
 	      ddsvm.read_element(_uris.at(i),this->_logger);

--- a/src/txtinputfileconn.h
+++ b/src/txtinputfileconn.h
@@ -313,6 +313,9 @@ namespace dd
 	_sequence = ad_input.get("sequence").get<int>();
       if (ad_input.has("read_forward"))
 	_seq_forward = ad_input.get("read_forward").get<bool>();
+
+      // timeout
+      this->set_timeout(ad_input);
     }
 
     int feature_size() const
@@ -352,7 +355,7 @@ namespace dd
       
       for (std::string u: _uris)
 	{
-	  DataEl<DDTxt> dtxt;
+	  DataEl<DDTxt> dtxt(this->_input_timeout);
 	  dtxt._ctype._ctfc = this;
 	  if (dtxt.read_element(u,this->_logger) || (_txt.empty() && _db_fname.empty()))
 	    {

--- a/src/utils/httpclient.hpp
+++ b/src/utils/httpclient.hpp
@@ -30,15 +30,18 @@
 namespace dd
 {
 
+  static int _default_timeout = 600; // 10 mins
+  static int _max_timeout = 6000; // 10 hours
+  
   class httpclient
   {
   public:
     static void get_call(const std::string &url,
 			 const std::string &http_method,
 			 int &outcode,
-			 std::string &outstr)
+			 std::string &outstr,
+			 const int &timeout=_default_timeout)
     {
-      curlpp::Cleanup cl;
       std::ostringstream os;
       curlpp::Easy request;
       curlpp::options::WriteStream ws(&os);
@@ -47,9 +50,14 @@ namespace dd
       request.setOpt(ws);
       request.setOpt(pr);
       request.setOpt(cURLpp::Options::FollowLocation(true));
+      if (timeout > _max_timeout)
+	{
+	  outcode = 400;
+	  throw std::runtime_error("timeout value is above max default timeout (6000)");
+	}
+      request.setOpt(cURLpp::Options::Timeout(timeout));
       request.perform();
       outstr = os.str();
-      //std::cout << "outstr=" << outstr << std::endl;
       outcode = curlpp::infos::ResponseCode::get(request);
     }
     
@@ -60,7 +68,6 @@ namespace dd
 			  std::string &outstr,
 			  const std::string &content_type="Content-Type: application/json")
     {
-      curlpp::Cleanup cl;
       std::ostringstream os;
       curlpp::Easy request_put;
       curlpp::options::WriteStream ws(&os);
@@ -78,7 +85,6 @@ namespace dd
       //std::cout << "outstr=" << outstr << std::endl;
       outcode = curlpp::infos::ResponseCode::get(request_put);
     }
-    
   };
   
 }

--- a/src/utils/httpclient.hpp
+++ b/src/utils/httpclient.hpp
@@ -53,7 +53,7 @@ namespace dd
       if (timeout > _max_timeout)
 	{
 	  outcode = 400;
-	  throw std::runtime_error("timeout value is above max default timeout (6000)");
+	  throw std::runtime_error("timeout value is above max default timeout (" + std::to_string(_max_timeout) + ")");
 	}
       request.setOpt(cURLpp::Options::Timeout(timeout));
       request.perform();

--- a/src/utils/httpclient.hpp
+++ b/src/utils/httpclient.hpp
@@ -31,7 +31,7 @@ namespace dd
 {
 
   static int _default_timeout = 600; // 10 mins
-  static int _max_timeout = 6000; // 10 hours
+  static int _max_timeout = 36000; // 10 hours
   
   class httpclient
   {


### PR DESCRIPTION
This PR adds timeout control to the input connector, via `parameters.input.timeout`:
- at service creation, and stays the default value through the service's life
- can be overridden with every `/predict` call

Additional elements:
- default timeout is set to 600 seconds (10 mins)
- there's a max timeout value set to 36000 seconds (10 hours), any timeout set above that threshold leads to a 400 error. 