### PR TITLE
Update all Docker images to Ubuntu 18.04

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,5 @@
-cpu.Dockerfile
-gpu.Dockerfile
-cpu-armv7.Dockerfile
+docker/cpu.Dockerfile
+docker/cpu-armv7.Dockerfile
+docker/gpu.Dockerfile
+docker/gpu-xenial.Dockerfile
+build/

--- a/docker/README.md
+++ b/docker/README.md
@@ -117,9 +117,11 @@ where `path/to/volume` is the path to your local volume that you'd like to attac
 Dockerfiles are stored in the "docker" folder, but **you must launch build from root directory**.
 
 We choose to prefix Dockerfiles with target architecture :
-* cpu-armv7.Dockerfile
+
 * cpu.Dockerfile
+* cpu-armv7.Dockerfile
 * gpu.Dockerfile
+* gpu-xenial.Dockerfile
 
 ### Build script 
 
@@ -139,7 +141,7 @@ Expected values :
   * tf-cpu
   * caffe-cpu-tf
   * caffe-tf
-  * caffe2
+  * caffe2 (Only with gpu-xenial.Dockerfile)
   * p100
   * volta
   * volta-faiss

--- a/docker/cpu-arm.Dockerfile
+++ b/docker/cpu-arm.Dockerfile
@@ -1,18 +1,28 @@
-FROM armv7/armhf-ubuntu:16.04 AS build
+# Default ARM version
+ARG ARM_VERSION=arm32v7
+
+FROM ${ARM_VERSION}/ubuntu:18.04 AS build
 
 ARG DEEPDETECT_ARCH=cpu
 ARG DEEPDETECT_BUILD=armv7
 
-RUN apt-get update && \
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update && \
     apt-get install -y git \
     build-essential \
+    cmake \
     libgoogle-glog-dev \
     libgflags-dev \
     libeigen3-dev \
     libopencv-dev \
-    libcppnetlib-dev \
     libboost-dev \
+    libboost-filesystem-dev \
+    libboost-thread-dev \
+    libboost-system-dev \
     libboost-iostreams-dev \
+    libboost-program-options-dev \
+    libboost-test-dev \
+    libssl-dev \
     libcurl4-openssl-dev \
     protobuf-compiler \
     libopenblas-dev \
@@ -33,15 +43,15 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# Need cmake > 3.10 : https://github.com/jolibrain/ncnn/blob/master/CMakeLists.txt#L14
-RUN mkdir /tmp/cmake && cd /tmp/cmake && \
-    apt remove cmake && \
-    wget https://cmake.org/files/v3.10/cmake-3.10.3.tar.gz && \
-    tar xf cmake-3.10.3.tar.gz && \
-    cd cmake-3.10.3 && \
-    ./configure && \
-    make install && \
-    rm -rf /tmp/cmake
+# Build cpp-netlib
+RUN wget https://github.com/cpp-netlib/cpp-netlib/archive/cpp-netlib-0.11.2-final.tar.gz && \
+    tar xvzf cpp-netlib-0.11.2-final.tar.gz && \
+    cd cpp-netlib-cpp-netlib-0.11.2-final && \
+    mkdir build && \
+    cd build && \
+    cmake .. && \
+    make && \
+    make install
 
 WORKDIR /opt
 RUN git clone https://github.com/jpbarrette/curlpp.git
@@ -64,7 +74,7 @@ RUN mkdir build && \
 RUN ./docker/get_libs.sh
 
 # Build final Docker image
-FROM armv7/armhf-ubuntu:16.04
+FROM ${ARM_VERSION}/ubuntu:18.04
 
 # Copy Deepdetect binaries from previous step
 COPY --from=build /opt/deepdetect/build/main /opt/deepdetect/build/main
@@ -78,18 +88,18 @@ RUN apt-get update && \
 	libopenblas-base \
 	liblmdb0 \
 	libleveldb1v5 \
-	libboost-regex1.58.0 \
+    libboost-regex1.62.0 \
 	libgoogle-glog0v5 \
-	libopencv-highgui2.4v5 \
-	libcppnetlib0 \
-	libgflags2v5 \
-	libcurl3 \
-	libhdf5-cpp-11 \
-	libboost-filesystem1.58.0 \
-	libboost-thread1.58.0 \
-	libboost-iostreams1.58.0 \
+	libopencv-highgui3.2 \
+	libgflags2.2 \
+	libcurl4 \
+	libhdf5-cpp-100 \
+	libboost-filesystem1.65.1 \
+	libboost-thread1.65.1 \
+	libboost-iostreams1.65.1 \
+    libboost-regex1.65.1 \
 	libarchive13 \
