### PR TITLE
[FIX] dice loss for 2 classes + contour weighting

### DIFF
--- a/src/backends/caffe/caffelib.cc
+++ b/src/backends/caffe/caffelib.cc
@@ -3525,8 +3525,6 @@ void CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::update
 	    if (lparam->has_convolution_param())
 	      {
             int num_output = lparam->mutable_convolution_param()->num_output();
-            if (_loss == "dice" && _nclasses <= 2 && lparam->name() == "linear_aggregation" && num_output == 1)
-              continue;
             if (last_layer || num_output == 0)
               lparam->mutable_convolution_param()->set_num_output(_nclasses);
             if (last_layer && num_output != 0)
@@ -3810,58 +3808,19 @@ void CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::update
     mvn_param->add_bottom(logits);
     mvn_param->add_top(logits_norm);
 
-    if (_nclasses <= 2)
-      {
-        caffe::LayerParameter* conv_param = insert_layer_before(net_param, softml_pos++);
-        *conv_param->mutable_name() = "linear_aggregation";
-        *conv_param->mutable_type() = "Convolution";
-        conv_param->add_bottom(logits_norm);
-        conv_param->add_top(agg_output);
-        caffe::ConvolutionParameter* conv_param_param = conv_param->mutable_convolution_param();
-        conv_param_param->set_num_output(1);
-        conv_param_param->set_axis(1);
-        conv_param_param->add_kernel_size(1);
-        caffe::FillerParameter* filler_param = conv_param_param->mutable_weight_filler();
-        filler_param->set_std(0.5);
-        filler_param->set_type("gaussian");
-
-        caffe::LayerParameter* sigmoid_loss_param = insert_layer_before(net_param, softml_pos++);
-        sigmoid_loss_param->set_name("probabilizer");
-        sigmoid_loss_param->set_type("Sigmoid");
-        sigmoid_loss_param->add_bottom(agg_output);
-        sigmoid_loss_param->add_top(loss_input);
-        sigmoid_loss_param->add_include();
-        nsr = sigmoid_loss_param->mutable_include(0);
-        nsr->set_phase(caffe::TRAIN);
-      }
-    else
-      {
-        caffe::LayerParameter* sigmoid_loss_param = insert_layer_before(net_param, softml_pos++);
-        sigmoid_loss_param->set_name("probabilizer");
-        sigmoid_loss_param->set_type("Softmax");
-        sigmoid_loss_param->add_bottom(logits_norm);
-        sigmoid_loss_param->add_top(loss_input);
-        sigmoid_loss_param->add_include();
-        nsr = sigmoid_loss_param->mutable_include(0);
-        nsr->set_phase(caffe::TRAIN);
-      }
-
+	caffe::LayerParameter* sigmoid_loss_param = insert_layer_before(net_param, softml_pos++);
+	sigmoid_loss_param->set_name("probabilizer");
+	sigmoid_loss_param->set_type("Softmax");
+	sigmoid_loss_param->add_bottom(logits_norm);
+	sigmoid_loss_param->add_top(loss_input);
+	sigmoid_loss_param->add_include();
+	nsr = sigmoid_loss_param->mutable_include(0);
+	nsr->set_phase(caffe::TRAIN);
 
     caffe::LayerParameter* final_interp_param = find_layer_by_name(net_param,"final_interp");
-    if (_nclasses <= 2)
-      {
-        *final_interp_param->mutable_bottom(0) = agg_output;
-        caffe::LayerParameter* probt_param = find_layer_by_name(net_param, "probt");
-        *probt_param->mutable_type() = "Sigmoid";
-      }
-    else
-      {
-        *final_interp_param->mutable_bottom(0) = logits_norm;
-        caffe::LayerParameter* probt_param = find_layer_by_name(net_param, "probt");
-        *probt_param->mutable_type() = "Softmax";
-      }
-
-
+	*final_interp_param->mutable_bottom(0) = logits_norm;
+	caffe::LayerParameter* probt_param = find_layer_by_name(net_param, "probt");
+	*probt_param->mutable_type() = "Softmax";
 
     caffe::LayerParameter *lossparam = net_param.mutable_layer(softml_pos);
     *lossparam->mutable_type() = "DiceCoefLoss";
@@ -3873,10 +3832,7 @@ void CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::update
     // now work on deploy.txt
     int final_interp_pos = find_index_layer_by_type(deploy_net_param, "Interp");
     final_interp_param = deploy_net_param.mutable_layer(final_interp_pos);
-    if (_nclasses <= 2)
-      *final_interp_param->mutable_bottom(0) = agg_output;
-    else
-      *final_interp_param->mutable_bottom(0) = logits_norm;
+	*final_interp_param->mutable_bottom(0) = logits_norm;
 
     mvn_param = insert_layer_before(deploy_net_param, final_interp_pos++);
     *mvn_param->mutable_name() = "normalization";
@@ -3885,29 +3841,8 @@ void CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::update
     mvn_param->add_bottom(logits);
     mvn_param->add_top(logits_norm);
 
-
-    if (_nclasses <= 2)
-      {
-        caffe::LayerParameter *conv_param = insert_layer_before(deploy_net_param, final_interp_pos);
-        *conv_param->mutable_name() = "linear_aggregation";
-        *conv_param->mutable_type() = "Convolution";
-        conv_param->add_bottom(logits_norm);
-        conv_param->add_top(agg_output);
-        caffe::ConvolutionParameter*conv_param_param = conv_param->mutable_convolution_param();
-        conv_param_param->set_num_output(1);
-        conv_param_param->set_axis(1);
-        conv_param_param->add_kernel_size(1);
-        caffe::FillerParameter*filler_param = conv_param_param->mutable_weight_filler();
-        filler_param->set_std(0.5);
-        filler_param->set_type("gaussian");
-        caffe::LayerParameter *probt_param = find_layer_by_name(deploy_net_param, "probt");
-        *probt_param->mutable_type() = "Sigmoid";
-      }
-    else
-      {
-        caffe::LayerParameter *probt_param = find_layer_by_name(deploy_net_param, "probt");
-        *probt_param->mutable_type() = "Softmax";
-      }
+	probt_param = find_layer_by_name(deploy_net_param, "probt");
+	*probt_param->mutable_type() = "Softmax";
   }
 
   template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
