### PR TITLE
fix: force  caffe engine  when (de)conv dilation > 1

### DIFF
--- a/src/backends/caffe/caffelib.h
+++ b/src/backends/caffe/caffelib.h
@@ -222,8 +222,10 @@ namespace dd
     private:
       void update_protofile_classes(caffe::NetParameter &net_param);
 
+#ifdef USE_CUDNN
       void update_protofile_engine(const APIData&ad);
       void update_protofile_engine(caffe::NetParameter &net_param, const APIData&ad);
+#endif
 
       void update_protofiles_one_hot(caffe::NetParameter &net_param);
 


### PR DESCRIPTION
(de)conv with dilation > 1 in conjunction with cudnn engine option are rejected by caffe. this PR forces CAFFE engine for such cases even if cudnn is specifically asked for 

mllib.engine options are now:
"DEFAULT" : caffe default : ie CPU/CUDA/CUDNN depending on caffe compilation (and internally forces  CUDA/CPU if dilation > 1)
"CAFFE": force caffe engine, ie no cudnn (CPU or CUDA depending on caffe compilation)
"CUDNN": vanilla caffe cudnn implementation,(ie multiple_handle)
"CUDNN_SINGLE_HANDLE" : uses less memory than CUDNN
"CUDNN_MIN_MEMORY" : forces minimum memory algorithms

if dilation > 1, DEFAULT is forced on
