### PR TITLE
fixed model copy calls between directories (aka publishing) with deploy modified

### DIFF
--- a/src/backends/caffe/caffelib.cc
+++ b/src/backends/caffe/caffelib.cc
@@ -364,8 +364,8 @@ namespace dd
 	  configure_image_augmentation(ad,net_param);
 
 #ifdef USE_CUDNN
-    update_protofile_engine(net_param, ad);
-    update_protofile_engine(deploy_net_param, ad);
+	update_protofile_engine(net_param, ad);
+	update_protofile_engine(deploy_net_param, ad);
 #endif
 
 	// adapt number of neuron output
@@ -1027,6 +1027,13 @@ namespace dd
     if (_regression && multi) // multisoft case
       if (ad.has("nclasses"))
         _nclasses = ad.get("nclasses").get<int>();
+
+    // import model from existing directory upon request
+    if (ad.has("from_repository"))
+      this->_mlmodel.copy_to_target(ad.get("from_repository").get<std::string>(),
+				    this->_mlmodel._repo,
+				    this->_logger);
+    
     // instantiate model template here, if any
     if (ad.has("template") && ad.get("template").get<std::string>() != "")
       instantiate_template(ad);
@@ -1042,12 +1049,6 @@ namespace dd
     // the first present measure will be used to snapshot best model
     _best_metrics = {"map", "meaniou", "mlacc", "delta_score_0.1", "bacc", "f1", "net_meas", "acc", "L1_mean_error", "eucll"};
     _best_metric_value = std::numeric_limits<double>::infinity();
-
-    // import model from existing directory upon request
-    if (ad.has("from_repository"))
-      this->_mlmodel.copy_to_target(ad.get("from_repository").get<std::string>(),
-				    this->_mlmodel._repo,
-				    this->_logger);
   }
 
   template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
@@ -3437,7 +3438,7 @@ namespace dd
 	std::string deploy_file = this->_mlmodel._repo + "/deploy.prototxt";
 	caffe::NetParameter deploy_net_param;
 	caffe::ReadProtoFromTextFile(deploy_file,&deploy_net_param);
-    update_protofile_engine(deploy_net_param, ad);
+	update_protofile_engine(deploy_net_param, ad);
 	caffe::WriteProtoToTextFile(deploy_net_param,deploy_file);
 
     if (this->_mlmodel._model_template.empty())


### PR DESCRIPTION
This fixes a bug affecting model publication on DD platform with the new `engine` selection scheme #696 