### PR TITLE
Image rotation action, usable in `chains`

### DIFF
--- a/src/chain_actions.cc
+++ b/src/chain_actions.cc
@@ -49,6 +49,10 @@ namespace dd
       if (_params.has("save_crops"))
 	save_crops = _params.get("save_crops").get<bool>();
 
+      std::string save_path;
+      if (_params.has("save_path"))
+	save_path = _params.get("save_path").get<std::string>() + "/";
+      
       // iterate image batch
       for (size_t i=0;i<vad.size();i++)
 	{
@@ -95,7 +99,7 @@ namespace dd
 	      if (save_crops)
 		{
 		  std::string puri = dd_utils::split(uri,'/').back();
-		  cv::imwrite("crop_" + puri + "_" + std::to_string(j) + ".png",cropped_img);
+		  cv::imwrite(save_path + "crop_" + puri + "_" + std::to_string(j) + ".png",cropped_img);
 		}
 	      cropped_imgs.push_back(std::move(cropped_img));
 	    }

--- a/src/chain_actions.cc
+++ b/src/chain_actions.cc
@@ -106,7 +106,7 @@ namespace dd
 	  ccls.add("classes",cad_cls);
 	  cvad.push_back(ccls);
 	}
-      // store serialized crops into action output store
+      // store crops into action output store
       APIData action_out;
       action_out.add("data_raw_img",cropped_imgs);
       action_out.add("cids",bbox_ids);
@@ -116,6 +116,58 @@ namespace dd
       model_out.add("predictions",cvad);
     }
 
+  void ImgsRotateAction::apply(APIData &model_out,
+			       ChainData &cdata)
+  {
+    // get label
+    std::vector<APIData> vad = model_out.getv("predictions");
+    std::vector<cv::Mat> imgs = model_out.getobj("input").get("imgs").get<std::vector<cv::Mat>>();
+    std::vector<std::pair<int,int>> imgs_size = model_out.getobj("input").get("imgs_size").get<std::vector<std::pair<int,int>>>();
+    std::vector<cv::Mat> rimgs;
+    std::vector<std::string> uris;
+    
+    //std::vector<APIData> cvad;
+    for (size_t i=0;i<vad.size();i++) // iterate predictions
+      {
+	std::string uri = vad.at(i).get("uri").get<std::string>();
+	uris.push_back(uri);
+	cv::Mat img = imgs.at(i);
+	std::vector<APIData> ad_cls = vad.at(i).getv("classes");
+	std::vector<APIData> cad_cls;
+
+	// rotate and make image available to next service
+	if (ad_cls.size() > 0)
+	  {
+	    std::string cat1 = ad_cls.at(0).get("cat").get<std::string>();
+	    cv::Mat rimg, timg;
+	    if (cat1 == "0")
+	      {
+		rimg = img;
+	      }
+	    else if (cat1 == "90")
+	      {
+		cv::transpose(img,timg);
+		cv::flip(timg,rimg,1);
+	      }
+	    else if (cat1 == "180")
+	      {
+		cv::flip(img,rimg,-1);
+	      }
+	    else if (cat1 == "270")
+	      {
+		cv::transpose(img,timg);
+		cv::flip(timg,rimg,0);
+	      }
+	    rimgs.push_back(rimg);
+	  }
+      }
+    // store rotated images into action output store
+    APIData action_out;
+    action_out.add("data_raw_img",rimgs);
+    action_out.add("cids",uris);
+    cdata.add_action_data(_action_id,action_out);
+  }
+  
   void ClassFilter::apply(APIData &model_out,
 			  ChainData &cdata)
   {
@@ -168,19 +220,27 @@ namespace dd
     if (_adc.has("id"))
         action_id = _adc.get("id").get<std::string>();
     else action_id = std::to_string(cdata._action_data.size());
-    if (action_type == "crop") {
+    if (action_type == "crop")
+      {
         ImgsCropAction act(_adc, action_id, action_type);
         act.apply(model_out, cdata);
-    } else if (action_type == "filter") {
+      }
+    else if (action_type == "rotate")
+      {
+	ImgsRotateAction act(_adc,action_id,action_type);
+	act.apply(model_out,cdata);
+      }
+    else if (action_type == "filter")
+      {
         ClassFilter act(_adc, action_id, action_type);
         act.apply(model_out, cdata);
-    }
+      }
 #ifdef USE_DLIB
-        else if (action_type == "dlib_align_crop")
-{
-DlibAlignCropAction act(_adc,action_id,action_type);
-act.apply(model_out,cdata);
-}
+    else if (action_type == "dlib_align_crop")
+      {
+	DlibAlignCropAction act(_adc,action_id,action_type);
+	act.apply(model_out,cdata);
+      }
 #endif
     else {
         throw ActionBadParamException("unknown action " + action_type);

--- a/src/chain_actions.cc
+++ b/src/chain_actions.cc
@@ -134,6 +134,14 @@ namespace dd
     std::string orientation = "relative"; // other: absolute
     if (_params.has("orientation"))
       orientation = _params.get("orientation").get<std::string>();
+
+    bool save_img = false;
+    if (_params.has("save_img"))
+      save_img = _params.get("save_img").get<bool>();
+
+    std::string save_path;
+    if (_params.has("save_path"))
+      save_path = _params.get("save_path").get<std::string>() + "/";
     
     for (size_t i=0;i<vad.size();i++) // iterate predictions
       {
@@ -173,7 +181,16 @@ namespace dd
 		cv::flip(timg,rimg,orient);
 	      }
 	    if (!rimg.empty())
-	      rimgs.push_back(rimg);
+	      {
+		rimgs.push_back(rimg);
+
+		// save image if requested
+		if (save_img)
+		  {
+		    std::string puri = dd_utils::split(uri,'/').back();
+		    cv::imwrite(save_path + "rot_" + puri + "_" + cat1 + ".png",rimg);
+		  }
+	      }
 	  }
       }
     // store rotated images into action output store

--- a/src/chain_actions.h
+++ b/src/chain_actions.h
@@ -94,6 +94,20 @@ namespace dd
 	       ChainData &cdata);
   };
 
+  class ImgsRotateAction : public ChainAction
+  {
+  public:
+    ImgsRotateAction(const APIData &adc,
+		     const std::string &action_id,
+		     const std::string &action_type)
+      :ChainAction(adc,action_id,action_type) {}
+
+    ~ImgsRotateAction() {}
+    
+    void apply(APIData &model_out,
+	       ChainData &cdata);
+  };
+  
   class ClassFilter : public ChainAction
   {
   public:
@@ -117,7 +131,7 @@ namespace dd
     void apply_action(const std::string &action_type,
 		      APIData &model_out,
 		      ChainData &cdata);
-
+    
     APIData _adc; /**< action ad object. */
   };
   


### PR DESCRIPTION
Image rotation action, typically useful prior to an OCR model that requires an element with text is correctly rotated. 

The `rotate` action is to be used as follows:

- within a chain:
```
{                                                                                                     
                 "action": {                                                                                          
                     "type": "rotate"                                                                                 
                 }                                                                                                    
}
```

- action takes the output label of a classifier model that **must** be one of the following strings: `["0","90","180","270"]` as the rotation angle in degrees. The output of the action is then the image (or object crop depending on the chain) rotated by the angle predicted by the model.

- action has parameter `orientation` with values as `"relative"` (default) or `"absolute"`:
  - `"relative"`: the output orientation label yields the image/crop orientation, e.g. 90, and must be corrected relative to this value in order to get rotate to 0, e.g. with -90 = 270 rotation.
  - `"absolute"`: the output orientation is the command to the rotation to be applied.