@@ -3971,7 +3906,8 @@ void CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::update
 
 
         if (diceParams.has("contour"))
-          {
+		  {
+
             APIData contourdata = diceParams.getobj("contour");
 
             if (contourdata.has("shape"))
@@ -4010,18 +3946,16 @@ void CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::update
                     this->_logger->warn("dice contour amplitude unrecognized, float expected");
                   }
               }
+			this->_logger->warn("dice contour is not working (2020 - 05 - 19) disabling it");
+			contours = caffe::DiceCoefLossParameter::NO;
+
           }
       }
 
 
-    if (_nclasses <= 2)
-      dclp->set_generalization(caffe::DiceCoefLossParameter::NONE);
-    else
-      {
-        dclp->set_generalization(genMode);
-        if (genMode != caffe::DiceCoefLossParameter::MULTICLASS)
-          dclp->set_weight_mode(weightMode);
-      }
+	dclp->set_generalization(genMode);
+	if (genMode != caffe::DiceCoefLossParameter::MULTICLASS)
+		dclp->set_weight_mode(weightMode);
 
     dclp->set_contour_shape(contours);
     if (contours != caffe::DiceCoefLossParameter::NO)
@@ -4049,49 +3983,17 @@ void CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::update
     mvn_param->add_bottom(logits);
     mvn_param->add_top(logits_norm);
 
+	caffe::LayerParameter* softmax_param = insert_layer_before(net_param, softml_pos++);
+	softmax_param->set_name("probabilizer_multi");
+	softmax_param->set_type("Softmax");
+	softmax_param->add_bottom(logits_norm);
+	softmax_param->add_top(loss_input);
+	softmax_param->add_include();
+	caffe::NetStateRule *nsr = softmax_param->mutable_include(0);
+	nsr->set_phase(caffe::TRAIN);
 
-    if (_nclasses <= 2)
-      {
-        caffe::LayerParameter* conv_param = insert_layer_before(net_param, softml_pos++);
-        *conv_param->mutable_name() = "linear_aggregation";
-        *conv_param->mutable_type() = "Convolution";
-        conv_param->add_bottom(logits_norm);
-        conv_param->add_top(agg_output);
-        caffe::ConvolutionParameter* conv_param_param = conv_param->mutable_convolution_param();
-        conv_param_param->set_num_output(1);
-        conv_param_param->set_axis(1);
-        conv_param_param->add_kernel_size(1);
-        caffe::FillerParameter* filler_param = conv_param_param->mutable_weight_filler();
-        filler_param->set_std(0.5);
-        filler_param->set_type("gaussian");
-
-        caffe::LayerParameter* sigmoid_loss_param = insert_layer_before(net_param, softml_pos++);
-        sigmoid_loss_param->set_name("probabilizer");
-        sigmoid_loss_param->set_type("Sigmoid");
-        sigmoid_loss_param->add_bottom(agg_output);
-        sigmoid_loss_param->add_top(loss_input);
-        sigmoid_loss_param->add_include();
-        caffe::NetStateRule *nsr = sigmoid_loss_param->mutable_include(0);
-        nsr->set_phase(caffe::TRAIN);
-
-        caffe::LayerParameter* probt_param = find_layer_by_name(net_param, "probt");
-        *probt_param->mutable_type() = "Sigmoid";
-        *probt_param->mutable_bottom(0) = agg_output;
-      }
-    else
-      {
-        caffe::LayerParameter* softmax_param = insert_layer_before(net_param, softml_pos++);
-        softmax_param->set_name("probabilizer_multi");
-        softmax_param->set_type("Softmax");
-        softmax_param->add_bottom(logits_norm);
-        softmax_param->add_top(loss_input);
-        softmax_param->add_include();
-        caffe::NetStateRule *nsr = softmax_param->mutable_include(0);
-        nsr->set_phase(caffe::TRAIN);
-
-        caffe::LayerParameter* probt_param = find_layer_by_name(net_param, "probt");
-        *probt_param->mutable_bottom(0) = logits_norm;
-      }
+	caffe::LayerParameter* probt_param = find_layer_by_name(net_param, "probt");
+	*probt_param->mutable_bottom(0) = logits_norm;
 
     caffe::LayerParameter *lossparam = net_param.mutable_layer(softml_pos);
     lossparam->clear_softmax_param();
