### PR TITLE
[FIX] segfault in case of predict with svmCaffeInputConn and db:true

### DIFF
--- a/src/backends/caffe/caffeinputconns.cc
+++ b/src/backends/caffe/caffeinputconns.cc
@@ -2202,7 +2202,7 @@ namespace dd
 						const std::unordered_map<int,double> &vals,
 						const int &count)
   {
-    if (!_db)
+    if (!_db || !_train)
       {
 	SVMInputFileConn::add_train_svmline(label,vals,count);
 	return;

--- a/src/backends/caffe/caffeinputconns.h
+++ b/src/backends/caffe/caffeinputconns.h
@@ -1456,7 +1456,7 @@ namespace dd
     std::vector<caffe::SparseDatum> get_dv_test_sparse_db(const int &num);
     std::vector<caffe::SparseDatum> get_dv_test_sparse(const int &num)
       {
-	if (!_db)
+	if (!_db || !_train)
 	  {
 	    int i = 0;
 	    std::vector<caffe::SparseDatum> dv;


### PR DESCRIPTION
this PR fixes this segfault :
do not honor db flag in case of predict for svm caffe input connector