### PR TITLE
Chains: avoid encoding + serializing crops, passing raw cv::Mat instead

### DIFF
--- a/src/chain_actions.cc
+++ b/src/chain_actions.cc
@@ -94,7 +94,7 @@ namespace dd
 		  std::string puri = dd_utils::split(uri,'/').back();
 		  cv::imwrite("crop_" + puri + "_" + std::to_string(j) + ".png",cropped_img);
 		}
-	      cropped_imgs.push_back(cropped_img);
+	      cropped_imgs.push_back(std::move(cropped_img));
 	    }
 	  APIData ccls;
 	  ccls.add("uri",uri);

--- a/src/chain_actions.cc
+++ b/src/chain_actions.cc
@@ -33,7 +33,7 @@ namespace dd
       std::vector<APIData> vad = model_out.getv("predictions");
       std::vector<cv::Mat> imgs = model_out.getobj("input").get("imgs").get<std::vector<cv::Mat>>();
       std::vector<std::pair<int,int>> imgs_size = model_out.getobj("input").get("imgs_size").get<std::vector<std::pair<int,int>>>();
-      std::vector<std::string> cropped_imgs;
+      std::vector<cv::Mat> cropped_imgs;
       std::vector<std::string> bbox_ids;
 
       // check for action parameters
@@ -94,14 +94,7 @@ namespace dd
 		  std::string puri = dd_utils::split(uri,'/').back();
 		  cv::imwrite("crop_" + puri + "_" + std::to_string(j) + ".png",cropped_img);
 		}
-	      
-	      // serialize crop into string (will be auto read by read_element in imginputconn)
-	      std::vector<unsigned char> cropped_img_ser;
-	      bool str_encoding = cv::imencode(".bmp",cropped_img,cropped_img_ser);
-	      if (!str_encoding)
-		throw ActionInternalException("crop encoding error for uri " + uri);
-	      std::string cropped_img_str = std::string(cropped_img_ser.begin(),cropped_img_ser.end());
-	      cropped_imgs.push_back(cropped_img_str);
+	      cropped_imgs.push_back(cropped_img);
 	    }
 	  APIData ccls;
 	  ccls.add("uri",uri);
@@ -112,7 +105,7 @@ namespace dd
 	}
       // store serialized crops into action output store
       APIData action_out;
-      action_out.add("data",cropped_imgs);
+      action_out.add("data_raw_img",cropped_imgs);
       action_out.add("cids",bbox_ids);
       cdata.add_action_data(_action_id,action_out);      
       

--- a/src/imginputfileconn.h
+++ b/src/imginputfileconn.h
@@ -32,6 +32,7 @@
 #define CV_LOAD_IMAGE_GRAYSCALE cv::IMREAD_GRAYSCALE
 #define CV_LOAD_IMAGE_UNCHANGED cv::IMREAD_UNCHANGED
 #define CV_BGR2RGB cv::COLOR_BGR2RGB
+#define CV_BGR2GRAY cv::COLOR_BGR2GRAY
 #define CV_INTER_CUBIC cv::INTER_CUBIC
 #endif
 #include "ext/base64/base64.h"
@@ -511,6 +512,12 @@ namespace dd
 	    {
 	      cv::Mat rimg;
 	      resize(img,rimg,cv::Size(_width,_height),0,0);
+	      if (_bw)
+		{
+		  cv::Mat bwimg;
+		  cv::cvtColor(rimg, bwimg, CV_BGR2GRAY);
+		  rimg = bwimg;
+		}
 	      _images_size.push_back(std::pair<int,int>(img.rows,img.cols));
 	      if (_keep_orig)
 		_orig_images.push_back(std::move(img));

--- a/src/imginputfileconn.h
+++ b/src/imginputfileconn.h
@@ -523,6 +523,11 @@ namespace dd
 		_orig_images.push_back(std::move(img));
 	      if (!_ids.empty())
 		uris.push_back(_ids.at(i));
+	      else
+		{
+		  _ids.push_back(std::to_string(i));
+		  uris.push_back(_ids.back());
+		}
 	      rimgs.push_back(std::move(rimg));
 	      ++i;
 	    }

--- a/src/services.h
+++ b/src/services.h
@@ -658,7 +658,14 @@ namespace dd
 	      spdlog::drop(cname);
 	      throw InputConnectorBadParamException("no action data for action id " + parent_id);
 	    }
-	  adc.add("data",act_data.get("data").get<std::vector<std::string>>()); // action output data must be string for now (more types to be supported / auto-detected)
+	  if (act_data.has("data"))
+	    {
+	      adc.add("data",act_data.get("data").get<std::vector<std::string>>()); // action output data must be string for now (more types to be supported / auto-detected)
+	    }
+	  else if (act_data.has("data_raw_img")) // raw images
+	    {
+	      adc.add("data_raw_img",act_data.get("data_raw_img").get<std::vector<cv::Mat>>());
+	    }
 	  adc.add("ids",act_data.get("cids").get<std::vector<std::string>>()); // chain ids of processed elements
 	  adc.add("meta_uris",meta_uris);
 	  adc.add("index_uris",index_uris);


### PR DESCRIPTION
This PR should speed up chains with many crops, removing the encoding and serializing steps.