### PR TITLE
[FIX] reversed precision and recall in case of classification + output all (per class) precision,recall,f1 if asked for

### DIFF
--- a/src/backends/caffe/caffelib.cc
+++ b/src/backends/caffe/caffelib.cc
@@ -1546,14 +1546,18 @@ namespace dd
 	    
 	    for (auto m: meas_str)
 	      {
-		if (m != "cmdiag" && m != "cmfull" && m != "clacc" && m != "labels" && m!= "cliou") // do not report confusion matrix in server logs
+
+			if (m != "cmdiag" && m != "cmfull" && m != "clacc" && m != "labels" && m!= "cliou"
+				&& m != "precisions" && m != "recalls" && m != "f1s")
+			  // do not report confusion matrix in server logs
 		  {
 		    double mval = meas_obj.get(m).get<double>();
 		    this->_logger->info("{}={}",m,mval);
 		    this->add_meas(m,mval);
 		    this->add_meas_per_iter(m,mval);
 		  }
-		else if (m == "cmdiag" || m == "clacc" || m == "cliou")
+		else if (m == "cmdiag" || m == "clacc" || m == "cliou"
+				 || m == "precisions" || m == "recalls" || m == "f1s")
 		  {
 		    std::vector<double> mdiag = meas_obj.get(m).get<std::vector<double>>();
 		    std::vector<std::string> cnames;


### PR DESCRIPTION
fix reversed precision and recall in test outputs

also output every precision, recall and f1 if `measure=[..., "f1full"]`

global f1 computation has slightly changed : 
it is now the mean of per class f1, while before it was f1 score computed on mean recalls and precisions
(ie the mean and f1  operators have switched) 