### PR TITLE
engine selection at service creation time : CAFFE of CUDNN

### DIFF
--- a/src/backends/caffe/caffelib.h
+++ b/src/backends/caffe/caffelib.h
@@ -195,13 +195,15 @@ namespace dd
        * @param has_class_weights whether training uses class weights
        * @param ignore_label label to be ignored, -1 otherwise
        * @param timesteps number of timesteps for recurrent models
+       * @param ad_mllib in order to change engine CUDNN vs CAFFE for cudnn memory consumption problems
        */
       void update_protofile_net(const std::string &net_file,
 				const std::string &deploy_file,
 				const TInputConnectorStrategy &inputc,
 				const bool &has_class_weights,
 				const int &ignore_label,
-				const int &timesteps);
+                const int &timesteps,
+                const APIData& ad_mllib);
 
       /**
        * \brief updates the softmax temperature
@@ -217,6 +219,9 @@ namespace dd
       
     private:
       void update_protofile_classes(caffe::NetParameter &net_param);
+
+      void update_protofile_engine(const APIData&ad);
+      void update_protofile_engine(caffe::NetParameter &net_param, const APIData&ad);
 
       void update_protofiles_one_hot(caffe::NetParameter &net_param);
 


### PR DESCRIPTION
this PR allows to select engine (cudnn or caffe (which is CPU or GPU depending on GPU availability)) at service creation time, for layers that can, ie conv, deconv, tanh, relu, sigmoid, pooling, lrn, and softmax.

 This is a workaround to memory over consumption / leakage seen with some models that do a _lot_ of cudnncreate 

if unset, use default, which is cudnn is deepdetect+caffe was compiled with -DUSE_CUDNN=ON , or caffe in other case

parameter is parameters.mllib.engine  , can be set to "CUDNN" or "CAFFE"



example: 
curl -X PUT http://localhost:8080/services/ocr -d '{
 "description": "ocr",
 "model": {
  "repository": "/home/infantes/airbusey_comp_ocr_resnext50_v4"
 },
 "mllib": "caffe",
 "type": "supervised",
 "parameters": {
  "input": {
   "connector": "image",
   "width":250,
   "height":200, "ctc":true, "bw":false, "db":true
  },
  "mllib" : {
     "nclasses":40, "finetuning": true,
     "rotate":false,
     "mirror":false,
     "scale":1,
     "engine": "CUDNN",
     "db":true,
     "noise": {
          "all_effects":true,
          "prob":0.01
     },
    "distort": {
        "all_effects":true,
        "prob":0.01
    },
    "geometry" : {
         "persp_horizontal":true,
         "persp_vertical":true,
         "zoom_out":true,
         "pad_mode":"constant",
         "prob":0.001
     },
     "gpu":true,
     "gpuid":1

  }
 }
}'