### PR TITLE
Add mutex to TensorRT prediction calls

### DIFF
--- a/src/backends/tensorrt/tensorrtlib.cc
+++ b/src/backends/tensorrt/tensorrtlib.cc
@@ -227,6 +227,8 @@ namespace dd
   int TensorRTLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::predict(const APIData &ad,
                                                                                       APIData &out)
   {
+    std::lock_guard<std::mutex> lock(_net_mutex); // no concurrent calls since the net is not re-instantiated
+    
     APIData ad_output = ad.getobj("parameters").getobj("output");    
     int blank_label = -1;
     std::string out_blob = "prob";

--- a/src/backends/tensorrt/tensorrtlib.h
+++ b/src/backends/tensorrt/tensorrtlib.h
@@ -142,6 +142,8 @@ namespace dd
 
     std::vector<float> _floatOut;
     std::vector<int> _keepCount;
+
+    std::mutex _net_mutex; /**< mutex around net, e.g. no concurrent predict calls as net is not re-instantiated. Use batches instead. */
     };
 
 }


### PR DESCRIPTION
This protects against parallel calls that may fill the GPU memory up. Batches should be used instead.