### PR TITLE
Update PSPNet with ResNet-50

### DIFF
--- a/templates/caffe/pspnet_101/deploy.prototxt
+++ b/templates/caffe/pspnet_101/deploy.prototxt
@@ -32,7 +32,7 @@ layer {
   }
 }
 layer {
-  name: "conv1_1_3x3_s2/bn"
+  name: "conv1_1_3x3_s2/bnc"
   type: "BatchNorm"
   bottom: "conv1_1_3x3_s2"
   top: "conv1_1_3x3_s2"
@@ -76,7 +76,7 @@ layer {
   }
 }
 layer {
-  name: "conv1_2_3x3/bn"
+  name: "conv1_2_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv1_2_3x3"
   top: "conv1_2_3x3"
@@ -120,7 +120,7 @@ layer {
   }
 }
 layer {
-  name: "conv1_3_3x3/bn"
+  name: "conv1_3_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv1_3_3x3"
   top: "conv1_3_3x3"
@@ -176,7 +176,7 @@ layer {
   }
 }
 layer {
-  name: "conv2_1_1x1_reduce/bn"
+  name: "conv2_1_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv2_1_1x1_reduce"
   top: "conv2_1_1x1_reduce"
@@ -220,7 +220,7 @@ layer {
   }
 }
 layer {
-  name: "conv2_1_3x3/bn"
+  name: "conv2_1_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv2_1_3x3"
   top: "conv2_1_3x3"
@@ -264,7 +264,7 @@ layer {
   }
 }
 layer {
-  name: "conv2_1_1x1_increase/bn"
+  name: "conv2_1_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv2_1_1x1_increase"
   top: "conv2_1_1x1_increase"
@@ -302,7 +302,7 @@ layer {
   }
 }
 layer {
-  name: "conv2_1_1x1_proj/bn"
+  name: "conv2_1_1x1_proj/bnc"
   type: "BatchNorm"
   bottom: "conv2_1_1x1_proj"
   top: "conv2_1_1x1_proj"
@@ -356,7 +356,7 @@ layer {
   }
 }
 layer {
-  name: "conv2_2_1x1_reduce/bn"
+  name: "conv2_2_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv2_2_1x1_reduce"
   top: "conv2_2_1x1_reduce"
@@ -400,7 +400,7 @@ layer {
   }
 }
 layer {
-  name: "conv2_2_3x3/bn"
+  name: "conv2_2_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv2_2_3x3"
   top: "conv2_2_3x3"
@@ -444,7 +444,7 @@ layer {
   }
 }
 layer {
-  name: "conv2_2_1x1_increase/bn"
+  name: "conv2_2_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv2_2_1x1_increase"
   top: "conv2_2_1x1_increase"
@@ -498,7 +498,7 @@ layer {
   }
 }
 layer {
-  name: "conv2_3_1x1_reduce/bn"
+  name: "conv2_3_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv2_3_1x1_reduce"
   top: "conv2_3_1x1_reduce"
@@ -542,7 +542,7 @@ layer {
   }
 }
 layer {
-  name: "conv2_3_3x3/bn"
+  name: "conv2_3_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv2_3_3x3"
   top: "conv2_3_3x3"
@@ -586,7 +586,7 @@ layer {
   }
 }
 layer {
-  name: "conv2_3_1x1_increase/bn"
+  name: "conv2_3_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv2_3_1x1_increase"
   top: "conv2_3_1x1_increase"
@@ -640,7 +640,7 @@ layer {
   }
 }
 layer {
-  name: "conv3_1_1x1_reduce/bn"
+  name: "conv3_1_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv3_1_1x1_reduce"
   top: "conv3_1_1x1_reduce"
@@ -684,7 +684,7 @@ layer {
   }
 }
 layer {
-  name: "conv3_1_3x3/bn"
+  name: "conv3_1_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv3_1_3x3"
   top: "conv3_1_3x3"
@@ -728,7 +728,7 @@ layer {
   }
 }
 layer {
-  name: "conv3_1_1x1_increase/bn"
+  name: "conv3_1_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv3_1_1x1_increase"
   top: "conv3_1_1x1_increase"
@@ -766,7 +766,7 @@ layer {
   }
 }
 layer {
-  name: "conv3_1_1x1_proj/bn"
+  name: "conv3_1_1x1_proj/bnc"
   type: "BatchNorm"
   bottom: "conv3_1_1x1_proj"
   top: "conv3_1_1x1_proj"
@@ -820,7 +820,7 @@ layer {
   }
 }
 layer {
-  name: "conv3_2_1x1_reduce/bn"
+  name: "conv3_2_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv3_2_1x1_reduce"
   top: "conv3_2_1x1_reduce"
@@ -864,7 +864,7 @@ layer {
   }
 }
 layer {
-  name: "conv3_2_3x3/bn"
+  name: "conv3_2_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv3_2_3x3"
   top: "conv3_2_3x3"
@@ -908,7 +908,7 @@ layer {
   }
 }
 layer {
-  name: "conv3_2_1x1_increase/bn"
+  name: "conv3_2_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv3_2_1x1_increase"
   top: "conv3_2_1x1_increase"
@@ -962,7 +962,7 @@ layer {
   }
 }
 layer {
-  name: "conv3_3_1x1_reduce/bn"
+  name: "conv3_3_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv3_3_1x1_reduce"
   top: "conv3_3_1x1_reduce"
@@ -1006,7 +1006,7 @@ layer {
   }
 }
 layer {
-  name: "conv3_3_3x3/bn"
+  name: "conv3_3_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv3_3_3x3"
   top: "conv3_3_3x3"
@@ -1050,7 +1050,7 @@ layer {
   }
 }
 layer {
-  name: "conv3_3_1x1_increase/bn"
+  name: "conv3_3_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv3_3_1x1_increase"
   top: "conv3_3_1x1_increase"
@@ -1104,7 +1104,7 @@ layer {
   }
 }
 layer {
-  name: "conv3_4_1x1_reduce/bn"
+  name: "conv3_4_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv3_4_1x1_reduce"
   top: "conv3_4_1x1_reduce"
@@ -1148,7 +1148,7 @@ layer {
   }
 }
 layer {
-  name: "conv3_4_3x3/bn"
+  name: "conv3_4_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv3_4_3x3"
   top: "conv3_4_3x3"
@@ -1192,7 +1192,7 @@ layer {
   }
 }
 layer {
-  name: "conv3_4_1x1_increase/bn"
+  name: "conv3_4_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv3_4_1x1_increase"
   top: "conv3_4_1x1_increase"
@@ -1246,7 +1246,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_1_1x1_reduce/bn"
+  name: "conv4_1_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_1_1x1_reduce"
   top: "conv4_1_1x1_reduce"
@@ -1291,7 +1291,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_1_3x3/bn"
+  name: "conv4_1_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_1_3x3"
   top: "conv4_1_3x3"
@@ -1335,7 +1335,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_1_1x1_increase/bn"
+  name: "conv4_1_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_1_1x1_increase"
   top: "conv4_1_1x1_increase"
@@ -1373,7 +1373,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_1_1x1_proj/bn"
+  name: "conv4_1_1x1_proj/bnc"
   type: "BatchNorm"
   bottom: "conv4_1_1x1_proj"
   top: "conv4_1_1x1_proj"
@@ -1427,7 +1427,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_2_1x1_reduce/bn"
+  name: "conv4_2_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_2_1x1_reduce"
   top: "conv4_2_1x1_reduce"
@@ -1472,7 +1472,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_2_3x3/bn"
+  name: "conv4_2_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_2_3x3"
   top: "conv4_2_3x3"
@@ -1516,7 +1516,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_2_1x1_increase/bn"
+  name: "conv4_2_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_2_1x1_increase"
   top: "conv4_2_1x1_increase"
@@ -1570,7 +1570,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_3_1x1_reduce/bn"
+  name: "conv4_3_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_3_1x1_reduce"
   top: "conv4_3_1x1_reduce"
@@ -1615,7 +1615,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_3_3x3/bn"
+  name: "conv4_3_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_3_3x3"
   top: "conv4_3_3x3"
@@ -1659,7 +1659,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_3_1x1_increase/bn"
+  name: "conv4_3_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_3_1x1_increase"
   top: "conv4_3_1x1_increase"
@@ -1713,7 +1713,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_4_1x1_reduce/bn"
+  name: "conv4_4_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_4_1x1_reduce"
   top: "conv4_4_1x1_reduce"
@@ -1758,7 +1758,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_4_3x3/bn"
+  name: "conv4_4_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_4_3x3"
   top: "conv4_4_3x3"
@@ -1802,7 +1802,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_4_1x1_increase/bn"
+  name: "conv4_4_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_4_1x1_increase"
   top: "conv4_4_1x1_increase"
@@ -1856,7 +1856,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_5_1x1_reduce/bn"
+  name: "conv4_5_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_5_1x1_reduce"
   top: "conv4_5_1x1_reduce"
@@ -1901,7 +1901,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_5_3x3/bn"
+  name: "conv4_5_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_5_3x3"
   top: "conv4_5_3x3"
@@ -1945,7 +1945,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_5_1x1_increase/bn"
+  name: "conv4_5_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_5_1x1_increase"
   top: "conv4_5_1x1_increase"
@@ -1999,7 +1999,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_6_1x1_reduce/bn"
+  name: "conv4_6_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_6_1x1_reduce"
   top: "conv4_6_1x1_reduce"
@@ -2044,7 +2044,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_6_3x3/bn"
+  name: "conv4_6_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_6_3x3"
   top: "conv4_6_3x3"
@@ -2088,7 +2088,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_6_1x1_increase/bn"
+  name: "conv4_6_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_6_1x1_increase"
   top: "conv4_6_1x1_increase"
@@ -2142,7 +2142,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_7_1x1_reduce/bn"
+  name: "conv4_7_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_7_1x1_reduce"
   top: "conv4_7_1x1_reduce"
@@ -2187,7 +2187,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_7_3x3/bn"
+  name: "conv4_7_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_7_3x3"
   top: "conv4_7_3x3"
@@ -2231,7 +2231,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_7_1x1_increase/bn"
+  name: "conv4_7_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_7_1x1_increase"
   top: "conv4_7_1x1_increase"
@@ -2285,7 +2285,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_8_1x1_reduce/bn"
+  name: "conv4_8_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_8_1x1_reduce"
   top: "conv4_8_1x1_reduce"
@@ -2330,7 +2330,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_8_3x3/bn"
+  name: "conv4_8_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_8_3x3"
   top: "conv4_8_3x3"
@@ -2374,7 +2374,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_8_1x1_increase/bn"
+  name: "conv4_8_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_8_1x1_increase"
   top: "conv4_8_1x1_increase"
@@ -2428,7 +2428,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_9_1x1_reduce/bn"
+  name: "conv4_9_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_9_1x1_reduce"
   top: "conv4_9_1x1_reduce"
@@ -2473,7 +2473,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_9_3x3/bn"
+  name: "conv4_9_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_9_3x3"
   top: "conv4_9_3x3"
@@ -2517,7 +2517,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_9_1x1_increase/bn"
+  name: "conv4_9_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_9_1x1_increase"
   top: "conv4_9_1x1_increase"
@@ -2571,7 +2571,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_10_1x1_reduce/bn"
+  name: "conv4_10_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_10_1x1_reduce"
   top: "conv4_10_1x1_reduce"
@@ -2616,7 +2616,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_10_3x3/bn"
+  name: "conv4_10_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_10_3x3"
   top: "conv4_10_3x3"
@@ -2660,7 +2660,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_10_1x1_increase/bn"
+  name: "conv4_10_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_10_1x1_increase"
   top: "conv4_10_1x1_increase"
@@ -2714,7 +2714,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_11_1x1_reduce/bn"
+  name: "conv4_11_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_11_1x1_reduce"
   top: "conv4_11_1x1_reduce"
@@ -2759,7 +2759,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_11_3x3/bn"
+  name: "conv4_11_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_11_3x3"
   top: "conv4_11_3x3"
@@ -2803,7 +2803,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_11_1x1_increase/bn"
+  name: "conv4_11_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_11_1x1_increase"
   top: "conv4_11_1x1_increase"
@@ -2857,7 +2857,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_12_1x1_reduce/bn"
+  name: "conv4_12_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_12_1x1_reduce"
   top: "conv4_12_1x1_reduce"
@@ -2902,7 +2902,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_12_3x3/bn"
+  name: "conv4_12_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_12_3x3"
   top: "conv4_12_3x3"
@@ -2946,7 +2946,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_12_1x1_increase/bn"
+  name: "conv4_12_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_12_1x1_increase"
   top: "conv4_12_1x1_increase"
@@ -3000,7 +3000,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_13_1x1_reduce/bn"
+  name: "conv4_13_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_13_1x1_reduce"
   top: "conv4_13_1x1_reduce"
@@ -3045,7 +3045,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_13_3x3/bn"
+  name: "conv4_13_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_13_3x3"
   top: "conv4_13_3x3"
@@ -3089,7 +3089,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_13_1x1_increase/bn"
+  name: "conv4_13_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_13_1x1_increase"
   top: "conv4_13_1x1_increase"
@@ -3143,7 +3143,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_14_1x1_reduce/bn"
+  name: "conv4_14_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_14_1x1_reduce"
   top: "conv4_14_1x1_reduce"
@@ -3188,7 +3188,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_14_3x3/bn"
+  name: "conv4_14_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_14_3x3"
   top: "conv4_14_3x3"
@@ -3232,7 +3232,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_14_1x1_increase/bn"
+  name: "conv4_14_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_14_1x1_increase"
   top: "conv4_14_1x1_increase"
@@ -3286,7 +3286,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_15_1x1_reduce/bn"
+  name: "conv4_15_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_15_1x1_reduce"
   top: "conv4_15_1x1_reduce"
@@ -3331,7 +3331,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_15_3x3/bn"
+  name: "conv4_15_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_15_3x3"
   top: "conv4_15_3x3"
@@ -3375,7 +3375,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_15_1x1_increase/bn"
+  name: "conv4_15_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_15_1x1_increase"
   top: "conv4_15_1x1_increase"
@@ -3429,7 +3429,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_16_1x1_reduce/bn"
+  name: "conv4_16_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_16_1x1_reduce"
   top: "conv4_16_1x1_reduce"
@@ -3474,7 +3474,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_16_3x3/bn"
+  name: "conv4_16_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_16_3x3"
   top: "conv4_16_3x3"
@@ -3518,7 +3518,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_16_1x1_increase/bn"
+  name: "conv4_16_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_16_1x1_increase"
   top: "conv4_16_1x1_increase"
@@ -3572,7 +3572,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_17_1x1_reduce/bn"
+  name: "conv4_17_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_17_1x1_reduce"
   top: "conv4_17_1x1_reduce"
@@ -3617,7 +3617,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_17_3x3/bn"
+  name: "conv4_17_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_17_3x3"
   top: "conv4_17_3x3"
@@ -3661,7 +3661,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_17_1x1_increase/bn"
+  name: "conv4_17_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_17_1x1_increase"
   top: "conv4_17_1x1_increase"
@@ -3715,7 +3715,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_18_1x1_reduce/bn"
+  name: "conv4_18_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_18_1x1_reduce"
   top: "conv4_18_1x1_reduce"
@@ -3760,7 +3760,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_18_3x3/bn"
+  name: "conv4_18_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_18_3x3"
   top: "conv4_18_3x3"
@@ -3804,7 +3804,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_18_1x1_increase/bn"
+  name: "conv4_18_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_18_1x1_increase"
   top: "conv4_18_1x1_increase"
@@ -3858,7 +3858,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_19_1x1_reduce/bn"
+  name: "conv4_19_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_19_1x1_reduce"
   top: "conv4_19_1x1_reduce"
@@ -3903,7 +3903,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_19_3x3/bn"
+  name: "conv4_19_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_19_3x3"
   top: "conv4_19_3x3"
@@ -3947,7 +3947,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_19_1x1_increase/bn"
+  name: "conv4_19_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_19_1x1_increase"
   top: "conv4_19_1x1_increase"
@@ -4001,7 +4001,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_20_1x1_reduce/bn"
+  name: "conv4_20_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_20_1x1_reduce"
   top: "conv4_20_1x1_reduce"
@@ -4046,7 +4046,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_20_3x3/bn"
+  name: "conv4_20_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_20_3x3"
   top: "conv4_20_3x3"
@@ -4090,7 +4090,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_20_1x1_increase/bn"
+  name: "conv4_20_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_20_1x1_increase"
   top: "conv4_20_1x1_increase"
@@ -4144,7 +4144,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_21_1x1_reduce/bn"
+  name: "conv4_21_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_21_1x1_reduce"
   top: "conv4_21_1x1_reduce"
@@ -4189,7 +4189,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_21_3x3/bn"
+  name: "conv4_21_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_21_3x3"
   top: "conv4_21_3x3"
@@ -4233,7 +4233,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_21_1x1_increase/bn"
+  name: "conv4_21_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_21_1x1_increase"
   top: "conv4_21_1x1_increase"
@@ -4287,7 +4287,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_22_1x1_reduce/bn"
+  name: "conv4_22_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_22_1x1_reduce"
   top: "conv4_22_1x1_reduce"
@@ -4332,7 +4332,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_22_3x3/bn"
+  name: "conv4_22_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_22_3x3"
   top: "conv4_22_3x3"
@@ -4376,7 +4376,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_22_1x1_increase/bn"
+  name: "conv4_22_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_22_1x1_increase"
   top: "conv4_22_1x1_increase"
@@ -4430,7 +4430,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_23_1x1_reduce/bn"
+  name: "conv4_23_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_23_1x1_reduce"
   top: "conv4_23_1x1_reduce"
@@ -4475,7 +4475,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_23_3x3/bn"
+  name: "conv4_23_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_23_3x3"
   top: "conv4_23_3x3"
@@ -4519,7 +4519,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_23_1x1_increase/bn"
+  name: "conv4_23_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_23_1x1_increase"
   top: "conv4_23_1x1_increase"
@@ -4573,7 +4573,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_1_1x1_reduce/bn"
+  name: "conv5_1_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv5_1_1x1_reduce"
   top: "conv5_1_1x1_reduce"
@@ -4618,7 +4618,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_1_3x3/bn"
+  name: "conv5_1_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv5_1_3x3"
   top: "conv5_1_3x3"
@@ -4662,7 +4662,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_1_1x1_increase/bn"
+  name: "conv5_1_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv5_1_1x1_increase"
   top: "conv5_1_1x1_increase"
@@ -4700,7 +4700,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_1_1x1_proj/bn"
+  name: "conv5_1_1x1_proj/bnc"
   type: "BatchNorm"
   bottom: "conv5_1_1x1_proj"
   top: "conv5_1_1x1_proj"
@@ -4754,7 +4754,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_2_1x1_reduce/bn"
+  name: "conv5_2_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv5_2_1x1_reduce"
   top: "conv5_2_1x1_reduce"
@@ -4799,7 +4799,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_2_3x3/bn"
+  name: "conv5_2_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv5_2_3x3"
   top: "conv5_2_3x3"
@@ -4843,7 +4843,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_2_1x1_increase/bn"
+  name: "conv5_2_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv5_2_1x1_increase"
   top: "conv5_2_1x1_increase"
@@ -4897,7 +4897,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_3_1x1_reduce/bn"
+  name: "conv5_3_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv5_3_1x1_reduce"
   top: "conv5_3_1x1_reduce"
@@ -4942,7 +4942,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_3_3x3/bn"
+  name: "conv5_3_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv5_3_3x3"
   top: "conv5_3_3x3"
@@ -4986,7 +4986,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_3_1x1_increase/bn"
+  name: "conv5_3_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv5_3_1x1_increase"
   top: "conv5_3_1x1_increase"
@@ -5049,7 +5049,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_3_pool1_conv/bn"
+  name: "conv5_3_pool1_conv/bnc"
   type: "BatchNorm"
   bottom: "conv5_3_pool1_conv"
   top: "conv5_3_pool1_conv"
@@ -5113,7 +5113,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_3_pool2_conv/bn"
+  name: "conv5_3_pool2_conv/bnc"
   type: "BatchNorm"
   bottom: "conv5_3_pool2_conv"
   top: "conv5_3_pool2_conv"
@@ -5177,7 +5177,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_3_pool3_conv/bn"
+  name: "conv5_3_pool3_conv/bnc"
   type: "BatchNorm"
   bottom: "conv5_3_pool3_conv"
   top: "conv5_3_pool3_conv"
@@ -5241,7 +5241,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_3_pool6_conv/bn"
+  name: "conv5_3_pool6_conv/bnc"
   type: "BatchNorm"
   bottom: "conv5_3_pool6_conv"
   top: "conv5_3_pool6_conv"
@@ -5305,7 +5305,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_4/bn"
+  name: "conv5_4/bnc"
   type: "BatchNorm"
   bottom: "conv5_4"
   top: "conv5_4"

--- a/templates/caffe/pspnet_101/pspnet_101.prototxt
+++ b/templates/caffe/pspnet_101/pspnet_101.prototxt
@@ -50,7 +50,7 @@ layer {
   }
 }
 layer {
-  name: "conv1_1_3x3_s2/bn"
+  name: "conv1_1_3x3_s2/bnc"
   type: "BatchNorm"
   bottom: "conv1_1_3x3_s2"
   top: "conv1_1_3x3_s2"
@@ -94,7 +94,7 @@ layer {
   }
 }
 layer {
-  name: "conv1_2_3x3/bn"
+  name: "conv1_2_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv1_2_3x3"
   top: "conv1_2_3x3"
@@ -138,7 +138,7 @@ layer {
   }
 }
 layer {
-  name: "conv1_3_3x3/bn"
+  name: "conv1_3_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv1_3_3x3"
   top: "conv1_3_3x3"
@@ -194,7 +194,7 @@ layer {
   }
 }
 layer {
-  name: "conv2_1_1x1_reduce/bn"
+  name: "conv2_1_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv2_1_1x1_reduce"
   top: "conv2_1_1x1_reduce"
@@ -238,7 +238,7 @@ layer {
   }
 }
 layer {
-  name: "conv2_1_3x3/bn"
+  name: "conv2_1_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv2_1_3x3"
   top: "conv2_1_3x3"
@@ -282,7 +282,7 @@ layer {
   }
 }
 layer {
-  name: "conv2_1_1x1_increase/bn"
+  name: "conv2_1_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv2_1_1x1_increase"
   top: "conv2_1_1x1_increase"
@@ -320,7 +320,7 @@ layer {
   }
 }
 layer {
-  name: "conv2_1_1x1_proj/bn"
+  name: "conv2_1_1x1_proj/bnc"
   type: "BatchNorm"
   bottom: "conv2_1_1x1_proj"
   top: "conv2_1_1x1_proj"
@@ -374,7 +374,7 @@ layer {
   }
 }
 layer {
-  name: "conv2_2_1x1_reduce/bn"
+  name: "conv2_2_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv2_2_1x1_reduce"
   top: "conv2_2_1x1_reduce"
@@ -418,7 +418,7 @@ layer {
   }
 }
 layer {
-  name: "conv2_2_3x3/bn"
+  name: "conv2_2_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv2_2_3x3"
   top: "conv2_2_3x3"
@@ -462,7 +462,7 @@ layer {
   }
 }
 layer {
-  name: "conv2_2_1x1_increase/bn"
+  name: "conv2_2_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv2_2_1x1_increase"
   top: "conv2_2_1x1_increase"
@@ -516,7 +516,7 @@ layer {
   }
 }
 layer {
-  name: "conv2_3_1x1_reduce/bn"
+  name: "conv2_3_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv2_3_1x1_reduce"
   top: "conv2_3_1x1_reduce"
@@ -560,7 +560,7 @@ layer {
   }
 }
 layer {
-  name: "conv2_3_3x3/bn"
+  name: "conv2_3_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv2_3_3x3"
   top: "conv2_3_3x3"
@@ -604,7 +604,7 @@ layer {
   }
 }
 layer {
-  name: "conv2_3_1x1_increase/bn"
+  name: "conv2_3_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv2_3_1x1_increase"
   top: "conv2_3_1x1_increase"
@@ -658,7 +658,7 @@ layer {
   }
 }
 layer {
-  name: "conv3_1_1x1_reduce/bn"
+  name: "conv3_1_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv3_1_1x1_reduce"
   top: "conv3_1_1x1_reduce"
@@ -702,7 +702,7 @@ layer {
   }
 }
 layer {
-  name: "conv3_1_3x3/bn"
+  name: "conv3_1_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv3_1_3x3"
   top: "conv3_1_3x3"
@@ -746,7 +746,7 @@ layer {
   }
 }
 layer {
-  name: "conv3_1_1x1_increase/bn"
+  name: "conv3_1_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv3_1_1x1_increase"
   top: "conv3_1_1x1_increase"
@@ -784,7 +784,7 @@ layer {
   }
 }
 layer {
-  name: "conv3_1_1x1_proj/bn"
+  name: "conv3_1_1x1_proj/bnc"
   type: "BatchNorm"
   bottom: "conv3_1_1x1_proj"
   top: "conv3_1_1x1_proj"
@@ -838,7 +838,7 @@ layer {
   }
 }
 layer {
-  name: "conv3_2_1x1_reduce/bn"
+  name: "conv3_2_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv3_2_1x1_reduce"
   top: "conv3_2_1x1_reduce"
@@ -882,7 +882,7 @@ layer {
   }
 }
 layer {
-  name: "conv3_2_3x3/bn"
+  name: "conv3_2_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv3_2_3x3"
   top: "conv3_2_3x3"
@@ -926,7 +926,7 @@ layer {
   }
 }
 layer {
-  name: "conv3_2_1x1_increase/bn"
+  name: "conv3_2_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv3_2_1x1_increase"
   top: "conv3_2_1x1_increase"
@@ -980,7 +980,7 @@ layer {
   }
 }
 layer {
-  name: "conv3_3_1x1_reduce/bn"
+  name: "conv3_3_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv3_3_1x1_reduce"
   top: "conv3_3_1x1_reduce"
@@ -1024,7 +1024,7 @@ layer {
   }
 }
 layer {
-  name: "conv3_3_3x3/bn"
+  name: "conv3_3_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv3_3_3x3"
   top: "conv3_3_3x3"
@@ -1068,7 +1068,7 @@ layer {
   }
 }
 layer {
-  name: "conv3_3_1x1_increase/bn"
+  name: "conv3_3_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv3_3_1x1_increase"
   top: "conv3_3_1x1_increase"
@@ -1122,7 +1122,7 @@ layer {
   }
 }
 layer {
-  name: "conv3_4_1x1_reduce/bn"
+  name: "conv3_4_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv3_4_1x1_reduce"
   top: "conv3_4_1x1_reduce"
@@ -1166,7 +1166,7 @@ layer {
   }
 }
 layer {
-  name: "conv3_4_3x3/bn"
+  name: "conv3_4_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv3_4_3x3"
   top: "conv3_4_3x3"
@@ -1210,7 +1210,7 @@ layer {
   }
 }
 layer {
-  name: "conv3_4_1x1_increase/bn"
+  name: "conv3_4_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv3_4_1x1_increase"
   top: "conv3_4_1x1_increase"
@@ -1264,7 +1264,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_1_1x1_reduce/bn"
+  name: "conv4_1_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_1_1x1_reduce"
   top: "conv4_1_1x1_reduce"
@@ -1309,7 +1309,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_1_3x3/bn"
+  name: "conv4_1_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_1_3x3"
   top: "conv4_1_3x3"
@@ -1353,7 +1353,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_1_1x1_increase/bn"
+  name: "conv4_1_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_1_1x1_increase"
   top: "conv4_1_1x1_increase"
@@ -1391,7 +1391,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_1_1x1_proj/bn"
+  name: "conv4_1_1x1_proj/bnc"
   type: "BatchNorm"
   bottom: "conv4_1_1x1_proj"
   top: "conv4_1_1x1_proj"
@@ -1445,7 +1445,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_2_1x1_reduce/bn"
+  name: "conv4_2_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_2_1x1_reduce"
   top: "conv4_2_1x1_reduce"
@@ -1490,7 +1490,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_2_3x3/bn"
+  name: "conv4_2_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_2_3x3"
   top: "conv4_2_3x3"
@@ -1534,7 +1534,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_2_1x1_increase/bn"
+  name: "conv4_2_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_2_1x1_increase"
   top: "conv4_2_1x1_increase"
@@ -1588,7 +1588,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_3_1x1_reduce/bn"
+  name: "conv4_3_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_3_1x1_reduce"
   top: "conv4_3_1x1_reduce"
@@ -1633,7 +1633,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_3_3x3/bn"
+  name: "conv4_3_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_3_3x3"
   top: "conv4_3_3x3"
@@ -1677,7 +1677,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_3_1x1_increase/bn"
+  name: "conv4_3_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_3_1x1_increase"
   top: "conv4_3_1x1_increase"
@@ -1731,7 +1731,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_4_1x1_reduce/bn"
+  name: "conv4_4_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_4_1x1_reduce"
   top: "conv4_4_1x1_reduce"
@@ -1776,7 +1776,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_4_3x3/bn"
+  name: "conv4_4_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_4_3x3"
   top: "conv4_4_3x3"
@@ -1820,7 +1820,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_4_1x1_increase/bn"
+  name: "conv4_4_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_4_1x1_increase"
   top: "conv4_4_1x1_increase"
@@ -1874,7 +1874,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_5_1x1_reduce/bn"
+  name: "conv4_5_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_5_1x1_reduce"
   top: "conv4_5_1x1_reduce"
@@ -1919,7 +1919,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_5_3x3/bn"
+  name: "conv4_5_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_5_3x3"
   top: "conv4_5_3x3"
@@ -1963,7 +1963,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_5_1x1_increase/bn"
+  name: "conv4_5_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_5_1x1_increase"
   top: "conv4_5_1x1_increase"
@@ -2017,7 +2017,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_6_1x1_reduce/bn"
+  name: "conv4_6_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_6_1x1_reduce"
   top: "conv4_6_1x1_reduce"
@@ -2062,7 +2062,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_6_3x3/bn"
+  name: "conv4_6_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_6_3x3"
   top: "conv4_6_3x3"
@@ -2106,7 +2106,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_6_1x1_increase/bn"
+  name: "conv4_6_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_6_1x1_increase"
   top: "conv4_6_1x1_increase"
@@ -2160,7 +2160,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_7_1x1_reduce/bn"
+  name: "conv4_7_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_7_1x1_reduce"
   top: "conv4_7_1x1_reduce"
@@ -2205,7 +2205,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_7_3x3/bn"
+  name: "conv4_7_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_7_3x3"
   top: "conv4_7_3x3"
@@ -2249,7 +2249,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_7_1x1_increase/bn"
+  name: "conv4_7_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_7_1x1_increase"
   top: "conv4_7_1x1_increase"
@@ -2303,7 +2303,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_8_1x1_reduce/bn"
+  name: "conv4_8_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_8_1x1_reduce"
   top: "conv4_8_1x1_reduce"
@@ -2348,7 +2348,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_8_3x3/bn"
+  name: "conv4_8_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_8_3x3"
   top: "conv4_8_3x3"
@@ -2392,7 +2392,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_8_1x1_increase/bn"
+  name: "conv4_8_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_8_1x1_increase"
   top: "conv4_8_1x1_increase"
@@ -2446,7 +2446,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_9_1x1_reduce/bn"
+  name: "conv4_9_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_9_1x1_reduce"
   top: "conv4_9_1x1_reduce"
@@ -2491,7 +2491,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_9_3x3/bn"
+  name: "conv4_9_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_9_3x3"
   top: "conv4_9_3x3"
@@ -2535,7 +2535,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_9_1x1_increase/bn"
+  name: "conv4_9_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_9_1x1_increase"
   top: "conv4_9_1x1_increase"
@@ -2589,7 +2589,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_10_1x1_reduce/bn"
+  name: "conv4_10_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_10_1x1_reduce"
   top: "conv4_10_1x1_reduce"
@@ -2634,7 +2634,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_10_3x3/bn"
+  name: "conv4_10_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_10_3x3"
   top: "conv4_10_3x3"
@@ -2678,7 +2678,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_10_1x1_increase/bn"
+  name: "conv4_10_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_10_1x1_increase"
   top: "conv4_10_1x1_increase"
@@ -2732,7 +2732,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_11_1x1_reduce/bn"
+  name: "conv4_11_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_11_1x1_reduce"
   top: "conv4_11_1x1_reduce"
@@ -2777,7 +2777,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_11_3x3/bn"
+  name: "conv4_11_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_11_3x3"
   top: "conv4_11_3x3"
@@ -2821,7 +2821,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_11_1x1_increase/bn"
+  name: "conv4_11_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_11_1x1_increase"
   top: "conv4_11_1x1_increase"
@@ -2875,7 +2875,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_12_1x1_reduce/bn"
+  name: "conv4_12_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_12_1x1_reduce"
   top: "conv4_12_1x1_reduce"
@@ -2920,7 +2920,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_12_3x3/bn"
+  name: "conv4_12_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_12_3x3"
   top: "conv4_12_3x3"
@@ -2964,7 +2964,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_12_1x1_increase/bn"
+  name: "conv4_12_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_12_1x1_increase"
   top: "conv4_12_1x1_increase"
@@ -3018,7 +3018,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_13_1x1_reduce/bn"
+  name: "conv4_13_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_13_1x1_reduce"
   top: "conv4_13_1x1_reduce"
@@ -3063,7 +3063,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_13_3x3/bn"
+  name: "conv4_13_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_13_3x3"
   top: "conv4_13_3x3"
@@ -3107,7 +3107,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_13_1x1_increase/bn"
+  name: "conv4_13_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_13_1x1_increase"
   top: "conv4_13_1x1_increase"
@@ -3161,7 +3161,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_14_1x1_reduce/bn"
+  name: "conv4_14_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_14_1x1_reduce"
   top: "conv4_14_1x1_reduce"
@@ -3206,7 +3206,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_14_3x3/bn"
+  name: "conv4_14_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_14_3x3"
   top: "conv4_14_3x3"
@@ -3250,7 +3250,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_14_1x1_increase/bn"
+  name: "conv4_14_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_14_1x1_increase"
   top: "conv4_14_1x1_increase"
@@ -3304,7 +3304,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_15_1x1_reduce/bn"
+  name: "conv4_15_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_15_1x1_reduce"
   top: "conv4_15_1x1_reduce"
@@ -3349,7 +3349,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_15_3x3/bn"
+  name: "conv4_15_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_15_3x3"
   top: "conv4_15_3x3"
@@ -3393,7 +3393,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_15_1x1_increase/bn"
+  name: "conv4_15_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_15_1x1_increase"
   top: "conv4_15_1x1_increase"
@@ -3447,7 +3447,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_16_1x1_reduce/bn"
+  name: "conv4_16_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_16_1x1_reduce"
   top: "conv4_16_1x1_reduce"
@@ -3492,7 +3492,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_16_3x3/bn"
+  name: "conv4_16_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_16_3x3"
   top: "conv4_16_3x3"
@@ -3536,7 +3536,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_16_1x1_increase/bn"
+  name: "conv4_16_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_16_1x1_increase"
   top: "conv4_16_1x1_increase"
@@ -3590,7 +3590,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_17_1x1_reduce/bn"
+  name: "conv4_17_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_17_1x1_reduce"
   top: "conv4_17_1x1_reduce"
@@ -3635,7 +3635,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_17_3x3/bn"
+  name: "conv4_17_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_17_3x3"
   top: "conv4_17_3x3"
@@ -3679,7 +3679,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_17_1x1_increase/bn"
+  name: "conv4_17_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_17_1x1_increase"
   top: "conv4_17_1x1_increase"
@@ -3733,7 +3733,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_18_1x1_reduce/bn"
+  name: "conv4_18_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_18_1x1_reduce"
   top: "conv4_18_1x1_reduce"
@@ -3778,7 +3778,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_18_3x3/bn"
+  name: "conv4_18_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_18_3x3"
   top: "conv4_18_3x3"
@@ -3822,7 +3822,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_18_1x1_increase/bn"
+  name: "conv4_18_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_18_1x1_increase"
   top: "conv4_18_1x1_increase"
@@ -3876,7 +3876,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_19_1x1_reduce/bn"
+  name: "conv4_19_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_19_1x1_reduce"
   top: "conv4_19_1x1_reduce"
@@ -3921,7 +3921,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_19_3x3/bn"
+  name: "conv4_19_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_19_3x3"
   top: "conv4_19_3x3"
@@ -3965,7 +3965,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_19_1x1_increase/bn"
+  name: "conv4_19_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_19_1x1_increase"
   top: "conv4_19_1x1_increase"
@@ -4019,7 +4019,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_20_1x1_reduce/bn"
+  name: "conv4_20_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_20_1x1_reduce"
   top: "conv4_20_1x1_reduce"
@@ -4064,7 +4064,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_20_3x3/bn"
+  name: "conv4_20_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_20_3x3"
   top: "conv4_20_3x3"
@@ -4108,7 +4108,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_20_1x1_increase/bn"
+  name: "conv4_20_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_20_1x1_increase"
   top: "conv4_20_1x1_increase"
@@ -4162,7 +4162,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_21_1x1_reduce/bn"
+  name: "conv4_21_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_21_1x1_reduce"
   top: "conv4_21_1x1_reduce"
@@ -4207,7 +4207,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_21_3x3/bn"
+  name: "conv4_21_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_21_3x3"
   top: "conv4_21_3x3"
@@ -4251,7 +4251,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_21_1x1_increase/bn"
+  name: "conv4_21_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_21_1x1_increase"
   top: "conv4_21_1x1_increase"
@@ -4305,7 +4305,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_22_1x1_reduce/bn"
+  name: "conv4_22_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_22_1x1_reduce"
   top: "conv4_22_1x1_reduce"
@@ -4350,7 +4350,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_22_3x3/bn"
+  name: "conv4_22_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_22_3x3"
   top: "conv4_22_3x3"
@@ -4394,7 +4394,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_22_1x1_increase/bn"
+  name: "conv4_22_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_22_1x1_increase"
   top: "conv4_22_1x1_increase"
@@ -4448,7 +4448,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_23_1x1_reduce/bn"
+  name: "conv4_23_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_23_1x1_reduce"
   top: "conv4_23_1x1_reduce"
@@ -4493,7 +4493,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_23_3x3/bn"
+  name: "conv4_23_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_23_3x3"
   top: "conv4_23_3x3"
@@ -4537,7 +4537,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_23_1x1_increase/bn"
+  name: "conv4_23_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_23_1x1_increase"
   top: "conv4_23_1x1_increase"
@@ -4591,7 +4591,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_1_1x1_reduce/bn"
+  name: "conv5_1_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv5_1_1x1_reduce"
   top: "conv5_1_1x1_reduce"
@@ -4636,7 +4636,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_1_3x3/bn"
+  name: "conv5_1_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv5_1_3x3"
   top: "conv5_1_3x3"
@@ -4680,7 +4680,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_1_1x1_increase/bn"
+  name: "conv5_1_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv5_1_1x1_increase"
   top: "conv5_1_1x1_increase"
@@ -4718,7 +4718,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_1_1x1_proj/bn"
+  name: "conv5_1_1x1_proj/bnc"
   type: "BatchNorm"
   bottom: "conv5_1_1x1_proj"
   top: "conv5_1_1x1_proj"
@@ -4772,7 +4772,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_2_1x1_reduce/bn"
+  name: "conv5_2_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv5_2_1x1_reduce"
   top: "conv5_2_1x1_reduce"
@@ -4817,7 +4817,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_2_3x3/bn"
+  name: "conv5_2_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv5_2_3x3"
   top: "conv5_2_3x3"
@@ -4861,7 +4861,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_2_1x1_increase/bn"
+  name: "conv5_2_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv5_2_1x1_increase"
   top: "conv5_2_1x1_increase"
@@ -4915,7 +4915,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_3_1x1_reduce/bn"
+  name: "conv5_3_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv5_3_1x1_reduce"
   top: "conv5_3_1x1_reduce"
@@ -4960,7 +4960,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_3_3x3/bn"
+  name: "conv5_3_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv5_3_3x3"
   top: "conv5_3_3x3"
@@ -5004,7 +5004,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_3_1x1_increase/bn"
+  name: "conv5_3_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv5_3_1x1_increase"
   top: "conv5_3_1x1_increase"
@@ -5067,7 +5067,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_3_pool1_conv/bn"
+  name: "conv5_3_pool1_conv/bnc"
   type: "BatchNorm"
   bottom: "conv5_3_pool1_conv"
   top: "conv5_3_pool1_conv"
@@ -5131,7 +5131,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_3_pool2_conv/bn"
+  name: "conv5_3_pool2_conv/bnc"
   type: "BatchNorm"
   bottom: "conv5_3_pool2_conv"
   top: "conv5_3_pool2_conv"
@@ -5195,7 +5195,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_3_pool3_conv/bn"
+  name: "conv5_3_pool3_conv/bnc"
   type: "BatchNorm"
   bottom: "conv5_3_pool3_conv"
   top: "conv5_3_pool3_conv"
@@ -5259,7 +5259,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_3_pool6_conv/bn"
+  name: "conv5_3_pool6_conv/bnc"
   type: "BatchNorm"
   bottom: "conv5_3_pool6_conv"
   top: "conv5_3_pool6_conv"
@@ -5323,7 +5323,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_4/bn"
+  name: "conv5_4/bnc"
   type: "BatchNorm"
   bottom: "conv5_4"
   top: "conv5_4"

--- a/templates/caffe/pspnet_50/deploy.prototxt
+++ b/templates/caffe/pspnet_50/deploy.prototxt
@@ -7,2536 +7,2401 @@ layer {
   memory_data_param {
     batch_size: 1
     channels: 3
-    height: 473
-    width: 473
+    height: 480
+    width: 480
   }
 }
 layer {
-  name: "conv1_1_3x3_s2"
+  name: "conv1"
   type: "Convolution"
   bottom: "data"
-  top: "conv1_1_3x3_s2"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
+  top: "conv1"
   convolution_param {
     num_output: 64
-    pad: 1
-    kernel_size: 3
+    pad: 3
+    kernel_size: 7
     stride: 2
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
-  }
-}
-layer {
-  name: "conv1_1_3x3_s2/bnc"
-  type: "BatchNorm"
-  bottom: "conv1_1_3x3_s2"
-  top: "conv1_1_3x3_s2"
-}
-
-layer {
- name: "conv1_1_3x3_s2/scale"
- type: "Scale"
-bottom: "conv1_1_3x3_s2"
- top: "conv1_1_3x3_s2"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv1_1_3x3_s2/relu"
-  type: "ReLU"
-  bottom: "conv1_1_3x3_s2"
-  top: "conv1_1_3x3_s2"
-}
-layer {
-  name: "conv1_2_3x3"
-  type: "Convolution"
-  bottom: "conv1_1_3x3_s2"
-  top: "conv1_2_3x3"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
-  convolution_param {
-    num_output: 64
-    pad: 1
-    kernel_size: 3
-    stride: 1
-    weight_filler {
-      type: "msra"
+    bias_filler {
+      type: "constant"
+      value: 0.2
     }
-    bias_term: false
   }
 }
 layer {
-  name: "conv1_2_3x3/bnc"
+  name: "bn_conv1"
   type: "BatchNorm"
-  bottom: "conv1_2_3x3"
-  top: "conv1_2_3x3"
-}
-
-layer {
- name: "conv1_2_3x3/scale"
- type: "Scale"
-bottom: "conv1_2_3x3"
- top: "conv1_2_3x3"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv1_2_3x3/relu"
-  type: "ReLU"
-  bottom: "conv1_2_3x3"
-  top: "conv1_2_3x3"
-}
-layer {
-  name: "conv1_3_3x3"
-  type: "Convolution"
-  bottom: "conv1_2_3x3"
-  top: "conv1_3_3x3"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
-  convolution_param {
-    num_output: 128
-    pad: 1
-    kernel_size: 3
-    stride: 1
-    weight_filler {
-      type: "msra"
-    }
-    bias_term: false
+  bottom: "conv1"
+  top: "conv1"
+  batch_norm_param {
   }
 }
 layer {
-  name: "conv1_3_3x3/bnc"
-  type: "BatchNorm"
-  bottom: "conv1_3_3x3"
-  top: "conv1_3_3x3"
+  name: "scale_conv1"
+  type: "Scale"
+  bottom: "conv1"
+  top: "conv1"
+  scale_param {
+    bias_term: true
+  }
 }
-
 layer {
- name: "conv1_3_3x3/scale"
- type: "Scale"
-bottom: "conv1_3_3x3"
- top: "conv1_3_3x3"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv1_3_3x3/relu"
+  name: "conv1_relu"
   type: "ReLU"
-  bottom: "conv1_3_3x3"
-  top: "conv1_3_3x3"
+  bottom: "conv1"
+  top: "conv1"
 }
 layer {
-  name: "pool1_3x3_s2"
+  name: "pool1"
   type: "Pooling"
-  bottom: "conv1_3_3x3"
-  top: "pool1_3x3_s2"
+  bottom: "conv1"
+  top: "pool1"
   pooling_param {
     pool: MAX
     kernel_size: 3
     stride: 2
-    pad: 1
   }
 }
 layer {
-  name: "conv2_1_1x1_reduce"
+  name: "res2a_branch1"
   type: "Convolution"
-  bottom: "pool1_3x3_s2"
-  top: "conv2_1_1x1_reduce"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
-  convolution_param {
-    num_output: 64
-    pad: 0
-    kernel_size: 1
-    stride: 1
-    weight_filler {
-      type: "msra"
-    }
-    bias_term: false
-  }
-}
-layer {
-  name: "conv2_1_1x1_reduce/bnc"
-  type: "BatchNorm"
-  bottom: "conv2_1_1x1_reduce"
-  top: "conv2_1_1x1_reduce"
-}
-
-layer {
- name: "conv2_1_1x1_reduce/scale"
- type: "Scale"
-bottom: "conv2_1_1x1_reduce"
- top: "conv2_1_1x1_reduce"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv2_1_1x1_reduce/relu"
-  type: "ReLU"
-  bottom: "conv2_1_1x1_reduce"
-  top: "conv2_1_1x1_reduce"
-}
-layer {
-  name: "conv2_1_3x3"
-  type: "Convolution"
-  bottom: "conv2_1_1x1_reduce"
-  top: "conv2_1_3x3"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
-  convolution_param {
-    num_output: 64
-    pad: 1
-    kernel_size: 3
-    stride: 1
-    weight_filler {
-      type: "msra"
-    }
-    bias_term: false
-  }
-}
-layer {
-  name: "conv2_1_3x3/bnc"
-  type: "BatchNorm"
-  bottom: "conv2_1_3x3"
-  top: "conv2_1_3x3"
-}
-
-layer {
- name: "conv2_1_3x3/scale"
- type: "Scale"
-bottom: "conv2_1_3x3"
- top: "conv2_1_3x3"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv2_1_3x3/relu"
-  type: "ReLU"
-  bottom: "conv2_1_3x3"
-  top: "conv2_1_3x3"
-}
-layer {
-  name: "conv2_1_1x1_increase"
-  type: "Convolution"
-  bottom: "conv2_1_3x3"
-  top: "conv2_1_1x1_increase"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
+  bottom: "pool1"
+  top: "res2a_branch1"
   convolution_param {
     num_output: 256
+    bias_term: false
     pad: 0
     kernel_size: 1
     stride: 1
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
-  }
-}
-layer {
-  name: "conv2_1_1x1_increase/bnc"
-  type: "BatchNorm"
-  bottom: "conv2_1_1x1_increase"
-  top: "conv2_1_1x1_increase"
-}
-
-layer {
- name: "conv2_1_1x1_increase/scale"
- type: "Scale"
-bottom: "conv2_1_1x1_increase"
- top: "conv2_1_1x1_increase"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv2_1_1x1_proj"
-  type: "Convolution"
-  bottom: "pool1_3x3_s2"
-  top: "conv2_1_1x1_proj"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
-  convolution_param {
-    num_output: 256
-    pad: 0
-    kernel_size: 1
-    stride: 1
-    weight_filler {
-      type: "msra"
+    bias_filler {
+      type: "constant"
+      value: 0.2
     }
-    bias_term: false
   }
 }
 layer {
-  name: "conv2_1_1x1_proj/bnc"
+  name: "bn2a_branch1"
   type: "BatchNorm"
-  bottom: "conv2_1_1x1_proj"
-  top: "conv2_1_1x1_proj"
-}
-
-layer {
- name: "conv2_1_1x1_proj/scale"
- type: "Scale"
-bottom: "conv2_1_1x1_proj"
- top: "conv2_1_1x1_proj"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv2_1"
-  type: "Eltwise"
-  bottom: "conv2_1_1x1_proj"
-  bottom: "conv2_1_1x1_increase"
-  top: "conv2_1"
-  eltwise_param {
-    operation: SUM
+  bottom: "res2a_branch1"
+  top: "res2a_branch1"
+  batch_norm_param {
   }
 }
 layer {
-  name: "conv2_1/relu"
-  type: "ReLU"
-  bottom: "conv2_1"
-  top: "conv2_1"
+  name: "scale2a_branch1"
+  type: "Scale"
+  bottom: "res2a_branch1"
+  top: "res2a_branch1"
+  scale_param {
+    bias_term: true
+  }
 }
 layer {
-  name: "conv2_2_1x1_reduce"
+  name: "res2a_branch2a"
   type: "Convolution"
-  bottom: "conv2_1"
-  top: "conv2_2_1x1_reduce"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
+  bottom: "pool1"
+  top: "res2a_branch2a"
   convolution_param {
     num_output: 64
+    bias_term: false
     pad: 0
     kernel_size: 1
     stride: 1
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
   }
 }
 layer {
-  name: "conv2_2_1x1_reduce/bnc"
+  name: "bn2a_branch2a"
   type: "BatchNorm"
-  bottom: "conv2_2_1x1_reduce"
-  top: "conv2_2_1x1_reduce"
-}
-
-layer {
- name: "conv2_2_1x1_reduce/scale"
- type: "Scale"
-bottom: "conv2_2_1x1_reduce"
- top: "conv2_2_1x1_reduce"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv2_2_1x1_reduce/relu"
-  type: "ReLU"
-  bottom: "conv2_2_1x1_reduce"
-  top: "conv2_2_1x1_reduce"
-}
-layer {
-  name: "conv2_2_3x3"
-  type: "Convolution"
-  bottom: "conv2_2_1x1_reduce"
-  top: "conv2_2_3x3"
-  param {
-    lr_mult: 1
-    decay_mult: 1
+  bottom: "res2a_branch2a"
+  top: "res2a_branch2a"
+  batch_norm_param {
   }
+}
+layer {
+  name: "scale2a_branch2a"
+  type: "Scale"
+  bottom: "res2a_branch2a"
+  top: "res2a_branch2a"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res2a_branch2a_relu"
+  type: "ReLU"
+  bottom: "res2a_branch2a"
+  top: "res2a_branch2a"
+}
+layer {
+  name: "res2a_branch2b"
+  type: "Convolution"
+  bottom: "res2a_branch2a"
+  top: "res2a_branch2b"
   convolution_param {
     num_output: 64
+    bias_term: false
     pad: 1
     kernel_size: 3
     stride: 1
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
   }
 }
 layer {
-  name: "conv2_2_3x3/bnc"
+  name: "bn2a_branch2b"
   type: "BatchNorm"
-  bottom: "conv2_2_3x3"
-  top: "conv2_2_3x3"
-}
-
-layer {
- name: "conv2_2_3x3/scale"
- type: "Scale"
-bottom: "conv2_2_3x3"
- top: "conv2_2_3x3"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv2_2_3x3/relu"
-  type: "ReLU"
-  bottom: "conv2_2_3x3"
-  top: "conv2_2_3x3"
-}
-layer {
-  name: "conv2_2_1x1_increase"
-  type: "Convolution"
-  bottom: "conv2_2_3x3"
-  top: "conv2_2_1x1_increase"
-  param {
-    lr_mult: 1
-    decay_mult: 1
+  bottom: "res2a_branch2b"
+  top: "res2a_branch2b"
+  batch_norm_param {
   }
+}
+layer {
+  name: "scale2a_branch2b"
+  type: "Scale"
+  bottom: "res2a_branch2b"
+  top: "res2a_branch2b"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res2a_branch2b_relu"
+  type: "ReLU"
+  bottom: "res2a_branch2b"
+  top: "res2a_branch2b"
+}
+layer {
+  name: "res2a_branch2c"
+  type: "Convolution"
+  bottom: "res2a_branch2b"
+  top: "res2a_branch2c"
   convolution_param {
     num_output: 256
+    bias_term: false
     pad: 0
     kernel_size: 1
     stride: 1
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
   }
 }
 layer {
-  name: "conv2_2_1x1_increase/bnc"
+  name: "bn2a_branch2c"
   type: "BatchNorm"
-  bottom: "conv2_2_1x1_increase"
-  top: "conv2_2_1x1_increase"
+  bottom: "res2a_branch2c"
+  top: "res2a_branch2c"
+  batch_norm_param {
+  }
 }
-
 layer {
- name: "conv2_2_1x1_increase/scale"
- type: "Scale"
-bottom: "conv2_2_1x1_increase"
- top: "conv2_2_1x1_increase"
- scale_param {
- bias_term: true
+  name: "scale2a_branch2c"
+  type: "Scale"
+  bottom: "res2a_branch2c"
+  top: "res2a_branch2c"
+  scale_param {
+    bias_term: true
+  }
 }
-}
-
 layer {
-  name: "conv2_2"
+  name: "res2a"
   type: "Eltwise"
-  bottom: "conv2_1"
-  bottom: "conv2_2_1x1_increase"
-  top: "conv2_2"
-  eltwise_param {
-    operation: SUM
-  }
+  bottom: "res2a_branch1"
+  bottom: "res2a_branch2c"
+  top: "res2a"
 }
 layer {
-  name: "conv2_2/relu"
+  name: "res2a_relu"
   type: "ReLU"
-  bottom: "conv2_2"
-  top: "conv2_2"
+  bottom: "res2a"
+  top: "res2a"
 }
 layer {
-  name: "conv2_3_1x1_reduce"
+  name: "res2b_branch2a"
   type: "Convolution"
-  bottom: "conv2_2"
-  top: "conv2_3_1x1_reduce"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
+  bottom: "res2a"
+  top: "res2b_branch2a"
   convolution_param {
     num_output: 64
+    bias_term: false
     pad: 0
     kernel_size: 1
     stride: 1
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
   }
 }
 layer {
-  name: "conv2_3_1x1_reduce/bnc"
+  name: "bn2b_branch2a"
   type: "BatchNorm"
-  bottom: "conv2_3_1x1_reduce"
-  top: "conv2_3_1x1_reduce"
-}
-
-layer {
- name: "conv2_3_1x1_reduce/scale"
- type: "Scale"
-bottom: "conv2_3_1x1_reduce"
- top: "conv2_3_1x1_reduce"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv2_3_1x1_reduce/relu"
-  type: "ReLU"
-  bottom: "conv2_3_1x1_reduce"
-  top: "conv2_3_1x1_reduce"
-}
-layer {
-  name: "conv2_3_3x3"
-  type: "Convolution"
-  bottom: "conv2_3_1x1_reduce"
-  top: "conv2_3_3x3"
-  param {
-    lr_mult: 1
-    decay_mult: 1
+  bottom: "res2b_branch2a"
+  top: "res2b_branch2a"
+  batch_norm_param {
   }
+}
+layer {
+  name: "scale2b_branch2a"
+  type: "Scale"
+  bottom: "res2b_branch2a"
+  top: "res2b_branch2a"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res2b_branch2a_relu"
+  type: "ReLU"
+  bottom: "res2b_branch2a"
+  top: "res2b_branch2a"
+}
+layer {
+  name: "res2b_branch2b"
+  type: "Convolution"
+  bottom: "res2b_branch2a"
+  top: "res2b_branch2b"
   convolution_param {
     num_output: 64
+    bias_term: false
     pad: 1
     kernel_size: 3
     stride: 1
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
   }
 }
 layer {
-  name: "conv2_3_3x3/bnc"
+  name: "bn2b_branch2b"
   type: "BatchNorm"
-  bottom: "conv2_3_3x3"
-  top: "conv2_3_3x3"
-}
-
-layer {
- name: "conv2_3_3x3/scale"
- type: "Scale"
-bottom: "conv2_3_3x3"
- top: "conv2_3_3x3"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv2_3_3x3/relu"
-  type: "ReLU"
-  bottom: "conv2_3_3x3"
-  top: "conv2_3_3x3"
-}
-layer {
-  name: "conv2_3_1x1_increase"
-  type: "Convolution"
-  bottom: "conv2_3_3x3"
-  top: "conv2_3_1x1_increase"
-  param {
-    lr_mult: 1
-    decay_mult: 1
+  bottom: "res2b_branch2b"
+  top: "res2b_branch2b"
+  batch_norm_param {
   }
+}
+layer {
+  name: "scale2b_branch2b"
+  type: "Scale"
+  bottom: "res2b_branch2b"
+  top: "res2b_branch2b"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res2b_branch2b_relu"
+  type: "ReLU"
+  bottom: "res2b_branch2b"
+  top: "res2b_branch2b"
+}
+layer {
+  name: "res2b_branch2c"
+  type: "Convolution"
+  bottom: "res2b_branch2b"
+  top: "res2b_branch2c"
   convolution_param {
     num_output: 256
+    bias_term: false
     pad: 0
     kernel_size: 1
     stride: 1
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
   }
 }
 layer {
-  name: "conv2_3_1x1_increase/bnc"
+  name: "bn2b_branch2c"
   type: "BatchNorm"
-  bottom: "conv2_3_1x1_increase"
-  top: "conv2_3_1x1_increase"
+  bottom: "res2b_branch2c"
+  top: "res2b_branch2c"
+  batch_norm_param {
+  }
 }
-
 layer {
- name: "conv2_3_1x1_increase/scale"
- type: "Scale"
-bottom: "conv2_3_1x1_increase"
- top: "conv2_3_1x1_increase"
- scale_param {
- bias_term: true
+  name: "scale2b_branch2c"
+  type: "Scale"
+  bottom: "res2b_branch2c"
+  top: "res2b_branch2c"
+  scale_param {
+    bias_term: true
+  }
 }
-}
-
 layer {
-  name: "conv2_3"
+  name: "res2b"
   type: "Eltwise"
-  bottom: "conv2_2"
-  bottom: "conv2_3_1x1_increase"
-  top: "conv2_3"
-  eltwise_param {
-    operation: SUM
-  }
+  bottom: "res2a"
+  bottom: "res2b_branch2c"
+  top: "res2b"
 }
 layer {
-  name: "conv2_3/relu"
+  name: "res2b_relu"
   type: "ReLU"
-  bottom: "conv2_3"
-  top: "conv2_3"
+  bottom: "res2b"
+  top: "res2b"
 }
 layer {
-  name: "conv3_1_1x1_reduce"
+  name: "res2c_branch2a"
   type: "Convolution"
-  bottom: "conv2_3"
-  top: "conv3_1_1x1_reduce"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
+  bottom: "res2b"
+  top: "res2c_branch2a"
   convolution_param {
-    num_output: 128
+    num_output: 64
+    bias_term: false
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "bn2c_branch2a"
+  type: "BatchNorm"
+  bottom: "res2c_branch2a"
+  top: "res2c_branch2a"
+  batch_norm_param {
+  }
+}
+layer {
+  name: "scale2c_branch2a"
+  type: "Scale"
+  bottom: "res2c_branch2a"
+  top: "res2c_branch2a"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res2c_branch2a_relu"
+  type: "ReLU"
+  bottom: "res2c_branch2a"
+  top: "res2c_branch2a"
+}
+layer {
+  name: "res2c_branch2b"
+  type: "Convolution"
+  bottom: "res2c_branch2a"
+  top: "res2c_branch2b"
+  convolution_param {
+    num_output: 64
+    bias_term: false
+    pad: 1
+    kernel_size: 3
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "bn2c_branch2b"
+  type: "BatchNorm"
+  bottom: "res2c_branch2b"
+  top: "res2c_branch2b"
+  batch_norm_param {
+  }
+}
+layer {
+  name: "scale2c_branch2b"
+  type: "Scale"
+  bottom: "res2c_branch2b"
+  top: "res2c_branch2b"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res2c_branch2b_relu"
+  type: "ReLU"
+  bottom: "res2c_branch2b"
+  top: "res2c_branch2b"
+}
+layer {
+  name: "res2c_branch2c"
+  type: "Convolution"
+  bottom: "res2c_branch2b"
+  top: "res2c_branch2c"
+  convolution_param {
+    num_output: 256
+    bias_term: false
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "bn2c_branch2c"
+  type: "BatchNorm"
+  bottom: "res2c_branch2c"
+  top: "res2c_branch2c"
+  batch_norm_param {
+  }
+}
+layer {
+  name: "scale2c_branch2c"
+  type: "Scale"
+  bottom: "res2c_branch2c"
+  top: "res2c_branch2c"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res2c"
+  type: "Eltwise"
+  bottom: "res2b"
+  bottom: "res2c_branch2c"
+  top: "res2c"
+}
+layer {
+  name: "res2c_relu"
+  type: "ReLU"
+  bottom: "res2c"
+  top: "res2c"
+}
+layer {
+  name: "res3a_branch1"
+  type: "Convolution"
+  bottom: "res2c"
+  top: "res3a_branch1"
+  convolution_param {
+    num_output: 512
+    bias_term: false
     pad: 0
     kernel_size: 1
     stride: 2
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
   }
 }
 layer {
-  name: "conv3_1_1x1_reduce/bnc"
+  name: "bn3a_branch1"
   type: "BatchNorm"
-  bottom: "conv3_1_1x1_reduce"
-  top: "conv3_1_1x1_reduce"
-}
-
-layer {
- name: "conv3_1_1x1_reduce/scale"
- type: "Scale"
-bottom: "conv3_1_1x1_reduce"
- top: "conv3_1_1x1_reduce"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv3_1_1x1_reduce/relu"
-  type: "ReLU"
-  bottom: "conv3_1_1x1_reduce"
-  top: "conv3_1_1x1_reduce"
-}
-layer {
-  name: "conv3_1_3x3"
-  type: "Convolution"
-  bottom: "conv3_1_1x1_reduce"
-  top: "conv3_1_3x3"
-  param {
-    lr_mult: 1
-    decay_mult: 1
+  bottom: "res3a_branch1"
+  top: "res3a_branch1"
+  batch_norm_param {
   }
+}
+layer {
+  name: "scale3a_branch1"
+  type: "Scale"
+  bottom: "res3a_branch1"
+  top: "res3a_branch1"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res3a_branch2a"
+  type: "Convolution"
+  bottom: "res2c"
+  top: "res3a_branch2a"
   convolution_param {
     num_output: 128
-    pad: 1
-    kernel_size: 3
-    stride: 1
-    weight_filler {
-      type: "msra"
-    }
     bias_term: false
-  }
-}
-layer {
-  name: "conv3_1_3x3/bnc"
-  type: "BatchNorm"
-  bottom: "conv3_1_3x3"
-  top: "conv3_1_3x3"
-}
-
-layer {
- name: "conv3_1_3x3/scale"
- type: "Scale"
-bottom: "conv3_1_3x3"
- top: "conv3_1_3x3"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv3_1_3x3/relu"
-  type: "ReLU"
-  bottom: "conv3_1_3x3"
-  top: "conv3_1_3x3"
-}
-layer {
-  name: "conv3_1_1x1_increase"
-  type: "Convolution"
-  bottom: "conv3_1_3x3"
-  top: "conv3_1_1x1_increase"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
-  convolution_param {
-    num_output: 512
-    pad: 0
-    kernel_size: 1
-    stride: 1
-    weight_filler {
-      type: "msra"
-    }
-    bias_term: false
-  }
-}
-layer {
-  name: "conv3_1_1x1_increase/bnc"
-  type: "BatchNorm"
-  bottom: "conv3_1_1x1_increase"
-  top: "conv3_1_1x1_increase"
-}
-
-layer {
- name: "conv3_1_1x1_increase/scale"
- type: "Scale"
-bottom: "conv3_1_1x1_increase"
- top: "conv3_1_1x1_increase"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv3_1_1x1_proj"
-  type: "Convolution"
-  bottom: "conv2_3"
-  top: "conv3_1_1x1_proj"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
-  convolution_param {
-    num_output: 512
     pad: 0
     kernel_size: 1
     stride: 2
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
   }
 }
 layer {
-  name: "conv3_1_1x1_proj/bnc"
+  name: "bn3a_branch2a"
   type: "BatchNorm"
-  bottom: "conv3_1_1x1_proj"
-  top: "conv3_1_1x1_proj"
-}
-
-layer {
- name: "conv3_1_1x1_proj/scale"
- type: "Scale"
-bottom: "conv3_1_1x1_proj"
- top: "conv3_1_1x1_proj"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv3_1"
-  type: "Eltwise"
-  bottom: "conv3_1_1x1_proj"
-  bottom: "conv3_1_1x1_increase"
-  top: "conv3_1"
-  eltwise_param {
-    operation: SUM
+  bottom: "res3a_branch2a"
+  top: "res3a_branch2a"
+  batch_norm_param {
   }
 }
 layer {
-  name: "conv3_1/relu"
+  name: "scale3a_branch2a"
+  type: "Scale"
+  bottom: "res3a_branch2a"
+  top: "res3a_branch2a"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res3a_branch2a_relu"
   type: "ReLU"
-  bottom: "conv3_1"
-  top: "conv3_1"
+  bottom: "res3a_branch2a"
+  top: "res3a_branch2a"
 }
 layer {
-  name: "conv3_2_1x1_reduce"
+  name: "res3a_branch2b"
   type: "Convolution"
-  bottom: "conv3_1"
-  top: "conv3_2_1x1_reduce"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
+  bottom: "res3a_branch2a"
+  top: "res3a_branch2b"
   convolution_param {
     num_output: 128
-    pad: 0
-    kernel_size: 1
-    stride: 1
-    weight_filler {
-      type: "msra"
-    }
     bias_term: false
-  }
-}
-layer {
-  name: "conv3_2_1x1_reduce/bnc"
-  type: "BatchNorm"
-  bottom: "conv3_2_1x1_reduce"
-  top: "conv3_2_1x1_reduce"
-}
-
-layer {
- name: "conv3_2_1x1_reduce/scale"
- type: "Scale"
-bottom: "conv3_2_1x1_reduce"
- top: "conv3_2_1x1_reduce"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv3_2_1x1_reduce/relu"
-  type: "ReLU"
-  bottom: "conv3_2_1x1_reduce"
-  top: "conv3_2_1x1_reduce"
-}
-layer {
-  name: "conv3_2_3x3"
-  type: "Convolution"
-  bottom: "conv3_2_1x1_reduce"
-  top: "conv3_2_3x3"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
-  convolution_param {
-    num_output: 128
     pad: 1
     kernel_size: 3
     stride: 1
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
   }
 }
 layer {
-  name: "conv3_2_3x3/bnc"
+  name: "bn3a_branch2b"
   type: "BatchNorm"
-  bottom: "conv3_2_3x3"
-  top: "conv3_2_3x3"
-}
-
-layer {
- name: "conv3_2_3x3/scale"
- type: "Scale"
-bottom: "conv3_2_3x3"
- top: "conv3_2_3x3"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv3_2_3x3/relu"
-  type: "ReLU"
-  bottom: "conv3_2_3x3"
-  top: "conv3_2_3x3"
-}
-layer {
-  name: "conv3_2_1x1_increase"
-  type: "Convolution"
-  bottom: "conv3_2_3x3"
-  top: "conv3_2_1x1_increase"
-  param {
-    lr_mult: 1
-    decay_mult: 1
+  bottom: "res3a_branch2b"
+  top: "res3a_branch2b"
+  batch_norm_param {
   }
+}
+layer {
+  name: "scale3a_branch2b"
+  type: "Scale"
+  bottom: "res3a_branch2b"
+  top: "res3a_branch2b"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res3a_branch2b_relu"
+  type: "ReLU"
+  bottom: "res3a_branch2b"
+  top: "res3a_branch2b"
+}
+layer {
+  name: "res3a_branch2c"
+  type: "Convolution"
+  bottom: "res3a_branch2b"
+  top: "res3a_branch2c"
   convolution_param {
     num_output: 512
+    bias_term: false
     pad: 0
     kernel_size: 1
     stride: 1
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
   }
 }
 layer {
-  name: "conv3_2_1x1_increase/bnc"
+  name: "bn3a_branch2c"
   type: "BatchNorm"
-  bottom: "conv3_2_1x1_increase"
-  top: "conv3_2_1x1_increase"
+  bottom: "res3a_branch2c"
+  top: "res3a_branch2c"
+  batch_norm_param {
+  }
 }
-
 layer {
- name: "conv3_2_1x1_increase/scale"
- type: "Scale"
-bottom: "conv3_2_1x1_increase"
- top: "conv3_2_1x1_increase"
- scale_param {
- bias_term: true
+  name: "scale3a_branch2c"
+  type: "Scale"
+  bottom: "res3a_branch2c"
+  top: "res3a_branch2c"
+  scale_param {
+    bias_term: true
+  }
 }
-}
-
 layer {
-  name: "conv3_2"
+  name: "res3a"
   type: "Eltwise"
-  bottom: "conv3_1"
-  bottom: "conv3_2_1x1_increase"
-  top: "conv3_2"
-  eltwise_param {
-    operation: SUM
-  }
+  bottom: "res3a_branch1"
+  bottom: "res3a_branch2c"
+  top: "res3a"
 }
 layer {
-  name: "conv3_2/relu"
+  name: "res3a_relu"
   type: "ReLU"
-  bottom: "conv3_2"
-  top: "conv3_2"
+  bottom: "res3a"
+  top: "res3a"
 }
 layer {
-  name: "conv3_3_1x1_reduce"
+  name: "res3b_branch2a"
   type: "Convolution"
-  bottom: "conv3_2"
-  top: "conv3_3_1x1_reduce"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
+  bottom: "res3a"
+  top: "res3b_branch2a"
   convolution_param {
     num_output: 128
+    bias_term: false
     pad: 0
     kernel_size: 1
     stride: 1
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
   }
 }
 layer {
-  name: "conv3_3_1x1_reduce/bnc"
+  name: "bn3b_branch2a"
   type: "BatchNorm"
-  bottom: "conv3_3_1x1_reduce"
-  top: "conv3_3_1x1_reduce"
-}
-
-layer {
- name: "conv3_3_1x1_reduce/scale"
- type: "Scale"
-bottom: "conv3_3_1x1_reduce"
- top: "conv3_3_1x1_reduce"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv3_3_1x1_reduce/relu"
-  type: "ReLU"
-  bottom: "conv3_3_1x1_reduce"
-  top: "conv3_3_1x1_reduce"
-}
-layer {
-  name: "conv3_3_3x3"
-  type: "Convolution"
-  bottom: "conv3_3_1x1_reduce"
-  top: "conv3_3_3x3"
-  param {
-    lr_mult: 1
-    decay_mult: 1
+  bottom: "res3b_branch2a"
+  top: "res3b_branch2a"
+  batch_norm_param {
   }
+}
+layer {
+  name: "scale3b_branch2a"
+  type: "Scale"
+  bottom: "res3b_branch2a"
+  top: "res3b_branch2a"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res3b_branch2a_relu"
+  type: "ReLU"
+  bottom: "res3b_branch2a"
+  top: "res3b_branch2a"
+}
+layer {
+  name: "res3b_branch2b"
+  type: "Convolution"
+  bottom: "res3b_branch2a"
+  top: "res3b_branch2b"
   convolution_param {
     num_output: 128
+    bias_term: false
     pad: 1
     kernel_size: 3
     stride: 1
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
   }
 }
 layer {
-  name: "conv3_3_3x3/bnc"
+  name: "bn3b_branch2b"
   type: "BatchNorm"
-  bottom: "conv3_3_3x3"
-  top: "conv3_3_3x3"
-}
-
-layer {
- name: "conv3_3_3x3/scale"
- type: "Scale"
-bottom: "conv3_3_3x3"
- top: "conv3_3_3x3"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv3_3_3x3/relu"
-  type: "ReLU"
-  bottom: "conv3_3_3x3"
-  top: "conv3_3_3x3"
-}
-layer {
-  name: "conv3_3_1x1_increase"
-  type: "Convolution"
-  bottom: "conv3_3_3x3"
-  top: "conv3_3_1x1_increase"
-  param {
-    lr_mult: 1
-    decay_mult: 1
+  bottom: "res3b_branch2b"
+  top: "res3b_branch2b"
+  batch_norm_param {
   }
+}
+layer {
+  name: "scale3b_branch2b"
+  type: "Scale"
+  bottom: "res3b_branch2b"
+  top: "res3b_branch2b"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res3b_branch2b_relu"
+  type: "ReLU"
+  bottom: "res3b_branch2b"
+  top: "res3b_branch2b"
+}
+layer {
+  name: "res3b_branch2c"
+  type: "Convolution"
+  bottom: "res3b_branch2b"
+  top: "res3b_branch2c"
   convolution_param {
     num_output: 512
+    bias_term: false
     pad: 0
     kernel_size: 1
     stride: 1
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
   }
 }
 layer {
-  name: "conv3_3_1x1_increase/bnc"
+  name: "bn3b_branch2c"
   type: "BatchNorm"
-  bottom: "conv3_3_1x1_increase"
-  top: "conv3_3_1x1_increase"
+  bottom: "res3b_branch2c"
+  top: "res3b_branch2c"
+  batch_norm_param {
+  }
 }
-
 layer {
- name: "conv3_3_1x1_increase/scale"
- type: "Scale"
-bottom: "conv3_3_1x1_increase"
- top: "conv3_3_1x1_increase"
- scale_param {
- bias_term: true
+  name: "scale3b_branch2c"
+  type: "Scale"
+  bottom: "res3b_branch2c"
+  top: "res3b_branch2c"
+  scale_param {
+    bias_term: true
+  }
 }
-}
-
 layer {
-  name: "conv3_3"
+  name: "res3b"
   type: "Eltwise"
-  bottom: "conv3_2"
-  bottom: "conv3_3_1x1_increase"
-  top: "conv3_3"
-  eltwise_param {
-    operation: SUM
-  }
+  bottom: "res3a"
+  bottom: "res3b_branch2c"
+  top: "res3b"
 }
 layer {
-  name: "conv3_3/relu"
+  name: "res3b_relu"
   type: "ReLU"
-  bottom: "conv3_3"
-  top: "conv3_3"
+  bottom: "res3b"
+  top: "res3b"
 }
 layer {
-  name: "conv3_4_1x1_reduce"
+  name: "res3c_branch2a"
   type: "Convolution"
-  bottom: "conv3_3"
-  top: "conv3_4_1x1_reduce"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
+  bottom: "res3b"
+  top: "res3c_branch2a"
   convolution_param {
     num_output: 128
+    bias_term: false
     pad: 0
     kernel_size: 1
     stride: 1
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
   }
 }
 layer {
-  name: "conv3_4_1x1_reduce/bnc"
+  name: "bn3c_branch2a"
   type: "BatchNorm"
-  bottom: "conv3_4_1x1_reduce"
-  top: "conv3_4_1x1_reduce"
-}
-
-layer {
- name: "conv3_4_1x1_reduce/scale"
- type: "Scale"
-bottom: "conv3_4_1x1_reduce"
- top: "conv3_4_1x1_reduce"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv3_4_1x1_reduce/relu"
-  type: "ReLU"
-  bottom: "conv3_4_1x1_reduce"
-  top: "conv3_4_1x1_reduce"
-}
-layer {
-  name: "conv3_4_3x3"
-  type: "Convolution"
-  bottom: "conv3_4_1x1_reduce"
-  top: "conv3_4_3x3"
-  param {
-    lr_mult: 1
-    decay_mult: 1
+  bottom: "res3c_branch2a"
+  top: "res3c_branch2a"
+  batch_norm_param {
   }
+}
+layer {
+  name: "scale3c_branch2a"
+  type: "Scale"
+  bottom: "res3c_branch2a"
+  top: "res3c_branch2a"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res3c_branch2a_relu"
+  type: "ReLU"
+  bottom: "res3c_branch2a"
+  top: "res3c_branch2a"
+}
+layer {
+  name: "res3c_branch2b"
+  type: "Convolution"
+  bottom: "res3c_branch2a"
+  top: "res3c_branch2b"
   convolution_param {
     num_output: 128
+    bias_term: false
     pad: 1
     kernel_size: 3
     stride: 1
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
   }
 }
 layer {
-  name: "conv3_4_3x3/bnc"
+  name: "bn3c_branch2b"
   type: "BatchNorm"
-  bottom: "conv3_4_3x3"
-  top: "conv3_4_3x3"
-}
-
-layer {
- name: "conv3_4_3x3/scale"
- type: "Scale"
-bottom: "conv3_4_3x3"
- top: "conv3_4_3x3"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv3_4_3x3/relu"
-  type: "ReLU"
-  bottom: "conv3_4_3x3"
-  top: "conv3_4_3x3"
-}
-layer {
-  name: "conv3_4_1x1_increase"
-  type: "Convolution"
-  bottom: "conv3_4_3x3"
-  top: "conv3_4_1x1_increase"
-  param {
-    lr_mult: 1
-    decay_mult: 1
+  bottom: "res3c_branch2b"
+  top: "res3c_branch2b"
+  batch_norm_param {
   }
+}
+layer {
+  name: "scale3c_branch2b"
+  type: "Scale"
+  bottom: "res3c_branch2b"
+  top: "res3c_branch2b"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res3c_branch2b_relu"
+  type: "ReLU"
+  bottom: "res3c_branch2b"
+  top: "res3c_branch2b"
+}
+layer {
+  name: "res3c_branch2c"
+  type: "Convolution"
+  bottom: "res3c_branch2b"
+  top: "res3c_branch2c"
   convolution_param {
     num_output: 512
+    bias_term: false
     pad: 0
     kernel_size: 1
     stride: 1
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
   }
 }
 layer {
-  name: "conv3_4_1x1_increase/bnc"
+  name: "bn3c_branch2c"
   type: "BatchNorm"
-  bottom: "conv3_4_1x1_increase"
-  top: "conv3_4_1x1_increase"
+  bottom: "res3c_branch2c"
+  top: "res3c_branch2c"
+  batch_norm_param {
+  }
 }
-
 layer {
- name: "conv3_4_1x1_increase/scale"
- type: "Scale"
-bottom: "conv3_4_1x1_increase"
- top: "conv3_4_1x1_increase"
- scale_param {
- bias_term: true
+  name: "scale3c_branch2c"
+  type: "Scale"
+  bottom: "res3c_branch2c"
+  top: "res3c_branch2c"
+  scale_param {
+    bias_term: true
+  }
 }
-}
-
 layer {
-  name: "conv3_4"
+  name: "res3c"
   type: "Eltwise"
-  bottom: "conv3_3"
-  bottom: "conv3_4_1x1_increase"
-  top: "conv3_4"
-  eltwise_param {
-    operation: SUM
-  }
+  bottom: "res3b"
+  bottom: "res3c_branch2c"
+  top: "res3c"
 }
 layer {
-  name: "conv3_4/relu"
+  name: "res3c_relu"
   type: "ReLU"
-  bottom: "conv3_4"
-  top: "conv3_4"
+  bottom: "res3c"
+  top: "res3c"
 }
 layer {
-  name: "conv4_1_1x1_reduce"
+  name: "res3d_branch2a"
   type: "Convolution"
-  bottom: "conv3_4"
-  top: "conv4_1_1x1_reduce"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
+  bottom: "res3c"
+  top: "res3d_branch2a"
   convolution_param {
-    num_output: 256
+    num_output: 128
+    bias_term: false
     pad: 0
     kernel_size: 1
     stride: 1
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
   }
 }
 layer {
-  name: "conv4_1_1x1_reduce/bnc"
+  name: "bn3d_branch2a"
   type: "BatchNorm"
-  bottom: "conv4_1_1x1_reduce"
-  top: "conv4_1_1x1_reduce"
-}
-
-layer {
- name: "conv4_1_1x1_reduce/scale"
- type: "Scale"
-bottom: "conv4_1_1x1_reduce"
- top: "conv4_1_1x1_reduce"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv4_1_1x1_reduce/relu"
-  type: "ReLU"
-  bottom: "conv4_1_1x1_reduce"
-  top: "conv4_1_1x1_reduce"
-}
-layer {
-  name: "conv4_1_3x3"
-  type: "Convolution"
-  bottom: "conv4_1_1x1_reduce"
-  top: "conv4_1_3x3"
-  param {
-    lr_mult: 1
-    decay_mult: 1
+  bottom: "res3d_branch2a"
+  top: "res3d_branch2a"
+  batch_norm_param {
   }
+}
+layer {
+  name: "scale3d_branch2a"
+  type: "Scale"
+  bottom: "res3d_branch2a"
+  top: "res3d_branch2a"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res3d_branch2a_relu"
+  type: "ReLU"
+  bottom: "res3d_branch2a"
+  top: "res3d_branch2a"
+}
+layer {
+  name: "res3d_branch2b"
+  type: "Convolution"
+  bottom: "res3d_branch2a"
+  top: "res3d_branch2b"
   convolution_param {
-    num_output: 256
-    pad: 2
-    dilation: 2
+    num_output: 128
+    bias_term: false
+    pad: 1
     kernel_size: 3
     stride: 1
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
   }
 }
 layer {
-  name: "conv4_1_3x3/bnc"
+  name: "bn3d_branch2b"
   type: "BatchNorm"
-  bottom: "conv4_1_3x3"
-  top: "conv4_1_3x3"
+  bottom: "res3d_branch2b"
+  top: "res3d_branch2b"
+  batch_norm_param {
+  }
 }
-
 layer {
- name: "conv4_1_3x3/scale"
- type: "Scale"
-bottom: "conv4_1_3x3"
- top: "conv4_1_3x3"
- scale_param {
- bias_term: true
+  name: "scale3d_branch2b"
+  type: "Scale"
+  bottom: "res3d_branch2b"
+  top: "res3d_branch2b"
+  scale_param {
+    bias_term: true
+  }
 }
-}
-
 layer {
-  name: "conv4_1_3x3/relu"
+  name: "res3d_branch2b_relu"
   type: "ReLU"
-  bottom: "conv4_1_3x3"
-  top: "conv4_1_3x3"
+  bottom: "res3d_branch2b"
+  top: "res3d_branch2b"
 }
 layer {
-  name: "conv4_1_1x1_increase"
+  name: "res3d_branch2c"
   type: "Convolution"
-  bottom: "conv4_1_3x3"
-  top: "conv4_1_1x1_increase"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
-  convolution_param {
-    num_output: 1024
-    pad: 0
-    kernel_size: 1
-    stride: 1
-    weight_filler {
-      type: "msra"
-    }
-    bias_term: false
-  }
-}
-layer {
-  name: "conv4_1_1x1_increase/bnc"
-  type: "BatchNorm"
-  bottom: "conv4_1_1x1_increase"
-  top: "conv4_1_1x1_increase"
-}
-
-layer {
- name: "conv4_1_1x1_increase/scale"
- type: "Scale"
-bottom: "conv4_1_1x1_increase"
- top: "conv4_1_1x1_increase"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv4_1_1x1_proj"
-  type: "Convolution"
-  bottom: "conv3_4"
-  top: "conv4_1_1x1_proj"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
-  convolution_param {
-    num_output: 1024
-    pad: 0
-    kernel_size: 1
-    stride: 1
-    weight_filler {
-      type: "msra"
-    }
-    bias_term: false
-  }
-}
-layer {
-  name: "conv4_1_1x1_proj/bnc"
-  type: "BatchNorm"
-  bottom: "conv4_1_1x1_proj"
-  top: "conv4_1_1x1_proj"
-}
-
-layer {
- name: "conv4_1_1x1_proj/scale"
- type: "Scale"
-bottom: "conv4_1_1x1_proj"
- top: "conv4_1_1x1_proj"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv4_1"
-  type: "Eltwise"
-  bottom: "conv4_1_1x1_proj"
-  bottom: "conv4_1_1x1_increase"
-  top: "conv4_1"
-  eltwise_param {
-    operation: SUM
-  }
-}
-layer {
-  name: "conv4_1/relu"
-  type: "ReLU"
-  bottom: "conv4_1"
-  top: "conv4_1"
-}
-layer {
-  name: "conv4_2_1x1_reduce"
-  type: "Convolution"
-  bottom: "conv4_1"
-  top: "conv4_2_1x1_reduce"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
-  convolution_param {
-    num_output: 256
-    pad: 0
-    kernel_size: 1
-    stride: 1
-    weight_filler {
-      type: "msra"
-    }
-    bias_term: false
-  }
-}
-layer {
-  name: "conv4_2_1x1_reduce/bnc"
-  type: "BatchNorm"
-  bottom: "conv4_2_1x1_reduce"
-  top: "conv4_2_1x1_reduce"
-}
-
-layer {
- name: "conv4_2_1x1_reduce/scale"
- type: "Scale"
-bottom: "conv4_2_1x1_reduce"
- top: "conv4_2_1x1_reduce"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv4_2_1x1_reduce/relu"
-  type: "ReLU"
-  bottom: "conv4_2_1x1_reduce"
-  top: "conv4_2_1x1_reduce"
-}
-layer {
-  name: "conv4_2_3x3"
-  type: "Convolution"
-  bottom: "conv4_2_1x1_reduce"
-  top: "conv4_2_3x3"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
-  convolution_param {
-    num_output: 256
-    pad: 2
-    dilation: 2
-    kernel_size: 3
-    stride: 1
-    weight_filler {
-      type: "msra"
-    }
-    bias_term: false
-  }
-}
-layer {
-  name: "conv4_2_3x3/bnc"
-  type: "BatchNorm"
-  bottom: "conv4_2_3x3"
-  top: "conv4_2_3x3"
-}
-
-layer {
- name: "conv4_2_3x3/scale"
- type: "Scale"
-bottom: "conv4_2_3x3"
- top: "conv4_2_3x3"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv4_2_3x3/relu"
-  type: "ReLU"
-  bottom: "conv4_2_3x3"
-  top: "conv4_2_3x3"
-}
-layer {
-  name: "conv4_2_1x1_increase"
-  type: "Convolution"
-  bottom: "conv4_2_3x3"
-  top: "conv4_2_1x1_increase"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
-  convolution_param {
-    num_output: 1024
-    pad: 0
-    kernel_size: 1
-    stride: 1
-    weight_filler {
-      type: "msra"
-    }
-    bias_term: false
-  }
-}
-layer {
-  name: "conv4_2_1x1_increase/bnc"
-  type: "BatchNorm"
-  bottom: "conv4_2_1x1_increase"
-  top: "conv4_2_1x1_increase"
-}
-
-layer {
- name: "conv4_2_1x1_increase/scale"
- type: "Scale"
-bottom: "conv4_2_1x1_increase"
- top: "conv4_2_1x1_increase"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv4_2"
-  type: "Eltwise"
-  bottom: "conv4_1"
-  bottom: "conv4_2_1x1_increase"
-  top: "conv4_2"
-  eltwise_param {
-    operation: SUM
-  }
-}
-layer {
-  name: "conv4_2/relu"
-  type: "ReLU"
-  bottom: "conv4_2"
-  top: "conv4_2"
-}
-layer {
-  name: "conv4_3_1x1_reduce"
-  type: "Convolution"
-  bottom: "conv4_2"
-  top: "conv4_3_1x1_reduce"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
-  convolution_param {
-    num_output: 256
-    pad: 0
-    kernel_size: 1
-    stride: 1
-    weight_filler {
-      type: "msra"
-    }
-    bias_term: false
-  }
-}
-layer {
-  name: "conv4_3_1x1_reduce/bnc"
-  type: "BatchNorm"
-  bottom: "conv4_3_1x1_reduce"
-  top: "conv4_3_1x1_reduce"
-}
-
-layer {
- name: "conv4_3_1x1_reduce/scale"
- type: "Scale"
-bottom: "conv4_3_1x1_reduce"
- top: "conv4_3_1x1_reduce"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv4_3_1x1_reduce/relu"
-  type: "ReLU"
-  bottom: "conv4_3_1x1_reduce"
-  top: "conv4_3_1x1_reduce"
-}
-layer {
-  name: "conv4_3_3x3"
-  type: "Convolution"
-  bottom: "conv4_3_1x1_reduce"
-  top: "conv4_3_3x3"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
-  convolution_param {
-    num_output: 256
-    pad: 2
-    dilation: 2
-    kernel_size: 3
-    stride: 1
-    weight_filler {
-      type: "msra"
-    }
-    bias_term: false
-  }
-}
-layer {
-  name: "conv4_3_3x3/bnc"
-  type: "BatchNorm"
-  bottom: "conv4_3_3x3"
-  top: "conv4_3_3x3"
-}
-
-layer {
- name: "conv4_3_3x3/scale"
- type: "Scale"
-bottom: "conv4_3_3x3"
- top: "conv4_3_3x3"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv4_3_3x3/relu"
-  type: "ReLU"
-  bottom: "conv4_3_3x3"
-  top: "conv4_3_3x3"
-}
-layer {
-  name: "conv4_3_1x1_increase"
-  type: "Convolution"
-  bottom: "conv4_3_3x3"
-  top: "conv4_3_1x1_increase"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
-  convolution_param {
-    num_output: 1024
-    pad: 0
-    kernel_size: 1
-    stride: 1
-    weight_filler {
-      type: "msra"
-    }
-    bias_term: false
-  }
-}
-layer {
-  name: "conv4_3_1x1_increase/bnc"
-  type: "BatchNorm"
-  bottom: "conv4_3_1x1_increase"
-  top: "conv4_3_1x1_increase"
-}
-
-layer {
- name: "conv4_3_1x1_increase/scale"
- type: "Scale"
-bottom: "conv4_3_1x1_increase"
- top: "conv4_3_1x1_increase"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv4_3"
-  type: "Eltwise"
-  bottom: "conv4_2"
-  bottom: "conv4_3_1x1_increase"
-  top: "conv4_3"
-  eltwise_param {
-    operation: SUM
-  }
-}
-layer {
-  name: "conv4_3/relu"
-  type: "ReLU"
-  bottom: "conv4_3"
-  top: "conv4_3"
-}
-layer {
-  name: "conv4_4_1x1_reduce"
-  type: "Convolution"
-  bottom: "conv4_3"
-  top: "conv4_4_1x1_reduce"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
-  convolution_param {
-    num_output: 256
-    pad: 0
-    kernel_size: 1
-    stride: 1
-    weight_filler {
-      type: "msra"
-    }
-    bias_term: false
-  }
-}
-layer {
-  name: "conv4_4_1x1_reduce/bnc"
-  type: "BatchNorm"
-  bottom: "conv4_4_1x1_reduce"
-  top: "conv4_4_1x1_reduce"
-}
-
-layer {
- name: "conv4_4_1x1_reduce/scale"
- type: "Scale"
-bottom: "conv4_4_1x1_reduce"
- top: "conv4_4_1x1_reduce"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv4_4_1x1_reduce/relu"
-  type: "ReLU"
-  bottom: "conv4_4_1x1_reduce"
-  top: "conv4_4_1x1_reduce"
-}
-layer {
-  name: "conv4_4_3x3"
-  type: "Convolution"
-  bottom: "conv4_4_1x1_reduce"
-  top: "conv4_4_3x3"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
-  convolution_param {
-    num_output: 256
-    pad: 2
-    dilation: 2
-    kernel_size: 3
-    stride: 1
-    weight_filler {
-      type: "msra"
-    }
-    bias_term: false
-  }
-}
-layer {
-  name: "conv4_4_3x3/bnc"
-  type: "BatchNorm"
-  bottom: "conv4_4_3x3"
-  top: "conv4_4_3x3"
-}
-
-layer {
- name: "conv4_4_3x3/scale"
- type: "Scale"
-bottom: "conv4_4_3x3"
- top: "conv4_4_3x3"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv4_4_3x3/relu"
-  type: "ReLU"
-  bottom: "conv4_4_3x3"
-  top: "conv4_4_3x3"
-}
-layer {
-  name: "conv4_4_1x1_increase"
-  type: "Convolution"
-  bottom: "conv4_4_3x3"
-  top: "conv4_4_1x1_increase"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
-  convolution_param {
-    num_output: 1024
-    pad: 0
-    kernel_size: 1
-    stride: 1
-    weight_filler {
-      type: "msra"
-    }
-    bias_term: false
-  }
-}
-layer {
-  name: "conv4_4_1x1_increase/bnc"
-  type: "BatchNorm"
-  bottom: "conv4_4_1x1_increase"
-  top: "conv4_4_1x1_increase"
-}
-
-layer {
- name: "conv4_4_1x1_increase/scale"
- type: "Scale"
-bottom: "conv4_4_1x1_increase"
- top: "conv4_4_1x1_increase"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv4_4"
-  type: "Eltwise"
-  bottom: "conv4_3"
-  bottom: "conv4_4_1x1_increase"
-  top: "conv4_4"
-  eltwise_param {
-    operation: SUM
-  }
-}
-layer {
-  name: "conv4_4/relu"
-  type: "ReLU"
-  bottom: "conv4_4"
-  top: "conv4_4"
-}
-layer {
-  name: "conv4_5_1x1_reduce"
-  type: "Convolution"
-  bottom: "conv4_4"
-  top: "conv4_5_1x1_reduce"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
-  convolution_param {
-    num_output: 256
-    pad: 0
-    kernel_size: 1
-    stride: 1
-    weight_filler {
-      type: "msra"
-    }
-    bias_term: false
-  }
-}
-layer {
-  name: "conv4_5_1x1_reduce/bnc"
-  type: "BatchNorm"
-  bottom: "conv4_5_1x1_reduce"
-  top: "conv4_5_1x1_reduce"
-}
-
-layer {
- name: "conv4_5_1x1_reduce/scale"
- type: "Scale"
-bottom: "conv4_5_1x1_reduce"
- top: "conv4_5_1x1_reduce"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv4_5_1x1_reduce/relu"
-  type: "ReLU"
-  bottom: "conv4_5_1x1_reduce"
-  top: "conv4_5_1x1_reduce"
-}
-layer {
-  name: "conv4_5_3x3"
-  type: "Convolution"
-  bottom: "conv4_5_1x1_reduce"
-  top: "conv4_5_3x3"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
-  convolution_param {
-    num_output: 256
-    pad: 2
-    dilation: 2
-    kernel_size: 3
-    stride: 1
-    weight_filler {
-      type: "msra"
-    }
-    bias_term: false
-  }
-}
-layer {
-  name: "conv4_5_3x3/bnc"
-  type: "BatchNorm"
-  bottom: "conv4_5_3x3"
-  top: "conv4_5_3x3"
-}
-
-layer {
- name: "conv4_5_3x3/scale"
- type: "Scale"
-bottom: "conv4_5_3x3"
- top: "conv4_5_3x3"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv4_5_3x3/relu"
-  type: "ReLU"
-  bottom: "conv4_5_3x3"
-  top: "conv4_5_3x3"
-}
-layer {
-  name: "conv4_5_1x1_increase"
-  type: "Convolution"
-  bottom: "conv4_5_3x3"
-  top: "conv4_5_1x1_increase"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
-  convolution_param {
-    num_output: 1024
-    pad: 0
-    kernel_size: 1
-    stride: 1
-    weight_filler {
-      type: "msra"
-    }
-    bias_term: false
-  }
-}
-layer {
-  name: "conv4_5_1x1_increase/bnc"
-  type: "BatchNorm"
-  bottom: "conv4_5_1x1_increase"
-  top: "conv4_5_1x1_increase"
-}
-
-layer {
- name: "conv4_5_1x1_increase/scale"
- type: "Scale"
-bottom: "conv4_5_1x1_increase"
- top: "conv4_5_1x1_increase"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv4_5"
-  type: "Eltwise"
-  bottom: "conv4_4"
-  bottom: "conv4_5_1x1_increase"
-  top: "conv4_5"
-  eltwise_param {
-    operation: SUM
-  }
-}
-layer {
-  name: "conv4_5/relu"
-  type: "ReLU"
-  bottom: "conv4_5"
-  top: "conv4_5"
-}
-layer {
-  name: "conv4_6_1x1_reduce"
-  type: "Convolution"
-  bottom: "conv4_5"
-  top: "conv4_6_1x1_reduce"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
-  convolution_param {
-    num_output: 256
-    pad: 0
-    kernel_size: 1
-    stride: 1
-    weight_filler {
-      type: "msra"
-    }
-    bias_term: false
-  }
-}
-layer {
-  name: "conv4_6_1x1_reduce/bnc"
-  type: "BatchNorm"
-  bottom: "conv4_6_1x1_reduce"
-  top: "conv4_6_1x1_reduce"
-}
-
-layer {
- name: "conv4_6_1x1_reduce/scale"
- type: "Scale"
-bottom: "conv4_6_1x1_reduce"
- top: "conv4_6_1x1_reduce"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv4_6_1x1_reduce/relu"
-  type: "ReLU"
-  bottom: "conv4_6_1x1_reduce"
-  top: "conv4_6_1x1_reduce"
-}
-layer {
-  name: "conv4_6_3x3"
-  type: "Convolution"
-  bottom: "conv4_6_1x1_reduce"
-  top: "conv4_6_3x3"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
-  convolution_param {
-    num_output: 256
-    pad: 2
-    dilation: 2
-    kernel_size: 3
-    stride: 1
-    weight_filler {
-      type: "msra"
-    }
-    bias_term: false
-  }
-}
-layer {
-  name: "conv4_6_3x3/bnc"
-  type: "BatchNorm"
-  bottom: "conv4_6_3x3"
-  top: "conv4_6_3x3"
-}
-
-layer {
- name: "conv4_6_3x3/scale"
- type: "Scale"
-bottom: "conv4_6_3x3"
- top: "conv4_6_3x3"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv4_6_3x3/relu"
-  type: "ReLU"
-  bottom: "conv4_6_3x3"
-  top: "conv4_6_3x3"
-}
-layer {
-  name: "conv4_6_1x1_increase"
-  type: "Convolution"
-  bottom: "conv4_6_3x3"
-  top: "conv4_6_1x1_increase"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
-  convolution_param {
-    num_output: 1024
-    pad: 0
-    kernel_size: 1
-    stride: 1
-    weight_filler {
-      type: "msra"
-    }
-    bias_term: false
-  }
-}
-layer {
-  name: "conv4_6_1x1_increase/bnc"
-  type: "BatchNorm"
-  bottom: "conv4_6_1x1_increase"
-  top: "conv4_6_1x1_increase"
-}
-
-layer {
- name: "conv4_6_1x1_increase/scale"
- type: "Scale"
-bottom: "conv4_6_1x1_increase"
- top: "conv4_6_1x1_increase"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv4_6"
-  type: "Eltwise"
-  bottom: "conv4_5"
-  bottom: "conv4_6_1x1_increase"
-  top: "conv4_6"
-  eltwise_param {
-    operation: SUM
-  }
-}
-layer {
-  name: "conv4_6/relu"
-  type: "ReLU"
-  bottom: "conv4_6"
-  top: "conv4_6"
-}
-layer {
-  name: "conv5_1_1x1_reduce"
-  type: "Convolution"
-  bottom: "conv4_6"
-  top: "conv5_1_1x1_reduce"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
+  bottom: "res3d_branch2b"
+  top: "res3d_branch2c"
   convolution_param {
     num_output: 512
+    bias_term: false
     pad: 0
     kernel_size: 1
     stride: 1
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
   }
 }
 layer {
-  name: "conv5_1_1x1_reduce/bnc"
+  name: "bn3d_branch2c"
   type: "BatchNorm"
-  bottom: "conv5_1_1x1_reduce"
-  top: "conv5_1_1x1_reduce"
-}
-
-layer {
- name: "conv5_1_1x1_reduce/scale"
- type: "Scale"
-bottom: "conv5_1_1x1_reduce"
- top: "conv5_1_1x1_reduce"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv5_1_1x1_reduce/relu"
-  type: "ReLU"
-  bottom: "conv5_1_1x1_reduce"
-  top: "conv5_1_1x1_reduce"
-}
-layer {
-  name: "conv5_1_3x3"
-  type: "Convolution"
-  bottom: "conv5_1_1x1_reduce"
-  top: "conv5_1_3x3"
-  param {
-    lr_mult: 1
-    decay_mult: 1
+  bottom: "res3d_branch2c"
+  top: "res3d_branch2c"
+  batch_norm_param {
   }
+}
+layer {
+  name: "scale3d_branch2c"
+  type: "Scale"
+  bottom: "res3d_branch2c"
+  top: "res3d_branch2c"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res3d"
+  type: "Eltwise"
+  bottom: "res3c"
+  bottom: "res3d_branch2c"
+  top: "res3d"
+}
+layer {
+  name: "res3d_relu"
+  type: "ReLU"
+  bottom: "res3d"
+  top: "res3d"
+}
+layer {
+  name: "res4a_branch1"
+  type: "Convolution"
+  bottom: "res3d"
+  top: "res4a_branch1"
   convolution_param {
-    num_output: 512
-    pad: 4
-    dilation: 4
+    num_output: 1024
+    bias_term: false
+    pad: 0
+    kernel_size: 1
+    stride: 2
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "bn4a_branch1"
+  type: "BatchNorm"
+  bottom: "res4a_branch1"
+  top: "res4a_branch1"
+  batch_norm_param {
+  }
+}
+layer {
+  name: "scale4a_branch1"
+  type: "Scale"
+  bottom: "res4a_branch1"
+  top: "res4a_branch1"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res4a_branch2a"
+  type: "Convolution"
+  bottom: "res3d"
+  top: "res4a_branch2a"
+  convolution_param {
+    num_output: 256
+    bias_term: false
+    pad: 0
+    kernel_size: 1
+    stride: 2
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "bn4a_branch2a"
+  type: "BatchNorm"
+  bottom: "res4a_branch2a"
+  top: "res4a_branch2a"
+  batch_norm_param {
+  }
+}
+layer {
+  name: "scale4a_branch2a"
+  type: "Scale"
+  bottom: "res4a_branch2a"
+  top: "res4a_branch2a"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res4a_branch2a_relu"
+  type: "ReLU"
+  bottom: "res4a_branch2a"
+  top: "res4a_branch2a"
+}
+layer {
+  name: "res4a_branch2b"
+  type: "Convolution"
+  bottom: "res4a_branch2a"
+  top: "res4a_branch2b"
+  convolution_param {
+    num_output: 256
+    bias_term: false
+    pad: 1
     kernel_size: 3
     stride: 1
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
   }
 }
 layer {
-  name: "conv5_1_3x3/bnc"
+  name: "bn4a_branch2b"
   type: "BatchNorm"
-  bottom: "conv5_1_3x3"
-  top: "conv5_1_3x3"
-}
-
-layer {
- name: "conv5_1_3x3/scale"
- type: "Scale"
-bottom: "conv5_1_3x3"
- top: "conv5_1_3x3"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv5_1_3x3/relu"
-  type: "ReLU"
-  bottom: "conv5_1_3x3"
-  top: "conv5_1_3x3"
-}
-layer {
-  name: "conv5_1_1x1_increase"
-  type: "Convolution"
-  bottom: "conv5_1_3x3"
-  top: "conv5_1_1x1_increase"
-  param {
-    lr_mult: 1
-    decay_mult: 1
+  bottom: "res4a_branch2b"
+  top: "res4a_branch2b"
+  batch_norm_param {
   }
+}
+layer {
+  name: "scale4a_branch2b"
+  type: "Scale"
+  bottom: "res4a_branch2b"
+  top: "res4a_branch2b"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res4a_branch2b_relu"
+  type: "ReLU"
+  bottom: "res4a_branch2b"
+  top: "res4a_branch2b"
+}
+layer {
+  name: "res4a_branch2c"
+  type: "Convolution"
+  bottom: "res4a_branch2b"
+  top: "res4a_branch2c"
+  convolution_param {
+    num_output: 1024
+    bias_term: false
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "bn4a_branch2c"
+  type: "BatchNorm"
+  bottom: "res4a_branch2c"
+  top: "res4a_branch2c"
+  batch_norm_param {
+  }
+}
+layer {
+  name: "scale4a_branch2c"
+  type: "Scale"
+  bottom: "res4a_branch2c"
+  top: "res4a_branch2c"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res4a"
+  type: "Eltwise"
+  bottom: "res4a_branch1"
+  bottom: "res4a_branch2c"
+  top: "res4a"
+}
+layer {
+  name: "res4a_relu"
+  type: "ReLU"
+  bottom: "res4a"
+  top: "res4a"
+}
+layer {
+  name: "res4b_branch2a"
+  type: "Convolution"
+  bottom: "res4a"
+  top: "res4b_branch2a"
+  convolution_param {
+    num_output: 256
+    bias_term: false
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "bn4b_branch2a"
+  type: "BatchNorm"
+  bottom: "res4b_branch2a"
+  top: "res4b_branch2a"
+  batch_norm_param {
+  }
+}
+layer {
+  name: "scale4b_branch2a"
+  type: "Scale"
+  bottom: "res4b_branch2a"
+  top: "res4b_branch2a"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res4b_branch2a_relu"
+  type: "ReLU"
+  bottom: "res4b_branch2a"
+  top: "res4b_branch2a"
+}
+layer {
+  name: "res4b_branch2b"
+  type: "Convolution"
+  bottom: "res4b_branch2a"
+  top: "res4b_branch2b"
+  convolution_param {
+    num_output: 256
+    bias_term: false
+    pad: 1
+    kernel_size: 3
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "bn4b_branch2b"
+  type: "BatchNorm"
+  bottom: "res4b_branch2b"
+  top: "res4b_branch2b"
+  batch_norm_param {
+  }
+}
+layer {
+  name: "scale4b_branch2b"
+  type: "Scale"
+  bottom: "res4b_branch2b"
+  top: "res4b_branch2b"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res4b_branch2b_relu"
+  type: "ReLU"
+  bottom: "res4b_branch2b"
+  top: "res4b_branch2b"
+}
+layer {
+  name: "res4b_branch2c"
+  type: "Convolution"
+  bottom: "res4b_branch2b"
+  top: "res4b_branch2c"
+  convolution_param {
+    num_output: 1024
+    bias_term: false
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "bn4b_branch2c"
+  type: "BatchNorm"
+  bottom: "res4b_branch2c"
+  top: "res4b_branch2c"
+  batch_norm_param {
+  }
+}
+layer {
+  name: "scale4b_branch2c"
+  type: "Scale"
+  bottom: "res4b_branch2c"
+  top: "res4b_branch2c"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res4b"
+  type: "Eltwise"
+  bottom: "res4a"
+  bottom: "res4b_branch2c"
+  top: "res4b"
+}
+layer {
+  name: "res4b_relu"
+  type: "ReLU"
+  bottom: "res4b"
+  top: "res4b"
+}
+layer {
+  name: "res4c_branch2a"
+  type: "Convolution"
+  bottom: "res4b"
+  top: "res4c_branch2a"
+  convolution_param {
+    num_output: 256
+    bias_term: false
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "bn4c_branch2a"
+  type: "BatchNorm"
+  bottom: "res4c_branch2a"
+  top: "res4c_branch2a"
+  batch_norm_param {
+  }
+}
+layer {
+  name: "scale4c_branch2a"
+  type: "Scale"
+  bottom: "res4c_branch2a"
+  top: "res4c_branch2a"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res4c_branch2a_relu"
+  type: "ReLU"
+  bottom: "res4c_branch2a"
+  top: "res4c_branch2a"
+}
+layer {
+  name: "res4c_branch2b"
+  type: "Convolution"
+  bottom: "res4c_branch2a"
+  top: "res4c_branch2b"
+  convolution_param {
+    num_output: 256
+    bias_term: false
+    pad: 1
+    kernel_size: 3
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "bn4c_branch2b"
+  type: "BatchNorm"
+  bottom: "res4c_branch2b"
+  top: "res4c_branch2b"
+  batch_norm_param {
+  }
+}
+layer {
+  name: "scale4c_branch2b"
+  type: "Scale"
+  bottom: "res4c_branch2b"
+  top: "res4c_branch2b"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res4c_branch2b_relu"
+  type: "ReLU"
+  bottom: "res4c_branch2b"
+  top: "res4c_branch2b"
+}
+layer {
+  name: "res4c_branch2c"
+  type: "Convolution"
+  bottom: "res4c_branch2b"
+  top: "res4c_branch2c"
+  convolution_param {
+    num_output: 1024
+    bias_term: false
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "bn4c_branch2c"
+  type: "BatchNorm"
+  bottom: "res4c_branch2c"
+  top: "res4c_branch2c"
+  batch_norm_param {
+  }
+}
+layer {
+  name: "scale4c_branch2c"
+  type: "Scale"
+  bottom: "res4c_branch2c"
+  top: "res4c_branch2c"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res4c"
+  type: "Eltwise"
+  bottom: "res4b"
+  bottom: "res4c_branch2c"
+  top: "res4c"
+}
+layer {
+  name: "res4c_relu"
+  type: "ReLU"
+  bottom: "res4c"
+  top: "res4c"
+}
+layer {
+  name: "res4d_branch2a"
+  type: "Convolution"
+  bottom: "res4c"
+  top: "res4d_branch2a"
+  convolution_param {
+    num_output: 256
+    bias_term: false
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "bn4d_branch2a"
+  type: "BatchNorm"
+  bottom: "res4d_branch2a"
+  top: "res4d_branch2a"
+  batch_norm_param {
+  }
+}
+layer {
+  name: "scale4d_branch2a"
+  type: "Scale"
+  bottom: "res4d_branch2a"
+  top: "res4d_branch2a"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res4d_branch2a_relu"
+  type: "ReLU"
+  bottom: "res4d_branch2a"
+  top: "res4d_branch2a"
+}
+layer {
+  name: "res4d_branch2b"
+  type: "Convolution"
+  bottom: "res4d_branch2a"
+  top: "res4d_branch2b"
+  convolution_param {
+    num_output: 256
+    bias_term: false
+    pad: 1
+    kernel_size: 3
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "bn4d_branch2b"
+  type: "BatchNorm"
+  bottom: "res4d_branch2b"
+  top: "res4d_branch2b"
+  batch_norm_param {
+  }
+}
+layer {
+  name: "scale4d_branch2b"
+  type: "Scale"
+  bottom: "res4d_branch2b"
+  top: "res4d_branch2b"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res4d_branch2b_relu"
+  type: "ReLU"
+  bottom: "res4d_branch2b"
+  top: "res4d_branch2b"
+}
+layer {
+  name: "res4d_branch2c"
+  type: "Convolution"
+  bottom: "res4d_branch2b"
+  top: "res4d_branch2c"
+  convolution_param {
+    num_output: 1024
+    bias_term: false
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "bn4d_branch2c"
+  type: "BatchNorm"
+  bottom: "res4d_branch2c"
+  top: "res4d_branch2c"
+  batch_norm_param {
+  }
+}
+layer {
+  name: "scale4d_branch2c"
+  type: "Scale"
+  bottom: "res4d_branch2c"
+  top: "res4d_branch2c"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res4d"
+  type: "Eltwise"
+  bottom: "res4c"
+  bottom: "res4d_branch2c"
+  top: "res4d"
+}
+layer {
+  name: "res4d_relu"
+  type: "ReLU"
+  bottom: "res4d"
+  top: "res4d"
+}
+layer {
+  name: "res4e_branch2a"
+  type: "Convolution"
+  bottom: "res4d"
+  top: "res4e_branch2a"
+  convolution_param {
+    num_output: 256
+    bias_term: false
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "bn4e_branch2a"
+  type: "BatchNorm"
+  bottom: "res4e_branch2a"
+  top: "res4e_branch2a"
+  batch_norm_param {
+  }
+}
+layer {
+  name: "scale4e_branch2a"
+  type: "Scale"
+  bottom: "res4e_branch2a"
+  top: "res4e_branch2a"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res4e_branch2a_relu"
+  type: "ReLU"
+  bottom: "res4e_branch2a"
+  top: "res4e_branch2a"
+}
+layer {
+  name: "res4e_branch2b"
+  type: "Convolution"
+  bottom: "res4e_branch2a"
+  top: "res4e_branch2b"
+  convolution_param {
+    num_output: 256
+    bias_term: false
+    pad: 1
+    kernel_size: 3
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "bn4e_branch2b"
+  type: "BatchNorm"
+  bottom: "res4e_branch2b"
+  top: "res4e_branch2b"
+  batch_norm_param {
+  }
+}
+layer {
+  name: "scale4e_branch2b"
+  type: "Scale"
+  bottom: "res4e_branch2b"
+  top: "res4e_branch2b"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res4e_branch2b_relu"
+  type: "ReLU"
+  bottom: "res4e_branch2b"
+  top: "res4e_branch2b"
+}
+layer {
+  name: "res4e_branch2c"
+  type: "Convolution"
+  bottom: "res4e_branch2b"
+  top: "res4e_branch2c"
+  convolution_param {
+    num_output: 1024
+    bias_term: false
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "bn4e_branch2c"
+  type: "BatchNorm"
+  bottom: "res4e_branch2c"
+  top: "res4e_branch2c"
+  batch_norm_param {
+  }
+}
+layer {
+  name: "scale4e_branch2c"
+  type: "Scale"
+  bottom: "res4e_branch2c"
+  top: "res4e_branch2c"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res4e"
+  type: "Eltwise"
+  bottom: "res4d"
+  bottom: "res4e_branch2c"
+  top: "res4e"
+}
+layer {
+  name: "res4e_relu"
+  type: "ReLU"
+  bottom: "res4e"
+  top: "res4e"
+}
+layer {
+  name: "res4f_branch2a"
+  type: "Convolution"
+  bottom: "res4e"
+  top: "res4f_branch2a"
+  convolution_param {
+    num_output: 256
+    bias_term: false
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "bn4f_branch2a"
+  type: "BatchNorm"
+  bottom: "res4f_branch2a"
+  top: "res4f_branch2a"
+  batch_norm_param {
+  }
+}
+layer {
+  name: "scale4f_branch2a"
+  type: "Scale"
+  bottom: "res4f_branch2a"
+  top: "res4f_branch2a"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res4f_branch2a_relu"
+  type: "ReLU"
+  bottom: "res4f_branch2a"
+  top: "res4f_branch2a"
+}
+layer {
+  name: "res4f_branch2b"
+  type: "Convolution"
+  bottom: "res4f_branch2a"
+  top: "res4f_branch2b"
+  convolution_param {
+    num_output: 256
+    bias_term: false
+    pad: 1
+    kernel_size: 3
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "bn4f_branch2b"
+  type: "BatchNorm"
+  bottom: "res4f_branch2b"
+  top: "res4f_branch2b"
+  batch_norm_param {
+  }
+}
+layer {
+  name: "scale4f_branch2b"
+  type: "Scale"
+  bottom: "res4f_branch2b"
+  top: "res4f_branch2b"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res4f_branch2b_relu"
+  type: "ReLU"
+  bottom: "res4f_branch2b"
+  top: "res4f_branch2b"
+}
+layer {
+  name: "res4f_branch2c"
+  type: "Convolution"
+  bottom: "res4f_branch2b"
+  top: "res4f_branch2c"
+  convolution_param {
+    num_output: 1024
+    bias_term: false
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "bn4f_branch2c"
+  type: "BatchNorm"
+  bottom: "res4f_branch2c"
+  top: "res4f_branch2c"
+  batch_norm_param {
+  }
+}
+layer {
+  name: "scale4f_branch2c"
+  type: "Scale"
+  bottom: "res4f_branch2c"
+  top: "res4f_branch2c"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res4f"
+  type: "Eltwise"
+  bottom: "res4e"
+  bottom: "res4f_branch2c"
+  top: "res4f"
+}
+layer {
+  name: "res4f_relu"
+  type: "ReLU"
+  bottom: "res4f"
+  top: "res4f"
+}
+layer {
+  name: "res5a_branch1"
+  type: "Convolution"
+  bottom: "res4f"
+  top: "res5a_branch1"
   convolution_param {
     num_output: 2048
+    bias_term: false
     pad: 0
     kernel_size: 1
-    stride: 1
+    stride: 2
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
-  }
-}
-layer {
-  name: "conv5_1_1x1_increase/bnc"
-  type: "BatchNorm"
-  bottom: "conv5_1_1x1_increase"
-  top: "conv5_1_1x1_increase"
-}
-
-layer {
- name: "conv5_1_1x1_increase/scale"
- type: "Scale"
-bottom: "conv5_1_1x1_increase"
- top: "conv5_1_1x1_increase"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv5_1_1x1_proj"
-  type: "Convolution"
-  bottom: "conv4_6"
-  top: "conv5_1_1x1_proj"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
-  convolution_param {
-    num_output: 2048
-    pad: 0
-    kernel_size: 1
-    stride: 1
-    weight_filler {
-      type: "msra"
+    bias_filler {
+      type: "constant"
+      value: 0.2
     }
-    bias_term: false
   }
 }
 layer {
-  name: "conv5_1_1x1_proj/bnc"
+  name: "bn5a_branch1"
   type: "BatchNorm"
-  bottom: "conv5_1_1x1_proj"
-  top: "conv5_1_1x1_proj"
-}
-
-layer {
- name: "conv5_1_1x1_proj/scale"
- type: "Scale"
-bottom: "conv5_1_1x1_proj"
- top: "conv5_1_1x1_proj"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv5_1"
-  type: "Eltwise"
-  bottom: "conv5_1_1x1_proj"
-  bottom: "conv5_1_1x1_increase"
-  top: "conv5_1"
-  eltwise_param {
-    operation: SUM
+  bottom: "res5a_branch1"
+  top: "res5a_branch1"
+  batch_norm_param {
   }
 }
 layer {
-  name: "conv5_1/relu"
-  type: "ReLU"
-  bottom: "conv5_1"
-  top: "conv5_1"
+  name: "scale5a_branch1"
+  type: "Scale"
+  bottom: "res5a_branch1"
+  top: "res5a_branch1"
+  scale_param {
+    bias_term: true
+  }
 }
 layer {
-  name: "conv5_2_1x1_reduce"
+  name: "res5a_branch2a"
   type: "Convolution"
-  bottom: "conv5_1"
-  top: "conv5_2_1x1_reduce"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
+  bottom: "res4f"
+  top: "res5a_branch2a"
   convolution_param {
     num_output: 512
+    bias_term: false
     pad: 0
     kernel_size: 1
-    stride: 1
+    stride: 2
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
   }
 }
 layer {
-  name: "conv5_2_1x1_reduce/bnc"
+  name: "bn5a_branch2a"
   type: "BatchNorm"
-  bottom: "conv5_2_1x1_reduce"
-  top: "conv5_2_1x1_reduce"
-}
-
-layer {
- name: "conv5_2_1x1_reduce/scale"
- type: "Scale"
-bottom: "conv5_2_1x1_reduce"
- top: "conv5_2_1x1_reduce"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv5_2_1x1_reduce/relu"
-  type: "ReLU"
-  bottom: "conv5_2_1x1_reduce"
-  top: "conv5_2_1x1_reduce"
-}
-layer {
-  name: "conv5_2_3x3"
-  type: "Convolution"
-  bottom: "conv5_2_1x1_reduce"
-  top: "conv5_2_3x3"
-  param {
-    lr_mult: 1
-    decay_mult: 1
+  bottom: "res5a_branch2a"
+  top: "res5a_branch2a"
+  batch_norm_param {
   }
+}
+layer {
+  name: "scale5a_branch2a"
+  type: "Scale"
+  bottom: "res5a_branch2a"
+  top: "res5a_branch2a"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res5a_branch2a_relu"
+  type: "ReLU"
+  bottom: "res5a_branch2a"
+  top: "res5a_branch2a"
+}
+layer {
+  name: "res5a_branch2b"
+  type: "Convolution"
+  bottom: "res5a_branch2a"
+  top: "res5a_branch2b"
   convolution_param {
     num_output: 512
-    pad: 4
-    dilation: 4
+    bias_term: false
+    pad: 1
     kernel_size: 3
     stride: 1
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
   }
 }
 layer {
-  name: "conv5_2_3x3/bnc"
+  name: "bn5a_branch2b"
   type: "BatchNorm"
-  bottom: "conv5_2_3x3"
-  top: "conv5_2_3x3"
-}
-
-layer {
- name: "conv5_2_3x3/scale"
- type: "Scale"
-bottom: "conv5_2_3x3"
- top: "conv5_2_3x3"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv5_2_3x3/relu"
-  type: "ReLU"
-  bottom: "conv5_2_3x3"
-  top: "conv5_2_3x3"
-}
-layer {
-  name: "conv5_2_1x1_increase"
-  type: "Convolution"
-  bottom: "conv5_2_3x3"
-  top: "conv5_2_1x1_increase"
-  param {
-    lr_mult: 1
-    decay_mult: 1
+  bottom: "res5a_branch2b"
+  top: "res5a_branch2b"
+  batch_norm_param {
   }
+}
+layer {
+  name: "scale5a_branch2b"
+  type: "Scale"
+  bottom: "res5a_branch2b"
+  top: "res5a_branch2b"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res5a_branch2b_relu"
+  type: "ReLU"
+  bottom: "res5a_branch2b"
+  top: "res5a_branch2b"
+}
+layer {
+  name: "res5a_branch2c"
+  type: "Convolution"
+  bottom: "res5a_branch2b"
+  top: "res5a_branch2c"
   convolution_param {
     num_output: 2048
+    bias_term: false
     pad: 0
     kernel_size: 1
     stride: 1
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
   }
 }
 layer {
-  name: "conv5_2_1x1_increase/bnc"
+  name: "bn5a_branch2c"
   type: "BatchNorm"
-  bottom: "conv5_2_1x1_increase"
-  top: "conv5_2_1x1_increase"
+  bottom: "res5a_branch2c"
+  top: "res5a_branch2c"
+  batch_norm_param {
+  }
 }
-
 layer {
- name: "conv5_2_1x1_increase/scale"
- type: "Scale"
-bottom: "conv5_2_1x1_increase"
- top: "conv5_2_1x1_increase"
- scale_param {
- bias_term: true
+  name: "scale5a_branch2c"
+  type: "Scale"
+  bottom: "res5a_branch2c"
+  top: "res5a_branch2c"
+  scale_param {
+    bias_term: true
+  }
 }
-}
-
 layer {
-  name: "conv5_2"
+  name: "res5a"
   type: "Eltwise"
-  bottom: "conv5_1"
-  bottom: "conv5_2_1x1_increase"
-  top: "conv5_2"
-  eltwise_param {
-    operation: SUM
-  }
+  bottom: "res5a_branch1"
+  bottom: "res5a_branch2c"
+  top: "res5a"
 }
 layer {
-  name: "conv5_2/relu"
+  name: "res5a_relu"
   type: "ReLU"
-  bottom: "conv5_2"
-  top: "conv5_2"
+  bottom: "res5a"
+  top: "res5a"
 }
 layer {
-  name: "conv5_3_1x1_reduce"
+  name: "res5b_branch2a"
   type: "Convolution"
-  bottom: "conv5_2"
-  top: "conv5_3_1x1_reduce"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
+  bottom: "res5a"
+  top: "res5b_branch2a"
   convolution_param {
     num_output: 512
+    bias_term: false
     pad: 0
     kernel_size: 1
     stride: 1
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
   }
 }
 layer {
-  name: "conv5_3_1x1_reduce/bnc"
+  name: "bn5b_branch2a"
   type: "BatchNorm"
-  bottom: "conv5_3_1x1_reduce"
-  top: "conv5_3_1x1_reduce"
-}
-
-layer {
- name: "conv5_3_1x1_reduce/scale"
- type: "Scale"
-bottom: "conv5_3_1x1_reduce"
- top: "conv5_3_1x1_reduce"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv5_3_1x1_reduce/relu"
-  type: "ReLU"
-  bottom: "conv5_3_1x1_reduce"
-  top: "conv5_3_1x1_reduce"
-}
-layer {
-  name: "conv5_3_3x3"
-  type: "Convolution"
-  bottom: "conv5_3_1x1_reduce"
-  top: "conv5_3_3x3"
-  param {
-    lr_mult: 1
-    decay_mult: 1
+  bottom: "res5b_branch2a"
+  top: "res5b_branch2a"
+  batch_norm_param {
   }
+}
+layer {
+  name: "scale5b_branch2a"
+  type: "Scale"
+  bottom: "res5b_branch2a"
+  top: "res5b_branch2a"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res5b_branch2a_relu"
+  type: "ReLU"
+  bottom: "res5b_branch2a"
+  top: "res5b_branch2a"
+}
+layer {
+  name: "res5b_branch2b"
+  type: "Convolution"
+  bottom: "res5b_branch2a"
+  top: "res5b_branch2b"
   convolution_param {
     num_output: 512
-    pad: 4
-    dilation: 4
+    bias_term: false
+    pad: 1
     kernel_size: 3
     stride: 1
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
   }
 }
 layer {
-  name: "conv5_3_3x3/bnc"
+  name: "bn5b_branch2b"
   type: "BatchNorm"
-  bottom: "conv5_3_3x3"
-  top: "conv5_3_3x3"
-}
-
-layer {
- name: "conv5_3_3x3/scale"
- type: "Scale"
-bottom: "conv5_3_3x3"
- top: "conv5_3_3x3"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv5_3_3x3/relu"
-  type: "ReLU"
-  bottom: "conv5_3_3x3"
-  top: "conv5_3_3x3"
-}
-layer {
-  name: "conv5_3_1x1_increase"
-  type: "Convolution"
-  bottom: "conv5_3_3x3"
-  top: "conv5_3_1x1_increase"
-  param {
-    lr_mult: 1
-    decay_mult: 1
+  bottom: "res5b_branch2b"
+  top: "res5b_branch2b"
+  batch_norm_param {
   }
+}
+layer {
+  name: "scale5b_branch2b"
+  type: "Scale"
+  bottom: "res5b_branch2b"
+  top: "res5b_branch2b"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res5b_branch2b_relu"
+  type: "ReLU"
+  bottom: "res5b_branch2b"
+  top: "res5b_branch2b"
+}
+layer {
+  name: "res5b_branch2c"
+  type: "Convolution"
+  bottom: "res5b_branch2b"
+  top: "res5b_branch2c"
   convolution_param {
     num_output: 2048
+    bias_term: false
     pad: 0
     kernel_size: 1
     stride: 1
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
   }
 }
 layer {
-  name: "conv5_3_1x1_increase/bnc"
+  name: "bn5b_branch2c"
   type: "BatchNorm"
-  bottom: "conv5_3_1x1_increase"
-  top: "conv5_3_1x1_increase"
-}
-
-layer {
- name: "conv5_3_1x1_increase/scale"
- type: "Scale"
-bottom: "conv5_3_1x1_increase"
- top: "conv5_3_1x1_increase"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv5_3"
-  type: "Eltwise"
-  bottom: "conv5_2"
-  bottom: "conv5_3_1x1_increase"
-  top: "conv5_3"
-  eltwise_param {
-    operation: SUM
+  bottom: "res5b_branch2c"
+  top: "res5b_branch2c"
+  batch_norm_param {
   }
 }
 layer {
-  name: "conv5_3/relu"
+  name: "scale5b_branch2c"
+  type: "Scale"
+  bottom: "res5b_branch2c"
+  top: "res5b_branch2c"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res5b"
+  type: "Eltwise"
+  bottom: "res5a"
+  bottom: "res5b_branch2c"
+  top: "res5b"
+}
+layer {
+  name: "res5b_relu"
   type: "ReLU"
-  bottom: "conv5_3"
-  top: "conv5_3"
+  bottom: "res5b"
+  top: "res5b"
+}
+layer {
+  name: "res5c_branch2a"
+  type: "Convolution"
+  bottom: "res5b"
+  top: "res5c_branch2a"
+  convolution_param {
+    num_output: 512
+    bias_term: false
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "bn5c_branch2a"
+  type: "BatchNorm"
+  bottom: "res5c_branch2a"
+  top: "res5c_branch2a"
+  batch_norm_param {
+  }
+}
+layer {
+  name: "scale5c_branch2a"
+  type: "Scale"
+  bottom: "res5c_branch2a"
+  top: "res5c_branch2a"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res5c_branch2a_relu"
+  type: "ReLU"
+  bottom: "res5c_branch2a"
+  top: "res5c_branch2a"
+}
+layer {
+  name: "res5c_branch2b"
+  type: "Convolution"
+  bottom: "res5c_branch2a"
+  top: "res5c_branch2b"
+  convolution_param {
+    num_output: 512
+    bias_term: false
+    pad: 1
+    kernel_size: 3
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "bn5c_branch2b"
+  type: "BatchNorm"
+  bottom: "res5c_branch2b"
+  top: "res5c_branch2b"
+  batch_norm_param {
+  }
+}
+layer {
+  name: "scale5c_branch2b"
+  type: "Scale"
+  bottom: "res5c_branch2b"
+  top: "res5c_branch2b"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res5c_branch2b_relu"
+  type: "ReLU"
+  bottom: "res5c_branch2b"
+  top: "res5c_branch2b"
+}
+layer {
+  name: "res5c_branch2c"
+  type: "Convolution"
+  bottom: "res5c_branch2b"
+  top: "res5c_branch2c"
+  convolution_param {
+    num_output: 2048
+    bias_term: false
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "bn5c_branch2c"
+  type: "BatchNorm"
+  bottom: "res5c_branch2c"
+  top: "res5c_branch2c"
+  batch_norm_param {
+  }
+}
+layer {
+  name: "scale5c_branch2c"
+  type: "Scale"
+  bottom: "res5c_branch2c"
+  top: "res5c_branch2c"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res5c"
+  type: "Eltwise"
+  bottom: "res5b"
+  bottom: "res5c_branch2c"
+  top: "res5c"
+}
+layer {
+  name: "res5c_relu"
+  type: "ReLU"
+  bottom: "res5c"
+  top: "res5c"
+}
+layer {
+  name: "res5c_interp"
+  type: "Interp"
+  bottom: "res5c"
+  top: "res5c_interp"
+  interp_param {
+    height: 60
+    width: 60
+  }
 }
 layer {
   name: "conv5_3_pool1"
   type: "Pooling"
-  bottom: "conv5_3"
+  bottom: "res5c_interp"
   top: "conv5_3_pool1"
   pooling_param {
     pool: AVE
@@ -2550,36 +2415,32 @@ layer {
   bottom: "conv5_3_pool1"
   top: "conv5_3_pool1_conv"
   param {
-    lr_mult: 10
-    decay_mult: 1
   }
   convolution_param {
     num_output: 512
+    bias_term: false
     kernel_size: 1
     stride: 1
     weight_filler {
       type: "msra"
     }
-    bias_term: false
   }
 }
 layer {
-  name: "conv5_3_pool1_conv/bnc"
+  name: "conv5_3_pool1_conv/bn"
   type: "BatchNorm"
   bottom: "conv5_3_pool1_conv"
   top: "conv5_3_pool1_conv"
 }
-
 layer {
- name: "conv5_3_pool1_conv/scale"
- type: "Scale"
-bottom: "conv5_3_pool1_conv"
- top: "conv5_3_pool1_conv"
- scale_param {
- bias_term: true
+  name: "conv5_3_pool1_conv/scale"
+  type: "Scale"
+  bottom: "conv5_3_pool1_conv"
+  top: "conv5_3_pool1_conv"
+  scale_param {
+    bias_term: true
+  }
 }
-}
-
 layer {
   name: "conv5_3_pool1_conv/relu"
   type: "ReLU"
@@ -2599,7 +2460,7 @@ layer {
 layer {
   name: "conv5_3_pool2"
   type: "Pooling"
-  bottom: "conv5_3"
+  bottom: "res5c_interp"
   top: "conv5_3_pool2"
   pooling_param {
     pool: AVE
@@ -2613,36 +2474,32 @@ layer {
   bottom: "conv5_3_pool2"
   top: "conv5_3_pool2_conv"
   param {
-    lr_mult: 10
-    decay_mult: 1
   }
   convolution_param {
     num_output: 512
+    bias_term: false
     kernel_size: 1
     stride: 1
     weight_filler {
       type: "msra"
     }
-    bias_term: false
   }
 }
 layer {
-  name: "conv5_3_pool2_conv/bnc"
+  name: "conv5_3_pool2_conv/bn"
   type: "BatchNorm"
   bottom: "conv5_3_pool2_conv"
   top: "conv5_3_pool2_conv"
 }
-
 layer {
- name: "conv5_3_pool2_conv/scale"
- type: "Scale"
-bottom: "conv5_3_pool2_conv"
- top: "conv5_3_pool2_conv"
- scale_param {
- bias_term: true
+  name: "conv5_3_pool2_conv/scale"
+  type: "Scale"
+  bottom: "conv5_3_pool2_conv"
+  top: "conv5_3_pool2_conv"
+  scale_param {
+    bias_term: true
+  }
 }
-}
-
 layer {
   name: "conv5_3_pool2_conv/relu"
   type: "ReLU"
@@ -2662,7 +2519,7 @@ layer {
 layer {
   name: "conv5_3_pool3"
   type: "Pooling"
-  bottom: "conv5_3"
+  bottom: "res5c_interp"
   top: "conv5_3_pool3"
   pooling_param {
     pool: AVE
@@ -2676,36 +2533,32 @@ layer {
   bottom: "conv5_3_pool3"
   top: "conv5_3_pool3_conv"
   param {
-    lr_mult: 10
-    decay_mult: 1
   }
   convolution_param {
     num_output: 512
+    bias_term: false
     kernel_size: 1
     stride: 1
     weight_filler {
       type: "msra"
     }
-    bias_term: false
   }
 }
 layer {
-  name: "conv5_3_pool3_conv/bnc"
+  name: "conv5_3_pool3_conv/bn"
   type: "BatchNorm"
   bottom: "conv5_3_pool3_conv"
   top: "conv5_3_pool3_conv"
 }
-
 layer {
- name: "conv5_3_pool3_conv/scale"
- type: "Scale"
-bottom: "conv5_3_pool3_conv"
- top: "conv5_3_pool3_conv"
- scale_param {
- bias_term: true
+  name: "conv5_3_pool3_conv/scale"
+  type: "Scale"
+  bottom: "conv5_3_pool3_conv"
+  top: "conv5_3_pool3_conv"
+  scale_param {
+    bias_term: true
+  }
 }
-}
-
 layer {
   name: "conv5_3_pool3_conv/relu"
   type: "ReLU"
@@ -2725,7 +2578,7 @@ layer {
 layer {
   name: "conv5_3_pool6"
   type: "Pooling"
-  bottom: "conv5_3"
+  bottom: "res5c_interp"
   top: "conv5_3_pool6"
   pooling_param {
     pool: AVE
@@ -2739,36 +2592,32 @@ layer {
   bottom: "conv5_3_pool6"
   top: "conv5_3_pool6_conv"
   param {
-    lr_mult: 10
-    decay_mult: 1
   }
   convolution_param {
     num_output: 512
+    bias_term: false
     kernel_size: 1
     stride: 1
     weight_filler {
       type: "msra"
     }
-    bias_term: false
   }
 }
 layer {
-  name: "conv5_3_pool6_conv/bnc"
+  name: "conv5_3_pool6_conv/bn"
   type: "BatchNorm"
   bottom: "conv5_3_pool6_conv"
   top: "conv5_3_pool6_conv"
 }
-
 layer {
- name: "conv5_3_pool6_conv/scale"
- type: "Scale"
-bottom: "conv5_3_pool6_conv"
- top: "conv5_3_pool6_conv"
- scale_param {
- bias_term: true
+  name: "conv5_3_pool6_conv/scale"
+  type: "Scale"
+  bottom: "conv5_3_pool6_conv"
+  top: "conv5_3_pool6_conv"
+  scale_param {
+    bias_term: true
+  }
 }
-}
-
 layer {
   name: "conv5_3_pool6_conv/relu"
   type: "ReLU"
@@ -2788,7 +2637,7 @@ layer {
 layer {
   name: "conv5_3_concat"
   type: "Concat"
-  bottom: "conv5_3"
+  bottom: "res5c_interp"
   bottom: "conv5_3_pool6_interp"
   bottom: "conv5_3_pool3_interp"
   bottom: "conv5_3_pool2_interp"
@@ -2801,37 +2650,18 @@ layer {
   bottom: "conv5_3_concat"
   top: "conv5_4"
   param {
-    lr_mult: 10
-    decay_mult: 1
   }
   convolution_param {
     num_output: 512
+    bias_term: false
+    pad: 1
     kernel_size: 3
     stride: 1
-    pad: 1
     weight_filler {
       type: "msra"
     }
-    bias_term: false
   }
 }
-layer {
-  name: "conv5_4/bnc"
-  type: "BatchNorm"
-  bottom: "conv5_4"
-  top: "conv5_4"
-}
-
-layer {
- name: "conv5_4/scale"
- type: "Scale"
-bottom: "conv5_4"
- top: "conv5_4"
- scale_param {
- bias_term: true
-}
-}
-
 layer {
   name: "conv5_4/relu"
   type: "ReLU"
@@ -2852,16 +2682,8 @@ layer {
   type: "Convolution"
   bottom: "conv5_4"
   top: "conv6"
-  param {
-    lr_mult: 10
-    decay_mult: 1
-  }
-  param {
-    lr_mult: 20
-    decay_mult: 1
-  }
   convolution_param {
-    num_output: 150
+    num_output: 2
     kernel_size: 1
     stride: 1
     weight_filler {
@@ -2875,7 +2697,8 @@ layer {
   bottom: "conv6"
   top: "final_interp"
   interp_param {
-    zoom_factor: 8
+    height: 480
+    width: 480
   }
 }
 layer {

--- a/templates/caffe/pspnet_50/deploy.prototxt
+++ b/templates/caffe/pspnet_50/deploy.prototxt
@@ -1178,7 +1178,7 @@ layer {
   convolution_param {
     num_output: 256
     bias_term: false
-    pad: 1
+    pad: 2
     kernel_size: 3
     stride: 1
     weight_filler {
@@ -1188,6 +1188,8 @@ layer {
       type: "constant"
       value: 0.2
     }
+    engine: DEFAULT
+    dilation: 2
   }
 }
 layer {
@@ -1314,7 +1316,7 @@ layer {
   convolution_param {
     num_output: 256
     bias_term: false
-    pad: 1
+    pad: 2
     kernel_size: 3
     stride: 1
     weight_filler {
@@ -1324,6 +1326,8 @@ layer {
       type: "constant"
       value: 0.2
     }
+    engine: DEFAULT
+    dilation: 2
   }
 }
 layer {
@@ -1450,7 +1454,7 @@ layer {
   convolution_param {
     num_output: 256
     bias_term: false
-    pad: 1
+    pad: 2
     kernel_size: 3
     stride: 1
     weight_filler {
@@ -1460,6 +1464,8 @@ layer {
       type: "constant"
       value: 0.2
     }
+    engine: DEFAULT
+    dilation: 2
   }
 }
 layer {
@@ -1586,7 +1592,7 @@ layer {
   convolution_param {
     num_output: 256
     bias_term: false
-    pad: 1
+    pad: 2
     kernel_size: 3
     stride: 1
     weight_filler {
@@ -1596,6 +1602,8 @@ layer {
       type: "constant"
       value: 0.2
     }
+    engine: DEFAULT
+    dilation: 2
   }
 }
 layer {
@@ -1722,7 +1730,7 @@ layer {
   convolution_param {
     num_output: 256
     bias_term: false
-    pad: 1
+    pad: 2
     kernel_size: 3
     stride: 1
     weight_filler {
@@ -1732,6 +1740,8 @@ layer {
       type: "constant"
       value: 0.2
     }
+    engine: DEFAULT
+    dilation: 2
   }
 }
 layer {
@@ -1858,7 +1868,7 @@ layer {
   convolution_param {
     num_output: 256
     bias_term: false
-    pad: 1
+    pad: 2
     kernel_size: 3
     stride: 1
     weight_filler {
@@ -1868,6 +1878,8 @@ layer {
       type: "constant"
       value: 0.2
     }
+    engine: DEFAULT
+    dilation: 2
   }
 }
 layer {
@@ -2031,7 +2043,7 @@ layer {
   convolution_param {
     num_output: 512
     bias_term: false
-    pad: 1
+    pad: 4
     kernel_size: 3
     stride: 1
     weight_filler {
@@ -2041,6 +2053,8 @@ layer {
       type: "constant"
       value: 0.2
     }
+    engine: DEFAULT
+    dilation: 4
   }
 }
 layer {
@@ -2167,7 +2181,7 @@ layer {
   convolution_param {
     num_output: 512
     bias_term: false
-    pad: 1
+    pad: 4
     kernel_size: 3
     stride: 1
     weight_filler {
@@ -2177,6 +2191,8 @@ layer {
       type: "constant"
       value: 0.2
     }
+    engine: DEFAULT
+    dilation: 4
   }
 }
 layer {
@@ -2303,7 +2319,7 @@ layer {
   convolution_param {
     num_output: 512
     bias_term: false
-    pad: 1
+    pad: 4
     kernel_size: 3
     stride: 1
     weight_filler {
@@ -2313,6 +2329,8 @@ layer {
       type: "constant"
       value: 0.2
     }
+    engine: DEFAULT
+    dilation: 4
   }
 }
 layer {
@@ -2415,6 +2433,8 @@ layer {
   bottom: "conv5_3_pool1"
   top: "conv5_3_pool1_conv"
   param {
+    lr_mult: 1
+    decay_mult: 1
   }
   convolution_param {
     num_output: 512
@@ -2474,6 +2494,8 @@ layer {
   bottom: "conv5_3_pool2"
   top: "conv5_3_pool2_conv"
   param {
+    lr_mult: 1
+    decay_mult: 1
   }
   convolution_param {
     num_output: 512
@@ -2533,6 +2555,8 @@ layer {
   bottom: "conv5_3_pool3"
   top: "conv5_3_pool3_conv"
   param {
+    lr_mult: 1
+    decay_mult: 1
   }
   convolution_param {
     num_output: 512
@@ -2592,6 +2616,8 @@ layer {
   bottom: "conv5_3_pool6"
   top: "conv5_3_pool6_conv"
   param {
+    lr_mult: 1
+    decay_mult: 1
   }
   convolution_param {
     num_output: 512
@@ -2650,6 +2676,8 @@ layer {
   bottom: "conv5_3_concat"
   top: "conv5_4"
   param {
+    lr_mult: 1
+    decay_mult: 1
   }
   convolution_param {
     num_output: 512
@@ -2682,6 +2710,14 @@ layer {
   type: "Convolution"
   bottom: "conv5_4"
   top: "conv6"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
   convolution_param {
     num_output: 2
     kernel_size: 1

--- a/templates/caffe/pspnet_50/deploy.prototxt
+++ b/templates/caffe/pspnet_50/deploy.prototxt
@@ -32,7 +32,7 @@ layer {
   }
 }
 layer {
-  name: "conv1_1_3x3_s2/bn"
+  name: "conv1_1_3x3_s2/bnc"
   type: "BatchNorm"
   bottom: "conv1_1_3x3_s2"
   top: "conv1_1_3x3_s2"
@@ -75,7 +75,7 @@ layer {
   }
 }
 layer {
-  name: "conv1_2_3x3/bn"
+  name: "conv1_2_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv1_2_3x3"
   top: "conv1_2_3x3"
@@ -118,7 +118,7 @@ layer {
   }
 }
 layer {
-  name: "conv1_3_3x3/bn"
+  name: "conv1_3_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv1_3_3x3"
   top: "conv1_3_3x3"
@@ -173,7 +173,7 @@ layer {
   }
 }
 layer {
-  name: "conv2_1_1x1_reduce/bn"
+  name: "conv2_1_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv2_1_1x1_reduce"
   top: "conv2_1_1x1_reduce"
@@ -216,7 +216,7 @@ layer {
   }
 }
 layer {
-  name: "conv2_1_3x3/bn"
+  name: "conv2_1_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv2_1_3x3"
   top: "conv2_1_3x3"
@@ -259,7 +259,7 @@ layer {
   }
 }
 layer {
-  name: "conv2_1_1x1_increase/bn"
+  name: "conv2_1_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv2_1_1x1_increase"
   top: "conv2_1_1x1_increase"
@@ -296,7 +296,7 @@ layer {
   }
 }
 layer {
-  name: "conv2_1_1x1_proj/bn"
+  name: "conv2_1_1x1_proj/bnc"
   type: "BatchNorm"
   bottom: "conv2_1_1x1_proj"
   top: "conv2_1_1x1_proj"
@@ -349,7 +349,7 @@ layer {
   }
 }
 layer {
-  name: "conv2_2_1x1_reduce/bn"
+  name: "conv2_2_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv2_2_1x1_reduce"
   top: "conv2_2_1x1_reduce"
@@ -392,7 +392,7 @@ layer {
   }
 }
 layer {
-  name: "conv2_2_3x3/bn"
+  name: "conv2_2_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv2_2_3x3"
   top: "conv2_2_3x3"
@@ -435,7 +435,7 @@ layer {
   }
 }
 layer {
-  name: "conv2_2_1x1_increase/bn"
+  name: "conv2_2_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv2_2_1x1_increase"
   top: "conv2_2_1x1_increase"
@@ -488,7 +488,7 @@ layer {
   }
 }
 layer {
-  name: "conv2_3_1x1_reduce/bn"
+  name: "conv2_3_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv2_3_1x1_reduce"
   top: "conv2_3_1x1_reduce"
@@ -531,7 +531,7 @@ layer {
   }
 }
 layer {
-  name: "conv2_3_3x3/bn"
+  name: "conv2_3_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv2_3_3x3"
   top: "conv2_3_3x3"
@@ -574,7 +574,7 @@ layer {
   }
 }
 layer {
-  name: "conv2_3_1x1_increase/bn"
+  name: "conv2_3_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv2_3_1x1_increase"
   top: "conv2_3_1x1_increase"
@@ -627,7 +627,7 @@ layer {
   }
 }
 layer {
-  name: "conv3_1_1x1_reduce/bn"
+  name: "conv3_1_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv3_1_1x1_reduce"
   top: "conv3_1_1x1_reduce"
@@ -670,7 +670,7 @@ layer {
   }
 }
 layer {
-  name: "conv3_1_3x3/bn"
+  name: "conv3_1_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv3_1_3x3"
   top: "conv3_1_3x3"
@@ -713,7 +713,7 @@ layer {
   }
 }
 layer {
-  name: "conv3_1_1x1_increase/bn"
+  name: "conv3_1_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv3_1_1x1_increase"
   top: "conv3_1_1x1_increase"
@@ -750,7 +750,7 @@ layer {
   }
 }
 layer {
-  name: "conv3_1_1x1_proj/bn"
+  name: "conv3_1_1x1_proj/bnc"
   type: "BatchNorm"
   bottom: "conv3_1_1x1_proj"
   top: "conv3_1_1x1_proj"
@@ -803,7 +803,7 @@ layer {
   }
 }
 layer {
-  name: "conv3_2_1x1_reduce/bn"
+  name: "conv3_2_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv3_2_1x1_reduce"
   top: "conv3_2_1x1_reduce"
@@ -846,7 +846,7 @@ layer {
   }
 }
 layer {
-  name: "conv3_2_3x3/bn"
+  name: "conv3_2_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv3_2_3x3"
   top: "conv3_2_3x3"
@@ -889,7 +889,7 @@ layer {
   }
 }
 layer {
-  name: "conv3_2_1x1_increase/bn"
+  name: "conv3_2_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv3_2_1x1_increase"
   top: "conv3_2_1x1_increase"
@@ -942,7 +942,7 @@ layer {
   }
 }
 layer {
-  name: "conv3_3_1x1_reduce/bn"
+  name: "conv3_3_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv3_3_1x1_reduce"
   top: "conv3_3_1x1_reduce"
@@ -985,7 +985,7 @@ layer {
   }
 }
 layer {
-  name: "conv3_3_3x3/bn"
+  name: "conv3_3_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv3_3_3x3"
   top: "conv3_3_3x3"
@@ -1028,7 +1028,7 @@ layer {
   }
 }
 layer {
-  name: "conv3_3_1x1_increase/bn"
+  name: "conv3_3_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv3_3_1x1_increase"
   top: "conv3_3_1x1_increase"
@@ -1081,7 +1081,7 @@ layer {
   }
 }
 layer {
-  name: "conv3_4_1x1_reduce/bn"
+  name: "conv3_4_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv3_4_1x1_reduce"
   top: "conv3_4_1x1_reduce"
@@ -1124,7 +1124,7 @@ layer {
   }
 }
 layer {
-  name: "conv3_4_3x3/bn"
+  name: "conv3_4_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv3_4_3x3"
   top: "conv3_4_3x3"
@@ -1167,7 +1167,7 @@ layer {
   }
 }
 layer {
-  name: "conv3_4_1x1_increase/bn"
+  name: "conv3_4_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv3_4_1x1_increase"
   top: "conv3_4_1x1_increase"
@@ -1220,7 +1220,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_1_1x1_reduce/bn"
+  name: "conv4_1_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_1_1x1_reduce"
   top: "conv4_1_1x1_reduce"
@@ -1264,7 +1264,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_1_3x3/bn"
+  name: "conv4_1_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_1_3x3"
   top: "conv4_1_3x3"
@@ -1307,7 +1307,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_1_1x1_increase/bn"
+  name: "conv4_1_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_1_1x1_increase"
   top: "conv4_1_1x1_increase"
@@ -1344,7 +1344,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_1_1x1_proj/bn"
+  name: "conv4_1_1x1_proj/bnc"
   type: "BatchNorm"
   bottom: "conv4_1_1x1_proj"
   top: "conv4_1_1x1_proj"
@@ -1397,7 +1397,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_2_1x1_reduce/bn"
+  name: "conv4_2_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_2_1x1_reduce"
   top: "conv4_2_1x1_reduce"
@@ -1441,7 +1441,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_2_3x3/bn"
+  name: "conv4_2_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_2_3x3"
   top: "conv4_2_3x3"
@@ -1484,7 +1484,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_2_1x1_increase/bn"
+  name: "conv4_2_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_2_1x1_increase"
   top: "conv4_2_1x1_increase"
@@ -1537,7 +1537,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_3_1x1_reduce/bn"
+  name: "conv4_3_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_3_1x1_reduce"
   top: "conv4_3_1x1_reduce"
@@ -1581,7 +1581,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_3_3x3/bn"
+  name: "conv4_3_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_3_3x3"
   top: "conv4_3_3x3"
@@ -1624,7 +1624,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_3_1x1_increase/bn"
+  name: "conv4_3_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_3_1x1_increase"
   top: "conv4_3_1x1_increase"
@@ -1677,7 +1677,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_4_1x1_reduce/bn"
+  name: "conv4_4_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_4_1x1_reduce"
   top: "conv4_4_1x1_reduce"
@@ -1721,7 +1721,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_4_3x3/bn"
+  name: "conv4_4_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_4_3x3"
   top: "conv4_4_3x3"
@@ -1764,7 +1764,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_4_1x1_increase/bn"
+  name: "conv4_4_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_4_1x1_increase"
   top: "conv4_4_1x1_increase"
@@ -1817,7 +1817,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_5_1x1_reduce/bn"
+  name: "conv4_5_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_5_1x1_reduce"
   top: "conv4_5_1x1_reduce"
@@ -1861,7 +1861,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_5_3x3/bn"
+  name: "conv4_5_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_5_3x3"
   top: "conv4_5_3x3"
@@ -1904,7 +1904,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_5_1x1_increase/bn"
+  name: "conv4_5_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_5_1x1_increase"
   top: "conv4_5_1x1_increase"
@@ -1957,7 +1957,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_6_1x1_reduce/bn"
+  name: "conv4_6_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_6_1x1_reduce"
   top: "conv4_6_1x1_reduce"
@@ -2001,7 +2001,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_6_3x3/bn"
+  name: "conv4_6_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_6_3x3"
   top: "conv4_6_3x3"
@@ -2044,7 +2044,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_6_1x1_increase/bn"
+  name: "conv4_6_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_6_1x1_increase"
   top: "conv4_6_1x1_increase"
@@ -2097,7 +2097,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_1_1x1_reduce/bn"
+  name: "conv5_1_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv5_1_1x1_reduce"
   top: "conv5_1_1x1_reduce"
@@ -2141,7 +2141,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_1_3x3/bn"
+  name: "conv5_1_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv5_1_3x3"
   top: "conv5_1_3x3"
@@ -2184,7 +2184,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_1_1x1_increase/bn"
+  name: "conv5_1_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv5_1_1x1_increase"
   top: "conv5_1_1x1_increase"
@@ -2221,7 +2221,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_1_1x1_proj/bn"
+  name: "conv5_1_1x1_proj/bnc"
   type: "BatchNorm"
   bottom: "conv5_1_1x1_proj"
   top: "conv5_1_1x1_proj"
@@ -2274,7 +2274,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_2_1x1_reduce/bn"
+  name: "conv5_2_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv5_2_1x1_reduce"
   top: "conv5_2_1x1_reduce"
@@ -2318,7 +2318,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_2_3x3/bn"
+  name: "conv5_2_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv5_2_3x3"
   top: "conv5_2_3x3"
@@ -2361,7 +2361,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_2_1x1_increase/bn"
+  name: "conv5_2_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv5_2_1x1_increase"
   top: "conv5_2_1x1_increase"
@@ -2414,7 +2414,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_3_1x1_reduce/bn"
+  name: "conv5_3_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv5_3_1x1_reduce"
   top: "conv5_3_1x1_reduce"
@@ -2458,7 +2458,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_3_3x3/bn"
+  name: "conv5_3_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv5_3_3x3"
   top: "conv5_3_3x3"
@@ -2501,7 +2501,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_3_1x1_increase/bn"
+  name: "conv5_3_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv5_3_1x1_increase"
   top: "conv5_3_1x1_increase"
@@ -2564,7 +2564,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_3_pool1_conv/bn"
+  name: "conv5_3_pool1_conv/bnc"
   type: "BatchNorm"
   bottom: "conv5_3_pool1_conv"
   top: "conv5_3_pool1_conv"
@@ -2627,7 +2627,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_3_pool2_conv/bn"
+  name: "conv5_3_pool2_conv/bnc"
   type: "BatchNorm"
   bottom: "conv5_3_pool2_conv"
   top: "conv5_3_pool2_conv"
@@ -2690,7 +2690,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_3_pool3_conv/bn"
+  name: "conv5_3_pool3_conv/bnc"
   type: "BatchNorm"
   bottom: "conv5_3_pool3_conv"
   top: "conv5_3_pool3_conv"
@@ -2753,7 +2753,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_3_pool6_conv/bn"
+  name: "conv5_3_pool6_conv/bnc"
   type: "BatchNorm"
   bottom: "conv5_3_pool6_conv"
   top: "conv5_3_pool6_conv"
@@ -2816,7 +2816,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_4/bn"
+  name: "conv5_4/bnc"
   type: "BatchNorm"
   bottom: "conv5_4"
   top: "conv5_4"

--- a/templates/caffe/pspnet_50/pspnet_50.prototxt
+++ b/templates/caffe/pspnet_50/pspnet_50.prototxt
@@ -1197,7 +1197,7 @@ layer {
   convolution_param {
     num_output: 256
     bias_term: false
-    pad: 1
+    pad: 2
     kernel_size: 3
     stride: 1
     weight_filler {
@@ -1207,6 +1207,8 @@ layer {
       type: "constant"
       value: 0.2
     }
+    engine: DEFAULT
+    dilation: 2
   }
 }
 layer {
@@ -1333,7 +1335,7 @@ layer {
   convolution_param {
     num_output: 256
     bias_term: false
-    pad: 1
+    pad: 2
     kernel_size: 3
     stride: 1
     weight_filler {
@@ -1343,6 +1345,8 @@ layer {
       type: "constant"
       value: 0.2
     }
+    engine: DEFAULT
+    dilation: 2
   }
 }
 layer {
@@ -1469,7 +1473,7 @@ layer {
   convolution_param {
     num_output: 256
     bias_term: false
-    pad: 1
+    pad: 2
     kernel_size: 3
     stride: 1
     weight_filler {
@@ -1479,6 +1483,8 @@ layer {
       type: "constant"
       value: 0.2
     }
+    engine: DEFAULT
+    dilation: 2
   }
 }
 layer {
@@ -1605,7 +1611,7 @@ layer {
   convolution_param {
     num_output: 256
     bias_term: false
-    pad: 1
+    pad: 2
     kernel_size: 3
     stride: 1
     weight_filler {
@@ -1615,6 +1621,8 @@ layer {
       type: "constant"
       value: 0.2
     }
+    engine: DEFAULT
+    dilation: 2
   }
 }
 layer {
@@ -1741,7 +1749,7 @@ layer {
   convolution_param {
     num_output: 256
     bias_term: false
-    pad: 1
+    pad: 2
     kernel_size: 3
     stride: 1
     weight_filler {
@@ -1751,6 +1759,8 @@ layer {
       type: "constant"
       value: 0.2
     }
+    engine: DEFAULT
+    dilation: 2
   }
 }
 layer {
@@ -1877,7 +1887,7 @@ layer {
   convolution_param {
     num_output: 256
     bias_term: false
-    pad: 1
+    pad: 2
     kernel_size: 3
     stride: 1
     weight_filler {
@@ -1887,6 +1897,8 @@ layer {
       type: "constant"
       value: 0.2
     }
+    engine: DEFAULT
+    dilation: 2
   }
 }
 layer {
@@ -2050,7 +2062,7 @@ layer {
   convolution_param {
     num_output: 512
     bias_term: false
-    pad: 1
+    pad: 4
     kernel_size: 3
     stride: 1
     weight_filler {
@@ -2060,6 +2072,8 @@ layer {
       type: "constant"
       value: 0.2
     }
+    engine: DEFAULT
+    dilation: 4
   }
 }
 layer {
@@ -2186,7 +2200,7 @@ layer {
   convolution_param {
     num_output: 512
     bias_term: false
-    pad: 1
+    pad: 4
     kernel_size: 3
     stride: 1
     weight_filler {
@@ -2196,6 +2210,8 @@ layer {
       type: "constant"
       value: 0.2
     }
+    engine: DEFAULT
+    dilation: 4
   }
 }
 layer {
@@ -2322,7 +2338,7 @@ layer {
   convolution_param {
     num_output: 512
     bias_term: false
-    pad: 1
+    pad: 4
     kernel_size: 3
     stride: 1
     weight_filler {
@@ -2332,6 +2348,8 @@ layer {
       type: "constant"
       value: 0.2
     }
+    engine: DEFAULT
+    dilation: 4
   }
 }
 layer {

--- a/templates/caffe/pspnet_50/pspnet_50.prototxt
+++ b/templates/caffe/pspnet_50/pspnet_50.prototxt
@@ -11,7 +11,8 @@ layer {
     source: "train.txt"
     batch_size: 5
     shuffle: true
-    mirror: true
+    new_height: 480
+    new_width: 480
   }
 }
 layer {
@@ -25,2536 +26,2401 @@ layer {
   memory_data_param {
     batch_size: 1
     channels: 3
-    height: 473
-    width: 473
+    height: 480
+    width: 480
   }
 }
 layer {
-  name: "conv1_1_3x3_s2"
+  name: "conv1"
   type: "Convolution"
   bottom: "data"
-  top: "conv1_1_3x3_s2"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
+  top: "conv1"
   convolution_param {
     num_output: 64
-    pad: 1
-    kernel_size: 3
+    pad: 3
+    kernel_size: 7
     stride: 2
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
-  }
-}
-layer {
-  name: "conv1_1_3x3_s2/bnc"
-  type: "BatchNorm"
-  bottom: "conv1_1_3x3_s2"
-  top: "conv1_1_3x3_s2"
-}
-
-layer {
- name: "conv1_1_3x3_s2/scale"
- type: "Scale"
-bottom: "conv1_1_3x3_s2"
- top: "conv1_1_3x3_s2"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv1_1_3x3_s2/relu"
-  type: "ReLU"
-  bottom: "conv1_1_3x3_s2"
-  top: "conv1_1_3x3_s2"
-}
-layer {
-  name: "conv1_2_3x3"
-  type: "Convolution"
-  bottom: "conv1_1_3x3_s2"
-  top: "conv1_2_3x3"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
-  convolution_param {
-    num_output: 64
-    pad: 1
-    kernel_size: 3
-    stride: 1
-    weight_filler {
-      type: "msra"
+    bias_filler {
+      type: "constant"
+      value: 0.2
     }
-    bias_term: false
   }
 }
 layer {
-  name: "conv1_2_3x3/bnc"
+  name: "bn_conv1"
   type: "BatchNorm"
-  bottom: "conv1_2_3x3"
-  top: "conv1_2_3x3"
-}
-
-layer {
- name: "conv1_2_3x3/scale"
- type: "Scale"
-bottom: "conv1_2_3x3"
- top: "conv1_2_3x3"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv1_2_3x3/relu"
-  type: "ReLU"
-  bottom: "conv1_2_3x3"
-  top: "conv1_2_3x3"
-}
-layer {
-  name: "conv1_3_3x3"
-  type: "Convolution"
-  bottom: "conv1_2_3x3"
-  top: "conv1_3_3x3"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
-  convolution_param {
-    num_output: 128
-    pad: 1
-    kernel_size: 3
-    stride: 1
-    weight_filler {
-      type: "msra"
-    }
-    bias_term: false
+  bottom: "conv1"
+  top: "conv1"
+  batch_norm_param {
   }
 }
 layer {
-  name: "conv1_3_3x3/bnc"
-  type: "BatchNorm"
-  bottom: "conv1_3_3x3"
-  top: "conv1_3_3x3"
+  name: "scale_conv1"
+  type: "Scale"
+  bottom: "conv1"
+  top: "conv1"
+  scale_param {
+    bias_term: true
+  }
 }
-
 layer {
- name: "conv1_3_3x3/scale"
- type: "Scale"
-bottom: "conv1_3_3x3"
- top: "conv1_3_3x3"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv1_3_3x3/relu"
+  name: "conv1_relu"
   type: "ReLU"
-  bottom: "conv1_3_3x3"
-  top: "conv1_3_3x3"
+  bottom: "conv1"
+  top: "conv1"
 }
 layer {
-  name: "pool1_3x3_s2"
+  name: "pool1"
   type: "Pooling"
-  bottom: "conv1_3_3x3"
-  top: "pool1_3x3_s2"
+  bottom: "conv1"
+  top: "pool1"
   pooling_param {
     pool: MAX
     kernel_size: 3
     stride: 2
-    pad: 1
   }
 }
 layer {
-  name: "conv2_1_1x1_reduce"
+  name: "res2a_branch1"
   type: "Convolution"
-  bottom: "pool1_3x3_s2"
-  top: "conv2_1_1x1_reduce"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
-  convolution_param {
-    num_output: 64
-    pad: 0
-    kernel_size: 1
-    stride: 1
-    weight_filler {
-      type: "msra"
-    }
-    bias_term: false
-  }
-}
-layer {
-  name: "conv2_1_1x1_reduce/bnc"
-  type: "BatchNorm"
-  bottom: "conv2_1_1x1_reduce"
-  top: "conv2_1_1x1_reduce"
-}
-
-layer {
- name: "conv2_1_1x1_reduce/scale"
- type: "Scale"
-bottom: "conv2_1_1x1_reduce"
- top: "conv2_1_1x1_reduce"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv2_1_1x1_reduce/relu"
-  type: "ReLU"
-  bottom: "conv2_1_1x1_reduce"
-  top: "conv2_1_1x1_reduce"
-}
-layer {
-  name: "conv2_1_3x3"
-  type: "Convolution"
-  bottom: "conv2_1_1x1_reduce"
-  top: "conv2_1_3x3"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
-  convolution_param {
-    num_output: 64
-    pad: 1
-    kernel_size: 3
-    stride: 1
-    weight_filler {
-      type: "msra"
-    }
-    bias_term: false
-  }
-}
-layer {
-  name: "conv2_1_3x3/bnc"
-  type: "BatchNorm"
-  bottom: "conv2_1_3x3"
-  top: "conv2_1_3x3"
-}
-
-layer {
- name: "conv2_1_3x3/scale"
- type: "Scale"
-bottom: "conv2_1_3x3"
- top: "conv2_1_3x3"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv2_1_3x3/relu"
-  type: "ReLU"
-  bottom: "conv2_1_3x3"
-  top: "conv2_1_3x3"
-}
-layer {
-  name: "conv2_1_1x1_increase"
-  type: "Convolution"
-  bottom: "conv2_1_3x3"
-  top: "conv2_1_1x1_increase"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
+  bottom: "pool1"
+  top: "res2a_branch1"
   convolution_param {
     num_output: 256
+    bias_term: false
     pad: 0
     kernel_size: 1
     stride: 1
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
-  }
-}
-layer {
-  name: "conv2_1_1x1_increase/bnc"
-  type: "BatchNorm"
-  bottom: "conv2_1_1x1_increase"
-  top: "conv2_1_1x1_increase"
-}
-
-layer {
- name: "conv2_1_1x1_increase/scale"
- type: "Scale"
-bottom: "conv2_1_1x1_increase"
- top: "conv2_1_1x1_increase"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv2_1_1x1_proj"
-  type: "Convolution"
-  bottom: "pool1_3x3_s2"
-  top: "conv2_1_1x1_proj"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
-  convolution_param {
-    num_output: 256
-    pad: 0
-    kernel_size: 1
-    stride: 1
-    weight_filler {
-      type: "msra"
+    bias_filler {
+      type: "constant"
+      value: 0.2
     }
-    bias_term: false
   }
 }
 layer {
-  name: "conv2_1_1x1_proj/bnc"
+  name: "bn2a_branch1"
   type: "BatchNorm"
-  bottom: "conv2_1_1x1_proj"
-  top: "conv2_1_1x1_proj"
-}
-
-layer {
- name: "conv2_1_1x1_proj/scale"
- type: "Scale"
-bottom: "conv2_1_1x1_proj"
- top: "conv2_1_1x1_proj"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv2_1"
-  type: "Eltwise"
-  bottom: "conv2_1_1x1_proj"
-  bottom: "conv2_1_1x1_increase"
-  top: "conv2_1"
-  eltwise_param {
-    operation: SUM
+  bottom: "res2a_branch1"
+  top: "res2a_branch1"
+  batch_norm_param {
   }
 }
 layer {
-  name: "conv2_1/relu"
-  type: "ReLU"
-  bottom: "conv2_1"
-  top: "conv2_1"
+  name: "scale2a_branch1"
+  type: "Scale"
+  bottom: "res2a_branch1"
+  top: "res2a_branch1"
+  scale_param {
+    bias_term: true
+  }
 }
 layer {
-  name: "conv2_2_1x1_reduce"
+  name: "res2a_branch2a"
   type: "Convolution"
-  bottom: "conv2_1"
-  top: "conv2_2_1x1_reduce"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
+  bottom: "pool1"
+  top: "res2a_branch2a"
   convolution_param {
     num_output: 64
+    bias_term: false
     pad: 0
     kernel_size: 1
     stride: 1
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
   }
 }
 layer {
-  name: "conv2_2_1x1_reduce/bnc"
+  name: "bn2a_branch2a"
   type: "BatchNorm"
-  bottom: "conv2_2_1x1_reduce"
-  top: "conv2_2_1x1_reduce"
-}
-
-layer {
- name: "conv2_2_1x1_reduce/scale"
- type: "Scale"
-bottom: "conv2_2_1x1_reduce"
- top: "conv2_2_1x1_reduce"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv2_2_1x1_reduce/relu"
-  type: "ReLU"
-  bottom: "conv2_2_1x1_reduce"
-  top: "conv2_2_1x1_reduce"
-}
-layer {
-  name: "conv2_2_3x3"
-  type: "Convolution"
-  bottom: "conv2_2_1x1_reduce"
-  top: "conv2_2_3x3"
-  param {
-    lr_mult: 1
-    decay_mult: 1
+  bottom: "res2a_branch2a"
+  top: "res2a_branch2a"
+  batch_norm_param {
   }
+}
+layer {
+  name: "scale2a_branch2a"
+  type: "Scale"
+  bottom: "res2a_branch2a"
+  top: "res2a_branch2a"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res2a_branch2a_relu"
+  type: "ReLU"
+  bottom: "res2a_branch2a"
+  top: "res2a_branch2a"
+}
+layer {
+  name: "res2a_branch2b"
+  type: "Convolution"
+  bottom: "res2a_branch2a"
+  top: "res2a_branch2b"
   convolution_param {
     num_output: 64
+    bias_term: false
     pad: 1
     kernel_size: 3
     stride: 1
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
   }
 }
 layer {
-  name: "conv2_2_3x3/bnc"
+  name: "bn2a_branch2b"
   type: "BatchNorm"
-  bottom: "conv2_2_3x3"
-  top: "conv2_2_3x3"
-}
-
-layer {
- name: "conv2_2_3x3/scale"
- type: "Scale"
-bottom: "conv2_2_3x3"
- top: "conv2_2_3x3"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv2_2_3x3/relu"
-  type: "ReLU"
-  bottom: "conv2_2_3x3"
-  top: "conv2_2_3x3"
-}
-layer {
-  name: "conv2_2_1x1_increase"
-  type: "Convolution"
-  bottom: "conv2_2_3x3"
-  top: "conv2_2_1x1_increase"
-  param {
-    lr_mult: 1
-    decay_mult: 1
+  bottom: "res2a_branch2b"
+  top: "res2a_branch2b"
+  batch_norm_param {
   }
+}
+layer {
+  name: "scale2a_branch2b"
+  type: "Scale"
+  bottom: "res2a_branch2b"
+  top: "res2a_branch2b"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res2a_branch2b_relu"
+  type: "ReLU"
+  bottom: "res2a_branch2b"
+  top: "res2a_branch2b"
+}
+layer {
+  name: "res2a_branch2c"
+  type: "Convolution"
+  bottom: "res2a_branch2b"
+  top: "res2a_branch2c"
   convolution_param {
     num_output: 256
+    bias_term: false
     pad: 0
     kernel_size: 1
     stride: 1
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
   }
 }
 layer {
-  name: "conv2_2_1x1_increase/bnc"
+  name: "bn2a_branch2c"
   type: "BatchNorm"
-  bottom: "conv2_2_1x1_increase"
-  top: "conv2_2_1x1_increase"
+  bottom: "res2a_branch2c"
+  top: "res2a_branch2c"
+  batch_norm_param {
+  }
 }
-
 layer {
- name: "conv2_2_1x1_increase/scale"
- type: "Scale"
-bottom: "conv2_2_1x1_increase"
- top: "conv2_2_1x1_increase"
- scale_param {
- bias_term: true
+  name: "scale2a_branch2c"
+  type: "Scale"
+  bottom: "res2a_branch2c"
+  top: "res2a_branch2c"
+  scale_param {
+    bias_term: true
+  }
 }
-}
-
 layer {
-  name: "conv2_2"
+  name: "res2a"
   type: "Eltwise"
-  bottom: "conv2_1"
-  bottom: "conv2_2_1x1_increase"
-  top: "conv2_2"
-  eltwise_param {
-    operation: SUM
-  }
+  bottom: "res2a_branch1"
+  bottom: "res2a_branch2c"
+  top: "res2a"
 }
 layer {
-  name: "conv2_2/relu"
+  name: "res2a_relu"
   type: "ReLU"
-  bottom: "conv2_2"
-  top: "conv2_2"
+  bottom: "res2a"
+  top: "res2a"
 }
 layer {
-  name: "conv2_3_1x1_reduce"
+  name: "res2b_branch2a"
   type: "Convolution"
-  bottom: "conv2_2"
-  top: "conv2_3_1x1_reduce"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
+  bottom: "res2a"
+  top: "res2b_branch2a"
   convolution_param {
     num_output: 64
+    bias_term: false
     pad: 0
     kernel_size: 1
     stride: 1
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
   }
 }
 layer {
-  name: "conv2_3_1x1_reduce/bnc"
+  name: "bn2b_branch2a"
   type: "BatchNorm"
-  bottom: "conv2_3_1x1_reduce"
-  top: "conv2_3_1x1_reduce"
-}
-
-layer {
- name: "conv2_3_1x1_reduce/scale"
- type: "Scale"
-bottom: "conv2_3_1x1_reduce"
- top: "conv2_3_1x1_reduce"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv2_3_1x1_reduce/relu"
-  type: "ReLU"
-  bottom: "conv2_3_1x1_reduce"
-  top: "conv2_3_1x1_reduce"
-}
-layer {
-  name: "conv2_3_3x3"
-  type: "Convolution"
-  bottom: "conv2_3_1x1_reduce"
-  top: "conv2_3_3x3"
-  param {
-    lr_mult: 1
-    decay_mult: 1
+  bottom: "res2b_branch2a"
+  top: "res2b_branch2a"
+  batch_norm_param {
   }
+}
+layer {
+  name: "scale2b_branch2a"
+  type: "Scale"
+  bottom: "res2b_branch2a"
+  top: "res2b_branch2a"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res2b_branch2a_relu"
+  type: "ReLU"
+  bottom: "res2b_branch2a"
+  top: "res2b_branch2a"
+}
+layer {
+  name: "res2b_branch2b"
+  type: "Convolution"
+  bottom: "res2b_branch2a"
+  top: "res2b_branch2b"
   convolution_param {
     num_output: 64
+    bias_term: false
     pad: 1
     kernel_size: 3
     stride: 1
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
   }
 }
 layer {
-  name: "conv2_3_3x3/bnc"
+  name: "bn2b_branch2b"
   type: "BatchNorm"
-  bottom: "conv2_3_3x3"
-  top: "conv2_3_3x3"
-}
-
-layer {
- name: "conv2_3_3x3/scale"
- type: "Scale"
-bottom: "conv2_3_3x3"
- top: "conv2_3_3x3"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv2_3_3x3/relu"
-  type: "ReLU"
-  bottom: "conv2_3_3x3"
-  top: "conv2_3_3x3"
-}
-layer {
-  name: "conv2_3_1x1_increase"
-  type: "Convolution"
-  bottom: "conv2_3_3x3"
-  top: "conv2_3_1x1_increase"
-  param {
-    lr_mult: 1
-    decay_mult: 1
+  bottom: "res2b_branch2b"
+  top: "res2b_branch2b"
+  batch_norm_param {
   }
+}
+layer {
+  name: "scale2b_branch2b"
+  type: "Scale"
+  bottom: "res2b_branch2b"
+  top: "res2b_branch2b"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res2b_branch2b_relu"
+  type: "ReLU"
+  bottom: "res2b_branch2b"
+  top: "res2b_branch2b"
+}
+layer {
+  name: "res2b_branch2c"
+  type: "Convolution"
+  bottom: "res2b_branch2b"
+  top: "res2b_branch2c"
   convolution_param {
     num_output: 256
+    bias_term: false
     pad: 0
     kernel_size: 1
     stride: 1
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
   }
 }
 layer {
-  name: "conv2_3_1x1_increase/bnc"
+  name: "bn2b_branch2c"
   type: "BatchNorm"
-  bottom: "conv2_3_1x1_increase"
-  top: "conv2_3_1x1_increase"
+  bottom: "res2b_branch2c"
+  top: "res2b_branch2c"
+  batch_norm_param {
+  }
 }
-
 layer {
- name: "conv2_3_1x1_increase/scale"
- type: "Scale"
-bottom: "conv2_3_1x1_increase"
- top: "conv2_3_1x1_increase"
- scale_param {
- bias_term: true
+  name: "scale2b_branch2c"
+  type: "Scale"
+  bottom: "res2b_branch2c"
+  top: "res2b_branch2c"
+  scale_param {
+    bias_term: true
+  }
 }
-}
-
 layer {
-  name: "conv2_3"
+  name: "res2b"
   type: "Eltwise"
-  bottom: "conv2_2"
-  bottom: "conv2_3_1x1_increase"
-  top: "conv2_3"
-  eltwise_param {
-    operation: SUM
-  }
+  bottom: "res2a"
+  bottom: "res2b_branch2c"
+  top: "res2b"
 }
 layer {
-  name: "conv2_3/relu"
+  name: "res2b_relu"
   type: "ReLU"
-  bottom: "conv2_3"
-  top: "conv2_3"
+  bottom: "res2b"
+  top: "res2b"
 }
 layer {
-  name: "conv3_1_1x1_reduce"
+  name: "res2c_branch2a"
   type: "Convolution"
-  bottom: "conv2_3"
-  top: "conv3_1_1x1_reduce"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
+  bottom: "res2b"
+  top: "res2c_branch2a"
   convolution_param {
-    num_output: 128
+    num_output: 64
+    bias_term: false
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "bn2c_branch2a"
+  type: "BatchNorm"
+  bottom: "res2c_branch2a"
+  top: "res2c_branch2a"
+  batch_norm_param {
+  }
+}
+layer {
+  name: "scale2c_branch2a"
+  type: "Scale"
+  bottom: "res2c_branch2a"
+  top: "res2c_branch2a"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res2c_branch2a_relu"
+  type: "ReLU"
+  bottom: "res2c_branch2a"
+  top: "res2c_branch2a"
+}
+layer {
+  name: "res2c_branch2b"
+  type: "Convolution"
+  bottom: "res2c_branch2a"
+  top: "res2c_branch2b"
+  convolution_param {
+    num_output: 64
+    bias_term: false
+    pad: 1
+    kernel_size: 3
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "bn2c_branch2b"
+  type: "BatchNorm"
+  bottom: "res2c_branch2b"
+  top: "res2c_branch2b"
+  batch_norm_param {
+  }
+}
+layer {
+  name: "scale2c_branch2b"
+  type: "Scale"
+  bottom: "res2c_branch2b"
+  top: "res2c_branch2b"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res2c_branch2b_relu"
+  type: "ReLU"
+  bottom: "res2c_branch2b"
+  top: "res2c_branch2b"
+}
+layer {
+  name: "res2c_branch2c"
+  type: "Convolution"
+  bottom: "res2c_branch2b"
+  top: "res2c_branch2c"
+  convolution_param {
+    num_output: 256
+    bias_term: false
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "bn2c_branch2c"
+  type: "BatchNorm"
+  bottom: "res2c_branch2c"
+  top: "res2c_branch2c"
+  batch_norm_param {
+  }
+}
+layer {
+  name: "scale2c_branch2c"
+  type: "Scale"
+  bottom: "res2c_branch2c"
+  top: "res2c_branch2c"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res2c"
+  type: "Eltwise"
+  bottom: "res2b"
+  bottom: "res2c_branch2c"
+  top: "res2c"
+}
+layer {
+  name: "res2c_relu"
+  type: "ReLU"
+  bottom: "res2c"
+  top: "res2c"
+}
+layer {
+  name: "res3a_branch1"
+  type: "Convolution"
+  bottom: "res2c"
+  top: "res3a_branch1"
+  convolution_param {
+    num_output: 512
+    bias_term: false
     pad: 0
     kernel_size: 1
     stride: 2
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
   }
 }
 layer {
-  name: "conv3_1_1x1_reduce/bnc"
+  name: "bn3a_branch1"
   type: "BatchNorm"
-  bottom: "conv3_1_1x1_reduce"
-  top: "conv3_1_1x1_reduce"
-}
-
-layer {
- name: "conv3_1_1x1_reduce/scale"
- type: "Scale"
-bottom: "conv3_1_1x1_reduce"
- top: "conv3_1_1x1_reduce"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv3_1_1x1_reduce/relu"
-  type: "ReLU"
-  bottom: "conv3_1_1x1_reduce"
-  top: "conv3_1_1x1_reduce"
-}
-layer {
-  name: "conv3_1_3x3"
-  type: "Convolution"
-  bottom: "conv3_1_1x1_reduce"
-  top: "conv3_1_3x3"
-  param {
-    lr_mult: 1
-    decay_mult: 1
+  bottom: "res3a_branch1"
+  top: "res3a_branch1"
+  batch_norm_param {
   }
+}
+layer {
+  name: "scale3a_branch1"
+  type: "Scale"
+  bottom: "res3a_branch1"
+  top: "res3a_branch1"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res3a_branch2a"
+  type: "Convolution"
+  bottom: "res2c"
+  top: "res3a_branch2a"
   convolution_param {
     num_output: 128
-    pad: 1
-    kernel_size: 3
-    stride: 1
-    weight_filler {
-      type: "msra"
-    }
     bias_term: false
-  }
-}
-layer {
-  name: "conv3_1_3x3/bnc"
-  type: "BatchNorm"
-  bottom: "conv3_1_3x3"
-  top: "conv3_1_3x3"
-}
-
-layer {
- name: "conv3_1_3x3/scale"
- type: "Scale"
-bottom: "conv3_1_3x3"
- top: "conv3_1_3x3"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv3_1_3x3/relu"
-  type: "ReLU"
-  bottom: "conv3_1_3x3"
-  top: "conv3_1_3x3"
-}
-layer {
-  name: "conv3_1_1x1_increase"
-  type: "Convolution"
-  bottom: "conv3_1_3x3"
-  top: "conv3_1_1x1_increase"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
-  convolution_param {
-    num_output: 512
-    pad: 0
-    kernel_size: 1
-    stride: 1
-    weight_filler {
-      type: "msra"
-    }
-    bias_term: false
-  }
-}
-layer {
-  name: "conv3_1_1x1_increase/bnc"
-  type: "BatchNorm"
-  bottom: "conv3_1_1x1_increase"
-  top: "conv3_1_1x1_increase"
-}
-
-layer {
- name: "conv3_1_1x1_increase/scale"
- type: "Scale"
-bottom: "conv3_1_1x1_increase"
- top: "conv3_1_1x1_increase"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv3_1_1x1_proj"
-  type: "Convolution"
-  bottom: "conv2_3"
-  top: "conv3_1_1x1_proj"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
-  convolution_param {
-    num_output: 512
     pad: 0
     kernel_size: 1
     stride: 2
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
   }
 }
 layer {
-  name: "conv3_1_1x1_proj/bnc"
+  name: "bn3a_branch2a"
   type: "BatchNorm"
-  bottom: "conv3_1_1x1_proj"
-  top: "conv3_1_1x1_proj"
-}
-
-layer {
- name: "conv3_1_1x1_proj/scale"
- type: "Scale"
-bottom: "conv3_1_1x1_proj"
- top: "conv3_1_1x1_proj"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv3_1"
-  type: "Eltwise"
-  bottom: "conv3_1_1x1_proj"
-  bottom: "conv3_1_1x1_increase"
-  top: "conv3_1"
-  eltwise_param {
-    operation: SUM
+  bottom: "res3a_branch2a"
+  top: "res3a_branch2a"
+  batch_norm_param {
   }
 }
 layer {
-  name: "conv3_1/relu"
+  name: "scale3a_branch2a"
+  type: "Scale"
+  bottom: "res3a_branch2a"
+  top: "res3a_branch2a"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res3a_branch2a_relu"
   type: "ReLU"
-  bottom: "conv3_1"
-  top: "conv3_1"
+  bottom: "res3a_branch2a"
+  top: "res3a_branch2a"
 }
 layer {
-  name: "conv3_2_1x1_reduce"
+  name: "res3a_branch2b"
   type: "Convolution"
-  bottom: "conv3_1"
-  top: "conv3_2_1x1_reduce"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
+  bottom: "res3a_branch2a"
+  top: "res3a_branch2b"
   convolution_param {
     num_output: 128
-    pad: 0
-    kernel_size: 1
-    stride: 1
-    weight_filler {
-      type: "msra"
-    }
     bias_term: false
-  }
-}
-layer {
-  name: "conv3_2_1x1_reduce/bnc"
-  type: "BatchNorm"
-  bottom: "conv3_2_1x1_reduce"
-  top: "conv3_2_1x1_reduce"
-}
-
-layer {
- name: "conv3_2_1x1_reduce/scale"
- type: "Scale"
-bottom: "conv3_2_1x1_reduce"
- top: "conv3_2_1x1_reduce"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv3_2_1x1_reduce/relu"
-  type: "ReLU"
-  bottom: "conv3_2_1x1_reduce"
-  top: "conv3_2_1x1_reduce"
-}
-layer {
-  name: "conv3_2_3x3"
-  type: "Convolution"
-  bottom: "conv3_2_1x1_reduce"
-  top: "conv3_2_3x3"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
-  convolution_param {
-    num_output: 128
     pad: 1
     kernel_size: 3
     stride: 1
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
   }
 }
 layer {
-  name: "conv3_2_3x3/bnc"
+  name: "bn3a_branch2b"
   type: "BatchNorm"
-  bottom: "conv3_2_3x3"
-  top: "conv3_2_3x3"
-}
-
-layer {
- name: "conv3_2_3x3/scale"
- type: "Scale"
-bottom: "conv3_2_3x3"
- top: "conv3_2_3x3"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv3_2_3x3/relu"
-  type: "ReLU"
-  bottom: "conv3_2_3x3"
-  top: "conv3_2_3x3"
-}
-layer {
-  name: "conv3_2_1x1_increase"
-  type: "Convolution"
-  bottom: "conv3_2_3x3"
-  top: "conv3_2_1x1_increase"
-  param {
-    lr_mult: 1
-    decay_mult: 1
+  bottom: "res3a_branch2b"
+  top: "res3a_branch2b"
+  batch_norm_param {
   }
+}
+layer {
+  name: "scale3a_branch2b"
+  type: "Scale"
+  bottom: "res3a_branch2b"
+  top: "res3a_branch2b"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res3a_branch2b_relu"
+  type: "ReLU"
+  bottom: "res3a_branch2b"
+  top: "res3a_branch2b"
+}
+layer {
+  name: "res3a_branch2c"
+  type: "Convolution"
+  bottom: "res3a_branch2b"
+  top: "res3a_branch2c"
   convolution_param {
     num_output: 512
+    bias_term: false
     pad: 0
     kernel_size: 1
     stride: 1
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
   }
 }
 layer {
-  name: "conv3_2_1x1_increase/bnc"
+  name: "bn3a_branch2c"
   type: "BatchNorm"
-  bottom: "conv3_2_1x1_increase"
-  top: "conv3_2_1x1_increase"
+  bottom: "res3a_branch2c"
+  top: "res3a_branch2c"
+  batch_norm_param {
+  }
 }
-
 layer {
- name: "conv3_2_1x1_increase/scale"
- type: "Scale"
-bottom: "conv3_2_1x1_increase"
- top: "conv3_2_1x1_increase"
- scale_param {
- bias_term: true
+  name: "scale3a_branch2c"
+  type: "Scale"
+  bottom: "res3a_branch2c"
+  top: "res3a_branch2c"
+  scale_param {
+    bias_term: true
+  }
 }
-}
-
 layer {
-  name: "conv3_2"
+  name: "res3a"
   type: "Eltwise"
-  bottom: "conv3_1"
-  bottom: "conv3_2_1x1_increase"
-  top: "conv3_2"
-  eltwise_param {
-    operation: SUM
-  }
+  bottom: "res3a_branch1"
+  bottom: "res3a_branch2c"
+  top: "res3a"
 }
 layer {
-  name: "conv3_2/relu"
+  name: "res3a_relu"
   type: "ReLU"
-  bottom: "conv3_2"
-  top: "conv3_2"
+  bottom: "res3a"
+  top: "res3a"
 }
 layer {
-  name: "conv3_3_1x1_reduce"
+  name: "res3b_branch2a"
   type: "Convolution"
-  bottom: "conv3_2"
-  top: "conv3_3_1x1_reduce"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
+  bottom: "res3a"
+  top: "res3b_branch2a"
   convolution_param {
     num_output: 128
+    bias_term: false
     pad: 0
     kernel_size: 1
     stride: 1
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
   }
 }
 layer {
-  name: "conv3_3_1x1_reduce/bnc"
+  name: "bn3b_branch2a"
   type: "BatchNorm"
-  bottom: "conv3_3_1x1_reduce"
-  top: "conv3_3_1x1_reduce"
-}
-
-layer {
- name: "conv3_3_1x1_reduce/scale"
- type: "Scale"
-bottom: "conv3_3_1x1_reduce"
- top: "conv3_3_1x1_reduce"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv3_3_1x1_reduce/relu"
-  type: "ReLU"
-  bottom: "conv3_3_1x1_reduce"
-  top: "conv3_3_1x1_reduce"
-}
-layer {
-  name: "conv3_3_3x3"
-  type: "Convolution"
-  bottom: "conv3_3_1x1_reduce"
-  top: "conv3_3_3x3"
-  param {
-    lr_mult: 1
-    decay_mult: 1
+  bottom: "res3b_branch2a"
+  top: "res3b_branch2a"
+  batch_norm_param {
   }
+}
+layer {
+  name: "scale3b_branch2a"
+  type: "Scale"
+  bottom: "res3b_branch2a"
+  top: "res3b_branch2a"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res3b_branch2a_relu"
+  type: "ReLU"
+  bottom: "res3b_branch2a"
+  top: "res3b_branch2a"
+}
+layer {
+  name: "res3b_branch2b"
+  type: "Convolution"
+  bottom: "res3b_branch2a"
+  top: "res3b_branch2b"
   convolution_param {
     num_output: 128
+    bias_term: false
     pad: 1
     kernel_size: 3
     stride: 1
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
   }
 }
 layer {
-  name: "conv3_3_3x3/bnc"
+  name: "bn3b_branch2b"
   type: "BatchNorm"
-  bottom: "conv3_3_3x3"
-  top: "conv3_3_3x3"
-}
-
-layer {
- name: "conv3_3_3x3/scale"
- type: "Scale"
-bottom: "conv3_3_3x3"
- top: "conv3_3_3x3"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv3_3_3x3/relu"
-  type: "ReLU"
-  bottom: "conv3_3_3x3"
-  top: "conv3_3_3x3"
-}
-layer {
-  name: "conv3_3_1x1_increase"
-  type: "Convolution"
-  bottom: "conv3_3_3x3"
-  top: "conv3_3_1x1_increase"
-  param {
-    lr_mult: 1
-    decay_mult: 1
+  bottom: "res3b_branch2b"
+  top: "res3b_branch2b"
+  batch_norm_param {
   }
+}
+layer {
+  name: "scale3b_branch2b"
+  type: "Scale"
+  bottom: "res3b_branch2b"
+  top: "res3b_branch2b"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res3b_branch2b_relu"
+  type: "ReLU"
+  bottom: "res3b_branch2b"
+  top: "res3b_branch2b"
+}
+layer {
+  name: "res3b_branch2c"
+  type: "Convolution"
+  bottom: "res3b_branch2b"
+  top: "res3b_branch2c"
   convolution_param {
     num_output: 512
+    bias_term: false
     pad: 0
     kernel_size: 1
     stride: 1
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
   }
 }
 layer {
-  name: "conv3_3_1x1_increase/bnc"
+  name: "bn3b_branch2c"
   type: "BatchNorm"
-  bottom: "conv3_3_1x1_increase"
-  top: "conv3_3_1x1_increase"
+  bottom: "res3b_branch2c"
+  top: "res3b_branch2c"
+  batch_norm_param {
+  }
 }
-
 layer {
- name: "conv3_3_1x1_increase/scale"
- type: "Scale"
-bottom: "conv3_3_1x1_increase"
- top: "conv3_3_1x1_increase"
- scale_param {
- bias_term: true
+  name: "scale3b_branch2c"
+  type: "Scale"
+  bottom: "res3b_branch2c"
+  top: "res3b_branch2c"
+  scale_param {
+    bias_term: true
+  }
 }
-}
-
 layer {
-  name: "conv3_3"
+  name: "res3b"
   type: "Eltwise"
-  bottom: "conv3_2"
-  bottom: "conv3_3_1x1_increase"
-  top: "conv3_3"
-  eltwise_param {
-    operation: SUM
-  }
+  bottom: "res3a"
+  bottom: "res3b_branch2c"
+  top: "res3b"
 }
 layer {
-  name: "conv3_3/relu"
+  name: "res3b_relu"
   type: "ReLU"
-  bottom: "conv3_3"
-  top: "conv3_3"
+  bottom: "res3b"
+  top: "res3b"
 }
 layer {
-  name: "conv3_4_1x1_reduce"
+  name: "res3c_branch2a"
   type: "Convolution"
-  bottom: "conv3_3"
-  top: "conv3_4_1x1_reduce"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
+  bottom: "res3b"
+  top: "res3c_branch2a"
   convolution_param {
     num_output: 128
+    bias_term: false
     pad: 0
     kernel_size: 1
     stride: 1
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
   }
 }
 layer {
-  name: "conv3_4_1x1_reduce/bnc"
+  name: "bn3c_branch2a"
   type: "BatchNorm"
-  bottom: "conv3_4_1x1_reduce"
-  top: "conv3_4_1x1_reduce"
-}
-
-layer {
- name: "conv3_4_1x1_reduce/scale"
- type: "Scale"
-bottom: "conv3_4_1x1_reduce"
- top: "conv3_4_1x1_reduce"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv3_4_1x1_reduce/relu"
-  type: "ReLU"
-  bottom: "conv3_4_1x1_reduce"
-  top: "conv3_4_1x1_reduce"
-}
-layer {
-  name: "conv3_4_3x3"
-  type: "Convolution"
-  bottom: "conv3_4_1x1_reduce"
-  top: "conv3_4_3x3"
-  param {
-    lr_mult: 1
-    decay_mult: 1
+  bottom: "res3c_branch2a"
+  top: "res3c_branch2a"
+  batch_norm_param {
   }
+}
+layer {
+  name: "scale3c_branch2a"
+  type: "Scale"
+  bottom: "res3c_branch2a"
+  top: "res3c_branch2a"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res3c_branch2a_relu"
+  type: "ReLU"
+  bottom: "res3c_branch2a"
+  top: "res3c_branch2a"
+}
+layer {
+  name: "res3c_branch2b"
+  type: "Convolution"
+  bottom: "res3c_branch2a"
+  top: "res3c_branch2b"
   convolution_param {
     num_output: 128
+    bias_term: false
     pad: 1
     kernel_size: 3
     stride: 1
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
   }
 }
 layer {
-  name: "conv3_4_3x3/bnc"
+  name: "bn3c_branch2b"
   type: "BatchNorm"
-  bottom: "conv3_4_3x3"
-  top: "conv3_4_3x3"
-}
-
-layer {
- name: "conv3_4_3x3/scale"
- type: "Scale"
-bottom: "conv3_4_3x3"
- top: "conv3_4_3x3"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv3_4_3x3/relu"
-  type: "ReLU"
-  bottom: "conv3_4_3x3"
-  top: "conv3_4_3x3"
-}
-layer {
-  name: "conv3_4_1x1_increase"
-  type: "Convolution"
-  bottom: "conv3_4_3x3"
-  top: "conv3_4_1x1_increase"
-  param {
-    lr_mult: 1
-    decay_mult: 1
+  bottom: "res3c_branch2b"
+  top: "res3c_branch2b"
+  batch_norm_param {
   }
+}
+layer {
+  name: "scale3c_branch2b"
+  type: "Scale"
+  bottom: "res3c_branch2b"
+  top: "res3c_branch2b"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res3c_branch2b_relu"
+  type: "ReLU"
+  bottom: "res3c_branch2b"
+  top: "res3c_branch2b"
+}
+layer {
+  name: "res3c_branch2c"
+  type: "Convolution"
+  bottom: "res3c_branch2b"
+  top: "res3c_branch2c"
   convolution_param {
     num_output: 512
+    bias_term: false
     pad: 0
     kernel_size: 1
     stride: 1
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
   }
 }
 layer {
-  name: "conv3_4_1x1_increase/bnc"
+  name: "bn3c_branch2c"
   type: "BatchNorm"
-  bottom: "conv3_4_1x1_increase"
-  top: "conv3_4_1x1_increase"
+  bottom: "res3c_branch2c"
+  top: "res3c_branch2c"
+  batch_norm_param {
+  }
 }
-
 layer {
- name: "conv3_4_1x1_increase/scale"
- type: "Scale"
-bottom: "conv3_4_1x1_increase"
- top: "conv3_4_1x1_increase"
- scale_param {
- bias_term: true
+  name: "scale3c_branch2c"
+  type: "Scale"
+  bottom: "res3c_branch2c"
+  top: "res3c_branch2c"
+  scale_param {
+    bias_term: true
+  }
 }
-}
-
 layer {
-  name: "conv3_4"
+  name: "res3c"
   type: "Eltwise"
-  bottom: "conv3_3"
-  bottom: "conv3_4_1x1_increase"
-  top: "conv3_4"
-  eltwise_param {
-    operation: SUM
-  }
+  bottom: "res3b"
+  bottom: "res3c_branch2c"
+  top: "res3c"
 }
 layer {
-  name: "conv3_4/relu"
+  name: "res3c_relu"
   type: "ReLU"
-  bottom: "conv3_4"
-  top: "conv3_4"
+  bottom: "res3c"
+  top: "res3c"
 }
 layer {
-  name: "conv4_1_1x1_reduce"
+  name: "res3d_branch2a"
   type: "Convolution"
-  bottom: "conv3_4"
-  top: "conv4_1_1x1_reduce"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
+  bottom: "res3c"
+  top: "res3d_branch2a"
   convolution_param {
-    num_output: 256
+    num_output: 128
+    bias_term: false
     pad: 0
     kernel_size: 1
     stride: 1
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
   }
 }
 layer {
-  name: "conv4_1_1x1_reduce/bnc"
+  name: "bn3d_branch2a"
   type: "BatchNorm"
-  bottom: "conv4_1_1x1_reduce"
-  top: "conv4_1_1x1_reduce"
-}
-
-layer {
- name: "conv4_1_1x1_reduce/scale"
- type: "Scale"
-bottom: "conv4_1_1x1_reduce"
- top: "conv4_1_1x1_reduce"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv4_1_1x1_reduce/relu"
-  type: "ReLU"
-  bottom: "conv4_1_1x1_reduce"
-  top: "conv4_1_1x1_reduce"
-}
-layer {
-  name: "conv4_1_3x3"
-  type: "Convolution"
-  bottom: "conv4_1_1x1_reduce"
-  top: "conv4_1_3x3"
-  param {
-    lr_mult: 1
-    decay_mult: 1
+  bottom: "res3d_branch2a"
+  top: "res3d_branch2a"
+  batch_norm_param {
   }
+}
+layer {
+  name: "scale3d_branch2a"
+  type: "Scale"
+  bottom: "res3d_branch2a"
+  top: "res3d_branch2a"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res3d_branch2a_relu"
+  type: "ReLU"
+  bottom: "res3d_branch2a"
+  top: "res3d_branch2a"
+}
+layer {
+  name: "res3d_branch2b"
+  type: "Convolution"
+  bottom: "res3d_branch2a"
+  top: "res3d_branch2b"
   convolution_param {
-    num_output: 256
-    pad: 2
-    dilation: 2
+    num_output: 128
+    bias_term: false
+    pad: 1
     kernel_size: 3
     stride: 1
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
   }
 }
 layer {
-  name: "conv4_1_3x3/bnc"
+  name: "bn3d_branch2b"
   type: "BatchNorm"
-  bottom: "conv4_1_3x3"
-  top: "conv4_1_3x3"
+  bottom: "res3d_branch2b"
+  top: "res3d_branch2b"
+  batch_norm_param {
+  }
 }
-
 layer {
- name: "conv4_1_3x3/scale"
- type: "Scale"
-bottom: "conv4_1_3x3"
- top: "conv4_1_3x3"
- scale_param {
- bias_term: true
+  name: "scale3d_branch2b"
+  type: "Scale"
+  bottom: "res3d_branch2b"
+  top: "res3d_branch2b"
+  scale_param {
+    bias_term: true
+  }
 }
-}
-
 layer {
-  name: "conv4_1_3x3/relu"
+  name: "res3d_branch2b_relu"
   type: "ReLU"
-  bottom: "conv4_1_3x3"
-  top: "conv4_1_3x3"
+  bottom: "res3d_branch2b"
+  top: "res3d_branch2b"
 }
 layer {
-  name: "conv4_1_1x1_increase"
+  name: "res3d_branch2c"
   type: "Convolution"
-  bottom: "conv4_1_3x3"
-  top: "conv4_1_1x1_increase"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
-  convolution_param {
-    num_output: 1024
-    pad: 0
-    kernel_size: 1
-    stride: 1
-    weight_filler {
-      type: "msra"
-    }
-    bias_term: false
-  }
-}
-layer {
-  name: "conv4_1_1x1_increase/bnc"
-  type: "BatchNorm"
-  bottom: "conv4_1_1x1_increase"
-  top: "conv4_1_1x1_increase"
-}
-
-layer {
- name: "conv4_1_1x1_increase/scale"
- type: "Scale"
-bottom: "conv4_1_1x1_increase"
- top: "conv4_1_1x1_increase"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv4_1_1x1_proj"
-  type: "Convolution"
-  bottom: "conv3_4"
-  top: "conv4_1_1x1_proj"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
-  convolution_param {
-    num_output: 1024
-    pad: 0
-    kernel_size: 1
-    stride: 1
-    weight_filler {
-      type: "msra"
-    }
-    bias_term: false
-  }
-}
-layer {
-  name: "conv4_1_1x1_proj/bnc"
-  type: "BatchNorm"
-  bottom: "conv4_1_1x1_proj"
-  top: "conv4_1_1x1_proj"
-}
-
-layer {
- name: "conv4_1_1x1_proj/scale"
- type: "Scale"
-bottom: "conv4_1_1x1_proj"
- top: "conv4_1_1x1_proj"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv4_1"
-  type: "Eltwise"
-  bottom: "conv4_1_1x1_proj"
-  bottom: "conv4_1_1x1_increase"
-  top: "conv4_1"
-  eltwise_param {
-    operation: SUM
-  }
-}
-layer {
-  name: "conv4_1/relu"
-  type: "ReLU"
-  bottom: "conv4_1"
-  top: "conv4_1"
-}
-layer {
-  name: "conv4_2_1x1_reduce"
-  type: "Convolution"
-  bottom: "conv4_1"
-  top: "conv4_2_1x1_reduce"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
-  convolution_param {
-    num_output: 256
-    pad: 0
-    kernel_size: 1
-    stride: 1
-    weight_filler {
-      type: "msra"
-    }
-    bias_term: false
-  }
-}
-layer {
-  name: "conv4_2_1x1_reduce/bnc"
-  type: "BatchNorm"
-  bottom: "conv4_2_1x1_reduce"
-  top: "conv4_2_1x1_reduce"
-}
-
-layer {
- name: "conv4_2_1x1_reduce/scale"
- type: "Scale"
-bottom: "conv4_2_1x1_reduce"
- top: "conv4_2_1x1_reduce"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv4_2_1x1_reduce/relu"
-  type: "ReLU"
-  bottom: "conv4_2_1x1_reduce"
-  top: "conv4_2_1x1_reduce"
-}
-layer {
-  name: "conv4_2_3x3"
-  type: "Convolution"
-  bottom: "conv4_2_1x1_reduce"
-  top: "conv4_2_3x3"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
-  convolution_param {
-    num_output: 256
-    pad: 2
-    dilation: 2
-    kernel_size: 3
-    stride: 1
-    weight_filler {
-      type: "msra"
-    }
-    bias_term: false
-  }
-}
-layer {
-  name: "conv4_2_3x3/bnc"
-  type: "BatchNorm"
-  bottom: "conv4_2_3x3"
-  top: "conv4_2_3x3"
-}
-
-layer {
- name: "conv4_2_3x3/scale"
- type: "Scale"
-bottom: "conv4_2_3x3"
- top: "conv4_2_3x3"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv4_2_3x3/relu"
-  type: "ReLU"
-  bottom: "conv4_2_3x3"
-  top: "conv4_2_3x3"
-}
-layer {
-  name: "conv4_2_1x1_increase"
-  type: "Convolution"
-  bottom: "conv4_2_3x3"
-  top: "conv4_2_1x1_increase"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
-  convolution_param {
-    num_output: 1024
-    pad: 0
-    kernel_size: 1
-    stride: 1
-    weight_filler {
-      type: "msra"
-    }
-    bias_term: false
-  }
-}
-layer {
-  name: "conv4_2_1x1_increase/bnc"
-  type: "BatchNorm"
-  bottom: "conv4_2_1x1_increase"
-  top: "conv4_2_1x1_increase"
-}
-
-layer {
- name: "conv4_2_1x1_increase/scale"
- type: "Scale"
-bottom: "conv4_2_1x1_increase"
- top: "conv4_2_1x1_increase"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv4_2"
-  type: "Eltwise"
-  bottom: "conv4_1"
-  bottom: "conv4_2_1x1_increase"
-  top: "conv4_2"
-  eltwise_param {
-    operation: SUM
-  }
-}
-layer {
-  name: "conv4_2/relu"
-  type: "ReLU"
-  bottom: "conv4_2"
-  top: "conv4_2"
-}
-layer {
-  name: "conv4_3_1x1_reduce"
-  type: "Convolution"
-  bottom: "conv4_2"
-  top: "conv4_3_1x1_reduce"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
-  convolution_param {
-    num_output: 256
-    pad: 0
-    kernel_size: 1
-    stride: 1
-    weight_filler {
-      type: "msra"
-    }
-    bias_term: false
-  }
-}
-layer {
-  name: "conv4_3_1x1_reduce/bnc"
-  type: "BatchNorm"
-  bottom: "conv4_3_1x1_reduce"
-  top: "conv4_3_1x1_reduce"
-}
-
-layer {
- name: "conv4_3_1x1_reduce/scale"
- type: "Scale"
-bottom: "conv4_3_1x1_reduce"
- top: "conv4_3_1x1_reduce"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv4_3_1x1_reduce/relu"
-  type: "ReLU"
-  bottom: "conv4_3_1x1_reduce"
-  top: "conv4_3_1x1_reduce"
-}
-layer {
-  name: "conv4_3_3x3"
-  type: "Convolution"
-  bottom: "conv4_3_1x1_reduce"
-  top: "conv4_3_3x3"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
-  convolution_param {
-    num_output: 256
-    pad: 2
-    dilation: 2
-    kernel_size: 3
-    stride: 1
-    weight_filler {
-      type: "msra"
-    }
-    bias_term: false
-  }
-}
-layer {
-  name: "conv4_3_3x3/bnc"
-  type: "BatchNorm"
-  bottom: "conv4_3_3x3"
-  top: "conv4_3_3x3"
-}
-
-layer {
- name: "conv4_3_3x3/scale"
- type: "Scale"
-bottom: "conv4_3_3x3"
- top: "conv4_3_3x3"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv4_3_3x3/relu"
-  type: "ReLU"
-  bottom: "conv4_3_3x3"
-  top: "conv4_3_3x3"
-}
-layer {
-  name: "conv4_3_1x1_increase"
-  type: "Convolution"
-  bottom: "conv4_3_3x3"
-  top: "conv4_3_1x1_increase"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
-  convolution_param {
-    num_output: 1024
-    pad: 0
-    kernel_size: 1
-    stride: 1
-    weight_filler {
-      type: "msra"
-    }
-    bias_term: false
-  }
-}
-layer {
-  name: "conv4_3_1x1_increase/bnc"
-  type: "BatchNorm"
-  bottom: "conv4_3_1x1_increase"
-  top: "conv4_3_1x1_increase"
-}
-
-layer {
- name: "conv4_3_1x1_increase/scale"
- type: "Scale"
-bottom: "conv4_3_1x1_increase"
- top: "conv4_3_1x1_increase"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv4_3"
-  type: "Eltwise"
-  bottom: "conv4_2"
-  bottom: "conv4_3_1x1_increase"
-  top: "conv4_3"
-  eltwise_param {
-    operation: SUM
-  }
-}
-layer {
-  name: "conv4_3/relu"
-  type: "ReLU"
-  bottom: "conv4_3"
-  top: "conv4_3"
-}
-layer {
-  name: "conv4_4_1x1_reduce"
-  type: "Convolution"
-  bottom: "conv4_3"
-  top: "conv4_4_1x1_reduce"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
-  convolution_param {
-    num_output: 256
-    pad: 0
-    kernel_size: 1
-    stride: 1
-    weight_filler {
-      type: "msra"
-    }
-    bias_term: false
-  }
-}
-layer {
-  name: "conv4_4_1x1_reduce/bnc"
-  type: "BatchNorm"
-  bottom: "conv4_4_1x1_reduce"
-  top: "conv4_4_1x1_reduce"
-}
-
-layer {
- name: "conv4_4_1x1_reduce/scale"
- type: "Scale"
-bottom: "conv4_4_1x1_reduce"
- top: "conv4_4_1x1_reduce"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv4_4_1x1_reduce/relu"
-  type: "ReLU"
-  bottom: "conv4_4_1x1_reduce"
-  top: "conv4_4_1x1_reduce"
-}
-layer {
-  name: "conv4_4_3x3"
-  type: "Convolution"
-  bottom: "conv4_4_1x1_reduce"
-  top: "conv4_4_3x3"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
-  convolution_param {
-    num_output: 256
-    pad: 2
-    dilation: 2
-    kernel_size: 3
-    stride: 1
-    weight_filler {
-      type: "msra"
-    }
-    bias_term: false
-  }
-}
-layer {
-  name: "conv4_4_3x3/bnc"
-  type: "BatchNorm"
-  bottom: "conv4_4_3x3"
-  top: "conv4_4_3x3"
-}
-
-layer {
- name: "conv4_4_3x3/scale"
- type: "Scale"
-bottom: "conv4_4_3x3"
- top: "conv4_4_3x3"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv4_4_3x3/relu"
-  type: "ReLU"
-  bottom: "conv4_4_3x3"
-  top: "conv4_4_3x3"
-}
-layer {
-  name: "conv4_4_1x1_increase"
-  type: "Convolution"
-  bottom: "conv4_4_3x3"
-  top: "conv4_4_1x1_increase"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
-  convolution_param {
-    num_output: 1024
-    pad: 0
-    kernel_size: 1
-    stride: 1
-    weight_filler {
-      type: "msra"
-    }
-    bias_term: false
-  }
-}
-layer {
-  name: "conv4_4_1x1_increase/bnc"
-  type: "BatchNorm"
-  bottom: "conv4_4_1x1_increase"
-  top: "conv4_4_1x1_increase"
-}
-
-layer {
- name: "conv4_4_1x1_increase/scale"
- type: "Scale"
-bottom: "conv4_4_1x1_increase"
- top: "conv4_4_1x1_increase"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv4_4"
-  type: "Eltwise"
-  bottom: "conv4_3"
-  bottom: "conv4_4_1x1_increase"
-  top: "conv4_4"
-  eltwise_param {
-    operation: SUM
-  }
-}
-layer {
-  name: "conv4_4/relu"
-  type: "ReLU"
-  bottom: "conv4_4"
-  top: "conv4_4"
-}
-layer {
-  name: "conv4_5_1x1_reduce"
-  type: "Convolution"
-  bottom: "conv4_4"
-  top: "conv4_5_1x1_reduce"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
-  convolution_param {
-    num_output: 256
-    pad: 0
-    kernel_size: 1
-    stride: 1
-    weight_filler {
-      type: "msra"
-    }
-    bias_term: false
-  }
-}
-layer {
-  name: "conv4_5_1x1_reduce/bnc"
-  type: "BatchNorm"
-  bottom: "conv4_5_1x1_reduce"
-  top: "conv4_5_1x1_reduce"
-}
-
-layer {
- name: "conv4_5_1x1_reduce/scale"
- type: "Scale"
-bottom: "conv4_5_1x1_reduce"
- top: "conv4_5_1x1_reduce"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv4_5_1x1_reduce/relu"
-  type: "ReLU"
-  bottom: "conv4_5_1x1_reduce"
-  top: "conv4_5_1x1_reduce"
-}
-layer {
-  name: "conv4_5_3x3"
-  type: "Convolution"
-  bottom: "conv4_5_1x1_reduce"
-  top: "conv4_5_3x3"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
-  convolution_param {
-    num_output: 256
-    pad: 2
-    dilation: 2
-    kernel_size: 3
-    stride: 1
-    weight_filler {
-      type: "msra"
-    }
-    bias_term: false
-  }
-}
-layer {
-  name: "conv4_5_3x3/bnc"
-  type: "BatchNorm"
-  bottom: "conv4_5_3x3"
-  top: "conv4_5_3x3"
-}
-
-layer {
- name: "conv4_5_3x3/scale"
- type: "Scale"
-bottom: "conv4_5_3x3"
- top: "conv4_5_3x3"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv4_5_3x3/relu"
-  type: "ReLU"
-  bottom: "conv4_5_3x3"
-  top: "conv4_5_3x3"
-}
-layer {
-  name: "conv4_5_1x1_increase"
-  type: "Convolution"
-  bottom: "conv4_5_3x3"
-  top: "conv4_5_1x1_increase"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
-  convolution_param {
-    num_output: 1024
-    pad: 0
-    kernel_size: 1
-    stride: 1
-    weight_filler {
-      type: "msra"
-    }
-    bias_term: false
-  }
-}
-layer {
-  name: "conv4_5_1x1_increase/bnc"
-  type: "BatchNorm"
-  bottom: "conv4_5_1x1_increase"
-  top: "conv4_5_1x1_increase"
-}
-
-layer {
- name: "conv4_5_1x1_increase/scale"
- type: "Scale"
-bottom: "conv4_5_1x1_increase"
- top: "conv4_5_1x1_increase"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv4_5"
-  type: "Eltwise"
-  bottom: "conv4_4"
-  bottom: "conv4_5_1x1_increase"
-  top: "conv4_5"
-  eltwise_param {
-    operation: SUM
-  }
-}
-layer {
-  name: "conv4_5/relu"
-  type: "ReLU"
-  bottom: "conv4_5"
-  top: "conv4_5"
-}
-layer {
-  name: "conv4_6_1x1_reduce"
-  type: "Convolution"
-  bottom: "conv4_5"
-  top: "conv4_6_1x1_reduce"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
-  convolution_param {
-    num_output: 256
-    pad: 0
-    kernel_size: 1
-    stride: 1
-    weight_filler {
-      type: "msra"
-    }
-    bias_term: false
-  }
-}
-layer {
-  name: "conv4_6_1x1_reduce/bnc"
-  type: "BatchNorm"
-  bottom: "conv4_6_1x1_reduce"
-  top: "conv4_6_1x1_reduce"
-}
-
-layer {
- name: "conv4_6_1x1_reduce/scale"
- type: "Scale"
-bottom: "conv4_6_1x1_reduce"
- top: "conv4_6_1x1_reduce"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv4_6_1x1_reduce/relu"
-  type: "ReLU"
-  bottom: "conv4_6_1x1_reduce"
-  top: "conv4_6_1x1_reduce"
-}
-layer {
-  name: "conv4_6_3x3"
-  type: "Convolution"
-  bottom: "conv4_6_1x1_reduce"
-  top: "conv4_6_3x3"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
-  convolution_param {
-    num_output: 256
-    pad: 2
-    dilation: 2
-    kernel_size: 3
-    stride: 1
-    weight_filler {
-      type: "msra"
-    }
-    bias_term: false
-  }
-}
-layer {
-  name: "conv4_6_3x3/bnc"
-  type: "BatchNorm"
-  bottom: "conv4_6_3x3"
-  top: "conv4_6_3x3"
-}
-
-layer {
- name: "conv4_6_3x3/scale"
- type: "Scale"
-bottom: "conv4_6_3x3"
- top: "conv4_6_3x3"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv4_6_3x3/relu"
-  type: "ReLU"
-  bottom: "conv4_6_3x3"
-  top: "conv4_6_3x3"
-}
-layer {
-  name: "conv4_6_1x1_increase"
-  type: "Convolution"
-  bottom: "conv4_6_3x3"
-  top: "conv4_6_1x1_increase"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
-  convolution_param {
-    num_output: 1024
-    pad: 0
-    kernel_size: 1
-    stride: 1
-    weight_filler {
-      type: "msra"
-    }
-    bias_term: false
-  }
-}
-layer {
-  name: "conv4_6_1x1_increase/bnc"
-  type: "BatchNorm"
-  bottom: "conv4_6_1x1_increase"
-  top: "conv4_6_1x1_increase"
-}
-
-layer {
- name: "conv4_6_1x1_increase/scale"
- type: "Scale"
-bottom: "conv4_6_1x1_increase"
- top: "conv4_6_1x1_increase"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv4_6"
-  type: "Eltwise"
-  bottom: "conv4_5"
-  bottom: "conv4_6_1x1_increase"
-  top: "conv4_6"
-  eltwise_param {
-    operation: SUM
-  }
-}
-layer {
-  name: "conv4_6/relu"
-  type: "ReLU"
-  bottom: "conv4_6"
-  top: "conv4_6"
-}
-layer {
-  name: "conv5_1_1x1_reduce"
-  type: "Convolution"
-  bottom: "conv4_6"
-  top: "conv5_1_1x1_reduce"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
+  bottom: "res3d_branch2b"
+  top: "res3d_branch2c"
   convolution_param {
     num_output: 512
+    bias_term: false
     pad: 0
     kernel_size: 1
     stride: 1
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
   }
 }
 layer {
-  name: "conv5_1_1x1_reduce/bnc"
+  name: "bn3d_branch2c"
   type: "BatchNorm"
-  bottom: "conv5_1_1x1_reduce"
-  top: "conv5_1_1x1_reduce"
-}
-
-layer {
- name: "conv5_1_1x1_reduce/scale"
- type: "Scale"
-bottom: "conv5_1_1x1_reduce"
- top: "conv5_1_1x1_reduce"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv5_1_1x1_reduce/relu"
-  type: "ReLU"
-  bottom: "conv5_1_1x1_reduce"
-  top: "conv5_1_1x1_reduce"
-}
-layer {
-  name: "conv5_1_3x3"
-  type: "Convolution"
-  bottom: "conv5_1_1x1_reduce"
-  top: "conv5_1_3x3"
-  param {
-    lr_mult: 1
-    decay_mult: 1
+  bottom: "res3d_branch2c"
+  top: "res3d_branch2c"
+  batch_norm_param {
   }
+}
+layer {
+  name: "scale3d_branch2c"
+  type: "Scale"
+  bottom: "res3d_branch2c"
+  top: "res3d_branch2c"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res3d"
+  type: "Eltwise"
+  bottom: "res3c"
+  bottom: "res3d_branch2c"
+  top: "res3d"
+}
+layer {
+  name: "res3d_relu"
+  type: "ReLU"
+  bottom: "res3d"
+  top: "res3d"
+}
+layer {
+  name: "res4a_branch1"
+  type: "Convolution"
+  bottom: "res3d"
+  top: "res4a_branch1"
   convolution_param {
-    num_output: 512
-    pad: 4
-    dilation: 4
+    num_output: 1024
+    bias_term: false
+    pad: 0
+    kernel_size: 1
+    stride: 2
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "bn4a_branch1"
+  type: "BatchNorm"
+  bottom: "res4a_branch1"
+  top: "res4a_branch1"
+  batch_norm_param {
+  }
+}
+layer {
+  name: "scale4a_branch1"
+  type: "Scale"
+  bottom: "res4a_branch1"
+  top: "res4a_branch1"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res4a_branch2a"
+  type: "Convolution"
+  bottom: "res3d"
+  top: "res4a_branch2a"
+  convolution_param {
+    num_output: 256
+    bias_term: false
+    pad: 0
+    kernel_size: 1
+    stride: 2
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "bn4a_branch2a"
+  type: "BatchNorm"
+  bottom: "res4a_branch2a"
+  top: "res4a_branch2a"
+  batch_norm_param {
+  }
+}
+layer {
+  name: "scale4a_branch2a"
+  type: "Scale"
+  bottom: "res4a_branch2a"
+  top: "res4a_branch2a"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res4a_branch2a_relu"
+  type: "ReLU"
+  bottom: "res4a_branch2a"
+  top: "res4a_branch2a"
+}
+layer {
+  name: "res4a_branch2b"
+  type: "Convolution"
+  bottom: "res4a_branch2a"
+  top: "res4a_branch2b"
+  convolution_param {
+    num_output: 256
+    bias_term: false
+    pad: 1
     kernel_size: 3
     stride: 1
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
   }
 }
 layer {
-  name: "conv5_1_3x3/bnc"
+  name: "bn4a_branch2b"
   type: "BatchNorm"
-  bottom: "conv5_1_3x3"
-  top: "conv5_1_3x3"
-}
-
-layer {
- name: "conv5_1_3x3/scale"
- type: "Scale"
-bottom: "conv5_1_3x3"
- top: "conv5_1_3x3"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv5_1_3x3/relu"
-  type: "ReLU"
-  bottom: "conv5_1_3x3"
-  top: "conv5_1_3x3"
-}
-layer {
-  name: "conv5_1_1x1_increase"
-  type: "Convolution"
-  bottom: "conv5_1_3x3"
-  top: "conv5_1_1x1_increase"
-  param {
-    lr_mult: 1
-    decay_mult: 1
+  bottom: "res4a_branch2b"
+  top: "res4a_branch2b"
+  batch_norm_param {
   }
+}
+layer {
+  name: "scale4a_branch2b"
+  type: "Scale"
+  bottom: "res4a_branch2b"
+  top: "res4a_branch2b"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res4a_branch2b_relu"
+  type: "ReLU"
+  bottom: "res4a_branch2b"
+  top: "res4a_branch2b"
+}
+layer {
+  name: "res4a_branch2c"
+  type: "Convolution"
+  bottom: "res4a_branch2b"
+  top: "res4a_branch2c"
+  convolution_param {
+    num_output: 1024
+    bias_term: false
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "bn4a_branch2c"
+  type: "BatchNorm"
+  bottom: "res4a_branch2c"
+  top: "res4a_branch2c"
+  batch_norm_param {
+  }
+}
+layer {
+  name: "scale4a_branch2c"
+  type: "Scale"
+  bottom: "res4a_branch2c"
+  top: "res4a_branch2c"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res4a"
+  type: "Eltwise"
+  bottom: "res4a_branch1"
+  bottom: "res4a_branch2c"
+  top: "res4a"
+}
+layer {
+  name: "res4a_relu"
+  type: "ReLU"
+  bottom: "res4a"
+  top: "res4a"
+}
+layer {
+  name: "res4b_branch2a"
+  type: "Convolution"
+  bottom: "res4a"
+  top: "res4b_branch2a"
+  convolution_param {
+    num_output: 256
+    bias_term: false
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "bn4b_branch2a"
+  type: "BatchNorm"
+  bottom: "res4b_branch2a"
+  top: "res4b_branch2a"
+  batch_norm_param {
+  }
+}
+layer {
+  name: "scale4b_branch2a"
+  type: "Scale"
+  bottom: "res4b_branch2a"
+  top: "res4b_branch2a"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res4b_branch2a_relu"
+  type: "ReLU"
+  bottom: "res4b_branch2a"
+  top: "res4b_branch2a"
+}
+layer {
+  name: "res4b_branch2b"
+  type: "Convolution"
+  bottom: "res4b_branch2a"
+  top: "res4b_branch2b"
+  convolution_param {
+    num_output: 256
+    bias_term: false
+    pad: 1
+    kernel_size: 3
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "bn4b_branch2b"
+  type: "BatchNorm"
+  bottom: "res4b_branch2b"
+  top: "res4b_branch2b"
+  batch_norm_param {
+  }
+}
+layer {
+  name: "scale4b_branch2b"
+  type: "Scale"
+  bottom: "res4b_branch2b"
+  top: "res4b_branch2b"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res4b_branch2b_relu"
+  type: "ReLU"
+  bottom: "res4b_branch2b"
+  top: "res4b_branch2b"
+}
+layer {
+  name: "res4b_branch2c"
+  type: "Convolution"
+  bottom: "res4b_branch2b"
+  top: "res4b_branch2c"
+  convolution_param {
+    num_output: 1024
+    bias_term: false
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "bn4b_branch2c"
+  type: "BatchNorm"
+  bottom: "res4b_branch2c"
+  top: "res4b_branch2c"
+  batch_norm_param {
+  }
+}
+layer {
+  name: "scale4b_branch2c"
+  type: "Scale"
+  bottom: "res4b_branch2c"
+  top: "res4b_branch2c"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res4b"
+  type: "Eltwise"
+  bottom: "res4a"
+  bottom: "res4b_branch2c"
+  top: "res4b"
+}
+layer {
+  name: "res4b_relu"
+  type: "ReLU"
+  bottom: "res4b"
+  top: "res4b"
+}
+layer {
+  name: "res4c_branch2a"
+  type: "Convolution"
+  bottom: "res4b"
+  top: "res4c_branch2a"
+  convolution_param {
+    num_output: 256
+    bias_term: false
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "bn4c_branch2a"
+  type: "BatchNorm"
+  bottom: "res4c_branch2a"
+  top: "res4c_branch2a"
+  batch_norm_param {
+  }
+}
+layer {
+  name: "scale4c_branch2a"
+  type: "Scale"
+  bottom: "res4c_branch2a"
+  top: "res4c_branch2a"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res4c_branch2a_relu"
+  type: "ReLU"
+  bottom: "res4c_branch2a"
+  top: "res4c_branch2a"
+}
+layer {
+  name: "res4c_branch2b"
+  type: "Convolution"
+  bottom: "res4c_branch2a"
+  top: "res4c_branch2b"
+  convolution_param {
+    num_output: 256
+    bias_term: false
+    pad: 1
+    kernel_size: 3
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "bn4c_branch2b"
+  type: "BatchNorm"
+  bottom: "res4c_branch2b"
+  top: "res4c_branch2b"
+  batch_norm_param {
+  }
+}
+layer {
+  name: "scale4c_branch2b"
+  type: "Scale"
+  bottom: "res4c_branch2b"
+  top: "res4c_branch2b"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res4c_branch2b_relu"
+  type: "ReLU"
+  bottom: "res4c_branch2b"
+  top: "res4c_branch2b"
+}
+layer {
+  name: "res4c_branch2c"
+  type: "Convolution"
+  bottom: "res4c_branch2b"
+  top: "res4c_branch2c"
+  convolution_param {
+    num_output: 1024
+    bias_term: false
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "bn4c_branch2c"
+  type: "BatchNorm"
+  bottom: "res4c_branch2c"
+  top: "res4c_branch2c"
+  batch_norm_param {
+  }
+}
+layer {
+  name: "scale4c_branch2c"
+  type: "Scale"
+  bottom: "res4c_branch2c"
+  top: "res4c_branch2c"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res4c"
+  type: "Eltwise"
+  bottom: "res4b"
+  bottom: "res4c_branch2c"
+  top: "res4c"
+}
+layer {
+  name: "res4c_relu"
+  type: "ReLU"
+  bottom: "res4c"
+  top: "res4c"
+}
+layer {
+  name: "res4d_branch2a"
+  type: "Convolution"
+  bottom: "res4c"
+  top: "res4d_branch2a"
+  convolution_param {
+    num_output: 256
+    bias_term: false
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "bn4d_branch2a"
+  type: "BatchNorm"
+  bottom: "res4d_branch2a"
+  top: "res4d_branch2a"
+  batch_norm_param {
+  }
+}
+layer {
+  name: "scale4d_branch2a"
+  type: "Scale"
+  bottom: "res4d_branch2a"
+  top: "res4d_branch2a"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res4d_branch2a_relu"
+  type: "ReLU"
+  bottom: "res4d_branch2a"
+  top: "res4d_branch2a"
+}
+layer {
+  name: "res4d_branch2b"
+  type: "Convolution"
+  bottom: "res4d_branch2a"
+  top: "res4d_branch2b"
+  convolution_param {
+    num_output: 256
+    bias_term: false
+    pad: 1
+    kernel_size: 3
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "bn4d_branch2b"
+  type: "BatchNorm"
+  bottom: "res4d_branch2b"
+  top: "res4d_branch2b"
+  batch_norm_param {
+  }
+}
+layer {
+  name: "scale4d_branch2b"
+  type: "Scale"
+  bottom: "res4d_branch2b"
+  top: "res4d_branch2b"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res4d_branch2b_relu"
+  type: "ReLU"
+  bottom: "res4d_branch2b"
+  top: "res4d_branch2b"
+}
+layer {
+  name: "res4d_branch2c"
+  type: "Convolution"
+  bottom: "res4d_branch2b"
+  top: "res4d_branch2c"
+  convolution_param {
+    num_output: 1024
+    bias_term: false
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "bn4d_branch2c"
+  type: "BatchNorm"
+  bottom: "res4d_branch2c"
+  top: "res4d_branch2c"
+  batch_norm_param {
+  }
+}
+layer {
+  name: "scale4d_branch2c"
+  type: "Scale"
+  bottom: "res4d_branch2c"
+  top: "res4d_branch2c"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res4d"
+  type: "Eltwise"
+  bottom: "res4c"
+  bottom: "res4d_branch2c"
+  top: "res4d"
+}
+layer {
+  name: "res4d_relu"
+  type: "ReLU"
+  bottom: "res4d"
+  top: "res4d"
+}
+layer {
+  name: "res4e_branch2a"
+  type: "Convolution"
+  bottom: "res4d"
+  top: "res4e_branch2a"
+  convolution_param {
+    num_output: 256
+    bias_term: false
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "bn4e_branch2a"
+  type: "BatchNorm"
+  bottom: "res4e_branch2a"
+  top: "res4e_branch2a"
+  batch_norm_param {
+  }
+}
+layer {
+  name: "scale4e_branch2a"
+  type: "Scale"
+  bottom: "res4e_branch2a"
+  top: "res4e_branch2a"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res4e_branch2a_relu"
+  type: "ReLU"
+  bottom: "res4e_branch2a"
+  top: "res4e_branch2a"
+}
+layer {
+  name: "res4e_branch2b"
+  type: "Convolution"
+  bottom: "res4e_branch2a"
+  top: "res4e_branch2b"
+  convolution_param {
+    num_output: 256
+    bias_term: false
+    pad: 1
+    kernel_size: 3
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "bn4e_branch2b"
+  type: "BatchNorm"
+  bottom: "res4e_branch2b"
+  top: "res4e_branch2b"
+  batch_norm_param {
+  }
+}
+layer {
+  name: "scale4e_branch2b"
+  type: "Scale"
+  bottom: "res4e_branch2b"
+  top: "res4e_branch2b"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res4e_branch2b_relu"
+  type: "ReLU"
+  bottom: "res4e_branch2b"
+  top: "res4e_branch2b"
+}
+layer {
+  name: "res4e_branch2c"
+  type: "Convolution"
+  bottom: "res4e_branch2b"
+  top: "res4e_branch2c"
+  convolution_param {
+    num_output: 1024
+    bias_term: false
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "bn4e_branch2c"
+  type: "BatchNorm"
+  bottom: "res4e_branch2c"
+  top: "res4e_branch2c"
+  batch_norm_param {
+  }
+}
+layer {
+  name: "scale4e_branch2c"
+  type: "Scale"
+  bottom: "res4e_branch2c"
+  top: "res4e_branch2c"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res4e"
+  type: "Eltwise"
+  bottom: "res4d"
+  bottom: "res4e_branch2c"
+  top: "res4e"
+}
+layer {
+  name: "res4e_relu"
+  type: "ReLU"
+  bottom: "res4e"
+  top: "res4e"
+}
+layer {
+  name: "res4f_branch2a"
+  type: "Convolution"
+  bottom: "res4e"
+  top: "res4f_branch2a"
+  convolution_param {
+    num_output: 256
+    bias_term: false
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "bn4f_branch2a"
+  type: "BatchNorm"
+  bottom: "res4f_branch2a"
+  top: "res4f_branch2a"
+  batch_norm_param {
+  }
+}
+layer {
+  name: "scale4f_branch2a"
+  type: "Scale"
+  bottom: "res4f_branch2a"
+  top: "res4f_branch2a"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res4f_branch2a_relu"
+  type: "ReLU"
+  bottom: "res4f_branch2a"
+  top: "res4f_branch2a"
+}
+layer {
+  name: "res4f_branch2b"
+  type: "Convolution"
+  bottom: "res4f_branch2a"
+  top: "res4f_branch2b"
+  convolution_param {
+    num_output: 256
+    bias_term: false
+    pad: 1
+    kernel_size: 3
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "bn4f_branch2b"
+  type: "BatchNorm"
+  bottom: "res4f_branch2b"
+  top: "res4f_branch2b"
+  batch_norm_param {
+  }
+}
+layer {
+  name: "scale4f_branch2b"
+  type: "Scale"
+  bottom: "res4f_branch2b"
+  top: "res4f_branch2b"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res4f_branch2b_relu"
+  type: "ReLU"
+  bottom: "res4f_branch2b"
+  top: "res4f_branch2b"
+}
+layer {
+  name: "res4f_branch2c"
+  type: "Convolution"
+  bottom: "res4f_branch2b"
+  top: "res4f_branch2c"
+  convolution_param {
+    num_output: 1024
+    bias_term: false
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "bn4f_branch2c"
+  type: "BatchNorm"
+  bottom: "res4f_branch2c"
+  top: "res4f_branch2c"
+  batch_norm_param {
+  }
+}
+layer {
+  name: "scale4f_branch2c"
+  type: "Scale"
+  bottom: "res4f_branch2c"
+  top: "res4f_branch2c"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res4f"
+  type: "Eltwise"
+  bottom: "res4e"
+  bottom: "res4f_branch2c"
+  top: "res4f"
+}
+layer {
+  name: "res4f_relu"
+  type: "ReLU"
+  bottom: "res4f"
+  top: "res4f"
+}
+layer {
+  name: "res5a_branch1"
+  type: "Convolution"
+  bottom: "res4f"
+  top: "res5a_branch1"
   convolution_param {
     num_output: 2048
+    bias_term: false
     pad: 0
     kernel_size: 1
-    stride: 1
+    stride: 2
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
-  }
-}
-layer {
-  name: "conv5_1_1x1_increase/bnc"
-  type: "BatchNorm"
-  bottom: "conv5_1_1x1_increase"
-  top: "conv5_1_1x1_increase"
-}
-
-layer {
- name: "conv5_1_1x1_increase/scale"
- type: "Scale"
-bottom: "conv5_1_1x1_increase"
- top: "conv5_1_1x1_increase"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv5_1_1x1_proj"
-  type: "Convolution"
-  bottom: "conv4_6"
-  top: "conv5_1_1x1_proj"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
-  convolution_param {
-    num_output: 2048
-    pad: 0
-    kernel_size: 1
-    stride: 1
-    weight_filler {
-      type: "msra"
+    bias_filler {
+      type: "constant"
+      value: 0.2
     }
-    bias_term: false
   }
 }
 layer {
-  name: "conv5_1_1x1_proj/bnc"
+  name: "bn5a_branch1"
   type: "BatchNorm"
-  bottom: "conv5_1_1x1_proj"
-  top: "conv5_1_1x1_proj"
-}
-
-layer {
- name: "conv5_1_1x1_proj/scale"
- type: "Scale"
-bottom: "conv5_1_1x1_proj"
- top: "conv5_1_1x1_proj"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv5_1"
-  type: "Eltwise"
-  bottom: "conv5_1_1x1_proj"
-  bottom: "conv5_1_1x1_increase"
-  top: "conv5_1"
-  eltwise_param {
-    operation: SUM
+  bottom: "res5a_branch1"
+  top: "res5a_branch1"
+  batch_norm_param {
   }
 }
 layer {
-  name: "conv5_1/relu"
-  type: "ReLU"
-  bottom: "conv5_1"
-  top: "conv5_1"
+  name: "scale5a_branch1"
+  type: "Scale"
+  bottom: "res5a_branch1"
+  top: "res5a_branch1"
+  scale_param {
+    bias_term: true
+  }
 }
 layer {
-  name: "conv5_2_1x1_reduce"
+  name: "res5a_branch2a"
   type: "Convolution"
-  bottom: "conv5_1"
-  top: "conv5_2_1x1_reduce"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
+  bottom: "res4f"
+  top: "res5a_branch2a"
   convolution_param {
     num_output: 512
+    bias_term: false
     pad: 0
     kernel_size: 1
-    stride: 1
+    stride: 2
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
   }
 }
 layer {
-  name: "conv5_2_1x1_reduce/bnc"
+  name: "bn5a_branch2a"
   type: "BatchNorm"
-  bottom: "conv5_2_1x1_reduce"
-  top: "conv5_2_1x1_reduce"
-}
-
-layer {
- name: "conv5_2_1x1_reduce/scale"
- type: "Scale"
-bottom: "conv5_2_1x1_reduce"
- top: "conv5_2_1x1_reduce"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv5_2_1x1_reduce/relu"
-  type: "ReLU"
-  bottom: "conv5_2_1x1_reduce"
-  top: "conv5_2_1x1_reduce"
-}
-layer {
-  name: "conv5_2_3x3"
-  type: "Convolution"
-  bottom: "conv5_2_1x1_reduce"
-  top: "conv5_2_3x3"
-  param {
-    lr_mult: 1
-    decay_mult: 1
+  bottom: "res5a_branch2a"
+  top: "res5a_branch2a"
+  batch_norm_param {
   }
+}
+layer {
+  name: "scale5a_branch2a"
+  type: "Scale"
+  bottom: "res5a_branch2a"
+  top: "res5a_branch2a"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res5a_branch2a_relu"
+  type: "ReLU"
+  bottom: "res5a_branch2a"
+  top: "res5a_branch2a"
+}
+layer {
+  name: "res5a_branch2b"
+  type: "Convolution"
+  bottom: "res5a_branch2a"
+  top: "res5a_branch2b"
   convolution_param {
     num_output: 512
-    pad: 4
-    dilation: 4
+    bias_term: false
+    pad: 1
     kernel_size: 3
     stride: 1
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
   }
 }
 layer {
-  name: "conv5_2_3x3/bnc"
+  name: "bn5a_branch2b"
   type: "BatchNorm"
-  bottom: "conv5_2_3x3"
-  top: "conv5_2_3x3"
-}
-
-layer {
- name: "conv5_2_3x3/scale"
- type: "Scale"
-bottom: "conv5_2_3x3"
- top: "conv5_2_3x3"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv5_2_3x3/relu"
-  type: "ReLU"
-  bottom: "conv5_2_3x3"
-  top: "conv5_2_3x3"
-}
-layer {
-  name: "conv5_2_1x1_increase"
-  type: "Convolution"
-  bottom: "conv5_2_3x3"
-  top: "conv5_2_1x1_increase"
-  param {
-    lr_mult: 1
-    decay_mult: 1
+  bottom: "res5a_branch2b"
+  top: "res5a_branch2b"
+  batch_norm_param {
   }
+}
+layer {
+  name: "scale5a_branch2b"
+  type: "Scale"
+  bottom: "res5a_branch2b"
+  top: "res5a_branch2b"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res5a_branch2b_relu"
+  type: "ReLU"
+  bottom: "res5a_branch2b"
+  top: "res5a_branch2b"
+}
+layer {
+  name: "res5a_branch2c"
+  type: "Convolution"
+  bottom: "res5a_branch2b"
+  top: "res5a_branch2c"
   convolution_param {
     num_output: 2048
+    bias_term: false
     pad: 0
     kernel_size: 1
     stride: 1
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
   }
 }
 layer {
-  name: "conv5_2_1x1_increase/bnc"
+  name: "bn5a_branch2c"
   type: "BatchNorm"
-  bottom: "conv5_2_1x1_increase"
-  top: "conv5_2_1x1_increase"
+  bottom: "res5a_branch2c"
+  top: "res5a_branch2c"
+  batch_norm_param {
+  }
 }
-
 layer {
- name: "conv5_2_1x1_increase/scale"
- type: "Scale"
-bottom: "conv5_2_1x1_increase"
- top: "conv5_2_1x1_increase"
- scale_param {
- bias_term: true
+  name: "scale5a_branch2c"
+  type: "Scale"
+  bottom: "res5a_branch2c"
+  top: "res5a_branch2c"
+  scale_param {
+    bias_term: true
+  }
 }
-}
-
 layer {
-  name: "conv5_2"
+  name: "res5a"
   type: "Eltwise"
-  bottom: "conv5_1"
-  bottom: "conv5_2_1x1_increase"
-  top: "conv5_2"
-  eltwise_param {
-    operation: SUM
-  }
+  bottom: "res5a_branch1"
+  bottom: "res5a_branch2c"
+  top: "res5a"
 }
 layer {
-  name: "conv5_2/relu"
+  name: "res5a_relu"
   type: "ReLU"
-  bottom: "conv5_2"
-  top: "conv5_2"
+  bottom: "res5a"
+  top: "res5a"
 }
 layer {
-  name: "conv5_3_1x1_reduce"
+  name: "res5b_branch2a"
   type: "Convolution"
-  bottom: "conv5_2"
-  top: "conv5_3_1x1_reduce"
-  param {
-    lr_mult: 1
-    decay_mult: 1
-  }
+  bottom: "res5a"
+  top: "res5b_branch2a"
   convolution_param {
     num_output: 512
+    bias_term: false
     pad: 0
     kernel_size: 1
     stride: 1
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
   }
 }
 layer {
-  name: "conv5_3_1x1_reduce/bnc"
+  name: "bn5b_branch2a"
   type: "BatchNorm"
-  bottom: "conv5_3_1x1_reduce"
-  top: "conv5_3_1x1_reduce"
-}
-
-layer {
- name: "conv5_3_1x1_reduce/scale"
- type: "Scale"
-bottom: "conv5_3_1x1_reduce"
- top: "conv5_3_1x1_reduce"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv5_3_1x1_reduce/relu"
-  type: "ReLU"
-  bottom: "conv5_3_1x1_reduce"
-  top: "conv5_3_1x1_reduce"
-}
-layer {
-  name: "conv5_3_3x3"
-  type: "Convolution"
-  bottom: "conv5_3_1x1_reduce"
-  top: "conv5_3_3x3"
-  param {
-    lr_mult: 1
-    decay_mult: 1
+  bottom: "res5b_branch2a"
+  top: "res5b_branch2a"
+  batch_norm_param {
   }
+}
+layer {
+  name: "scale5b_branch2a"
+  type: "Scale"
+  bottom: "res5b_branch2a"
+  top: "res5b_branch2a"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res5b_branch2a_relu"
+  type: "ReLU"
+  bottom: "res5b_branch2a"
+  top: "res5b_branch2a"
+}
+layer {
+  name: "res5b_branch2b"
+  type: "Convolution"
+  bottom: "res5b_branch2a"
+  top: "res5b_branch2b"
   convolution_param {
     num_output: 512
-    pad: 4
-    dilation: 4
+    bias_term: false
+    pad: 1
     kernel_size: 3
     stride: 1
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
   }
 }
 layer {
-  name: "conv5_3_3x3/bnc"
+  name: "bn5b_branch2b"
   type: "BatchNorm"
-  bottom: "conv5_3_3x3"
-  top: "conv5_3_3x3"
-}
-
-layer {
- name: "conv5_3_3x3/scale"
- type: "Scale"
-bottom: "conv5_3_3x3"
- top: "conv5_3_3x3"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv5_3_3x3/relu"
-  type: "ReLU"
-  bottom: "conv5_3_3x3"
-  top: "conv5_3_3x3"
-}
-layer {
-  name: "conv5_3_1x1_increase"
-  type: "Convolution"
-  bottom: "conv5_3_3x3"
-  top: "conv5_3_1x1_increase"
-  param {
-    lr_mult: 1
-    decay_mult: 1
+  bottom: "res5b_branch2b"
+  top: "res5b_branch2b"
+  batch_norm_param {
   }
+}
+layer {
+  name: "scale5b_branch2b"
+  type: "Scale"
+  bottom: "res5b_branch2b"
+  top: "res5b_branch2b"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res5b_branch2b_relu"
+  type: "ReLU"
+  bottom: "res5b_branch2b"
+  top: "res5b_branch2b"
+}
+layer {
+  name: "res5b_branch2c"
+  type: "Convolution"
+  bottom: "res5b_branch2b"
+  top: "res5b_branch2c"
   convolution_param {
     num_output: 2048
+    bias_term: false
     pad: 0
     kernel_size: 1
     stride: 1
     weight_filler {
-      type: "msra"
+      type: "xavier"
     }
-    bias_term: false
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
   }
 }
 layer {
-  name: "conv5_3_1x1_increase/bnc"
+  name: "bn5b_branch2c"
   type: "BatchNorm"
-  bottom: "conv5_3_1x1_increase"
-  top: "conv5_3_1x1_increase"
-}
-
-layer {
- name: "conv5_3_1x1_increase/scale"
- type: "Scale"
-bottom: "conv5_3_1x1_increase"
- top: "conv5_3_1x1_increase"
- scale_param {
- bias_term: true
-}
-}
-
-layer {
-  name: "conv5_3"
-  type: "Eltwise"
-  bottom: "conv5_2"
-  bottom: "conv5_3_1x1_increase"
-  top: "conv5_3"
-  eltwise_param {
-    operation: SUM
+  bottom: "res5b_branch2c"
+  top: "res5b_branch2c"
+  batch_norm_param {
   }
 }
 layer {
-  name: "conv5_3/relu"
+  name: "scale5b_branch2c"
+  type: "Scale"
+  bottom: "res5b_branch2c"
+  top: "res5b_branch2c"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res5b"
+  type: "Eltwise"
+  bottom: "res5a"
+  bottom: "res5b_branch2c"
+  top: "res5b"
+}
+layer {
+  name: "res5b_relu"
   type: "ReLU"
-  bottom: "conv5_3"
-  top: "conv5_3"
+  bottom: "res5b"
+  top: "res5b"
+}
+layer {
+  name: "res5c_branch2a"
+  type: "Convolution"
+  bottom: "res5b"
+  top: "res5c_branch2a"
+  convolution_param {
+    num_output: 512
+    bias_term: false
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "bn5c_branch2a"
+  type: "BatchNorm"
+  bottom: "res5c_branch2a"
+  top: "res5c_branch2a"
+  batch_norm_param {
+  }
+}
+layer {
+  name: "scale5c_branch2a"
+  type: "Scale"
+  bottom: "res5c_branch2a"
+  top: "res5c_branch2a"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res5c_branch2a_relu"
+  type: "ReLU"
+  bottom: "res5c_branch2a"
+  top: "res5c_branch2a"
+}
+layer {
+  name: "res5c_branch2b"
+  type: "Convolution"
+  bottom: "res5c_branch2a"
+  top: "res5c_branch2b"
+  convolution_param {
+    num_output: 512
+    bias_term: false
+    pad: 1
+    kernel_size: 3
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "bn5c_branch2b"
+  type: "BatchNorm"
+  bottom: "res5c_branch2b"
+  top: "res5c_branch2b"
+  batch_norm_param {
+  }
+}
+layer {
+  name: "scale5c_branch2b"
+  type: "Scale"
+  bottom: "res5c_branch2b"
+  top: "res5c_branch2b"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res5c_branch2b_relu"
+  type: "ReLU"
+  bottom: "res5c_branch2b"
+  top: "res5c_branch2b"
+}
+layer {
+  name: "res5c_branch2c"
+  type: "Convolution"
+  bottom: "res5c_branch2b"
+  top: "res5c_branch2c"
+  convolution_param {
+    num_output: 2048
+    bias_term: false
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layer {
+  name: "bn5c_branch2c"
+  type: "BatchNorm"
+  bottom: "res5c_branch2c"
+  top: "res5c_branch2c"
+  batch_norm_param {
+  }
+}
+layer {
+  name: "scale5c_branch2c"
+  type: "Scale"
+  bottom: "res5c_branch2c"
+  top: "res5c_branch2c"
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "res5c"
+  type: "Eltwise"
+  bottom: "res5b"
+  bottom: "res5c_branch2c"
+  top: "res5c"
+}
+layer {
+  name: "res5c_relu"
+  type: "ReLU"
+  bottom: "res5c"
+  top: "res5c"
+}
+layer {
+  name: "res5c_interp"
+  type: "Interp"
+  bottom: "res5c"
+  top: "res5c_interp"
+  interp_param {
+    height: 60
+    width: 60
+  }
 }
 layer {
   name: "conv5_3_pool1"
   type: "Pooling"
-  bottom: "conv5_3"
+  bottom: "res5c_interp"
   top: "conv5_3_pool1"
   pooling_param {
     pool: AVE
@@ -2568,36 +2434,34 @@ layer {
   bottom: "conv5_3_pool1"
   top: "conv5_3_pool1_conv"
   param {
-    lr_mult: 10
+    lr_mult: 1
     decay_mult: 1
   }
   convolution_param {
     num_output: 512
+    bias_term: false
     kernel_size: 1
     stride: 1
     weight_filler {
       type: "msra"
     }
-    bias_term: false
   }
 }
 layer {
-  name: "conv5_3_pool1_conv/bnc"
+  name: "conv5_3_pool1_conv/bn"
   type: "BatchNorm"
   bottom: "conv5_3_pool1_conv"
   top: "conv5_3_pool1_conv"
 }
-
 layer {
- name: "conv5_3_pool1_conv/scale"
- type: "Scale"
-bottom: "conv5_3_pool1_conv"
- top: "conv5_3_pool1_conv"
- scale_param {
- bias_term: true
+  name: "conv5_3_pool1_conv/scale"
+  type: "Scale"
+  bottom: "conv5_3_pool1_conv"
+  top: "conv5_3_pool1_conv"
+  scale_param {
+    bias_term: true
+  }
 }
-}
-
 layer {
   name: "conv5_3_pool1_conv/relu"
   type: "ReLU"
@@ -2617,7 +2481,7 @@ layer {
 layer {
   name: "conv5_3_pool2"
   type: "Pooling"
-  bottom: "conv5_3"
+  bottom: "res5c_interp"
   top: "conv5_3_pool2"
   pooling_param {
     pool: AVE
@@ -2631,36 +2495,34 @@ layer {
   bottom: "conv5_3_pool2"
   top: "conv5_3_pool2_conv"
   param {
-    lr_mult: 10
+    lr_mult: 1
     decay_mult: 1
   }
   convolution_param {
     num_output: 512
+    bias_term: false
     kernel_size: 1
     stride: 1
     weight_filler {
       type: "msra"
     }
-    bias_term: false
   }
 }
 layer {
-  name: "conv5_3_pool2_conv/bnc"
+  name: "conv5_3_pool2_conv/bn"
   type: "BatchNorm"
   bottom: "conv5_3_pool2_conv"
   top: "conv5_3_pool2_conv"
 }
-
 layer {
- name: "conv5_3_pool2_conv/scale"
- type: "Scale"
-bottom: "conv5_3_pool2_conv"
- top: "conv5_3_pool2_conv"
- scale_param {
- bias_term: true
+  name: "conv5_3_pool2_conv/scale"
+  type: "Scale"
+  bottom: "conv5_3_pool2_conv"
+  top: "conv5_3_pool2_conv"
+  scale_param {
+    bias_term: true
+  }
 }
-}
-
 layer {
   name: "conv5_3_pool2_conv/relu"
   type: "ReLU"
@@ -2680,7 +2542,7 @@ layer {
 layer {
   name: "conv5_3_pool3"
   type: "Pooling"
-  bottom: "conv5_3"
+  bottom: "res5c_interp"
   top: "conv5_3_pool3"
   pooling_param {
     pool: AVE
@@ -2694,36 +2556,34 @@ layer {
   bottom: "conv5_3_pool3"
   top: "conv5_3_pool3_conv"
   param {
-    lr_mult: 10
+    lr_mult: 1
     decay_mult: 1
   }
   convolution_param {
     num_output: 512
+    bias_term: false
     kernel_size: 1
     stride: 1
     weight_filler {
       type: "msra"
     }
-    bias_term: false
   }
 }
 layer {
-  name: "conv5_3_pool3_conv/bnc"
+  name: "conv5_3_pool3_conv/bn"
   type: "BatchNorm"
   bottom: "conv5_3_pool3_conv"
   top: "conv5_3_pool3_conv"
 }
-
 layer {
- name: "conv5_3_pool3_conv/scale"
- type: "Scale"
-bottom: "conv5_3_pool3_conv"
- top: "conv5_3_pool3_conv"
- scale_param {
- bias_term: true
+  name: "conv5_3_pool3_conv/scale"
+  type: "Scale"
+  bottom: "conv5_3_pool3_conv"
+  top: "conv5_3_pool3_conv"
+  scale_param {
+    bias_term: true
+  }
 }
-}
-
 layer {
   name: "conv5_3_pool3_conv/relu"
   type: "ReLU"
@@ -2743,7 +2603,7 @@ layer {
 layer {
   name: "conv5_3_pool6"
   type: "Pooling"
-  bottom: "conv5_3"
+  bottom: "res5c_interp"
   top: "conv5_3_pool6"
   pooling_param {
     pool: AVE
@@ -2757,36 +2617,34 @@ layer {
   bottom: "conv5_3_pool6"
   top: "conv5_3_pool6_conv"
   param {
-    lr_mult: 10
+    lr_mult: 1
     decay_mult: 1
   }
   convolution_param {
     num_output: 512
+    bias_term: false
     kernel_size: 1
     stride: 1
     weight_filler {
       type: "msra"
     }
-    bias_term: false
   }
 }
 layer {
-  name: "conv5_3_pool6_conv/bnc"
+  name: "conv5_3_pool6_conv/bn"
   type: "BatchNorm"
   bottom: "conv5_3_pool6_conv"
   top: "conv5_3_pool6_conv"
 }
-
 layer {
- name: "conv5_3_pool6_conv/scale"
- type: "Scale"
-bottom: "conv5_3_pool6_conv"
- top: "conv5_3_pool6_conv"
- scale_param {
- bias_term: true
+  name: "conv5_3_pool6_conv/scale"
+  type: "Scale"
+  bottom: "conv5_3_pool6_conv"
+  top: "conv5_3_pool6_conv"
+  scale_param {
+    bias_term: true
+  }
 }
-}
-
 layer {
   name: "conv5_3_pool6_conv/relu"
   type: "ReLU"
@@ -2806,7 +2664,7 @@ layer {
 layer {
   name: "conv5_3_concat"
   type: "Concat"
-  bottom: "conv5_3"
+  bottom: "res5c_interp"
   bottom: "conv5_3_pool6_interp"
   bottom: "conv5_3_pool3_interp"
   bottom: "conv5_3_pool2_interp"
@@ -2819,37 +2677,20 @@ layer {
   bottom: "conv5_3_concat"
   top: "conv5_4"
   param {
-    lr_mult: 10
+    lr_mult: 1
     decay_mult: 1
   }
   convolution_param {
     num_output: 512
+    bias_term: false
+    pad: 1
     kernel_size: 3
     stride: 1
-    pad: 1
     weight_filler {
       type: "msra"
     }
-    bias_term: false
   }
 }
-layer {
-  name: "conv5_4/bnc"
-  type: "BatchNorm"
-  bottom: "conv5_4"
-  top: "conv5_4"
-}
-
-layer {
- name: "conv5_4/scale"
- type: "Scale"
-bottom: "conv5_4"
- top: "conv5_4"
- scale_param {
- bias_term: true
-}
-}
-
 layer {
   name: "conv5_4/relu"
   type: "ReLU"
@@ -2871,15 +2712,15 @@ layer {
   bottom: "conv5_4"
   top: "conv6"
   param {
-    lr_mult: 10
+    lr_mult: 1
     decay_mult: 1
   }
   param {
-    lr_mult: 20
+    lr_mult: 1
     decay_mult: 1
   }
   convolution_param {
-    num_output: 150
+    num_output: 2
     kernel_size: 1
     stride: 1
     weight_filler {
@@ -2887,18 +2728,19 @@ layer {
     }
   }
 }
-
 layer {
-  bottom: "label"
-  top: "label_shrink"
   name: "label_shrink"
   type: "Interp"
+  bottom: "label"
+  top: "label_shrink"
+  include {
+    phase: TRAIN
+  }
   interp_param {
-     width: 60
-     height: 60
+    height: 60
+    width: 60
   }
 }
-
 layer {
   name: "loss"
   type: "SoftmaxWithLoss"
@@ -2909,20 +2751,19 @@ layer {
     phase: TRAIN
   }
 }
-
 layer {
   name: "final_interp"
   type: "Interp"
   bottom: "conv6"
   top: "final_interp"
-  interp_param {
-    zoom_factor: 8
-  }
   include {
     phase: TEST
   }
+  interp_param {
+    height: 480
+    width: 480
+  }
 }
-
 layer {
   name: "probt"
   type: "Softmax"

--- a/templates/caffe/pspnet_50/pspnet_50.prototxt
+++ b/templates/caffe/pspnet_50/pspnet_50.prototxt
@@ -50,7 +50,7 @@ layer {
   }
 }
 layer {
-  name: "conv1_1_3x3_s2/bn"
+  name: "conv1_1_3x3_s2/bnc"
   type: "BatchNorm"
   bottom: "conv1_1_3x3_s2"
   top: "conv1_1_3x3_s2"
@@ -93,7 +93,7 @@ layer {
   }
 }
 layer {
-  name: "conv1_2_3x3/bn"
+  name: "conv1_2_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv1_2_3x3"
   top: "conv1_2_3x3"
@@ -136,7 +136,7 @@ layer {
   }
 }
 layer {
-  name: "conv1_3_3x3/bn"
+  name: "conv1_3_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv1_3_3x3"
   top: "conv1_3_3x3"
@@ -191,7 +191,7 @@ layer {
   }
 }
 layer {
-  name: "conv2_1_1x1_reduce/bn"
+  name: "conv2_1_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv2_1_1x1_reduce"
   top: "conv2_1_1x1_reduce"
@@ -234,7 +234,7 @@ layer {
   }
 }
 layer {
-  name: "conv2_1_3x3/bn"
+  name: "conv2_1_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv2_1_3x3"
   top: "conv2_1_3x3"
@@ -277,7 +277,7 @@ layer {
   }
 }
 layer {
-  name: "conv2_1_1x1_increase/bn"
+  name: "conv2_1_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv2_1_1x1_increase"
   top: "conv2_1_1x1_increase"
@@ -314,7 +314,7 @@ layer {
   }
 }
 layer {
-  name: "conv2_1_1x1_proj/bn"
+  name: "conv2_1_1x1_proj/bnc"
   type: "BatchNorm"
   bottom: "conv2_1_1x1_proj"
   top: "conv2_1_1x1_proj"
@@ -367,7 +367,7 @@ layer {
   }
 }
 layer {
-  name: "conv2_2_1x1_reduce/bn"
+  name: "conv2_2_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv2_2_1x1_reduce"
   top: "conv2_2_1x1_reduce"
@@ -410,7 +410,7 @@ layer {
   }
 }
 layer {
-  name: "conv2_2_3x3/bn"
+  name: "conv2_2_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv2_2_3x3"
   top: "conv2_2_3x3"
@@ -453,7 +453,7 @@ layer {
   }
 }
 layer {
-  name: "conv2_2_1x1_increase/bn"
+  name: "conv2_2_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv2_2_1x1_increase"
   top: "conv2_2_1x1_increase"
@@ -506,7 +506,7 @@ layer {
   }
 }
 layer {
-  name: "conv2_3_1x1_reduce/bn"
+  name: "conv2_3_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv2_3_1x1_reduce"
   top: "conv2_3_1x1_reduce"
@@ -549,7 +549,7 @@ layer {
   }
 }
 layer {
-  name: "conv2_3_3x3/bn"
+  name: "conv2_3_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv2_3_3x3"
   top: "conv2_3_3x3"
@@ -592,7 +592,7 @@ layer {
   }
 }
 layer {
-  name: "conv2_3_1x1_increase/bn"
+  name: "conv2_3_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv2_3_1x1_increase"
   top: "conv2_3_1x1_increase"
@@ -645,7 +645,7 @@ layer {
   }
 }
 layer {
-  name: "conv3_1_1x1_reduce/bn"
+  name: "conv3_1_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv3_1_1x1_reduce"
   top: "conv3_1_1x1_reduce"
@@ -688,7 +688,7 @@ layer {
   }
 }
 layer {
-  name: "conv3_1_3x3/bn"
+  name: "conv3_1_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv3_1_3x3"
   top: "conv3_1_3x3"
@@ -731,7 +731,7 @@ layer {
   }
 }
 layer {
-  name: "conv3_1_1x1_increase/bn"
+  name: "conv3_1_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv3_1_1x1_increase"
   top: "conv3_1_1x1_increase"
@@ -768,7 +768,7 @@ layer {
   }
 }
 layer {
-  name: "conv3_1_1x1_proj/bn"
+  name: "conv3_1_1x1_proj/bnc"
   type: "BatchNorm"
   bottom: "conv3_1_1x1_proj"
   top: "conv3_1_1x1_proj"
@@ -821,7 +821,7 @@ layer {
   }
 }
 layer {
-  name: "conv3_2_1x1_reduce/bn"
+  name: "conv3_2_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv3_2_1x1_reduce"
   top: "conv3_2_1x1_reduce"
@@ -864,7 +864,7 @@ layer {
   }
 }
 layer {
-  name: "conv3_2_3x3/bn"
+  name: "conv3_2_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv3_2_3x3"
   top: "conv3_2_3x3"
@@ -907,7 +907,7 @@ layer {
   }
 }
 layer {
-  name: "conv3_2_1x1_increase/bn"
+  name: "conv3_2_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv3_2_1x1_increase"
   top: "conv3_2_1x1_increase"
@@ -960,7 +960,7 @@ layer {
   }
 }
 layer {
-  name: "conv3_3_1x1_reduce/bn"
+  name: "conv3_3_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv3_3_1x1_reduce"
   top: "conv3_3_1x1_reduce"
@@ -1003,7 +1003,7 @@ layer {
   }
 }
 layer {
-  name: "conv3_3_3x3/bn"
+  name: "conv3_3_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv3_3_3x3"
   top: "conv3_3_3x3"
@@ -1046,7 +1046,7 @@ layer {
   }
 }
 layer {
-  name: "conv3_3_1x1_increase/bn"
+  name: "conv3_3_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv3_3_1x1_increase"
   top: "conv3_3_1x1_increase"
@@ -1099,7 +1099,7 @@ layer {
   }
 }
 layer {
-  name: "conv3_4_1x1_reduce/bn"
+  name: "conv3_4_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv3_4_1x1_reduce"
   top: "conv3_4_1x1_reduce"
@@ -1142,7 +1142,7 @@ layer {
   }
 }
 layer {
-  name: "conv3_4_3x3/bn"
+  name: "conv3_4_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv3_4_3x3"
   top: "conv3_4_3x3"
@@ -1185,7 +1185,7 @@ layer {
   }
 }
 layer {
-  name: "conv3_4_1x1_increase/bn"
+  name: "conv3_4_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv3_4_1x1_increase"
   top: "conv3_4_1x1_increase"
@@ -1238,7 +1238,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_1_1x1_reduce/bn"
+  name: "conv4_1_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_1_1x1_reduce"
   top: "conv4_1_1x1_reduce"
@@ -1282,7 +1282,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_1_3x3/bn"
+  name: "conv4_1_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_1_3x3"
   top: "conv4_1_3x3"
@@ -1325,7 +1325,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_1_1x1_increase/bn"
+  name: "conv4_1_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_1_1x1_increase"
   top: "conv4_1_1x1_increase"
@@ -1362,7 +1362,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_1_1x1_proj/bn"
+  name: "conv4_1_1x1_proj/bnc"
   type: "BatchNorm"
   bottom: "conv4_1_1x1_proj"
   top: "conv4_1_1x1_proj"
@@ -1415,7 +1415,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_2_1x1_reduce/bn"
+  name: "conv4_2_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_2_1x1_reduce"
   top: "conv4_2_1x1_reduce"
@@ -1459,7 +1459,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_2_3x3/bn"
+  name: "conv4_2_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_2_3x3"
   top: "conv4_2_3x3"
@@ -1502,7 +1502,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_2_1x1_increase/bn"
+  name: "conv4_2_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_2_1x1_increase"
   top: "conv4_2_1x1_increase"
@@ -1555,7 +1555,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_3_1x1_reduce/bn"
+  name: "conv4_3_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_3_1x1_reduce"
   top: "conv4_3_1x1_reduce"
@@ -1599,7 +1599,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_3_3x3/bn"
+  name: "conv4_3_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_3_3x3"
   top: "conv4_3_3x3"
@@ -1642,7 +1642,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_3_1x1_increase/bn"
+  name: "conv4_3_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_3_1x1_increase"
   top: "conv4_3_1x1_increase"
@@ -1695,7 +1695,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_4_1x1_reduce/bn"
+  name: "conv4_4_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_4_1x1_reduce"
   top: "conv4_4_1x1_reduce"
@@ -1739,7 +1739,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_4_3x3/bn"
+  name: "conv4_4_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_4_3x3"
   top: "conv4_4_3x3"
@@ -1782,7 +1782,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_4_1x1_increase/bn"
+  name: "conv4_4_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_4_1x1_increase"
   top: "conv4_4_1x1_increase"
@@ -1835,7 +1835,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_5_1x1_reduce/bn"
+  name: "conv4_5_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_5_1x1_reduce"
   top: "conv4_5_1x1_reduce"
@@ -1879,7 +1879,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_5_3x3/bn"
+  name: "conv4_5_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_5_3x3"
   top: "conv4_5_3x3"
@@ -1922,7 +1922,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_5_1x1_increase/bn"
+  name: "conv4_5_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_5_1x1_increase"
   top: "conv4_5_1x1_increase"
@@ -1975,7 +1975,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_6_1x1_reduce/bn"
+  name: "conv4_6_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv4_6_1x1_reduce"
   top: "conv4_6_1x1_reduce"
@@ -2019,7 +2019,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_6_3x3/bn"
+  name: "conv4_6_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv4_6_3x3"
   top: "conv4_6_3x3"
@@ -2062,7 +2062,7 @@ layer {
   }
 }
 layer {
-  name: "conv4_6_1x1_increase/bn"
+  name: "conv4_6_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv4_6_1x1_increase"
   top: "conv4_6_1x1_increase"
@@ -2115,7 +2115,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_1_1x1_reduce/bn"
+  name: "conv5_1_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv5_1_1x1_reduce"
   top: "conv5_1_1x1_reduce"
@@ -2159,7 +2159,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_1_3x3/bn"
+  name: "conv5_1_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv5_1_3x3"
   top: "conv5_1_3x3"
@@ -2202,7 +2202,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_1_1x1_increase/bn"
+  name: "conv5_1_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv5_1_1x1_increase"
   top: "conv5_1_1x1_increase"
@@ -2239,7 +2239,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_1_1x1_proj/bn"
+  name: "conv5_1_1x1_proj/bnc"
   type: "BatchNorm"
   bottom: "conv5_1_1x1_proj"
   top: "conv5_1_1x1_proj"
@@ -2292,7 +2292,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_2_1x1_reduce/bn"
+  name: "conv5_2_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv5_2_1x1_reduce"
   top: "conv5_2_1x1_reduce"
@@ -2336,7 +2336,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_2_3x3/bn"
+  name: "conv5_2_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv5_2_3x3"
   top: "conv5_2_3x3"
@@ -2379,7 +2379,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_2_1x1_increase/bn"
+  name: "conv5_2_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv5_2_1x1_increase"
   top: "conv5_2_1x1_increase"
@@ -2432,7 +2432,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_3_1x1_reduce/bn"
+  name: "conv5_3_1x1_reduce/bnc"
   type: "BatchNorm"
   bottom: "conv5_3_1x1_reduce"
   top: "conv5_3_1x1_reduce"
@@ -2476,7 +2476,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_3_3x3/bn"
+  name: "conv5_3_3x3/bnc"
   type: "BatchNorm"
   bottom: "conv5_3_3x3"
   top: "conv5_3_3x3"
@@ -2519,7 +2519,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_3_1x1_increase/bn"
+  name: "conv5_3_1x1_increase/bnc"
   type: "BatchNorm"
   bottom: "conv5_3_1x1_increase"
   top: "conv5_3_1x1_increase"
@@ -2582,7 +2582,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_3_pool1_conv/bn"
+  name: "conv5_3_pool1_conv/bnc"
   type: "BatchNorm"
   bottom: "conv5_3_pool1_conv"
   top: "conv5_3_pool1_conv"
@@ -2645,7 +2645,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_3_pool2_conv/bn"
+  name: "conv5_3_pool2_conv/bnc"
   type: "BatchNorm"
   bottom: "conv5_3_pool2_conv"
   top: "conv5_3_pool2_conv"
@@ -2708,7 +2708,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_3_pool3_conv/bn"
+  name: "conv5_3_pool3_conv/bnc"
   type: "BatchNorm"
   bottom: "conv5_3_pool3_conv"
   top: "conv5_3_pool3_conv"
@@ -2771,7 +2771,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_3_pool6_conv/bn"
+  name: "conv5_3_pool6_conv/bnc"
   type: "BatchNorm"
   bottom: "conv5_3_pool6_conv"
   top: "conv5_3_pool6_conv"
@@ -2834,7 +2834,7 @@ layer {
   }
 }
 layer {
-  name: "conv5_4/bn"
+  name: "conv5_4/bnc"
   type: "BatchNorm"
   bottom: "conv5_4"
   top: "conv5_4"


### PR DESCRIPTION
This allows transfer learning on PSPNet segmentation models from ResNet-50. Tested, on par with VGG16 + PSP head.