### PR TITLE
Update to docker files

### DIFF
--- a/docker/cpu-caffe-tf/Dockerfile
+++ b/docker/cpu-caffe-tf/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:16.04
 
 RUN echo 'building CPU DeepDetect image'
 
-MAINTAINER Emmanuel Benazera "beniz@droidnik.fr"
+MAINTAINER Emmanuel Benazera "emmanuel.benazera@jolibrain.com"
 LABEL description="DeepDetect deep learning server & API / CPU version"
 
 RUN ln -sf /dev/stdout /var/log/deepdetect.log
@@ -41,6 +41,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   autoconf \
   libtool-bin \
   python-numpy \
+  python-future \
   swig \
   python-dev \
   python-setuptools \
@@ -55,7 +56,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   bash-completion \
   libspdlog-dev \
   ca-certificates && \
-  wget -O /tmp/bazel.deb https://github.com/bazelbuild/bazel/releases/download/0.21.0/bazel_0.21.0-linux-x86_64.deb && \
+  wget -O /tmp/bazel.deb https://github.com/bazelbuild/bazel/releases/download/0.24.1/bazel_0.24.1-linux-x86_64.deb && \
   dpkg -i /tmp/bazel.deb && \
   apt-get remove -y libcurlpp0 && \
   apt-get clean && \
@@ -71,10 +72,10 @@ RUN wget -O /opt/curlpp-v0.8.1.zip https://github.com/jpbarrette/curlpp/archive/
     cd /opt && \
     rm -rf curlpp-0.8.1 curlpp-v0.8.1.zip
 
-RUN git clone https://github.com/beniz/deepdetect.git && cd deepdetect && mkdir build
+RUN git clone https://github.com/jolibrain/deepdetect.git && cd deepdetect && mkdir build
 
 WORKDIR /opt/deepdetect/build
-RUN cmake .. -DUSE_TF=ON -DUSE_TF_CPU_ONLY=ON -DUSE_SIMSEARCH=ON -DUSE_TSNE=ON -DUSE_NCNN=ON && \
+RUN cmake .. -DUSE_TF=ON -DUSE_TF_CPU_ONLY=ON -DUSE_SIMSEARCH=ON -DUSE_TSNE=ON -DUSE_NCNN=OFF && \
     make
 
 # external volume to be mapped, e.g. for models or training data

--- a/docker/cpu-ncnn-pi3/Dockerfile
+++ b/docker/cpu-ncnn-pi3/Dockerfile
@@ -2,7 +2,7 @@ FROM armv7/armhf-ubuntu:16.04
 
 RUN echo 'Building CPU NCNN RPi3 DeepDetect image'
 
-MAINTAINER Emmanuel Benazera "beniz@droidnik.fr"
+MAINTAINER Emmanuel Benazera "emmanuel.benazera@jolibrain.com"
 LABEL description="DeepDetect deep learning server & API / CPU NCNN-only RPi3 version"
 
 RUN ln -sf /dev/stdout /var/log/deepdetect.log

--- a/docker/cpu/Dockerfile
+++ b/docker/cpu/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:16.04
 
 RUN echo 'building CPU DeepDetect image'
 
-MAINTAINER Emmanuel Benazera "beniz@droidnik.fr"
+MAINTAINER Emmanuel Benazera "emmanuel.benazera@jolibrain.com"
 LABEL description="DeepDetect deep learning server & API / CPU version"
 
 RUN ln -sf /dev/stdout /var/log/deepdetect.log
@@ -20,7 +20,7 @@ RUN make install
 RUN cp /usr/local/lib/libcurlpp.* /usr/lib/
 
 WORKDIR /opt
-RUN git clone https://github.com/beniz/deepdetect.git && cd deepdetect && mkdir build
+RUN git clone https://github.com/jolibrain/deepdetect.git && cd deepdetect && mkdir build
 
 WORKDIR /opt/deepdetect/build
 RUN cmake .. -DUSE_XGBOOST=ON -DUSE_SIMSEARCH=ON -DUSE_TSNE=ON -DUSE_NCNN=ON

--- a/docker/gpu-caffe-cpu-tf/Dockerfile
+++ b/docker/gpu-caffe-cpu-tf/Dockerfile
@@ -1,8 +1,8 @@
-FROM nvidia/cuda:8.0-cudnn7-devel-ubuntu16.04
+FROM nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04
 
 RUN echo 'building GPU DeepDetect image'
 
