### PR TITLE
geometry image deformation for detection/ssd

### DIFF
--- a/src/backends/caffe/caffelib.h
+++ b/src/backends/caffe/caffelib.h
@@ -97,6 +97,8 @@ namespace dd
                                         caffe::NetParameter &net_param,
                                         caffe::NetParameter &dnet_param);
 
+      void configure_geometry_augmentation(const APIData &ad, caffe::TransformationParameter * trp);
+
     /**
      * \brief configure noise data augmentation in training template
      * @param ad the template data object


### PR DESCRIPTION
This PR adds passing geometric image deformation option to AnnotatedDataLayer when instanciating template. 
since https://github.com/jolibrain/caffe/pull/67 , annotatedDataLayer can deform image using zoom in/out, perspective change (right/left/top/bottom) and consistently deforms bboxes

TESTED OK