-	libprotobuf9v5 && \
+	libprotobuf10 && \
     rm -rf /var/lib/apt/lists/*
 
 # Fix permissions

--- a/docker/gpu-xenial.Dockerfile
+++ b/docker/gpu-xenial.Dockerfile
@@ -1,18 +1,18 @@
 # Default CUDA version
-ARG CUDA_VERSION=10.2-cudnn7
+ARG CUDA_VERSION=9.0-cudnn7
 
 # Download default Deepdetect models
 ARG DEEPDETECT_DEFAULT_MODELS=true
 
-FROM nvidia/cuda:${CUDA_VERSION}-devel-ubuntu18.04 AS build
+FROM nvidia/cuda:${CUDA_VERSION}-devel-ubuntu16.04 AS build
 
 ARG DEEPDETECT_ARCH=gpu
 ARG DEEPDETECT_BUILD=default
 
 # Install build dependencies
-RUN export DEBIAN_FRONTEND=noninteractive && \
-    apt-get update && \
+RUN apt-get update && \
     apt-get install -y git \
+    cmake \
     automake \
     build-essential \
     openjdk-8-jdk \
@@ -24,14 +24,9 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     libgflags-dev \
     libeigen3-dev \
     libopencv-dev \
+    libcppnetlib-dev \
     libboost-dev \
-    libboost-filesystem-dev \
-    libboost-thread-dev \
-    libboost-system-dev \
     libboost-iostreams-dev \
-    libboost-program-options-dev \
-    libboost-test-dev \
-    libssl-dev \
     libcurlpp-dev \
     libcurl4-openssl-dev \
     protobuf-compiler \
@@ -54,8 +49,6 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     python-dev \
     python-wheel \
     python-pip \
-    python-six \
-    python-enum34 \
     unzip \
     libgoogle-perftools-dev \
     curl \
@@ -68,34 +61,13 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# Need recent cmake version for cuda 10
-RUN mkdir /tmp/cmake && cd /tmp/cmake && \
-    apt remove cmake && \
-    wget https://cmake.org/files/v3.14/cmake-3.14.0.tar.gz && \
-    tar xf cmake-3.14.0.tar.gz && \
-    cd cmake-3.14.0 && \
-    ./configure && \
-    make install && \
-    rm -rf /tmp/cmake
-
-# Build cpp-netlib
-RUN wget https://github.com/cpp-netlib/cpp-netlib/archive/cpp-netlib-0.11.2-final.tar.gz && \
-    tar xvzf cpp-netlib-0.11.2-final.tar.gz && \
-    cd cpp-netlib-cpp-netlib-0.11.2-final && \
-    mkdir build && \
-    cd build && \
-    cmake .. && \
-    make && \
-    make install
-
 # Fix "ImportError: No module named builtins"
-RUN pip install future pyyaml typing
+RUN pip install future pyyaml typing six enum enum34
 
 # Git config
 RUN git config --global user.email "build@local.local" && \
     git config --global user.name "Build"
 
-# Build curlpp
 WORKDIR /opt
 RUN git clone https://github.com/jpbarrette/curlpp.git
 WORKDIR /opt/curlpp
@@ -117,7 +89,7 @@ RUN mkdir build && \
 RUN ./docker/get_libs.sh
 
 # Build final Docker image
-FROM nvidia/cuda:${CUDA_VERSION}-runtime-ubuntu18.04
+FROM nvidia/cuda:${CUDA_VERSION}-runtime-ubuntu16.04
 
 # Download default Deepdetect models
 ARG DEEPDETECT_DEFAULT_MODELS=true
@@ -132,21 +104,21 @@ LABEL description="DeepDetect deep learning server & API / GPU version"
 # Install tools and dependencies
 RUN apt-get update && \ 
     apt-get install -y wget \
-	libopenblas-base \
-	liblmdb0 \
-	libleveldb1v5 \
-    libboost-regex1.62.0 \
-	libgoogle-glog0v5 \
-	libopencv-highgui3.2 \
-	libgflags2.2 \
-	libcurl4 \
-	libhdf5-cpp-100 \
-	libboost-filesystem1.65.1 \
-	libboost-thread1.65.1 \
-	libboost-iostreams1.65.1 \
-    libboost-regex1.65.1 \
-	libarchive13 \
-	libprotobuf10 && \
+    libopenblas-base \
+    liblmdb0 \
+    libleveldb1v5 \
+    libboost-regex1.58.0 \
+    libgoogle-glog0v5 \
+    libopencv-highgui2.4v5 \
+    libcppnetlib0 \
+    libgflags2v5 \
+    libcurl3 \
+    libhdf5-cpp-11 \
+    libboost-filesystem1.58.0 \
+    libboost-thread1.58.0 \
+    libboost-iostreams1.58.0 \
+    libarchive13 \
+    libprotobuf9v5 && \
     rm -rf /var/lib/apt/lists/*
 
 # Fix permissions


### PR DESCRIPTION
This PR update Docker base image from Ubuntu 16.04 LTS to  **Ubuntu 18.04 LTS**.

**Notes :**

* ARM : Base image [armhf/ubuntu](https://hub.docker.com/r/armhf/ubuntu) is deprected. We switch on [arm32v7/ubuntu](https://hub.docker.com/r/arm32v7/ubuntu/).
* CUDA : Cuda 9.0 is not available with Ubuntu 18.04 base image. We update CUDA from version 9.0 to **10.2** per default. 
* Caffe2 cannot build with Ubuntu 18.04 Docker base image. Dockerfile `gpu-xenial.Dockerfile` is a fallback solution.