-MAINTAINER Emmanuel Benazera "beniz@droidnik.fr"
+MAINTAINER Emmanuel Benazera "emmanuel.benazera@jolibrain.com"
 
 LABEL description="DeepDetect deep learning server & API / GPU version"
 
@@ -79,7 +79,7 @@ RUN if [ ! -f /usr/local/cuda/include/cudnn.h -a -f /usr/include/cudnn.h ]; then
     if [ ! -f /usr/local/cuda/lib64/libcudnn.so -a -f /usr/lib/x86_64-linux-gnu/libcudnn.so ]; then ln -s /usr/lib/x86_64-linux-gnu/libcudnn* /usr/local/cuda/lib64/; fi
 
 WORKDIR /opt
-RUN git clone https://github.com/beniz/deepdetect.git && cd deepdetect && mkdir build
+RUN git clone https://github.com/jolibrain/deepdetect.git && cd deepdetect && mkdir build
 
 WORKDIR /opt/deepdetect/build
 RUN export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64

--- a/docker/gpu-caffe-tf/Dockerfile
+++ b/docker/gpu-caffe-tf/Dockerfile
@@ -1,8 +1,8 @@
-FROM nvidia/cuda:8.0-cudnn7-devel-ubuntu16.04
+FROM nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04
 
 RUN echo 'building GPU DeepDetect image'
 
-MAINTAINER Emmanuel Benazera "beniz@droidnik.fr"
+MAINTAINER Emmanuel Benazera "emmanuel.benazera@jolibrain.com"
 
 LABEL description="DeepDetect deep learning server & API / GPU version"
 
@@ -56,7 +56,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   libspdlog-dev \
   bash-completion \
   ca-certificates && \
-  wget -O /tmp/bazel.deb https://github.com/bazelbuild/bazel/releases/download/0.21.0/bazel_0.21.0-linux-x86_64.deb && \
+  wget -O /tmp/bazel.deb https://github.com/bazelbuild/bazel/releases/download/0.24.1/bazel_0.24.1-linux-x86_64.deb && \
   dpkg -i /tmp/bazel.deb && \
   apt-get remove -y libcurlpp0 && \
   apt-get clean && \
@@ -77,7 +77,7 @@ RUN if [ ! -f /usr/local/cuda/include/cudnn.h -a -f /usr/include/cudnn.h ]; then
     if [ ! -f /usr/local/cuda/lib64/libcudnn.so -a -f /usr/lib/x86_64-linux-gnu/libcudnn.so ]; then ln -s /usr/lib/x86_64-linux-gnu/libcudnn* /usr/local/cuda/lib64/; fi
 
 WORKDIR /opt
-RUN git clone https://github.com/beniz/deepdetect.git && cd deepdetect && mkdir build
+RUN git clone https://github.com/jolibrain/deepdetect.git && cd deepdetect && mkdir build
 
 WORKDIR /opt/deepdetect/build
 RUN export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64

--- a/docker/gpu-caffe2/Dockerfile
+++ b/docker/gpu-caffe2/Dockerfile
@@ -1,8 +1,8 @@
-FROM nvidia/cuda:8.0-cudnn7-devel
+FROM nvidia/cuda:9.0-cudnn7-devel
 
 RUN echo 'building GPU DeepDetect image'
 
-MAINTAINER Emmanuel Benazera "beniz@droidnik.fr"
+MAINTAINER Emmanuel Benazera "emmanuel.benazera@jolibrain.com"
 
 LABEL description="DeepDetect deep learning server & API / GPU version"
 
@@ -25,7 +25,7 @@ RUN make install
 RUN cp /usr/local/lib/libcurlpp.* /usr/lib/
 
 WORKDIR /opt
-RUN git clone https://github.com/beniz/deepdetect.git && cd deepdetect && mkdir build
+RUN git clone https://github.com/jolibrain/deepdetect.git && cd deepdetect && mkdir build
 
 WORKDIR /opt/deepdetect/build
 RUN cmake .. -DUSE_CUDNN=ON -DUSE_XGBOOST=ON -DUSE_SIMSEARCH=ON -DUSE_TSNE=ON -DUSE_CAFFE2=ON -DCUDA_ARCH="-gencode arch=compute_30,code=sm_30 -gencode arch=compute_35,code=sm_35 -gencode arch=compute_50,code=sm_50 -gencode arch=compute_52,code=sm_52 -gencode arch=compute_53,code=sm_53 -gencode arch=compute_61,code=sm_61 -gencode arch=compute_62,code=sm_62"

