### PR TITLE
Pytorch inference fixes

### DIFF
--- a/src/backends/torch/torchinputconns.h
+++ b/src/backends/torch/torchinputconns.h
@@ -93,9 +93,19 @@ namespace dd
                 {
                     APIData input_ad = ad_param.getobj("input");
                     if (input_ad.has("std"))
-                        _std = input_ad.get("std").get<double>();
-                }
-            }
+		      {
+			try
+			  {
+			    _std = input_ad.get("std").get<double>();
+			  }
+			catch (std::exception&)
+			  {
+			    // try from int
+			    _std = input_ad.get("std").get<int>();
+			  }
+		      }
+		}
+	    }
 
             std::vector<at::Tensor> tensors;
             std::vector<int64_t> sizes{ _height, _width, 3 };

--- a/src/backends/torch/torchinputconns.h
+++ b/src/backends/torch/torchinputconns.h
@@ -85,28 +85,7 @@ namespace dd
             {
                 throw;
             }
-
-            if (ad.has("parameters"))
-            {
-                APIData ad_param = ad.getobj("parameters");
-                if (ad_param.has("input"))
-                {
-                    APIData input_ad = ad_param.getobj("input");
-                    if (input_ad.has("std"))
-		      {
-			try
-			  {
-			    _std = input_ad.get("std").get<double>();
-			  }
-			catch (std::exception&)
-			  {
-			    // try from int
-			    _std = input_ad.get("std").get<int>();
-			  }
-		      }
-		}
-	    }
-
+	    
             std::vector<at::Tensor> tensors;
             std::vector<int64_t> sizes{ _height, _width, 3 };
             at::TensorOptions options(at::ScalarType::Byte);
@@ -114,8 +93,17 @@ namespace dd
             for (const cv::Mat &bgr : this->_images) {
                 at::Tensor imgt = torch::from_blob(bgr.data, at::IntList(sizes), options);
                 imgt = imgt.toType(at::kFloat).permute({2, 0, 1});
-                if (_std != 1.0)
-                    imgt = imgt.mul(1. / _std);
+		size_t nchannels = imgt.size(0);
+		if (_scale != 1.0)
+		  imgt = imgt.mul(_scale);
+		if (!_mean.empty() && _mean.size() != nchannels)
+		  throw InputConnectorBadParamException("mean vector be of size the number of channels (" + std::to_string(nchannels) + ")");
+		for (size_t m=0;m<_mean.size();m++)
+		  imgt[0][m] = imgt[0][m].sub_(_mean.at(m));
+		if (!_std.empty() && _std.size() != nchannels)
+		  throw InputConnectorBadParamException("std vector be of size the number of channels (" + std::to_string(nchannels) + ")");
+		for (size_t s=0;s<_std.size();s++)
+		  imgt[0][s] = imgt[0][s].div_(_std.at(s));
                 tensors.push_back(imgt);
             }
 
@@ -124,8 +112,6 @@ namespace dd
 
     public:
         at::Tensor _in;
-
-        double _std = 1.0;
     };
 
 

--- a/src/backends/torch/torchlib.cc
+++ b/src/backends/torch/torchlib.cc
@@ -75,7 +75,15 @@ namespace dd
             _attention = true;
         }
 
-        _traced = torch::jit::load(this->_mlmodel._model_file, _device);
+	try
+	  {
+	    _traced = torch::jit::load(this->_mlmodel._model_file, _device);
+	  }
+	catch (std::exception&)
+	  {
+	    throw MLLibBadParamException("failed loading torch model file " + this->_mlmodel._model_file);
+	  }
+	
         _traced->eval();
     }
 

--- a/src/backends/torch/torchlib.cc
+++ b/src/backends/torch/torchlib.cc
@@ -136,36 +136,33 @@ namespace dd
         // Output
         std::vector<APIData> results_ads;
 
