### PR TITLE
fix: update CUDA_ARCH value in build/build.sh

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -130,52 +130,107 @@ gpu_build() {
     case ${DEEPDETECT_BUILD} in
 
     "tf")
-        cmake .. -DUSE_TF=ON -DUSE_CUDNN=ON -DUSE_XGBOOST=ON -DUSE_SIMSEARCH=ON -DUSE_TSNE=ON -DCUDA_ARCH="-gencode arch=compute_30,code=sm_30 -gencode arch=compute_35,code=sm_35 -gencode arch=compute_50,code=sm_50 -gencode arch=compute_52,code=sm_52 -gencode arch=compute_53,code=sm_53 -gencode arch=compute_61,code=sm_61 -gencode arch=compute_62,code=sm_62"
+        cmake .. \
+            -DUSE_TF=ON \
+            -DUSE_CUDNN=ON \
+            -DUSE_XGBOOST=ON \
+            -DUSE_SIMSEARCH=ON \
+            -DUSE_TSNE=ON \
+            -DCUDA_ARCH="-gencode arch=compute_37,code=sm_37 -gencode arch=compute_52,code=sm_52 -gencode arch=compute_61,code=sm_61 -gencode arch=compute_70,code=sm_70 -gencode arch=compute_75,code=sm_75"
         make -j
         ;;
 
     "tf-cpu")
-        cmake .. -DUSE_TF=ON -DUSE_TF_CPU_ONLY=ON -DUSE_CUDNN=ON -DUSE_XGBOOST=ON -DUSE_SIMSEARCH=ON -DUSE_TSNE=ON -DCUDA_ARCH="-gencode arch=compute_30,code=sm_30 -gencode arch=compute_35,code=sm_35 -gencode arch=compute_50,code=sm_50 -gencode arch=compute_52,code=sm_52 -gencode arch=compute_53,code=sm_53 -gencode arch=compute_61,code=sm_61 -gencode arch=compute_62,code=sm_62"
+        cmake .. \
+            -DUSE_TF=ON \
+            -DUSE_TF_CPU_ONLY=ON \
+            -DUSE_CUDNN=ON \
+            -DUSE_XGBOOST=ON \
+            -DUSE_SIMSEARCH=ON \
+            -DUSE_TSNE=ON \
+            -DCUDA_ARCH="-gencode arch=compute_37,code=sm_37 -gencode arch=compute_52,code=sm_52 -gencode arch=compute_61,code=sm_61 -gencode arch=compute_70,code=sm_70 -gencode arch=compute_75,code=sm_75"
         make -j
         ;;
 
     "caffe-cpu-tf")
-        cmake .. -DUSE_TF=ON -DUSE_TF_CPU_ONLY=ON -DUSE_CUDNN=ON -DUSE_XGBOOST=ON -DUSE_SIMSEARCH=ON -DUSE_TSNE=ON -DCUDA_ARCH="-gencode arch=compute_30,code=sm_30 -gencode arch=compute_35,code=sm_35 -gencode arch=compute_50,code=sm_50 -gencode arch=compute_52,code=sm_52 -gencode arch=compute_53,code=sm_53 -gencode arch=compute_61,code=sm_61"
+        cmake .. \
+            -DUSE_TF=ON \
+            -DUSE_TF_CPU_ONLY=ON \
+            -DUSE_CUDNN=ON \
+            -DUSE_XGBOOST=ON \
+            -DUSE_SIMSEARCH=ON \
+            -DUSE_TSNE=ON \
+            -DCUDA_ARCH="-gencode arch=compute_37,code=sm_37 -gencode arch=compute_52,code=sm_52 -gencode arch=compute_61,code=sm_61 -gencode arch=compute_70,code=sm_70 -gencode arch=compute_75,code=sm_75"
         make
         ;;
 
     "caffe-tf")
-        cmake .. -DUSE_TF=ON -DUSE_CUDNN=ON -DUSE_SIMSEARCH=ON -DUSE_TSNE=ON -DCUDA_ARCH="-gencode arch=compute_30,code=sm_30 -gencode arch=compute_35,code=sm_35 -gencode arch=compute_50,code=sm_50 -gencode arch=compute_52,code=sm_52 -gencode arch=compute_53,code=sm_53 -gencode arch=compute_61,code=sm_61"
+        cmake .. \
+            -DUSE_TF=ON \
+            -DUSE_CUDNN=ON \
+            -DUSE_SIMSEARCH=ON \
+            -DUSE_TSNE=ON \
+            -DCUDA_ARCH="-gencode arch=compute_37,code=sm_37 -gencode arch=compute_52,code=sm_52 -gencode arch=compute_61,code=sm_61 -gencode arch=compute_70,code=sm_70 -gencode arch=compute_75,code=sm_75"
         make -j
         ;;
 
     "caffe2")