@@ -4111,30 +4013,9 @@ void CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::update
     mvn_param->add_bottom(logits);
     mvn_param->add_top(logits_norm);
 
-    if (_nclasses <= 2)
-      {
-        caffe::LayerParameter* conv_param = insert_layer_before(deploy_net_param, final_pred);
-        *conv_param->mutable_name() = "linear_aggregation";
-        *conv_param->mutable_type() = "Convolution";
-        conv_param->add_bottom(logits_norm);
-        conv_param->add_top(agg_output);
-        caffe::ConvolutionParameter*conv_param_param = conv_param->mutable_convolution_param();
-        conv_param_param->set_num_output(1);
-        conv_param_param->set_axis(1);
-        conv_param_param->add_kernel_size(1);
-        caffe::FillerParameter*filler_param = conv_param_param->mutable_weight_filler();
-        filler_param->set_std(0.5);
-        filler_param->set_type("gaussian");
+	probt_param = find_layer_by_name(deploy_net_param, "pred");
+	*probt_param->mutable_bottom(0) = logits_norm;
 
-        caffe::LayerParameter* probt_param = find_layer_by_name(deploy_net_param, "pred");
-        *probt_param->mutable_type() = "Sigmoid";
-        *probt_param->mutable_bottom(0) = agg_output;
-      }
-    else
-      {
-        caffe::LayerParameter* probt_param = find_layer_by_name(deploy_net_param, "pred");
-        *probt_param->mutable_bottom(0) = logits_norm;
-      }
   }
 
 

--- a/tests/ut-caffe-mlp.cc
+++ b/tests/ut-caffe-mlp.cc
@@ -616,11 +616,12 @@ TEST(caffelib, configure_deeplabvgg16_diceloss)
   dice_class_weighting.add("compute_on",std::string("batch"));
   dice_class_weighting.add("weight",std::string("equalize_classes"));
   dice_param.add("class_weighting",dice_class_weighting);
-  APIData dice_contour;
-  dice_contour.add("shape",std::string("simple"));
-  dice_contour.add("size",3);
-  dice_contour.add("amplitude",20.5);
-  dice_param.add("contour",dice_contour);
+  // contour should not been used until fixed
+  // APIData dice_contour;
+  // dice_contour.add("shape",std::string("simple"));
+  // dice_contour.add("size",3);
+  // dice_contour.add("amplitude",20.5);
+  // dice_param.add("contour",dice_contour);
   ad.add("dice_param",dice_param);
   ad.add("ignore_label",0);
   ad.add("templates",std::string("../templates/caffe"));
@@ -653,10 +654,13 @@ TEST(caffelib, configure_deeplabvgg16_diceloss)
   ASSERT_TRUE(found);
 
   const caffe::DiceCoefLossParameter &clp = lparam->dice_coef_loss_param();
-  ASSERT_TRUE(clp.generalization() == caffe::DiceCoefLossParameter::NONE);
-  ASSERT_TRUE(clp.contour_shape() == caffe::DiceCoefLossParameter::SIMPLE);
-  ASSERT_TRUE(clp.contour_size() == 3);
-  ASSERT_TRUE(clp.contour_amplitude() == 20.5);
+  ASSERT_TRUE(clp.generalization() == caffe::DiceCoefLossParameter::MULTICLASS_WEIGHTED_BATCH);
+
+  //ASSERT_TRUE(clp.contour_shape() == caffe::DiceCoefLossParameter::SIMPLE);
+  // since 2020 05 20, contour is forced to no, because of an unfound bug
+  ASSERT_TRUE(clp.contour_shape() == caffe::DiceCoefLossParameter::NO);
+  //ASSERT_TRUE(clp.contour_size() == 3);
+  //ASSERT_TRUE(clp.contour_amplitude() == 20.5);
 
 
   remove("./deeplab_vgg16.prototxt");


### PR DESCRIPTION
- caffe dice connexion with prototxt was still done as in an old version of dice layer, fix is to use general case (ie >2 classes)
- dice contour weighting has a bug (normalization ??) disabling it for now