-        if (output_params.has("best"))
-        {
-            const int best_count = output_params.get("best").get<int>();
-            std::tuple<Tensor, Tensor> sorted_output = output.sort(1, true);
-            auto probs_acc = std::get<0>(sorted_output).accessor<float,2>();
-            auto indices_acc = std::get<1>(sorted_output).accessor<int64_t,2>();
+	// classification
+	std::tuple<Tensor, Tensor> sorted_output = output.sort(1, true);
+	auto probs_acc = std::get<0>(sorted_output).accessor<float,2>();
+	auto indices_acc = std::get<1>(sorted_output).accessor<int64_t,2>();
 
-            for (int i = 0; i < output.size(0); ++i)
-            {
-                APIData results_ad;
-                std::vector<double> probs;
-                std::vector<std::string> cats;
+	for (int i = 0; i < output.size(0); ++i)
+	  {
+	    APIData results_ad;
+	    std::vector<double> probs;
+	    std::vector<std::string> cats;
+	    
+	    for (int j = 0; j < probs_acc.size(1); ++j)
+	      {
+		probs.push_back(probs_acc[i][j]);
+		int index = indices_acc[i][j];
+		cats.push_back(this->_mlmodel.get_hcorresp(index));
+	      }
+	    
+	    results_ad.add("uri", inputc._uris.at(results_ads.size()));
+	    results_ad.add("loss", 0.0);
+	    results_ad.add("cats", cats);
+	    results_ad.add("probs", probs);
+	    
+	    results_ads.push_back(results_ad);
+	  }
 
-                for (int j = 0; j < best_count; ++j)
-                {
-                    probs.push_back(probs_acc[i][j]);
-                    int index = indices_acc[i][j];
-                    cats.push_back(this->_mlmodel.get_hcorresp(index));
-                }
-
-                results_ad.add("uri", inputc._uris.at(results_ads.size()));
-                results_ad.add("loss", 0.0);
-                results_ad.add("cats", cats);
-                results_ad.add("probs", probs);
-                results_ad.add("nclasses", _nclasses);
-
-                results_ads.push_back(results_ad);
-            }
-        }
-
+	out.add("nclasses",static_cast<int>(probs_acc.size(1)));
         outputc.add_results(results_ads);
         outputc.finalize(output_params, out, static_cast<MLModel*>(&this->_mlmodel));
 

--- a/src/backends/torch/torchlib.cc
+++ b/src/backends/torch/torchlib.cc
@@ -90,13 +90,13 @@ namespace dd
     template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
     void TorchLib<TInputConnectorStrategy, TOutputConnectorStrategy, TMLModel>::clear_mllib(const APIData &ad) 
     {
-
+      (void)ad;
     }
 
     template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
     int TorchLib<TInputConnectorStrategy, TOutputConnectorStrategy, TMLModel>::train(const APIData &ad, APIData &out) 
     {
-        
+      (void)out;
     }
 
     template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>

--- a/tests/ut-torchapi.cc
+++ b/tests/ut-torchapi.cc
@@ -41,12 +41,12 @@ TEST(torchapi, service_predict)
     // create service
     JsonAPI japi;
     std::string sname = "imgserv";
-    std::string jstr = "{\"mllib\":\"torch\",\"description\":\"resnet-50\",\"type\":\"supervised\",\"model\":{\"repository\":\"" +  incept_repo + "\"},\"parameters\":{\"input\":{\"connector\":\"image\",\"height\":224,\"width\":224,\"rgb\":true,\"std\":255.0}}}";
+    std::string jstr = "{\"mllib\":\"torch\",\"description\":\"resnet-50\",\"type\":\"supervised\",\"model\":{\"repository\":\"" +  incept_repo + "\"},\"parameters\":{\"input\":{\"connector\":\"image\",\"height\":224,\"width\":224,\"rgb\":true,\"scale\":0.0039}}}";
     std::string joutstr = japi.jrender(japi.service_create(sname,jstr));
     ASSERT_EQ(created_str,joutstr);
 
     // predict
-    std::string jpredictstr = "{\"service\":\"imgserv\",\"parameters\":{\"input\":{\"height\":224,\"width\":224,\"rgb\":true,\"std\":255.0},\"output\":{\"best\":1}},\"data\":[\"" + incept_repo + "cat.jpg\"]}";
+    std::string jpredictstr = "{\"service\":\"imgserv\",\"parameters\":{\"input\":{\"height\":224,\"width\":224,\"rgb\":true,\"scale\":0.0039},\"output\":{\"best\":1}},\"data\":[\"" + incept_repo + "cat.jpg\"]}";
     joutstr = japi.jrender(japi.service_predict(jpredictstr));
     JDoc jd;
     std::cout << "joutstr=" << joutstr << std::endl;


### PR DESCRIPTION
Small fixes and improvements to torch model inference:
- return all classes with `"best":-1`
- cleaner error message when model location is wrong
- allowing `std` as a vector of `float`
- introducing `scale` as an option to scale the image values

The torch image classification model service creation and prediction become:
- service creation
```json
curl -X PUT "http://localhost:8080/services/torch_resnet" -d '{
    "description": "image classification service",
    "mllib": "torch",
    "model": {
        "repository": "/path/to/resnet50_torch/"
    },                   
    "parameters": {
        "input": {                                                            
            "connector": "image"
        },"mllib":{}
    },              
    "type": "supervised"
}     
'
```
- prediction 
```json
curl -X POST "http://localhost:8080/predict" -d '{
    "service": "torch_resnet",
    "parameters": {
        "input": {
            "width":224,
            "height":224,
            "rgb":true,
            "scale":0.004,"mean":[0.485,0.456,0.406],"std":[0.229,0.224,0.225]
        },"mllib":{"gpu":true,"gpuid":0},
        "output": {
            "best":3
        }
    },
    "data":["/path/to/cat.jpg"]
}
'
```
This is using the `mean` and `std` values from https://pytorch.org/docs/stable/torchvision/models.html
```

```