### PR TITLE
Fixed inversion of ymin and ymax in detection models output

### DIFF
--- a/src/backends/caffe/caffelib.cc
+++ b/src/backends/caffe/caffelib.cc
@@ -2557,9 +2557,9 @@ namespace dd
 			cats.push_back(this->_mlmodel.get_hcorresp(detection[1]));
 			APIData ad_bbox;
 			ad_bbox.add("xmin",static_cast<double>(detection[3]*(cols-1)));
-			ad_bbox.add("ymax",static_cast<double>(detection[4]*(rows-1)));
+			ad_bbox.add("ymin",static_cast<double>(detection[4]*(rows-1)));
 			ad_bbox.add("xmax",static_cast<double>(detection[5]*(cols-1)));
-			ad_bbox.add("ymin",static_cast<double>(detection[6]*(rows-1)));
+			ad_bbox.add("ymax",static_cast<double>(detection[6]*(rows-1)));
 			bboxes.push_back(ad_bbox);
 		      }
 		    if (leave)

--- a/src/backends/ncnn/ncnnlib.cc
+++ b/src/backends/ncnn/ncnnlib.cc
@@ -244,9 +244,9 @@ namespace dd
 
                 APIData ad_bbox;
                 ad_bbox.add("xmin",static_cast<double>(values[2] * inputc.width()));
-                ad_bbox.add("ymax",static_cast<double>(values[3] * inputc.height()));
+                ad_bbox.add("ymin",static_cast<double>(values[3] * inputc.height()));
                 ad_bbox.add("xmax",static_cast<double>(values[4] * inputc.width()));
-                ad_bbox.add("ymin",static_cast<double>(values[5] * inputc.height()));
+                ad_bbox.add("ymax",static_cast<double>(values[5] * inputc.height()));
                 bboxes.push_back(ad_bbox);
             }
         }

--- a/src/backends/tensorrt/tensorrtlib.cc
+++ b/src/backends/tensorrt/tensorrtlib.cc
@@ -564,9 +564,9 @@ namespace dd
 		    cats.push_back(this->_mlmodel.get_hcorresp(detection[1]));
 		    APIData ad_bbox;
 		    ad_bbox.add("xmin",static_cast<double>(detection[3]*(cols-1)));
-		    ad_bbox.add("ymax",static_cast<double>(detection[4]*(rows-1)));
+		    ad_bbox.add("ymin",static_cast<double>(detection[4]*(rows-1)));
 		    ad_bbox.add("xmax",static_cast<double>(detection[5]*(cols-1)));
-		    ad_bbox.add("ymin",static_cast<double>(detection[6]*(rows-1)));
+		    ad_bbox.add("ymax",static_cast<double>(detection[6]*(rows-1)));
 		    bboxes.push_back(ad_bbox);
 		  }
 		if (leave)

--- a/src/chain_actions.cc
+++ b/src/chain_actions.cc
@@ -82,16 +82,16 @@ namespace dd
 
 	      double cxmin = std::max(0.0,xmin-deltax);
 	      double cxmax = std::min(static_cast<double>(img.cols),xmax+deltax);
-	      double cymax = std::max(0.0,ymax-deltay);
-	      double cymin = std::min(static_cast<double>(img.rows),ymin+deltay);
+	      double cymin = std::max(0.0,ymin-deltay);
+	      double cymax = std::min(static_cast<double>(img.rows),ymax+deltay);
 
-	      if (cxmin > img.cols || cymax > img.rows || cxmax < 0 || cymin < 0)
+	      if (cxmin > img.cols || cymin > img.rows || cxmax < 0 || cymax < 0)
 		{
 		  _chain_logger->warn("bounding box does not intersect image, skipping crop action");
 		  continue;
 		}
 	      
-	      cv::Rect roi(cxmin,cymax,cxmax-cxmin,cymin-cymax);
+	      cv::Rect roi(cxmin,cymax,cxmax-cxmin,cymax-cymin);
 	      cv::Mat cropped_img = img(roi);
 
 	      // adding bbox id


### PR DESCRIPTION
FIX https://github.com/jolibrain/deepdetect/issues/674

- ymin and ymax were previoulsy swapped, ie ymin was > ymax 
- this patch correctly set ymin and ymax so that it respects caffe detection_ouput layer semantics as for instance in https://github.com/jolibrain/caffe/blob/master/src/caffe/layers/detection_output_layer.cpp#L368

- when using output of detection models, if ymin and ymax are used as is, then problems are to be exepcted, but if they are used with somthing like height = abs(ymin-ymax) , then this patch will not change anything. 