### PR TITLE
Service statistics / metrics

### DIFF
--- a/src/backends/caffe/caffelib.cc
+++ b/src/backends/caffe/caffelib.cc
@@ -2347,6 +2347,7 @@ namespace dd
     
     try
       {
+	//TODO: time preprocessing
         inputc.transform(cad);
       }
     catch (std::exception &e)
@@ -2354,6 +2355,7 @@ namespace dd
         throw;
       }
     int batch_size = inputc.test_batch_size();
+    this->stat_inference_count(batch_size);
     if (ad_mllib.has("net"))
       {
 	APIData ad_net = ad_mllib.getobj("net");

--- a/src/backends/dlib/dliblib.cc
+++ b/src/backends/dlib/dliblib.cc
@@ -113,6 +113,7 @@ namespace dd {
 
         APIData ad_mllib = ad.getobj("parameters").getobj("mllib");
         int batch_size = inputc.batch_size();
+	this->stat_inference_count(batch_size);
         if (ad_mllib.has("test_batch_size")) {
             batch_size = ad_mllib.get("test_batch_size").get<int>();
         }

--- a/src/backends/ncnn/ncnnlib.cc
+++ b/src/backends/ncnn/ncnnlib.cc
@@ -161,6 +161,7 @@ namespace dd
             throw;
         }
 
+	this->stat_inference_count(inputc._ids.size());
 
         // if height (timestep) changes we need to clear net before recreating an extractor with new
         // height,

--- a/src/backends/tensorrt/tensorrtinputconns.cc
+++ b/src/backends/tensorrt/tensorrtinputconns.cc
@@ -86,6 +86,7 @@ namespace dd
 	  this->_ids.push_back(this->_uris.at(i));
 	_imgs_size.insert(std::pair<std::string,std::pair<int,int>>(this->_ids.at(i),this->_images_size.at(i)));
       }
+    _batch_size = this->_images.size();
     _batch_index = 0;
   }
 

--- a/src/backends/tensorrt/tensorrtinputconns.h
+++ b/src/backends/tensorrt/tensorrtinputconns.h
@@ -82,6 +82,7 @@ namespace dd
     std::string _meanfname = "mean.binaryproto";
     std::string _correspname = "corresp.txt";
     int _batch_index = 0;
+    int _batch_size = 0;
     int process_batch(const unsigned int batch_size);
     std::unordered_map<std::string,std::pair<int,int>> _imgs_size; /**< image sizes, used in detection. */
 

--- a/src/backends/tensorrt/tensorrtlib.cc
+++ b/src/backends/tensorrt/tensorrtlib.cc
@@ -424,6 +424,8 @@ namespace dd
     } catch (...) {
       throw;
     }
+
+    this->stat_add_inference_count(inputc._batch_size);
     
     int idoffset = 0;
     std::vector<APIData> vrad;

--- a/src/backends/tensorrt/tensorrtlib.cc
+++ b/src/backends/tensorrt/tensorrtlib.cc
@@ -425,7 +425,7 @@ namespace dd
       throw;
     }
 
-    this->stat_add_inference_count(inputc._batch_size);
+    this->stat_inference_count(inputc._batch_size);
     
     int idoffset = 0;
     std::vector<APIData> vrad;

--- a/src/backends/tf/tflib.cc
+++ b/src/backends/tf/tflib.cc
@@ -301,6 +301,7 @@ namespace dd
     
     APIData ad_mllib = ad.getobj("parameters").getobj("mllib");
     int batch_size = inputc.batch_size();
+    this->stat_inference_count(batch_size);
     if (ad_mllib.has("test_batch_size"))
       batch_size = ad_mllib.get("test_batch_size").get<int>();
 

--- a/src/backends/torch/torchlib.cc
+++ b/src/backends/torch/torchlib.cc
@@ -594,9 +594,14 @@ namespace dd
         inputc._dataset.reset();
         TorchBatch batch = inputc._dataset.get_cached();
 
+	int bach_size = 0;
         std::vector<c10::IValue> in_vals;
         for (Tensor tensor : batch.data)
+	  {
             in_vals.push_back(tensor.to(_device));
+	    ++batch_size;
+	  }
+	this->stat_inference_count(batch_size);
         Tensor output;
         try
         {

--- a/src/backends/torch/torchlib.cc
+++ b/src/backends/torch/torchlib.cc
@@ -594,7 +594,7 @@ namespace dd
         inputc._dataset.reset();
         TorchBatch batch = inputc._dataset.get_cached();
 
-	int bach_size = 0;
+	int batch_size = 0;
         std::vector<c10::IValue> in_vals;
         for (Tensor tensor : batch.data)
 	  {

--- a/src/backends/xgb/xgblib.cc
+++ b/src/backends/xgb/xgblib.cc
@@ -448,6 +448,7 @@ namespace dd
     // results
     //float loss = 0.0; // XXX: how to acquire loss ?
     int batch_size = preds.Size();
+    this->stat_inference_count(batch_size);
     int nclasses = _nclasses;
     if (_objective == "multi:softprob")
       batch_size /= nclasses;

--- a/src/jsonapi.cc
+++ b/src/jsonapi.cc
@@ -1282,8 +1282,6 @@ namespace dd
     out.toJVal(jpred,jout);
     JVal jhead(rapidjson::kObjectType);
     jhead.AddMember("method","/chain",jpred.GetAllocator());
-    //jhead.AddMember("service",d["service"],jpred.GetAllocator());
-    //if (!has_measure)
     jhead.AddMember("time",jout["time"],jpred.GetAllocator());
     jpred.AddMember("head",jhead,jpred.GetAllocator());
     JVal jbody(rapidjson::kObjectType);


### PR DESCRIPTION
This PR adds mechanism that automatically collects per service statistics and metrics on `predict` calls (e.g. failed / succeed calls, avg batch size, ...).

Statistics adds to existing API calls output are obtained via either calls
- `GET /services/<service_name>`
- `GET /info?status=true`

- [x] Requests: counts, succeed, failed, avg batch size, ...
- [ ] Latency: preprocessing time / computing time / total request time (already avail), avg times, ...
- [ ] Models:  avg confidence, min/max confidence, ...