-        cmake .. -DUSE_CUDNN=ON -DUSE_XGBOOST=ON -DUSE_SIMSEARCH=ON -DUSE_TSNE=ON -DUSE_CAFFE2=ON -DCUDA_ARCH="-gencode arch=compute_30,code=sm_30 -gencode arch=compute_35,code=sm_35 -gencode arch=compute_50,code=sm_50 -gencode arch=compute_52,code=sm_52 -gencode arch=compute_53,code=sm_53 -gencode arch=compute_61,code=sm_61 -gencode arch=compute_62,code=sm_62"
+        cmake .. \
+            -DUSE_CUDNN=ON \
+            -DUSE_XGBOOST=ON \
+            -DUSE_SIMSEARCH=ON \
+            -DUSE_TSNE=ON \
+            -DUSE_CAFFE2=ON \
+            -DCUDA_ARCH="-gencode arch=compute_37,code=sm_37 -gencode arch=compute_52,code=sm_52 -gencode arch=compute_61,code=sm_61 -gencode arch=compute_70,code=sm_70 -gencode arch=compute_75,code=sm_75"
         make -j
         ;;
 
     "p100")
-        cmake .. -DUSE_CUDNN=ON -DUSE_SIMSEARCH=ON -DUSE_TSNE=ON -DCUDA_ARCH="-gencode arch=compute_60,code=sm_60"
+        cmake .. \
+            -DUSE_CUDNN=ON \
+            -DUSE_SIMSEARCH=ON \
+            -DUSE_TSNE=ON \
+            -DCUDA_ARCH="-gencode arch=compute_60,code=sm_60"
         make -j
         ;;
 
     "volta")
-        cmake .. -DUSE_CUDNN=ON -DUSE_SIMSEARCH=ON -DUSE_TSNE=ON -DCUDA_ARCH="-gencode arch=compute_70,code=sm_70"
+        cmake .. \
+            -DUSE_CUDNN=ON \
+            -DUSE_SIMSEARCH=ON \
+            -DUSE_TSNE=ON \
+            -DCUDA_ARCH="-gencode arch=compute_70,code=sm_70"
         make -j
         ;;
 
     "volta-faiss")
-        cmake .. -DUSE_CUDNN=ON -DUSE_FAISS=ON -DUSE_SIMSEARCH=ON -DUSE_TSNE=ON -DCUDA_ARCH="-gencode arch=compute_70,code=sm_70"
+        cmake .. \
+            -DUSE_CUDNN=ON \
+            -DUSE_FAISS=ON \
+            -DUSE_SIMSEARCH=ON \
+            -DUSE_TSNE=ON \
+            -DCUDA_ARCH="-gencode arch=compute_70,code=sm_70"
         make -j
         ;;
 
     "faiss")
-        cmake .. -DUSE_CUDNN=ON -DUSE_FAISS=ON -DUSE_XGBOOST=ON -DUSE_SIMSEARCH=ON -DUSE_TSNE=ON -DCUDA_ARCH="-gencode arch=compute_30,code=sm_30 -gencode arch=compute_35,code=sm_35 -gencode arch=compute_50,code=sm_50 -gencode arch=compute_52,code=sm_52 -gencode arch=compute_53,code=sm_53 -gencode arch=compute_61,code=sm_61 -gencode arch=compute_62,code=sm_62"
+        cmake .. \
+            -DUSE_CUDNN=ON \
+            -DUSE_FAISS=ON \
+            -DUSE_XGBOOST=ON \
+            -DUSE_SIMSEARCH=ON \
+            -DUSE_TSNE=ON \
+            -DCUDA_ARCH="-gencode arch=compute_37,code=sm_37 -gencode arch=compute_52,code=sm_52 -gencode arch=compute_61,code=sm_61 -gencode arch=compute_70,code=sm_70 -gencode arch=compute_75,code=sm_75"
         make -j
         ;;
 
     *)
-        cmake .. -DUSE_CUDNN=ON -DUSE_XGBOOST=ON -DUSE_SIMSEARCH=ON -DUSE_TSNE=ON -DCUDA_ARCH="-gencode arch=compute_30,code=sm_30 -gencode arch=compute_35,code=sm_35 -gencode arch=compute_50,code=sm_50 -gencode arch=compute_52,code=sm_52 -gencode arch=compute_53,code=sm_53 -gencode arch=compute_61,code=sm_61 -gencode arch=compute_62,code=sm_62"
+        cmake .. \
+            -DUSE_CUDNN=ON \
+            -DUSE_XGBOOST=ON \
+            -DUSE_SIMSEARCH=ON \
+            -DUSE_TSNE=ON \
+            -DCUDA_ARCH="-gencode arch=compute_37,code=sm_37 -gencode arch=compute_52,code=sm_52 -gencode arch=compute_61,code=sm_61 -gencode arch=compute_70,code=sm_70 -gencode arch=compute_75,code=sm_75"
         make -j
         ;;
     esac


### PR DESCRIPTION
Update list of gencode in `-DCUDA_ARCH` argument during build process.

Old gencodes:

`-DCUDA_ARCH="-gencode arch=compute_30,code=sm_30 -gencode arch=compute_35,code=sm_35 -gencode arch=compute_50,code=sm_50 -gencode arch=compute_52,code=sm_52 -gencode arch=compute_53,code=sm_53 -gencode arch=compute_61,code=sm_61 -gencode arch=compute_62,code=sm_62"`

New gencodes:

`-DCUDA_ARCH="-gencode arch=compute_37,code=sm_37 -gencode arch=compute_52,code=sm_52 -gencode arch=compute_61,code=sm_61 -gencode arch=compute_70,code=sm_70 -gencode arch=compute_75,code=sm_75"`