--- a/docker/gpu-p100/Dockerfile
+++ b/docker/gpu-p100/Dockerfile
@@ -2,7 +2,7 @@ FROM nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04
 
 RUN echo 'building GPU DeepDetect image'
 
-MAINTAINER Emmanuel Benazera "beniz@droidnik.fr"
+MAINTAINER Emmanuel Benazera "emmanuel.benazera@jolibrain.com"
 
 LABEL description="DeepDetect deep learning server & API / GPU version"
 
@@ -21,7 +21,7 @@ RUN make install
 RUN cp /usr/local/lib/libcurlpp.* /usr/lib/
 
 WORKDIR /opt
-RUN git clone https://github.com/beniz/deepdetect.git && cd deepdetect && mkdir build
+RUN git clone https://github.com/jolibrain/deepdetect.git && cd deepdetect && mkdir build
 
 WORKDIR /opt/deepdetect/build
 RUN cmake .. -DUSE_CUDNN=ON -DUSE_SIMSEARCH=ON -DUSE_TSNE=ON -DCUDA_ARCH="-gencode arch=compute_60,code=sm_60"

--- a/docker/gpu-volta/Dockerfile
+++ b/docker/gpu-volta/Dockerfile
@@ -2,7 +2,7 @@ FROM nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04
 
 RUN echo 'building GPU DeepDetect image'
 
-MAINTAINER Emmanuel Benazera "beniz@droidnik.fr"
+MAINTAINER Emmanuel Benazera "emmanuel.benazera@jolibrain.com"
 
 LABEL description="DeepDetect deep learning server & API / GPU version"
 
@@ -21,7 +21,7 @@ RUN make install
 RUN cp /usr/local/lib/libcurlpp.* /usr/lib/
 
 WORKDIR /opt
-RUN git clone https://github.com/beniz/deepdetect.git && cd deepdetect && mkdir build
+RUN git clone https://github.com/jolibrain/deepdetect.git && cd deepdetect && mkdir build
 
 WORKDIR /opt/deepdetect/build
 RUN cmake .. -DUSE_CUDNN=ON -DUSE_SIMSEARCH=ON -DUSE_TSNE=ON -DCUDA_ARCH="-gencode arch=compute_70,code=sm_70"

--- a/docker/gpu/Dockerfile
+++ b/docker/gpu/Dockerfile
@@ -1,8 +1,8 @@
-FROM nvidia/cuda:8.0-cudnn7-devel
+FROM nvidia/cuda:9.0-cudnn7-devel
 
 RUN echo 'building GPU DeepDetect image'
 
-MAINTAINER Emmanuel Benazera "beniz@droidnik.fr"
+MAINTAINER Emmanuel Benazera "emmanuel.benazera@jolibrain.com"
 
 LABEL description="DeepDetect deep learning server & API / GPU version"
 
@@ -21,7 +21,7 @@ RUN make install
 RUN cp /usr/local/lib/libcurlpp.* /usr/lib/
 
 WORKDIR /opt
-RUN git clone https://github.com/beniz/deepdetect.git && cd deepdetect && mkdir build
+RUN git clone https://github.com/jolibrain/deepdetect.git && cd deepdetect && mkdir build
 
 WORKDIR /opt/deepdetect/build
 RUN cmake .. -DUSE_CUDNN=ON -DUSE_XGBOOST=ON -DUSE_SIMSEARCH=ON -DUSE_TSNE=ON -DCUDA_ARCH="-gencode arch=compute_30,code=sm_30 -gencode arch=compute_35,code=sm_35 -gencode arch=compute_50,code=sm_50 -gencode arch=compute_52,code=sm_52 -gencode arch=compute_53,code=sm_53 -gencode arch=compute_61,code=sm_61 -gencode arch=compute_62,code=sm_62"


### PR DESCRIPTION
- Bazel version 0.24 for TF builds
- Maintainer name update
- All builds based on CUDA 9 to avoid unsupported ops in CUDA 8.