### PR TITLE
feat: format the code with clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,135 @@
+---
+Language:        Cpp
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: false
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Right
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: MultiLine
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  true
+  AfterClass:      true
+  AfterControlStatement: true
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterNamespace:  true
+  AfterObjCDeclaration: true
+  AfterStruct:     true
+  AfterUnion:      true
+  AfterExternBlock: true
+  BeforeCatch:     true
+  BeforeElse:      true
+  IndentBraces:    true
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: All
+BreakBeforeBraces: GNU
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     79
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: false
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: false
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+    SortPriority:    0
+  - Regex:           '.*'
+    Priority:        1
+    SortPriority:    0
+IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentCaseLabels: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: All
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Right
+ReflowComments:  true
+SortIncludes:    false
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+Standard:        c++11
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseCRLF:         false
+UseTab:          Never
+...

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1011,6 +1011,34 @@ if (BUILD_TOOLS)
   add_subdirectory(tools)
 endif()
 
+# Get all project files
+file(GLOB_RECURSE ALL_SOURCE_FILES src/*.cpp src/*.hpp src/*.h src/*.c tests/*.cc src/*.cc)
+list(FILTER ALL_SOURCE_FILES EXCLUDE REGEX "^${CMAKE_SOURCE_DIR}/src/ext/.*$")
+
+add_custom_target(
+        clang-format
+        COMMAND clang-format
+        -style=file
+        -i
+        ${ALL_SOURCE_FILES}
+)
+add_custom_target(
+        clang-format-check
+        COMMAND clang-format
+        --dry-run
+        --Werror
+        --ferror-limit=10
+        -style=file
+        -i
+        ${ALL_SOURCE_FILES}
+)
+
+option(INSTALL_GIT_HOOKS "install client side git hook" ON)
+if (INSTALL_GIT_HOOKS)
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/tools/git-pre-commit-hook
+                   ${CMAKE_CURRENT_SOURCE_DIR}/.git/hooks/pre-commit @ONLY)
+endif()
+
 # status
 message(STATUS "Build Tests          : ${BUILD_TESTS}")
 message(STATUS "Caffe DEBUG          : ${USE_CAFFE_DEBUG}")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,6 +8,7 @@ export PATH="/usr/lib/ccache/:$PATH"
 mkdir -p build
 cd build
 cmake .. -DBUILD_TESTS=ON -DUSE_CUDNN=ON -DUSE_SIMSEARCH=ON -DUSE_TSNE=ON -DUSE_XGBOOST=ON -DUSE_TORCH=ON -DUSE_NCNN=ON -DUSE_TENSORRT=ON -DCUDA_ARCH="-gencode arch=compute_61,code=sm_61"
+make clang-format-check
 make -j24
 ccache -s
 '''

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ http://www.deepdetect.com/overview/examples/
 |                          | Caffe | Tensorflow | Source        | Top-1 Accuracy (ImageNet) |
 |--------------------------|-------|------------|---------------|---------------------------|
 | AlexNet                  | Y     | N          | BVLC          |          57.1%                 |
-| SqueezeNet               | [Y](https://deepdetect.com/models/squeezenet/squeezenet_v1.1.caffemodel)     | N          | DeepScale              |       59.5%                    | 
+| SqueezeNet               | [Y](https://deepdetect.com/models/squeezenet/squeezenet_v1.1.caffemodel)     | N          | DeepScale              |       59.5%                    |
 | Inception v1 / GoogleNet | [Y](https://deepdetect.com/models/ggnet/bvlc_googlenet.caffemodel)     | [Y](https://deepdetect.com/models/tf/inception_v1.pb)          | BVLC / Google |             67.9%              |
 | Inception v2             | N     | [Y](https://deepdetect.com/models/tf/inception_v2.pb)          | Google        |     72.2%                      |
 | Inception v3             | N     | [Y](https://deepdetect.com/models/tf/inception_v3.pb)          | Google        |         76.9%                  |
@@ -263,7 +263,7 @@ Beware of dependencies, typically on Debian/Ubuntu Linux, do:
 sudo apt-get install build-essential libgoogle-glog-dev libgflags-dev libeigen3-dev libopencv-dev libcppnetlib-dev libboost-dev libboost-iostreams-dev libcurlpp-dev libcurl4-openssl-dev protobuf-compiler libopenblas-dev libhdf5-dev libprotobuf-dev libleveldb-dev libsnappy-dev liblmdb-dev libutfcpp-dev cmake libgoogle-perftools-dev unzip python-setuptools python-dev libspdlog-dev python-six python-enum34 libarchive-dev
 ```
 
-#### Choosing interfaces : 
+#### Choosing interfaces :
 
 DeepDetect can be used:
 - directly from command line for caffe models. To build the executable use:
@@ -274,7 +274,7 @@ cmake .. -DUSE_COMMAND_LINE=ON
 ```
 cmake .. -DUSE_COMMAND_LINE=ON -DUSE_JSON_API=ON
 ```
-- as a REST server (using JSON API). To build the server executable use (`USE_JSON_API` is auto-selected): 
+- as a REST server (using JSON API). To build the server executable use (`USE_JSON_API` is auto-selected):
 ```
 cmake .. -DUSE_HTTP_SERVER=ON
 ```
@@ -383,7 +383,7 @@ Specify the following option via cmake:
 ```$xslt
 cmake .. -DUSE_TENSORRT=ON
 ```
-TensorRT requires GPU and CUDNN, they are automatically switched on. 
+TensorRT requires GPU and CUDNN, they are automatically switched on.
 
 #### Build with TensorRT support + TRT oss parts
 Specify the following option via cmake:
@@ -442,6 +442,19 @@ Run tests with:
 ctest
 ```
 
+### Code Style Rules
+
+`clang-format` is used to enforce code style.
+
+You can automatically format it with:
+
+```
+cmake ..
+make clang-format
+```
+
+Or use your favorite editor with a clang-format plugin.
+
 ### Start the server
 
 ```
@@ -481,7 +494,7 @@ where `sname` is the service name and the JSON is a string without external quot
 - service prediction
 ```
 service_predict;JSON string
-``` 
+```
 
 ### Pure command line JSON API
 
@@ -502,7 +515,7 @@ where `<other options>` stands for the command line parameters from the command 
 -service_train (/train POST call JSON string) type: string default: ""
 -service_train_delete (/train DELETE call JSON string) type: string default: ""
 -service_train_status (/train GET call JSON string) type: string default: ""
-							  
+
 ```
 
 The options above can be obtained from running

--- a/src/apidata.cc
+++ b/src/apidata.cc
@@ -29,7 +29,7 @@ namespace dd
     (void)str;
     return vout();
   }
-  
+
   vout visitor_vad::operator()(const double &d)
   {
     (void)d;
@@ -53,7 +53,7 @@ namespace dd
     (void)i;
     return vout();
   }
-  
+
   vout visitor_vad::operator()(const bool &b)
   {
     (void)b;
@@ -64,19 +64,19 @@ namespace dd
   {
     return vout(ad);
   }
-  
+
   vout visitor_vad::operator()(const std::vector<double> &vd)
   {
     (void)vd;
     return vout();
   }
-  
+
   vout visitor_vad::operator()(const std::vector<int> &vd)
   {
     (void)vd;
     return vout();
   }
-  
+
   vout visitor_vad::operator()(const std::vector<bool> &vd)
   {
     (void)vd;
@@ -95,17 +95,17 @@ namespace dd
     return vout();
   }
 
-  vout visitor_vad::operator()(const std::vector<std::pair<int,int>> &vpi)
+  vout visitor_vad::operator()(const std::vector<std::pair<int, int>> &vpi)
   {
     (void)vpi;
     return vout();
   }
-  
+
   vout visitor_vad::operator()(const std::vector<APIData> &vad)
   {
     return vout(vad);
   }
-  
+
   /*- APIData -*/
   APIData::APIData(const JVal &jval)
   {
@@ -114,89 +114,92 @@ namespace dd
 
   void APIData::fromJVal(const JVal &jval)
   {
-    for (rapidjson::Value::ConstMemberIterator cit=jval.MemberBegin();cit!=jval.MemberEnd();++cit)
+    for (rapidjson::Value::ConstMemberIterator cit = jval.MemberBegin();
+         cit != jval.MemberEnd(); ++cit)
       {
-	if (cit->value.IsNull())
-	  {
-	  }
-	else if (cit->value.IsBool())
-	  {
-	    add(cit->name.GetString(),cit->value.GetBool());
-	  }
-	else if (cit->value.IsObject())
-	  {
-	    APIData ad(jval[cit->name.GetString()]);
-	    std::vector<APIData> vad = { ad };
-	    add(cit->name.GetString(),vad);
-	  }
-	else if (cit->value.IsArray()) // only supports array that bears a single type, number, string or object
-	  {
-	    const JVal &jarr = jval[cit->name.GetString()];
-	    if (jarr.Size() != 0)
-	      {
-		if (jarr[0].IsDouble())
-		  {
-		    std::vector<double> vd;
-		    for (rapidjson::SizeType i=0;i<jarr.Size();i++)
-		      {
-			vd.push_back(jarr[i].GetDouble());
-		      }
-		    add(cit->name.GetString(),vd);
-		  }
-		else if (jarr[0].IsInt())
-		  {
-		    std::vector<int> vd;
-		    for (rapidjson::SizeType i=0;i<jarr.Size();i++)
-		      {
-			vd.push_back(jarr[i].GetInt());
-		      }
-		    add(cit->name.GetString(),vd);
-		  }
-		else if (jarr[0].IsBool())
-		  {
-		    std::vector<bool> vd;
-		    for (rapidjson::SizeType i=0;i<jarr.Size();i++)
-		      {
-			vd.push_back(jarr[i].GetBool());
-		      }
-		    add(cit->name.GetString(),vd);
-		  }
-		else if (jarr[0].IsString())
-		  {
-		    std::vector<std::string> vs;
-		    for (rapidjson::SizeType i=0;i<jarr.Size();i++)
-		      vs.push_back(jarr[i].GetString());
-		    add(cit->name.GetString(),vs);
-		  }
-		else if (jarr[0].IsObject())
-		  {
-		    std::vector<APIData> vad;
-		    for (rapidjson::SizeType i=0;i<jarr.Size();i++)
-		      {
-			APIData nad;
-			nad.fromJVal(jarr[i]);
-			vad.push_back(nad);
-		      }
-		    add(cit->name.GetString(),vad);
-		  }
-		else
-		  {
-		    throw DataConversionException("conversion error: unknown type of array");
-		  }
-	      }
-	  }
-	else if (cit->value.IsString())
-	  {
-	    add(cit->name.GetString(),std::string(cit->value.GetString()));
-	  }
-	else if (cit->value.IsDouble())
-	  {
-	    add(cit->name.GetString(),cit->value.GetDouble());
-	  }
-	else if (cit->value.IsInt())
-	  {
-	    add(cit->name.GetString(),cit->value.GetInt());
-	  }
+        if (cit->value.IsNull())
+          {
+          }
+        else if (cit->value.IsBool())
+          {
+            add(cit->name.GetString(), cit->value.GetBool());
+          }
+        else if (cit->value.IsObject())
+          {
+            APIData ad(jval[cit->name.GetString()]);
+            std::vector<APIData> vad = { ad };
+            add(cit->name.GetString(), vad);
+          }
+        else if (cit->value.IsArray()) // only supports array that bears a
+                                       // single type, number, string or object
+          {
+            const JVal &jarr = jval[cit->name.GetString()];
+            if (jarr.Size() != 0)
+              {
+                if (jarr[0].IsDouble())
+                  {
+                    std::vector<double> vd;
+                    for (rapidjson::SizeType i = 0; i < jarr.Size(); i++)
+                      {
+                        vd.push_back(jarr[i].GetDouble());
+                      }
+                    add(cit->name.GetString(), vd);
+                  }
+                else if (jarr[0].IsInt())
+                  {
+                    std::vector<int> vd;
+                    for (rapidjson::SizeType i = 0; i < jarr.Size(); i++)
+                      {
+                        vd.push_back(jarr[i].GetInt());
+                      }
+                    add(cit->name.GetString(), vd);
+                  }
+                else if (jarr[0].IsBool())
+                  {
+                    std::vector<bool> vd;
+                    for (rapidjson::SizeType i = 0; i < jarr.Size(); i++)
+                      {
+                        vd.push_back(jarr[i].GetBool());
+                      }
+                    add(cit->name.GetString(), vd);
+                  }
+                else if (jarr[0].IsString())
+                  {
+                    std::vector<std::string> vs;
+                    for (rapidjson::SizeType i = 0; i < jarr.Size(); i++)
+                      vs.push_back(jarr[i].GetString());
+                    add(cit->name.GetString(), vs);
+                  }
+                else if (jarr[0].IsObject())
+                  {
+                    std::vector<APIData> vad;
+                    for (rapidjson::SizeType i = 0; i < jarr.Size(); i++)
+                      {
+                        APIData nad;
+                        nad.fromJVal(jarr[i]);
+                        vad.push_back(nad);
+                      }
+                    add(cit->name.GetString(), vad);
+                  }
+                else
+                  {
+                    throw DataConversionException(
+                        "conversion error: unknown type of array");
+                  }
+              }
+          }
+        else if (cit->value.IsString())
+          {
+            add(cit->name.GetString(), std::string(cit->value.GetString()));
+          }
+        else if (cit->value.IsDouble())
+          {
+            add(cit->name.GetString(), cit->value.GetDouble());
+          }
+        else if (cit->value.IsInt())
+          {
+            add(cit->name.GetString(), cit->value.GetInt());
+          }
       }
   }
 
@@ -204,24 +207,24 @@ namespace dd
   {
     visitor_rjson vrj(&jd);
     auto hit = _data.begin();
-    while(hit!=_data.end())
+    while (hit != _data.end())
       {
-	vrj.set_key((*hit).first);
-	mapbox::util::apply_visitor(vrj,(*hit).second);
-	++hit;
+        vrj.set_key((*hit).first);
+        mapbox::util::apply_visitor(vrj, (*hit).second);
+        ++hit;
       }
   }
-  
+
   void APIData::toJVal(JDoc &jd, JVal &jv) const
   {
-    visitor_rjson vrj(&jd,&jv);
+    visitor_rjson vrj(&jd, &jv);
     auto hit = _data.begin();
-    while(hit!=_data.end())
+    while (hit != _data.end())
       {
-	vrj.set_key((*hit).first);
-	mapbox::util::apply_visitor(vrj,(*hit).second);
-	++hit;
+        vrj.set_key((*hit).first);
+        mapbox::util::apply_visitor(vrj, (*hit).second);
+        ++hit;
       }
   }
-  
+
 }

--- a/src/apidata.h
+++ b/src/apidata.h
@@ -38,12 +38,16 @@ namespace dd
 {
   class APIData;
 
-  // recursive variant container, see utils/variant.hpp and utils/recursive_wrapper.hpp
-  typedef mapbox::util::variant<std::string,double,int,long int,long long int,bool,
-    std::vector<std::string>,std::vector<double>,std::vector<int>,std::vector<bool>,
-    std::vector<cv::Mat>,std::vector<std::pair<int,int>>,
-    mapbox::util::recursive_wrapper<APIData>,
-    mapbox::util::recursive_wrapper<std::vector<APIData>>> ad_variant_type;
+  // recursive variant container, see utils/variant.hpp and
+  // utils/recursive_wrapper.hpp
+  typedef mapbox::util::variant<
+      std::string, double, int, long int, long long int, bool,
+      std::vector<std::string>, std::vector<double>, std::vector<int>,
+      std::vector<bool>, std::vector<cv::Mat>,
+      std::vector<std::pair<int, int>>,
+      mapbox::util::recursive_wrapper<APIData>,
+      mapbox::util::recursive_wrapper<std::vector<APIData>>>
+      ad_variant_type;
 
   /**
    * \brief data conversion exception
@@ -51,24 +55,40 @@ namespace dd
   class DataConversionException : public std::exception
   {
   public:
-    DataConversionException(const std::string &s)
-      :_s(s) {}
-    ~DataConversionException() {}
-    const char *what() const noexcept { return _s.c_str(); }
+    DataConversionException(const std::string &s) : _s(s)
+    {
+    }
+    ~DataConversionException()
+    {
+    }
+    const char *what() const noexcept
+    {
+      return _s.c_str();
+    }
+
   private:
     std::string _s;
   };
-  
+
   /**
    * \brief object for visitor output
    */
   class vout
   {
   public:
-    vout() {}
-    vout(const APIData &ad) { _vad.push_back(ad); }
-    vout(const std::vector<APIData> &vad):_vad(vad) {}
-    ~vout() {}
+    vout()
+    {
+    }
+    vout(const APIData &ad)
+    {
+      _vad.push_back(ad);
+    }
+    vout(const std::vector<APIData> &vad) : _vad(vad)
+    {
+    }
+    ~vout()
+    {
+    }
     std::vector<APIData> _vad;
   };
 
@@ -78,9 +98,11 @@ namespace dd
   class visitor_vad
   {
   public:
-    visitor_vad() {}
-    ~visitor_vad() {};
-    
+    visitor_vad()
+    {
+    }
+    ~visitor_vad(){};
+
     vout operator()(const std::string &str);
     vout operator()(const double &d);
     vout operator()(const int &i);
@@ -92,15 +114,15 @@ namespace dd
     vout operator()(const std::vector<bool> &vd);
     vout operator()(const std::vector<std::string> &vs);
     vout operator()(const std::vector<cv::Mat> &vcv);
-    vout operator()(const std::vector<std::pair<int,int>> &vpi);
+    vout operator()(const std::vector<std::pair<int, int>> &vpi);
     vout operator()(const APIData &ad);
     vout operator()(const std::vector<APIData> &vad);
-    
+
     /*template<typename T>
       vout operator() (const T &t)
       {
-	return process(t);
-	}*/
+        return process(t);
+        }*/
   };
 
   /**
@@ -112,21 +134,25 @@ namespace dd
     /**
      * \brief empty constructor
      */
-    APIData() {}
-    
+    APIData()
+    {
+    }
+
     /**
      * \brief constructor from rapidjson JSON object, see dd_types.h
      */
     APIData(const JVal &jval);
 
-    APIData(const APIData &ad)
-      :_data(ad._data)
-    {}
-    
+    APIData(const APIData &ad) : _data(ad._data)
+    {
+    }
+
     /**
      * \brief destructor
      */
-    ~APIData() {}
+    ~APIData()
+    {
+    }
 
     /**
      * \brief add key / object to data object
@@ -136,9 +162,9 @@ namespace dd
     inline void add(const std::string &key, const ad_variant_type &val)
     {
       auto hit = _data.begin();
-      if ((hit=_data.find(key))!=_data.end())
-	_data.erase(hit);
-      _data.insert(std::pair<std::string,ad_variant_type>(key,val));
+      if ((hit = _data.find(key)) != _data.end())
+        _data.erase(hit);
+      _data.insert(std::pair<std::string, ad_variant_type>(key, val));
     }
 
     /**
@@ -148,25 +174,26 @@ namespace dd
     inline void erase(const std::string &key)
     {
       auto hit = _data.begin();
-      if ((hit=_data.find(key))!=_data.end())
-	_data.erase(hit);
+      if ((hit = _data.find(key)) != _data.end())
+        _data.erase(hit);
     }
-    
+
     /**
      * \brief get value from data object
-     *        at this stage, type of value is unknown and the typed object 
+     *        at this stage, type of value is unknown and the typed object
      *        must be later acquired with e.g. 'get<std::string>(val)
      * @param key string unique key
      * @return variant value
      */
     inline ad_variant_type get(const std::string &key) const
     {
-      std::unordered_map<std::string,ad_variant_type>::const_iterator hit;
-      if ((hit=_data.find(key))!=_data.end())
-	return (*hit).second;
-      else return std::string(); // beware
+      std::unordered_map<std::string, ad_variant_type>::const_iterator hit;
+      if ((hit = _data.find(key)) != _data.end())
+        return (*hit).second;
+      else
+        return std::string(); // beware
     }
-    
+
     /**
      * \brief get vector container as variant value
      * @param key string unique value
@@ -175,7 +202,7 @@ namespace dd
     inline std::vector<APIData> getv(const std::string &key) const
     {
       visitor_vad vv;
-      vout v = mapbox::util::apply_visitor(vv,get(key));
+      vout v = mapbox::util::apply_visitor(vv, get(key));
       return v._vad;
     }
 
@@ -187,9 +214,9 @@ namespace dd
     inline APIData getobj(const std::string &key) const
     {
       visitor_vad vv;
-      vout v = mapbox::util::apply_visitor(vv,get(key));
+      vout v = mapbox::util::apply_visitor(vv, get(key));
       if (v._vad.empty())
-	return APIData();
+        return APIData();
       return v._vad.at(0);
     }
 
@@ -199,13 +226,14 @@ namespace dd
      * @param key string unique key to look for
      * @return APIData as recursive variant value object
      */
-    static APIData findv(const std::vector<APIData> &vad, const std::string &key)
+    static APIData findv(const std::vector<APIData> &vad,
+                         const std::string &key)
     {
       for (const APIData &v : vad)
-	{
-	  if (v.has(key))
-	    return v;
-	}
+        {
+          if (v.has(key))
+            return v;
+        }
       return APIData();
     }
 
@@ -216,21 +244,22 @@ namespace dd
      */
     inline bool has(const std::string &key) const
     {
-      std::unordered_map<std::string,ad_variant_type>::const_iterator hit;
-      if ((hit=_data.find(key))!=_data.end())
-	return true;
-      else return false;
+      std::unordered_map<std::string, ad_variant_type>::const_iterator hit;
+      if ((hit = _data.find(key)) != _data.end())
+        return true;
+      else
+        return false;
     }
 
     std::vector<std::string> list_keys() const
-      {
-	std::vector<std::string> keys;
-	for (auto kv: _data)
-	  {
-	    keys.push_back(kv.first);
-	  }
-	return keys;
-      }
+    {
+      std::vector<std::string> keys;
+      for (auto kv : _data)
+        {
+          keys.push_back(kv.first);
+        }
+      return keys;
+    }
 
     /**
      * \brief number of hosted keys at this level of the object
@@ -260,7 +289,7 @@ namespace dd
      * @param jval destination JSON value
      */
     void toJVal(JDoc &jd, JVal &jv) const;
-    
+
   public:
     /**
      * \brief render Mustache template based on this APIData object
@@ -278,7 +307,7 @@ namespace dd
       d.Accept(writer);
       std::string reststring = buffer.GetString();
       std::cout << "to jdoc=" << reststring << std::endl;*/
-      
+
       mustache::RenderTemplate(tpl, "", d, &ss);
       return ss.str();
     }
@@ -287,8 +316,9 @@ namespace dd
     {
       return _data.empty();
     }
-    
-    std::unordered_map<std::string,ad_variant_type> _data; /**< data as hashtable of variant types. */
+
+    std::unordered_map<std::string, ad_variant_type>
+        _data; /**< data as hashtable of variant types. */
   };
 
   /**
@@ -296,119 +326,148 @@ namespace dd
    */
   class visitor_rjson
   {
-  public:    
-    visitor_rjson(JDoc *jd):_jd(jd) {}
-    visitor_rjson(JDoc *jd, JVal *jv):_jd(jd),_jv(jv) {}
-    visitor_rjson(const visitor_rjson &vrj):_jd(vrj._jd),_jv(vrj._jv)
-      { _jvkey.CopyFrom(vrj._jvkey,_jd->GetAllocator()); }
-    ~visitor_rjson() {}
+  public:
+    visitor_rjson(JDoc *jd) : _jd(jd)
+    {
+    }
+    visitor_rjson(JDoc *jd, JVal *jv) : _jd(jd), _jv(jv)
+    {
+    }
+    visitor_rjson(const visitor_rjson &vrj) : _jd(vrj._jd), _jv(vrj._jv)
+    {
+      _jvkey.CopyFrom(vrj._jvkey, _jd->GetAllocator());
+    }
+    ~visitor_rjson()
+    {
+    }
 
     void set_key(const std::string &key)
     {
-      _jvkey.SetString(key.c_str(),_jd->GetAllocator());
+      _jvkey.SetString(key.c_str(), _jd->GetAllocator());
     }
 
     void operator()(const std::string &str)
     {
       if (!_jv)
-	_jd->AddMember(_jvkey,JVal().SetString(str.c_str(),_jd->GetAllocator()),_jd->GetAllocator());
-      else _jv->AddMember(_jvkey,JVal().SetString(str.c_str(),_jd->GetAllocator()),_jd->GetAllocator());
+        _jd->AddMember(_jvkey,
+                       JVal().SetString(str.c_str(), _jd->GetAllocator()),
+                       _jd->GetAllocator());
+      else
+        _jv->AddMember(_jvkey,
+                       JVal().SetString(str.c_str(), _jd->GetAllocator()),
+                       _jd->GetAllocator());
     }
     void operator()(const int &i)
     {
       if (!_jv)
-	_jd->AddMember(_jvkey,JVal(i),_jd->GetAllocator());
-      else _jv->AddMember(_jvkey,JVal(i),_jd->GetAllocator());
+        _jd->AddMember(_jvkey, JVal(i), _jd->GetAllocator());
+      else
+        _jv->AddMember(_jvkey, JVal(i), _jd->GetAllocator());
     }
     void operator()(const long int &i)
     {
       if (!_jv)
-	_jd->AddMember(_jvkey,JVal(static_cast<uint64_t>(i)),_jd->GetAllocator());
-      else _jv->AddMember(_jvkey,JVal(static_cast<uint64_t>(i)),_jd->GetAllocator());
+        _jd->AddMember(_jvkey, JVal(static_cast<uint64_t>(i)),
+                       _jd->GetAllocator());
+      else
+        _jv->AddMember(_jvkey, JVal(static_cast<uint64_t>(i)),
+                       _jd->GetAllocator());
     }
     void operator()(const long long int &i)
     {
       if (!_jv)
-	_jd->AddMember(_jvkey,JVal(static_cast<uint64_t>(i)),_jd->GetAllocator());
-      else _jv->AddMember(_jvkey,JVal(static_cast<uint64_t>(i)),_jd->GetAllocator());
+        _jd->AddMember(_jvkey, JVal(static_cast<uint64_t>(i)),
+                       _jd->GetAllocator());
+      else
+        _jv->AddMember(_jvkey, JVal(static_cast<uint64_t>(i)),
+                       _jd->GetAllocator());
     }
     void operator()(const double &d)
     {
       if (!_jv)
-	_jd->AddMember(_jvkey,JVal(d),_jd->GetAllocator());
-      else _jv->AddMember(_jvkey,JVal(d),_jd->GetAllocator());
+        _jd->AddMember(_jvkey, JVal(d), _jd->GetAllocator());
+      else
+        _jv->AddMember(_jvkey, JVal(d), _jd->GetAllocator());
     }
     void operator()(const bool &b)
     {
       if (!_jv)
-	_jd->AddMember(_jvkey,JVal(b),_jd->GetAllocator());
-      else _jv->AddMember(_jvkey,JVal(b),_jd->GetAllocator());
+        _jd->AddMember(_jvkey, JVal(b), _jd->GetAllocator());
+      else
+        _jv->AddMember(_jvkey, JVal(b), _jd->GetAllocator());
     }
     void operator()(const APIData &ad)
     {
-      JVal jv(rapidjson::kObjectType); 
-      visitor_rjson vrj(_jd,&jv);
+      JVal jv(rapidjson::kObjectType);
+      visitor_rjson vrj(_jd, &jv);
       auto hit = ad._data.begin();
-      while(hit!=ad._data.end())
-	{
-	  vrj.set_key((*hit).first);
-	  mapbox::util::apply_visitor(vrj,(*hit).second);
-	  ++hit;
-	}
+      while (hit != ad._data.end())
+        {
+          vrj.set_key((*hit).first);
+          mapbox::util::apply_visitor(vrj, (*hit).second);
+          ++hit;
+        }
       if (!_jv)
-	_jd->AddMember(_jvkey,jv,_jd->GetAllocator());
-      else _jv->AddMember(_jvkey,jv,_jd->GetAllocator());
+        _jd->AddMember(_jvkey, jv, _jd->GetAllocator());
+      else
+        _jv->AddMember(_jvkey, jv, _jd->GetAllocator());
     }
     void operator()(const std::vector<double> &vd)
     {
       JVal jarr(rapidjson::kArrayType);
-      for (size_t i=0;i<vd.size();i++)
-	{
-	  jarr.PushBack(JVal(vd.at(i)),_jd->GetAllocator());
-	}
+      for (size_t i = 0; i < vd.size(); i++)
+        {
+          jarr.PushBack(JVal(vd.at(i)), _jd->GetAllocator());
+        }
       if (!_jv)
-	_jd->AddMember(_jvkey,jarr,_jd->GetAllocator());
-      else _jv->AddMember(_jvkey,jarr,_jd->GetAllocator());
+        _jd->AddMember(_jvkey, jarr, _jd->GetAllocator());
+      else
+        _jv->AddMember(_jvkey, jarr, _jd->GetAllocator());
     }
     void operator()(const std::vector<int> &vd)
     {
       JVal jarr(rapidjson::kArrayType);
-      for (size_t i=0;i<vd.size();i++)
-	{
-	  jarr.PushBack(JVal(vd.at(i)),_jd->GetAllocator());
-	}
+      for (size_t i = 0; i < vd.size(); i++)
+        {
+          jarr.PushBack(JVal(vd.at(i)), _jd->GetAllocator());
+        }
       if (!_jv)
-	_jd->AddMember(_jvkey,jarr,_jd->GetAllocator());
-      else _jv->AddMember(_jvkey,jarr,_jd->GetAllocator());
+        _jd->AddMember(_jvkey, jarr, _jd->GetAllocator());
+      else
+        _jv->AddMember(_jvkey, jarr, _jd->GetAllocator());
     }
     void operator()(const std::vector<bool> &vd)
     {
       JVal jarr(rapidjson::kArrayType);
-      for (size_t i=0;i<vd.size();i++)
-	{
-	  jarr.PushBack(JVal(vd.at(i)),_jd->GetAllocator());
-	}
+      for (size_t i = 0; i < vd.size(); i++)
+        {
+          jarr.PushBack(JVal(vd.at(i)), _jd->GetAllocator());
+        }
       if (!_jv)
-	_jd->AddMember(_jvkey,jarr,_jd->GetAllocator());
-      else _jv->AddMember(_jvkey,jarr,_jd->GetAllocator());
+        _jd->AddMember(_jvkey, jarr, _jd->GetAllocator());
+      else
+        _jv->AddMember(_jvkey, jarr, _jd->GetAllocator());
     }
     void operator()(const std::vector<std::string> &vs)
     {
       JVal jarr(rapidjson::kArrayType);
-      for (size_t i=0;i<vs.size();i++)
-	{
-	  jarr.PushBack(JVal().SetString(vs.at(i).c_str(),_jd->GetAllocator()),_jd->GetAllocator());
-	}
+      for (size_t i = 0; i < vs.size(); i++)
+        {
+          jarr.PushBack(
+              JVal().SetString(vs.at(i).c_str(), _jd->GetAllocator()),
+              _jd->GetAllocator());
+        }
       if (!_jv)
-	_jd->AddMember(_jvkey,jarr,_jd->GetAllocator());
-      else _jv->AddMember(_jvkey,jarr,_jd->GetAllocator());
+        _jd->AddMember(_jvkey, jarr, _jd->GetAllocator());
+      else
+        _jv->AddMember(_jvkey, jarr, _jd->GetAllocator());
     }
     void operator()(const std::vector<cv::Mat> &vcv)
     {
       (void)vcv;
       // Not Implemented
     }
-    void operator()(const std::vector<std::pair<int,int>> &vpi)
+    void operator()(const std::vector<std::pair<int, int>> &vpi)
     {
       (void)vpi;
       // Not Implemented
@@ -417,36 +476,37 @@ namespace dd
     {
       JVal jov(rapidjson::kObjectType);
       jov = JVal(rapidjson::kArrayType);
-      for (size_t i=0;i<vad.size();i++)
-	{
-	  JVal jv(rapidjson::kObjectType); 
-	  visitor_rjson vrj(_jd,&jv);
-	  APIData ad = vad.at(i);
-	  auto hit = ad._data.begin();
-	  while(hit!=ad._data.end())
-	    {
-	      vrj.set_key((*hit).first);
-	      mapbox::util::apply_visitor(vrj,(*hit).second);
-	      ++hit;
-	    }
-	  jov.PushBack(jv,_jd->GetAllocator());
-	}
+      for (size_t i = 0; i < vad.size(); i++)
+        {
+          JVal jv(rapidjson::kObjectType);
+          visitor_rjson vrj(_jd, &jv);
+          APIData ad = vad.at(i);
+          auto hit = ad._data.begin();
+          while (hit != ad._data.end())
+            {
+              vrj.set_key((*hit).first);
+              mapbox::util::apply_visitor(vrj, (*hit).second);
+              ++hit;
+            }
+          jov.PushBack(jv, _jd->GetAllocator());
+        }
       if (!_jv)
-	_jd->AddMember(_jvkey,jov,_jd->GetAllocator());
-      else _jv->AddMember(_jvkey,jov,_jd->GetAllocator());
+        _jd->AddMember(_jvkey, jov, _jd->GetAllocator());
+      else
+        _jv->AddMember(_jvkey, jov, _jd->GetAllocator());
     }
 
     /*template<typename T>
       void operator() (T &t)
       {
-	process(t);
-	}*/
+        process(t);
+        }*/
 
     JVal _jvkey;
     JDoc *_jd = nullptr;
     JVal *_jv = nullptr;
   };
-  
+
 }
 
 #endif

--- a/src/apistrategy.h
+++ b/src/apistrategy.h
@@ -39,27 +39,27 @@ namespace dd
    * \brief main API class, built on top of Services
    */
   class APIStrategy : public Services
+  {
+  public:
+    APIStrategy()
     {
-    public:
-      APIStrategy()
-	{
 #ifdef USE_DD_SYSLOG
-	  _logger = spdlog::syslog_logger("api");
+      _logger = spdlog::syslog_logger("api");
 #else
-	  _logger = spdlog::stdout_logger_mt("api");
+      _logger = spdlog::stdout_logger_mt("api");
 #endif
-	};
-      ~APIStrategy()
-	{
-	  spdlog::drop("api");
-	}
-      
-      /**
-       * \brief handling of command line parameters
-       */
-      int boot(int argc, char *argv[]);
-      std::shared_ptr<spdlog::logger> _logger; /**< api logger. */
     };
+    ~APIStrategy()
+    {
+      spdlog::drop("api");
+    }
+
+    /**
+     * \brief handling of command line parameters
+     */
+    int boot(int argc, char *argv[]);
+    std::shared_ptr<spdlog::logger> _logger; /**< api logger. */
+  };
 }
 
 #endif

--- a/src/backends/caffe/caffeinputconns.cc
+++ b/src/backends/caffe/caffeinputconns.cc
@@ -39,42 +39,44 @@ using namespace caffe;
 
 namespace dd
 {
-  
+
   void CaffeInputInterface::write_class_weights(const std::string &model_repo,
-						const APIData &ad_mllib)
+                                                const APIData &ad_mllib)
   {
     std::string cl_file = model_repo + "/class_weights.binaryproto";
     if (ad_mllib.has("class_weights"))
       {
-	std::vector<double> cw;
-	try
-	  {
-	    cw = ad_mllib.get("class_weights").get<std::vector<double>>();
-	  }
-	catch (std::exception &e)
-	  {
-	    // let's try array of int, that's a common mistake
-	    std::vector<int> cwi = ad_mllib.get("class_weights").get<std::vector<int>>();
-	    for (int v: cwi)
-	      cw.push_back(static_cast<double>(v));
-	  }
-	int nclasses = cw.size();
-	BlobProto cw_blob;
-	cw_blob.set_num(1);
-	cw_blob.set_channels(1);
-	cw_blob.set_height(nclasses);
-	cw_blob.set_width(nclasses);
-	for (int i=0;i<nclasses;i++)
-	  {
-	    for (int j=0;j<nclasses;j++)
-	      {
-		if (i == j)
-		  cw_blob.add_data(cw.at(i));
-		else cw_blob.add_data(0.);
-	      }
-	  }
-	//_logger->info("write class weights to {}",cl_file);
-	WriteProtoToBinaryFile(cw_blob,cl_file.c_str());
+        std::vector<double> cw;
+        try
+          {
+            cw = ad_mllib.get("class_weights").get<std::vector<double>>();
+          }
+        catch (std::exception &e)
+          {
+            // let's try array of int, that's a common mistake
+            std::vector<int> cwi
+                = ad_mllib.get("class_weights").get<std::vector<int>>();
+            for (int v : cwi)
+              cw.push_back(static_cast<double>(v));
+          }
+        int nclasses = cw.size();
+        BlobProto cw_blob;
+        cw_blob.set_num(1);
+        cw_blob.set_channels(1);
+        cw_blob.set_height(nclasses);
+        cw_blob.set_width(nclasses);
+        for (int i = 0; i < nclasses; i++)
+          {
+            for (int j = 0; j < nclasses; j++)
+              {
+                if (i == j)
+                  cw_blob.add_data(cw.at(i));
+                else
+                  cw_blob.add_data(0.);
+              }
+          }
+        //_logger->info("write class weights to {}",cl_file);
+        WriteProtoToBinaryFile(cw_blob, cl_file.c_str());
       }
   }
 
@@ -82,776 +84,855 @@ namespace dd
   {
     size_t p = file.rfind('.');
     if (p == file.npos)
-      _logger->warn("Failed to guess the encoding of {}",file);
+      _logger->warn("Failed to guess the encoding of {}", file);
     std::string enc = file.substr(p);
-    std::transform(enc.begin(),enc.end(),enc.begin(),::tolower);
+    std::transform(enc.begin(), enc.end(), enc.begin(), ::tolower);
     return enc;
   }
-  
+
   // convert images into db entries
   // a path must:
   // - either contain directories as classes holding image
-  //   files for each class. The name of the class is the name of the directory.
+  //   files for each class. The name of the class is the name of the
+  //   directory.
   // - either be a file containing in each line the path to an image
   //   and the label associated
-  int ImgCaffeInputFileConn::images_to_db(const std::vector<std::string> &rpaths,
-					  const std::string &traindbname,
-					  const std::string &testdbname,
-					  const bool &folders,
-					  const std::string &backend,
-					  const bool &encoded,
-					  const std::string &encode_type)
+  int ImgCaffeInputFileConn::images_to_db(
+      const std::vector<std::string> &rpaths, const std::string &traindbname,
+      const std::string &testdbname, const bool &folders,
+      const std::string &backend, const bool &encoded,
+      const std::string &encode_type)
   {
     std::string dbfullname = traindbname + "." + backend;
     std::string testdbfullname = testdbname + "." + backend;
-    
+
     // test whether the train / test dbs are already in
     // since they may be long to build, we pass on them if there already
     // in the model repository.
     if (fileops::file_exists(dbfullname))
       {
-	_logger->warn("image db file {} already exists, bypassing creation but checking on records",dbfullname);
-	std::unique_ptr<db::DB> db(db::GetDB(backend));
-	db->Open(dbfullname.c_str(), db::READ);
-	_db_batchsize = db->Count();
-	_logger->warn("image db file {} with {} records",dbfullname,_db_batchsize);
-	if (!testdbname.empty() && fileops::file_exists(testdbfullname))
-	  {
-	    _logger->warn("image db file {} already exists, bypassing creation but checking on records",testdbfullname);
-	    std::unique_ptr<db::DB> tdb(db::GetDB(backend));
-	    tdb->Open(testdbfullname.c_str(), db::READ);
-	    _db_testbatchsize = tdb->Count();
-	    _logger->warn("image db file {} with {} records",testdbfullname,_db_testbatchsize);
-	  }
-	return 0;
+        _logger->warn("image db file {} already exists, bypassing creation "
+                      "but checking on records",
+                      dbfullname);
+        std::unique_ptr<db::DB> db(db::GetDB(backend));
+        db->Open(dbfullname.c_str(), db::READ);
+        _db_batchsize = db->Count();
+        _logger->warn("image db file {} with {} records", dbfullname,
+                      _db_batchsize);
+        if (!testdbname.empty() && fileops::file_exists(testdbfullname))
+          {
+            _logger->warn("image db file {} already exists, bypassing "
+                          "creation but checking on records",
+                          testdbfullname);
+            std::unique_ptr<db::DB> tdb(db::GetDB(backend));
+            tdb->Open(testdbfullname.c_str(), db::READ);
+            _db_testbatchsize = tdb->Count();
+            _logger->warn("image db file {} with {} records", testdbfullname,
+                          _db_testbatchsize);
+          }
+        return 0;
       }
 
     // list files and classes, possibly shuffle / split them
     int cl = 0;
-    std::unordered_map<int,std::string> hcorresp; // correspondence class number / class name
-    std::unordered_map<std::string,int> hcorresp_r; // reverse correspondence for test set.
-    std::vector<std::pair<std::string,int>> lfiles; // labeled files
-		
+    std::unordered_map<int, std::string>
+        hcorresp; // correspondence class number / class name
+    std::unordered_map<std::string, int>
+        hcorresp_r; // reverse correspondence for test set.
+    std::vector<std::pair<std::string, int>> lfiles; // labeled files
+
     // If the input is a folder
     if (folders)
       {
-      // list directories in dataset train folder
-      std::unordered_set<std::string> subdirs;
-      if (fileops::list_directory(rpaths.at(0),false,true,false,subdirs))
-        throw InputConnectorBadParamException("failed reading image train data directory " + rpaths.at(0));
+        // list directories in dataset train folder
+        std::unordered_set<std::string> subdirs;
+        if (fileops::list_directory(rpaths.at(0), false, true, false, subdirs))
+          throw InputConnectorBadParamException(
+              "failed reading image train data directory " + rpaths.at(0));
 
-      auto uit = subdirs.begin();
-      while(uit!=subdirs.end())
-        {
-        std::unordered_set<std::string> subdir_files;
-        if (fileops::list_directory((*uit),true,false,true,subdir_files))
-          throw InputConnectorBadParamException("failed reading image train data sub-directory " + (*uit));
-        std::string cls = dd_utils::split((*uit),'/').back();
-        hcorresp.insert(std::pair<int,std::string>(cl,cls));
-        hcorresp_r.insert(std::pair<std::string,int>(cls,cl));
-        auto fit = subdir_files.begin();
-        while(fit!=subdir_files.end()) // XXX: re-iterating the file is not optimal
+        auto uit = subdirs.begin();
+        while (uit != subdirs.end())
           {
-          lfiles.push_back(std::pair<std::string,int>((*fit),cl));
-          ++fit;
+            std::unordered_set<std::string> subdir_files;
+            if (fileops::list_directory((*uit), true, false, true,
+                                        subdir_files))
+              throw InputConnectorBadParamException(
+                  "failed reading image train data sub-directory " + (*uit));
+            std::string cls = dd_utils::split((*uit), '/').back();
+            hcorresp.insert(std::pair<int, std::string>(cl, cls));
+            hcorresp_r.insert(std::pair<std::string, int>(cls, cl));
+            auto fit = subdir_files.begin();
+            while (fit
+                   != subdir_files
+                          .end()) // XXX: re-iterating the file is not optimal
+              {
+                lfiles.push_back(std::pair<std::string, int>((*fit), cl));
+                ++fit;
+              }
+            ++cl;
+            ++uit;
           }
-        ++cl;
-        ++uit;
-        }
       }
     // Else if input is a file
     else
       {
-      std::ifstream infile(rpaths.at(0));
-      std::string line;
-      int line_num = 1;
-      int cl = 0;
-      while (std::getline(infile, line))
-        {
-        std::istringstream iss(line);
-        string filename;
-        string label;
-        iss >> filename >> label;
-
-        int label_int = cl;
-        std::unordered_map<std::string,int>::const_iterator it;
-        // Check if mapping does not exist
-        if ((it=hcorresp_r.find(label))==hcorresp_r.end())
-          {
-          hcorresp.insert(std::pair<int,std::string>(cl,label));
-          hcorresp_r.insert(std::pair<std::string,int>(label,cl));
-          cl++;
-          }
-        else
-          label_int = it->second;
-
-        line_num ++;
-        // Append lfiles
-        lfiles.push_back(std::pair<std::string,int>(filename, label_int));
-
-        }
-      }
-	
-    if (_shuffle)
-      {
-	std::mt19937 g;
-	if (_seed >= 0)
-	  g = std::mt19937(_seed);
-	else
-	  {
-	    std::random_device rd;
-	    g = std::mt19937(rd());
-	  }
-	std::shuffle(lfiles.begin(),lfiles.end(),g);
-      }
-    
-    // test split
-    std::vector<std::pair<std::string,int>> test_lfiles;
-    if (_test_split > 0.0)
-      {
-	int split_size = std::floor(lfiles.size() * (1.0-_test_split));
-	auto chit = lfiles.begin();
-	auto dchit = chit;
-	int cpos = 0;
-	while(chit!=lfiles.end())
-	  {
-	    if (cpos == split_size)
-	      {
-		if (dchit == lfiles.begin())
-		  dchit = chit;
-		test_lfiles.push_back((*chit));
-	      }
-	    else ++cpos;
-	    ++chit;
-	  }
-	lfiles.erase(dchit,lfiles.end());
-      }
-    else if (rpaths.size() > 1)
-      {
-      // If input is a folder
-      if (folders)
-        {
-        // list directories in dataset test folder
-        std::unordered_set<std::string> test_subdirs;
-        if (fileops::list_directory(rpaths.at(1),false,true,false,test_subdirs))
-          throw InputConnectorBadParamException("failed reading image test data directory " + rpaths.at(1));
-
-        // list files and classes, possibly shuffle / split them
-        std::unordered_map<std::string,int>::const_iterator hcit;
-        auto uit = test_subdirs.begin();
-        while(uit!=test_subdirs.end())
-          {
-          std::unordered_set<std::string> subdir_files;
-          if (fileops::list_directory((*uit),true,false,true,subdir_files))
-            throw InputConnectorBadParamException("failed reading image test data sub-directory " + (*uit));
-          std::string cls = dd_utils::split((*uit),'/').back();
-          if (!_autoencoder && (hcit=hcorresp_r.find(cls))==hcorresp_r.end())
-            {
-	      _logger->error("class {} appears in testing set but not in training set, skipping",cls);
-	      ++uit;
-	      continue;
-            }
-          int cl = _autoencoder ? 0 : (*hcit).second;
-          auto fit = subdir_files.begin();
-          while(fit!=subdir_files.end()) // XXX: re-iterating the file is not optimal
-	          {
-            test_lfiles.push_back(std::pair<std::string,int>((*fit),cl));
-            ++fit;
-            }
-          ++uit;
-          }
-        }
-      // Else if input is a file
-      else
-        {
         std::ifstream infile(rpaths.at(0));
         std::string line;
         int line_num = 1;
+        int cl = 0;
         while (std::getline(infile, line))
           {
-          std::istringstream iss(line);
-          string filename;
-          string label;
-          iss >> filename >> label;
+            std::istringstream iss(line);
+            string filename;
+            string label;
+            iss >> filename >> label;
 
-          // Check if mapping does not exist, go to next file
-          std::unordered_map<std::string,int>::const_iterator it;
-          if (!_autoencoder && (it=hcorresp_r.find(label))==hcorresp_r.end())
-            {
-	      _logger->error("class {} appears in testing set but not in training set, skipping",label);
-	      continue;
-            }
-          line_num++;
-          // Append lfiles
-          test_lfiles.push_back(std::pair<std::string,int>(filename, it->second));
+            int label_int = cl;
+            std::unordered_map<std::string, int>::const_iterator it;
+            // Check if mapping does not exist
+            if ((it = hcorresp_r.find(label)) == hcorresp_r.end())
+              {
+                hcorresp.insert(std::pair<int, std::string>(cl, label));
+                hcorresp_r.insert(std::pair<std::string, int>(label, cl));
+                cl++;
+              }
+            else
+              label_int = it->second;
+
+            line_num++;
+            // Append lfiles
+            lfiles.push_back(std::pair<std::string, int>(filename, label_int));
           }
-        }
+      }
+
+    if (_shuffle)
+      {
+        std::mt19937 g;
+        if (_seed >= 0)
+          g = std::mt19937(_seed);
+        else
+          {
+            std::random_device rd;
+            g = std::mt19937(rd());
+          }
+        std::shuffle(lfiles.begin(), lfiles.end(), g);
+      }
+
+    // test split
+    std::vector<std::pair<std::string, int>> test_lfiles;
+    if (_test_split > 0.0)
+      {
+        int split_size = std::floor(lfiles.size() * (1.0 - _test_split));
+        auto chit = lfiles.begin();
+        auto dchit = chit;
+        int cpos = 0;
+        while (chit != lfiles.end())
+          {
+            if (cpos == split_size)
+              {
+                if (dchit == lfiles.begin())
+                  dchit = chit;
+                test_lfiles.push_back((*chit));
+              }
+            else
+              ++cpos;
+            ++chit;
+          }
+        lfiles.erase(dchit, lfiles.end());
+      }
+    else if (rpaths.size() > 1)
+      {
+        // If input is a folder
+        if (folders)
+          {
+            // list directories in dataset test folder
+            std::unordered_set<std::string> test_subdirs;
+            if (fileops::list_directory(rpaths.at(1), false, true, false,
+                                        test_subdirs))
+              throw InputConnectorBadParamException(
+                  "failed reading image test data directory " + rpaths.at(1));
+
+            // list files and classes, possibly shuffle / split them
+            std::unordered_map<std::string, int>::const_iterator hcit;
+            auto uit = test_subdirs.begin();
+            while (uit != test_subdirs.end())
+              {
+                std::unordered_set<std::string> subdir_files;
+                if (fileops::list_directory((*uit), true, false, true,
+                                            subdir_files))
+                  throw InputConnectorBadParamException(
+                      "failed reading image test data sub-directory "
+                      + (*uit));
+                std::string cls = dd_utils::split((*uit), '/').back();
+                if (!_autoencoder
+                    && (hcit = hcorresp_r.find(cls)) == hcorresp_r.end())
+                  {
+                    _logger->error("class {} appears in testing set but not "
+                                   "in training set, skipping",
+                                   cls);
+                    ++uit;
+                    continue;
+                  }
+                int cl = _autoencoder ? 0 : (*hcit).second;
+                auto fit = subdir_files.begin();
+                while (fit != subdir_files.end()) // XXX: re-iterating the file
+                                                  // is not optimal
+                  {
+                    test_lfiles.push_back(
+                        std::pair<std::string, int>((*fit), cl));
+                    ++fit;
+                  }
+                ++uit;
+              }
+          }
+        // Else if input is a file
+        else
+          {
+            std::ifstream infile(rpaths.at(0));
+            std::string line;
+            int line_num = 1;
+            while (std::getline(infile, line))
+              {
+                std::istringstream iss(line);
+                string filename;
+                string label;
+                iss >> filename >> label;
+
+                // Check if mapping does not exist, go to next file
+                std::unordered_map<std::string, int>::const_iterator it;
+                if (!_autoencoder
+                    && (it = hcorresp_r.find(label)) == hcorresp_r.end())
+                  {
+                    _logger->error("class {} appears in testing set but not "
+                                   "in training set, skipping",
+                                   label);
+                    continue;
+                  }
+                line_num++;
+                // Append lfiles
+                test_lfiles.push_back(
+                    std::pair<std::string, int>(filename, it->second));
+              }
+          }
       }
     _db_batchsize = lfiles.size();
     _db_testbatchsize = test_lfiles.size();
-    
-    _logger->info("a total of {} images",lfiles.size());
+
+    _logger->info("a total of {} images", lfiles.size());
     if (lfiles.empty())
-      throw InputConnectorBadParamException("no image data found in repository");
-    
+      throw InputConnectorBadParamException(
+          "no image data found in repository");
+
     // write files to dbs (i.e. train and possibly test)
-    write_image_to_db(dbfullname,lfiles,backend,encoded,encode_type);
+    write_image_to_db(dbfullname, lfiles, backend, encoded, encode_type);
     if (!test_lfiles.empty())
-      write_image_to_db(testdbfullname,test_lfiles,backend,encoded,encode_type);
+      write_image_to_db(testdbfullname, test_lfiles, backend, encoded,
+                        encode_type);
 
     // write corresp file
-    std::ofstream correspf(_model_repo + "/" + _correspname,std::ios::binary);
+    std::ofstream correspf(_model_repo + "/" + _correspname, std::ios::binary);
     auto hit = hcorresp.begin();
-    while(hit!=hcorresp.end())
+    while (hit != hcorresp.end())
       {
-	correspf << (*hit).first << " " << (*hit).second << std::endl;
-	++hit;
+        correspf << (*hit).first << " " << (*hit).second << std::endl;
+        ++hit;
       }
     correspf.close();
-    
+
     return 0;
   }
 
-
-  void ImgCaffeInputFileConn::create_test_db_for_imagedatalayer(const std::string &test_lst,
-								const std::string &testdbname,
-								const std::string &backend,
-								const bool &encoded,
-								const std::string &encode_type) // 'png', 'jpg', ...
-{
-  std::string testdbfullname = testdbname + "." + backend;
-  if (fileops::file_exists(testdbfullname))
-    {
-      _logger->warn("test db {} already exists, bypassing creation",testdbfullname);
-      return;
-    }
-  vector<std::pair<std::string, std::vector<float> > > lines;
-  try
-    {
-      caffe::ReadImagesList(test_lst,&lines);
-    }
-  catch (std::exception &e)
-    {
-      _logger->error("failed reading image list for image data layer");
-      throw InputConnectorBadParamException("failed reading image list for image data layer");
-    }
-  if (lines.empty())
-    {
-      _logger->error("empty data from {}",test_lst);
-      throw InputConnectorBadParamException("empty data from " + test_lst);
-    }
-    std::vector<std::pair<std::string,int>> test_lfiles_1;
-    std::vector<std::pair<std::string,std::vector<float>>> test_lfiles_n;
-    int nlabels = (*lines.begin()).second.size();
-    for (auto line: lines)
+  void ImgCaffeInputFileConn::create_test_db_for_imagedatalayer(
+      const std::string &test_lst, const std::string &testdbname,
+      const std::string &backend, const bool &encoded,
+      const std::string &encode_type) // 'png', 'jpg', ...
+  {
+    std::string testdbfullname = testdbname + "." + backend;
+    if (fileops::file_exists(testdbfullname))
       {
-	if (nlabels == 1) // XXX: expected to be 1 for all samples, variable label size not yet allowed
-	  test_lfiles_1.push_back(std::pair<std::string,float>(_root_folder+line.first,line.second.at(0)));
-	else test_lfiles_n.push_back(std::pair<std::string,std::vector<float>>(_root_folder+line.first,line.second));
+        _logger->warn("test db {} already exists, bypassing creation",
+                      testdbfullname);
+        return;
+      }
+    vector<std::pair<std::string, std::vector<float>>> lines;
+    try
+      {
+        caffe::ReadImagesList(test_lst, &lines);
+      }
+    catch (std::exception &e)
+      {
+        _logger->error("failed reading image list for image data layer");
+        throw InputConnectorBadParamException(
+            "failed reading image list for image data layer");
+      }
+    if (lines.empty())
+      {
+        _logger->error("empty data from {}", test_lst);
+        throw InputConnectorBadParamException("empty data from " + test_lst);
+      }
+    std::vector<std::pair<std::string, int>> test_lfiles_1;
+    std::vector<std::pair<std::string, std::vector<float>>> test_lfiles_n;
+    int nlabels = (*lines.begin()).second.size();
+    for (auto line : lines)
+      {
+        if (nlabels == 1) // XXX: expected to be 1 for all samples, variable
+                          // label size not yet allowed
+          test_lfiles_1.push_back(std::pair<std::string, float>(
+              _root_folder + line.first, line.second.at(0)));
+        else
+          test_lfiles_n.push_back(std::pair<std::string, std::vector<float>>(
+              _root_folder + line.first, line.second));
       }
     if (nlabels == 1)
-      write_image_to_db(testdbfullname,test_lfiles_1,backend,encoded,encode_type);
-    else write_image_to_db_multilabel(testdbfullname,test_lfiles_n,backend,encoded,encode_type);
+      write_image_to_db(testdbfullname, test_lfiles_1, backend, encoded,
+                        encode_type);
+    else
+      write_image_to_db_multilabel(testdbfullname, test_lfiles_n, backend,
+                                   encoded, encode_type);
   }
 
-
-  void ImgCaffeInputFileConn::write_image_to_db(const std::string &dbfullname,
-						const std::vector<std::pair<std::string,int>> &lfiles,
-						const std::string &backend,
-						const bool &encoded,
-						const std::string &encode_type)
-  {    
-    // Create new DB
-    std::unique_ptr<db::DB> db(db::GetDB(backend));
-    db->Open(dbfullname.c_str(), db::NEW);
-    std::unique_ptr<db::Transaction> txn(db->NewTransaction());
-    
-    // Storing to db
-    int count = 0;
-    const int kMaxKeyLength = 256;
-    char key_cstr[kMaxKeyLength];
-    bool key_overflow = false;
-    
-    for (int line_id = 0; line_id < (int)lfiles.size(); ++line_id) {
-      Datum datum;
-      bool status;
-      std::string enc = encode_type;
-      if (encoded && !enc.size()) {
-	enc = guess_encoding(lfiles[line_id].first);
-      }
-      else if (!encoded)
-	enc = "";
-
-      status = ReadImageToDatum(lfiles[line_id].first,
-				lfiles[line_id].second, _height, _width, !_bw,
-				enc, &datum, this->_unchanged_data);
-      if (status == false) continue;
-      
-      // sequential
-      int length = snprintf(key_cstr, kMaxKeyLength, "%08d_%s", line_id,
-			    lfiles[line_id].first.c_str());
-      if (lfiles[line_id].first.size() > kMaxKeyLength)
-	key_overflow = true;
-      
-      // put in db
-      std::string out;
-      if(!datum.SerializeToString(&out))
-	_logger->error("Failed serialization of datum for db storage");
-      txn->Put(string(key_cstr, length), out);
-      
-      if (++count % 1000 == 0) {
-	// commit db
-	txn->Commit();
-	txn.reset(db->NewTransaction());
-	_logger->info("Processed {} files",count);
-      }
-    }
-    // write the last batch
-    if (count % 1000 != 0) {
-      txn->Commit();
-      _logger->info("Processed {} files",count);
-    }
-    if (key_overflow)
-      _logger->warn("Some of the keys in {} have been truncated to fit the 256 max key length requirement",
-		    dbfullname);
-  }
-
-  void ImgCaffeInputFileConn::write_image_to_db_multilabel(const std::string &dbfullname,
-							   const std::vector<std::pair<std::string,std::vector<float>>> &lfiles,
-							   const std::string &backend,
-							   const bool &encoded,
-							   const std::string &encode_type)
+  void ImgCaffeInputFileConn::write_image_to_db(
+      const std::string &dbfullname,
+      const std::vector<std::pair<std::string, int>> &lfiles,
+      const std::string &backend, const bool &encoded,
+      const std::string &encode_type)
   {
     // Create new DB
     std::unique_ptr<db::DB> db(db::GetDB(backend));
     db->Open(dbfullname.c_str(), db::NEW);
     std::unique_ptr<db::Transaction> txn(db->NewTransaction());
-    
+
     // Storing to db
     int count = 0;
     const int kMaxKeyLength = 256;
     char key_cstr[kMaxKeyLength];
     bool key_overflow = false;
-    
-    for (int line_id = 0; line_id < (int)lfiles.size(); ++line_id) {
-      Datum datum;
-      bool status;
-      std::string enc = encode_type;
-      if (encoded && !enc.size()) {
-	enc = guess_encoding(lfiles[line_id].first);
+
+    for (int line_id = 0; line_id < (int)lfiles.size(); ++line_id)
+      {
+        Datum datum;
+        bool status;
+        std::string enc = encode_type;
+        if (encoded && !enc.size())
+          {
+            enc = guess_encoding(lfiles[line_id].first);
+          }
+        else if (!encoded)
+          enc = "";
+
+        status = ReadImageToDatum(lfiles[line_id].first,
+                                  lfiles[line_id].second, _height, _width,
+                                  !_bw, enc, &datum, this->_unchanged_data);
+        if (status == false)
+          continue;
+
+        // sequential
+        int length = snprintf(key_cstr, kMaxKeyLength, "%08d_%s", line_id,
+                              lfiles[line_id].first.c_str());
+        if (lfiles[line_id].first.size() > kMaxKeyLength)
+          key_overflow = true;
+
+        // put in db
+        std::string out;
+        if (!datum.SerializeToString(&out))
+          _logger->error("Failed serialization of datum for db storage");
+        txn->Put(string(key_cstr, length), out);
+
+        if (++count % 1000 == 0)
+          {
+            // commit db
+            txn->Commit();
+            txn.reset(db->NewTransaction());
+            _logger->info("Processed {} files", count);
+          }
       }
-      status = ReadImageToDatum(lfiles[line_id].first,
-				lfiles[line_id].second[0], _height, _width, !_bw, // XXX: passing first label, fixing labels below
-				enc, &datum);
-      if (status == false)
-	{
-	  _logger->error("failed reading image {}",lfiles[line_id].first);
-	  continue;
-	}
-      
-      // store multi labels into float_data in the datum (encoded image should be into data as bytes)
-      std::vector<float> labels = lfiles[line_id].second;
-      for (auto l: labels)
-	{
-	  datum.add_float_data(l);
-	}
-      
-      // sequential
-      int length = snprintf(key_cstr, kMaxKeyLength, "%08d_%s", line_id,
-			    lfiles[line_id].first.c_str());
-      if (lfiles[line_id].first.size() > kMaxKeyLength)
-	key_overflow = true;
-      
-      // put in db
-      std::string out;
-      if(!datum.SerializeToString(&out))
-	_logger->error("Failed serialization of datum for db storage");
-      txn->Put(string(key_cstr, length), out);
-      
-      if (++count % 1000 == 0) {
-	// commit db
-	txn->Commit();
-	txn.reset(db->NewTransaction());
-	_logger->info("Processed {} files",count);
-      }
-    }
     // write the last batch
-    if (count % 1000 != 0) {
-      txn->Commit();
-      _logger->info("Processed {} files",count);
-    }
+    if (count % 1000 != 0)
+      {
+        txn->Commit();
+        _logger->info("Processed {} files", count);
+      }
     if (key_overflow)
-      _logger->warn("Some of the keys in {} have been truncated to fit the 256 max key length requirement",
-		    dbfullname);
+      _logger->warn("Some of the keys in {} have been truncated to fit the "
+                    "256 max key length requirement",
+                    dbfullname);
+  }
+
+  void ImgCaffeInputFileConn::write_image_to_db_multilabel(
+      const std::string &dbfullname,
+      const std::vector<std::pair<std::string, std::vector<float>>> &lfiles,
+      const std::string &backend, const bool &encoded,
+      const std::string &encode_type)
+  {
+    // Create new DB
+    std::unique_ptr<db::DB> db(db::GetDB(backend));
+    db->Open(dbfullname.c_str(), db::NEW);
+    std::unique_ptr<db::Transaction> txn(db->NewTransaction());
+
+    // Storing to db
+    int count = 0;
+    const int kMaxKeyLength = 256;
+    char key_cstr[kMaxKeyLength];
+    bool key_overflow = false;
+
+    for (int line_id = 0; line_id < (int)lfiles.size(); ++line_id)
+      {
+        Datum datum;
+        bool status;
+        std::string enc = encode_type;
+        if (encoded && !enc.size())
+          {
+            enc = guess_encoding(lfiles[line_id].first);
+          }
+        status = ReadImageToDatum(
+            lfiles[line_id].first, lfiles[line_id].second[0], _height, _width,
+            !_bw, // XXX: passing first label, fixing labels below
+            enc, &datum);
+        if (status == false)
+          {
+            _logger->error("failed reading image {}", lfiles[line_id].first);
+            continue;
+          }
+
+        // store multi labels into float_data in the datum (encoded image
+        // should be into data as bytes)
+        std::vector<float> labels = lfiles[line_id].second;
+        for (auto l : labels)
+          {
+            datum.add_float_data(l);
+          }
+
+        // sequential
+        int length = snprintf(key_cstr, kMaxKeyLength, "%08d_%s", line_id,
+                              lfiles[line_id].first.c_str());
+        if (lfiles[line_id].first.size() > kMaxKeyLength)
+          key_overflow = true;
+
+        // put in db
+        std::string out;
+        if (!datum.SerializeToString(&out))
+          _logger->error("Failed serialization of datum for db storage");
+        txn->Put(string(key_cstr, length), out);
+
+        if (++count % 1000 == 0)
+          {
+            // commit db
+            txn->Commit();
+            txn.reset(db->NewTransaction());
+            _logger->info("Processed {} files", count);
+          }
+      }
+    // write the last batch
+    if (count % 1000 != 0)
+      {
+        txn->Commit();
+        _logger->info("Processed {} files", count);
+      }
+    if (key_overflow)
+      _logger->warn("Some of the keys in {} have been truncated to fit the "
+                    "256 max key length requirement",
+                    dbfullname);
   }
 
   // - fixed size in-memory arrays put down to disk at once
 #ifdef USE_HDF5
-  void ImgCaffeInputFileConn::images_to_hdf5(const std::vector<std::string> &img_lists,
-					     const std::string &dbfullname,
-					     const std::string &test_dbfullname)
+  void ImgCaffeInputFileConn::images_to_hdf5(
+      const std::vector<std::string> &img_lists, const std::string &dbfullname,
+      const std::string &test_dbfullname)
   {
-    
+
     // test whether dbs already exist
     if (fileops::file_exists(dbfullname + "_0.h5"))
-      {	
-	if (!fileops::file_exists(_model_repo + "/" + _correspname))
-	  throw InputConnectorBadParamException("found h5 db but no corresp.txt file, erase h5 to rebuild them instead ?");
-	std::ifstream in(_model_repo + "/" + _correspname);
-	if (!in.is_open())
-	  throw InputConnectorBadParamException("failed opening corresp.txt file");
-	int nlines = 0;
-	std::string line;
-	while(getline(in,line))
-	  ++nlines;
-	_alphabet_size = nlines;
+      {
+        if (!fileops::file_exists(_model_repo + "/" + _correspname))
+          throw InputConnectorBadParamException(
+              "found h5 db but no corresp.txt file, erase h5 to rebuild them "
+              "instead ?");
+        std::ifstream in(_model_repo + "/" + _correspname);
+        if (!in.is_open())
+          throw InputConnectorBadParamException(
+              "failed opening corresp.txt file");
+        int nlines = 0;
+        std::string line;
+        while (getline(in, line))
+          ++nlines;
+        _alphabet_size = nlines;
 
-	if (!fileops::file_exists(_model_repo + "/testing.txt"))
-	  _logger->info("no hdf5 test db list found, no test set");
-	else
-	  {
-	    std::string tfilename;
-	    int tsize = 0;
-        std::ifstream in(_model_repo + "/testing.txt");
-	    while(getline(in,tfilename))
-	      {
-		H5::H5File tfile(tfilename, H5F_ACC_RDONLY);
-		H5::DataSet dataset = tfile.openDataSet("label");
-		//H5::FloatType datatype = dataset.getFloatType();
-		//tsize += datatype.getSize();
-		
-		H5::DataSpace dataspace = dataset.getSpace();
-		hsize_t dims[2];
-		dataspace.getSimpleExtentDims(dims,NULL);
-		tsize += dims[0];
-	      }
-	    _db_testbatchsize = tsize;
-	    _logger->info("hdf5 test set size={}",tsize);
-	  }
-	return;
+        if (!fileops::file_exists(_model_repo + "/testing.txt"))
+          _logger->info("no hdf5 test db list found, no test set");
+        else
+          {
+            std::string tfilename;
+            int tsize = 0;
+            std::ifstream in(_model_repo + "/testing.txt");
+            while (getline(in, tfilename))
+              {
+                H5::H5File tfile(tfilename, H5F_ACC_RDONLY);
+                H5::DataSet dataset = tfile.openDataSet("label");
+                // H5::FloatType datatype = dataset.getFloatType();
+                // tsize += datatype.getSize();
+
+                H5::DataSpace dataspace = dataset.getSpace();
+                hsize_t dims[2];
+                dataspace.getSimpleExtentDims(dims, NULL);
+                tsize += dims[0];
+              }
+            _db_testbatchsize = tsize;
+            _logger->info("hdf5 test set size={}", tsize);
+          }
+        return;
       }
-	
-    //TODO: read / shuffle / split list of images
-    
-    std::unordered_map<uint32_t,int> alphabet;
+
+    // TODO: read / shuffle / split list of images
+
+    std::unordered_map<uint32_t, int> alphabet;
     alphabet[0] = 0; // space character
     int max_ocr_length = -1;
 
     std::string train_list = _model_repo + "/training.txt";
-    write_images_to_hdf5(img_lists.at(0), dbfullname, train_list, alphabet, max_ocr_length, true);
-    _logger->info("ctc alphabet training size={}",alphabet.size());
-    
+    write_images_to_hdf5(img_lists.at(0), dbfullname, train_list, alphabet,
+                         max_ocr_length, true);
+    _logger->info("ctc alphabet training size={}", alphabet.size());
+
     if (img_lists.size() > 1)
       {
-	std::string test_list = _model_repo + "/testing.txt";
-	write_images_to_hdf5(img_lists.at(1), test_dbfullname, test_list, alphabet, max_ocr_length, false);
+        std::string test_list = _model_repo + "/testing.txt";
+        write_images_to_hdf5(img_lists.at(1), test_dbfullname, test_list,
+                             alphabet, max_ocr_length, false);
       }
-    
+
     // save the alphabet as corresp file
-    std::ofstream correspf(_model_repo + "/" + _correspname,std::ios::binary);
+    std::ofstream correspf(_model_repo + "/" + _correspname, std::ios::binary);
     auto hit = alphabet.begin();
-    while(hit!=alphabet.end())
+    while (hit != alphabet.end())
       {
-	correspf << (*hit).second << " " << std::to_string((*hit).first) << std::endl;
-	++hit;
+        correspf << (*hit).second << " " << std::to_string((*hit).first)
+                 << std::endl;
+        ++hit;
       }
     correspf.close();
     _alphabet_size = alphabet.size();
   }
 
-  void ImgCaffeInputFileConn::write_images_to_hdf5(const std::string &inputfilename,
-						   const std::string &dbfullname,
-						   const std::string &dblistfilename,
-						   std::unordered_map<uint32_t,int> &alphabet,
-						   int &max_ocr_length,
-						   const bool &train_db)
+  void ImgCaffeInputFileConn::write_images_to_hdf5(
+      const std::string &inputfilename, const std::string &dbfullname,
+      const std::string &dblistfilename,
+      std::unordered_map<uint32_t, int> &alphabet, int &max_ocr_length,
+      const bool &train_db)
   {
     std::ifstream train_file(inputfilename);
     std::string line;
-    std::unordered_map<uint32_t,int>::iterator ait;
-    
+    std::unordered_map<uint32_t, int>::iterator ait;
+
     // count file lines, we're using fixed-size in-memory array due to
     // complexity of hdf5 handling of incremental datasets
     int clines = 0;
-    while(std::getline(train_file, line))
+    while (std::getline(train_file, line))
       {
-	std::vector<std::string> elts = dd_utils::split(line,' ');
-	if (train_db)
-	  {
-	    int ocr_size = 0;
-	    for (size_t k=1;k<elts.size();k++)
-	      {
-		ocr_size += elts.at(k).size();
-		if (k != elts.size()-1)
-		  ++ocr_size; // space between words
-	      }
-	    max_ocr_length = std::max(max_ocr_length,ocr_size);
-	  }
-	++clines;
+        std::vector<std::string> elts = dd_utils::split(line, ' ');
+        if (train_db)
+          {
+            int ocr_size = 0;
+            for (size_t k = 1; k < elts.size(); k++)
+              {
+                ocr_size += elts.at(k).size();
+                if (k != elts.size() - 1)
+                  ++ocr_size; // space between words
+              }
+            max_ocr_length = std::max(max_ocr_length, ocr_size);
+          }
+        ++clines;
       }
     if (train_db)
       {
-	_logger->info("ctc/ocr dataset training size={}",clines);
-	_db_batchsize = clines;
+        _logger->info("ctc/ocr dataset training size={}", clines);
+        _db_batchsize = clines;
       }
     else
       {
-	_logger->info("ctc/ocr dataset testing size={}",clines);
-	_db_testbatchsize = clines;
+        _logger->info("ctc/ocr dataset testing size={}", clines);
+        _db_testbatchsize = clines;
       }
-    _logger->info("ctc output string max size={}",max_ocr_length);
+    _logger->info("ctc output string max size={}", max_ocr_length);
     train_file.clear();
     train_file.seekg(0, std::ios::beg);
-    
-    int cn = (_bw ? 1 : 3);
-    int max_lines = std::pow(10,9) / (_height*_width*3*4);
-    _logger->info("hdf5 using max number of lines={}",max_lines);
-        
-    cv::Size size(_width,_height);
-    int chunks = std::ceil(clines / static_cast<double>(max_lines));
-    _logger->info("proceeding with {} hdf5 chunks",chunks);
-    std::vector<std::string> dbchunks;
-    for (int ch=0;ch<chunks;ch++)
-      {
-	int tlines = (ch == chunks-1) ? clines % max_lines: max_lines;
-	if (tlines == 0)
-	  break;
-	boost::multi_array<float,4> img_data(boost::extents[tlines][cn][_height][_width]);
-	boost::multi_array<float,2> ocr_data(boost::extents[tlines][max_ocr_length]);
-	int nline = 0;
-	while (std::getline(train_file, line))
-	  {
-	    if (line.empty())
-	      {
-		_logger->warn("empty line in ocr dataset file {}:{}",inputfilename,nline);
-		continue;
-	      }
-	    std::vector<std::string> elts = dd_utils::split(line,' ');
-	    
-	    // first elt is the image path
-	    std::string img_path = elts.at(0);
-	    cv::Mat img = cv::imread(img_path, _unchanged_data ? CV_LOAD_IMAGE_UNCHANGED :
-                               (_bw ? CV_LOAD_IMAGE_GRAYSCALE : CV_LOAD_IMAGE_COLOR));
-	    if (img.empty())
-	      throw InputConnectorBadParamException("failed to read OCR image " + img_path);
-	    if (_align && img.rows > img.cols) // rotate so that width is longest axis
-	      {
-		cv::Mat timg;
-		cv::transpose(img,timg);
-		cv::flip(timg,img,1);
-	      }
-	    cv::Mat rimg;
-	    try
-	      {
-		cv::resize(img,rimg,size,0,0,CV_INTER_CUBIC);
-	      }
-	    catch(std::exception &e)
-	      {
-		_logger->error("failed resizing image {}: {}",img_path,e.what());
-		continue;
-	      }
-	    img = rimg;
-	    for(int r=0;r<img.rows;r++)
-	      {
-		for(int c=0;c<img.cols;c++)
-		  {
-		    cv::Point3_<uint8_t> pixel = img.at<cv::Point3_<uint8_t>>(r,c);
-		    img_data[nline][0][r][c] = pixel.x; // B
-		    img_data[nline][1][r][c] = pixel.y; // G
-		    img_data[nline][2][r][c] = pixel.z; // R
-		  }
-	      }
-	    
-	    // then come the CTC/OCR string
-	    int cpos = 0;
-	    for (size_t i=1;i<elts.size();i++)
-	      {
-		std::string ostr = elts.at(i);
-		char *ostr_c = (char*)ostr.c_str();
-		char *ostr_ci = ostr_c;
-		char *end = ostr_c + strlen(ostr_c);
-		while(ostr_ci<end && cpos < max_ocr_length)
-		{
-		    // check / add / get id from alphabet
-		    uint32_t c = utf8::next(ostr_ci,end);
-		    int nc = -1;
-		    if ((ait=alphabet.find(c))==alphabet.end())
-		      {
-			if (train_db)
-			  {
-			    nc = alphabet.size();
-			    alphabet.insert(std::pair<uint32_t,int>(c,nc));
-			  }
-			else
-			  {
-			    _logger->warn("character {} in test set not found in training set",c);
-			    nc = 0; // space, blank
-			  }
-		      }
-		    else nc = (*ait).second;
-		    ocr_data[nline][cpos] = static_cast<float>(nc);
-		    ++cpos;
-		}
-		// add space, only if more forthcoming words
-		if (cpos < max_ocr_length && i != elts.size()-1)
-		  {
-		    ocr_data[nline][cpos] = 0.0;
-		    ++cpos;
-		  }
-	      }
-	    // complete string with blank label
-	    while (cpos < max_ocr_length)
-	      {
-		ocr_data[nline][cpos] = 0.0;
-		++cpos;
-	      }
-	    if (nline == tlines-1)
-	      break;
-	    ++nline;
-	  }
 
-	std::string dbchunkname = dbfullname + "_" + std::to_string(ch) + ".h5";
-	dbchunks.push_back(dbchunkname);
-	H5::H5File hdffile(dbchunkname, H5F_ACC_TRUNC);
-	std::string dname;
-	if (train_db)
-	  dname = "train";
-	else dname = "test";
-	_logger->info("created hdf5 {} dataset for chunk {}",dname,ch);
-	
-	// create datasets
-	// image data
-	hsize_t img_dims[4]; 
-	img_dims[0] = tlines;
-	img_dims[1] = cn;
-	img_dims[2] = _height;
-	img_dims[3] = _width;
-	H5::DataSpace dataspace(4, img_dims);
-	H5::FloatType datatype(H5::PredType::NATIVE_FLOAT);
-	//datatype.setOrder( H5T_ORDER_LE );
-	H5::DataSet dataset = hdffile.createDataSet("data",datatype,dataspace);
-	dataset.write(img_data.data(), H5::PredType::NATIVE_FLOAT);
-	
-	// ocr data
-	hsize_t ocr_dims[2]; 
-	ocr_dims[0] = tlines;
-	ocr_dims[1] = max_ocr_length;
-	H5::DataSpace dataspace2(2, ocr_dims);
-	H5::FloatType datatype2(H5::PredType::NATIVE_FLOAT);
-	//datatype.setOrder( H5T_ORDER_LE );
-	H5::DataSet dataset2 = hdffile.createDataSet("label",datatype2,dataspace2);
-	dataset2.write(ocr_data.data(), H5::PredType::NATIVE_FLOAT);
+    int cn = (_bw ? 1 : 3);
+    int max_lines = std::pow(10, 9) / (_height * _width * 3 * 4);
+    _logger->info("hdf5 using max number of lines={}", max_lines);
+
+    cv::Size size(_width, _height);
+    int chunks = std::ceil(clines / static_cast<double>(max_lines));
+    _logger->info("proceeding with {} hdf5 chunks", chunks);
+    std::vector<std::string> dbchunks;
+    for (int ch = 0; ch < chunks; ch++)
+      {
+        int tlines = (ch == chunks - 1) ? clines % max_lines : max_lines;
+        if (tlines == 0)
+          break;
+        boost::multi_array<float, 4> img_data(
+            boost::extents[tlines][cn][_height][_width]);
+        boost::multi_array<float, 2> ocr_data(
+            boost::extents[tlines][max_ocr_length]);
+        int nline = 0;
+        while (std::getline(train_file, line))
+          {
+            if (line.empty())
+              {
+                _logger->warn("empty line in ocr dataset file {}:{}",
+                              inputfilename, nline);
+                continue;
+              }
+            std::vector<std::string> elts = dd_utils::split(line, ' ');
+
+            // first elt is the image path
+            std::string img_path = elts.at(0);
+            cv::Mat img = cv::imread(
+                img_path, _unchanged_data ? CV_LOAD_IMAGE_UNCHANGED
+                                          : (_bw ? CV_LOAD_IMAGE_GRAYSCALE
+                                                 : CV_LOAD_IMAGE_COLOR));
+            if (img.empty())
+              throw InputConnectorBadParamException("failed to read OCR image "
+                                                    + img_path);
+            if (_align
+                && img.rows > img.cols) // rotate so that width is longest axis
+              {
+                cv::Mat timg;
+                cv::transpose(img, timg);
+                cv::flip(timg, img, 1);
+              }
+            cv::Mat rimg;
+            try
+              {
+                cv::resize(img, rimg, size, 0, 0, CV_INTER_CUBIC);
+              }
+            catch (std::exception &e)
+              {
+                _logger->error("failed resizing image {}: {}", img_path,
+                               e.what());
+                continue;
+              }
+            img = rimg;
+            for (int r = 0; r < img.rows; r++)
+              {
+                for (int c = 0; c < img.cols; c++)
+                  {
+                    cv::Point3_<uint8_t> pixel
+                        = img.at<cv::Point3_<uint8_t>>(r, c);
+                    img_data[nline][0][r][c] = pixel.x; // B
+                    img_data[nline][1][r][c] = pixel.y; // G
+                    img_data[nline][2][r][c] = pixel.z; // R
+                  }
+              }
+
+            // then come the CTC/OCR string
+            int cpos = 0;
+            for (size_t i = 1; i < elts.size(); i++)
+              {
+                std::string ostr = elts.at(i);
+                char *ostr_c = (char *)ostr.c_str();
+                char *ostr_ci = ostr_c;
+                char *end = ostr_c + strlen(ostr_c);
+                while (ostr_ci < end && cpos < max_ocr_length)
+                  {
+                    // check / add / get id from alphabet
+                    uint32_t c = utf8::next(ostr_ci, end);
+                    int nc = -1;
+                    if ((ait = alphabet.find(c)) == alphabet.end())
+                      {
+                        if (train_db)
+                          {
+                            nc = alphabet.size();
+                            alphabet.insert(std::pair<uint32_t, int>(c, nc));
+                          }
+                        else
+                          {
+                            _logger->warn("character {} in test set not found "
+                                          "in training set",
+                                          c);
+                            nc = 0; // space, blank
+                          }
+                      }
+                    else
+                      nc = (*ait).second;
+                    ocr_data[nline][cpos] = static_cast<float>(nc);
+                    ++cpos;
+                  }
+                // add space, only if more forthcoming words
+                if (cpos < max_ocr_length && i != elts.size() - 1)
+                  {
+                    ocr_data[nline][cpos] = 0.0;
+                    ++cpos;
+                  }
+              }
+            // complete string with blank label
+            while (cpos < max_ocr_length)
+              {
+                ocr_data[nline][cpos] = 0.0;
+                ++cpos;
+              }
+            if (nline == tlines - 1)
+              break;
+            ++nline;
+          }
+
+        std::string dbchunkname
+            = dbfullname + "_" + std::to_string(ch) + ".h5";
+        dbchunks.push_back(dbchunkname);
+        H5::H5File hdffile(dbchunkname, H5F_ACC_TRUNC);
+        std::string dname;
+        if (train_db)
+          dname = "train";
+        else
+          dname = "test";
+        _logger->info("created hdf5 {} dataset for chunk {}", dname, ch);
+
+        // create datasets
+        // image data
+        hsize_t img_dims[4];
+        img_dims[0] = tlines;
+        img_dims[1] = cn;
+        img_dims[2] = _height;
+        img_dims[3] = _width;
+        H5::DataSpace dataspace(4, img_dims);
+        H5::FloatType datatype(H5::PredType::NATIVE_FLOAT);
+        // datatype.setOrder( H5T_ORDER_LE );
+        H5::DataSet dataset
+            = hdffile.createDataSet("data", datatype, dataspace);
+        dataset.write(img_data.data(), H5::PredType::NATIVE_FLOAT);
+
+        // ocr data
+        hsize_t ocr_dims[2];
+        ocr_dims[0] = tlines;
+        ocr_dims[1] = max_ocr_length;
+        H5::DataSpace dataspace2(2, ocr_dims);
+        H5::FloatType datatype2(H5::PredType::NATIVE_FLOAT);
+        // datatype.setOrder( H5T_ORDER_LE );
+        H5::DataSet dataset2
+            = hdffile.createDataSet("label", datatype2, dataspace2);
+        dataset2.write(ocr_data.data(), H5::PredType::NATIVE_FLOAT);
       }
-    
+
     // generate list of hdf5 db files
     std::ofstream tlist(dblistfilename.c_str());
-    for (auto s: dbchunks)
+    for (auto s : dbchunks)
       tlist << s << std::endl;
     tlist.close();
   }
-	#endif // USE_HDF5
+#endif // USE_HDF5
 
-  int ImgCaffeInputFileConn::objects_to_db(const std::vector<std::string> &filelists,
-					   const int &db_height,
-					   const int &db_width,
-					   const std::string &traindbname,
-					   const std::string &testdbname,
-					   const bool &encoded,
-					   const std::string &encode_type,
-					   const std::string &backend)
+  int ImgCaffeInputFileConn::objects_to_db(
+      const std::vector<std::string> &filelists, const int &db_height,
+      const int &db_width, const std::string &traindbname,
+      const std::string &testdbname, const bool &encoded,
+      const std::string &encode_type, const std::string &backend)
   {
     // bypass creation if dbs already exist
     if (fileops::file_exists(traindbname))
       {
-	std::string line;
-	std::ifstream fin_mean(_model_repo + "/mean_values.txt");
-	_mean_values.clear();
-	while(std::getline(fin_mean,line))
-	  {
-	    std::vector<std::string> elts = dd_utils::split(line,' ');
-	    for (auto s: elts)
-	      _mean_values.push_back(std::atof(s.c_str()));
-	    break;
-	  }
+        std::string line;
+        std::ifstream fin_mean(_model_repo + "/mean_values.txt");
+        _mean_values.clear();
+        while (std::getline(fin_mean, line))
+          {
+            std::vector<std::string> elts = dd_utils::split(line, ' ');
+            for (auto s : elts)
+              _mean_values.push_back(std::atof(s.c_str()));
+            break;
+          }
 
-	_logger->warn("object db file {} already exists, bypassing creation",traindbname);
-	std::unique_ptr<db::DB> db(db::GetDB(backend));
-	db->Open(traindbname.c_str(), db::READ);
-	_db_batchsize = db->Count();
-	_logger->warn("image db file {} with {} records",traindbname,_db_batchsize);
-	if (!testdbname.empty() && fileops::file_exists(testdbname))
-	  {
-	    _logger->warn("image db file {} already exists, bypassing creation but checking on records",testdbname);
-	    std::unique_ptr<db::DB> tdb(db::GetDB(backend));
-	    tdb->Open(testdbname.c_str(), db::READ);
-	    _db_testbatchsize = tdb->Count();
-	    _logger->warn("image db file {} with {} records",testdbname,_db_testbatchsize);
-	  }
-	return 0;
+        _logger->warn("object db file {} already exists, bypassing creation",
+                      traindbname);
+        std::unique_ptr<db::DB> db(db::GetDB(backend));
+        db->Open(traindbname.c_str(), db::READ);
+        _db_batchsize = db->Count();
+        _logger->warn("image db file {} with {} records", traindbname,
+                      _db_batchsize);
+        if (!testdbname.empty() && fileops::file_exists(testdbname))
+          {
+            _logger->warn("image db file {} already exists, bypassing "
+                          "creation but checking on records",
+                          testdbname);
+            std::unique_ptr<db::DB> tdb(db::GetDB(backend));
+            tdb->Open(testdbname.c_str(), db::READ);
+            _db_testbatchsize = tdb->Count();
+            _logger->warn("image db file {} with {} records", testdbname,
+                          _db_testbatchsize);
+          }
+        return 0;
       }
 
     // read train lines
     std::ifstream in(filelists.at(0));
     if (!in.is_open())
-      throw InputConnectorBadParamException("failed opening training data file " + filelists.at(0));
-    _logger->info("reading training data file {}",filelists.at(0));
+      throw InputConnectorBadParamException(
+          "failed opening training data file " + filelists.at(0));
+    _logger->info("reading training data file {}", filelists.at(0));
     std::string line;
-    std::vector<std::pair<std::string,std::string>> lines;
+    std::vector<std::pair<std::string, std::string>> lines;
     int clines = 0;
-    while(std::getline(in,line))
+    while (std::getline(in, line))
       {
-	std::vector<std::string> elts = dd_utils::split(line,' ');
-	if (elts.size() != 2)
-      {
-        _logger->error("wrong line {} : \"{}\" in data file {}", std::to_string(clines), line, filelists.at(0));
-        throw InputConnectorBadParamException("wrong line " + std::to_string(clines) + " in data file " + filelists.at(0));
+        std::vector<std::string> elts = dd_utils::split(line, ' ');
+        if (elts.size() != 2)
+          {
+            _logger->error("wrong line {} : \"{}\" in data file {}",
+                           std::to_string(clines), line, filelists.at(0));
+            throw InputConnectorBadParamException(
+                "wrong line " + std::to_string(clines) + " in data file "
+                + filelists.at(0));
+          }
+        lines.push_back(
+            std::pair<std::string, std::string>(elts.at(0), elts.at(1)));
+        ++clines;
       }
-	lines.push_back(std::pair<std::string,std::string>(elts.at(0),elts.at(1)));
-	++clines;
-      }
-    
-    //TODO: shuffle & split
-    
+
+    // TODO: shuffle & split
+
     // create train db
-    write_objects_to_db(traindbname,db_height,db_width,lines,encoded,encode_type,backend,true);
+    write_objects_to_db(traindbname, db_height, db_width, lines, encoded,
+                        encode_type, backend, true);
     _db_batchsize = lines.size();
-    
+
     // read test lines as needed
     if (filelists.size() < 2)
       return 0;
     std::ifstream tin(filelists.at(1));
     if (!tin.is_open())
-      throw InputConnectorBadParamException("failed opening testing data file " + filelists.at(1));
-    _logger->info("reading testing data file {}",filelists.at(1));
-    std::vector<std::pair<std::string,std::string>> tlines;
+      throw InputConnectorBadParamException("failed opening testing data file "
+                                            + filelists.at(1));
+    _logger->info("reading testing data file {}", filelists.at(1));
+    std::vector<std::pair<std::string, std::string>> tlines;
     clines = 0;
-    while(std::getline(tin,line))
+    while (std::getline(tin, line))
       {
-	std::vector<std::string> elts = dd_utils::split(line,' ');
-	if (elts.size() != 2)
-      {
-        _logger->error("wrong line {} : \"{}\" in data file {}", std::to_string(clines), line, filelists.at(1));
-        throw InputConnectorBadParamException("wrong line " + std::to_string(clines) + " in data file " + filelists.at(1));
+        std::vector<std::string> elts = dd_utils::split(line, ' ');
+        if (elts.size() != 2)
+          {
+            _logger->error("wrong line {} : \"{}\" in data file {}",
+                           std::to_string(clines), line, filelists.at(1));
+            throw InputConnectorBadParamException(
+                "wrong line " + std::to_string(clines) + " in data file "
+                + filelists.at(1));
+          }
+        tlines.push_back(
+            std::pair<std::string, std::string>(elts.at(0), elts.at(1)));
+        ++clines;
       }
-	tlines.push_back(std::pair<std::string,std::string>(elts.at(0),elts.at(1)));
-	++clines;
-      }
-    write_objects_to_db(testdbname,this->_height,this->_width,tlines,encoded,encode_type,backend,false);
+    write_objects_to_db(testdbname, this->_height, this->_width, tlines,
+                        encoded, encode_type, backend, false);
     _db_testbatchsize = tlines.size();
-    
-    //TODO: write corresp / map file
-    
+
+    // TODO: write corresp / map file
+
     return 0;
   }
 
-  void ImgCaffeInputFileConn::write_objects_to_db(const std::string &dbfullname,
-						  const int &db_height,
-						  const int &db_width,
-						  const std::vector<std::pair<std::string,std::string>> &lines,
-						  const bool &encoded,
-						  const std::string &encode_type,
-						  const std::string &backend,
-						  const bool &train)
+  void ImgCaffeInputFileConn::write_objects_to_db(
+      const std::string &dbfullname, const int &db_height, const int &db_width,
+      const std::vector<std::pair<std::string, std::string>> &lines,
+      const bool &encoded, const std::string &encode_type,
+      const std::string &backend, const bool &train)
   {
 
     // Create new DB
@@ -860,7 +941,7 @@ namespace dd
     std::unique_ptr<db::Transaction> txn(db->NewTransaction());
 
     // Storing to db
-    AnnotatedDatum_AnnotationType type = AnnotatedDatum_AnnotationType_BBOX; 
+    AnnotatedDatum_AnnotationType type = AnnotatedDatum_AnnotationType_BBOX;
 
     int count = 0;
     int data_size = 0;
@@ -871,131 +952,150 @@ namespace dd
     bool status = true;
     bool check_size = false; // check whether all datum have the same size
     std::vector<float> meanv;
-    
+
     std::map<std::string, int> name_to_label;
     std::string enc = encode_type;
-    
+
     for (size_t line_id = 0; line_id < lines.size(); ++line_id)
       {
-	AnnotatedDatum anno_datum;
-	Datum* datum = anno_datum.mutable_datum();
-	if (encoded && !enc.size())
-	  {
-	    // Guess the encoding type from the file name
-	    string fn = lines[line_id].first;
-	    size_t p = fn.rfind('.');
-	    if ( p == fn.npos )
-	      _logger->warn("failed to guess the encoding of '{}",fn);
-	    enc = fn.substr(p);
-	    std::transform(enc.begin(), enc.end(), enc.begin(), ::tolower);
-	    _logger->info("using encoding {}",enc);
-	  }
-	std::string filename = lines[line_id].first;
-	std::string labelname = lines[line_id].second;
-	int width = db_width; // do not resize images is default
-	int height = db_height;
-	status = ReadRichImageToAnnotatedDatum(filename, labelname, height,
-					       width, min_dim, max_dim, !_bw, enc, type, label_type,
-					       name_to_label, &anno_datum);
-	anno_datum.set_type(AnnotatedDatum_AnnotationType_BBOX);
-	if (status == false)
-	  {
-	    _logger->error("failed to read {} or {}",lines[line_id].first,lines[line_id].second);
-	    throw InputConnectorBadParamException("failed to read " + lines[line_id].first + " or " + lines[line_id].second + " at line " + std::to_string(line_id));
-	  }
-	if (check_size)
-	  {
-	    if (!data_size_initialized)
-	      {
-		data_size = datum->channels() * datum->height() * datum->width();
-		data_size_initialized = true;
-	      }
-	    else
-	      {
-		const std::string& data = datum->data();
-	        if (static_cast<int>(data.size()) != data_size)
-		  {
-		    _logger->error("incorrect data field size {}",data.size());
-		    throw InputConnectorBadParamException("incorrect data field size " + std::to_string(data.size()));
-		  }
-	      }
-	  }
+        AnnotatedDatum anno_datum;
+        Datum *datum = anno_datum.mutable_datum();
+        if (encoded && !enc.size())
+          {
+            // Guess the encoding type from the file name
+            string fn = lines[line_id].first;
+            size_t p = fn.rfind('.');
+            if (p == fn.npos)
+              _logger->warn("failed to guess the encoding of '{}", fn);
+            enc = fn.substr(p);
+            std::transform(enc.begin(), enc.end(), enc.begin(), ::tolower);
+            _logger->info("using encoding {}", enc);
+          }
+        std::string filename = lines[line_id].first;
+        std::string labelname = lines[line_id].second;
+        int width = db_width; // do not resize images is default
+        int height = db_height;
+        status = ReadRichImageToAnnotatedDatum(
+            filename, labelname, height, width, min_dim, max_dim, !_bw, enc,
+            type, label_type, name_to_label, &anno_datum);
+        anno_datum.set_type(AnnotatedDatum_AnnotationType_BBOX);
+        if (status == false)
+          {
+            _logger->error("failed to read {} or {}", lines[line_id].first,
+                           lines[line_id].second);
+            throw InputConnectorBadParamException(
+                "failed to read " + lines[line_id].first + " or "
+                + lines[line_id].second + " at line "
+                + std::to_string(line_id));
+          }
+        if (check_size)
+          {
+            if (!data_size_initialized)
+              {
+                data_size
+                    = datum->channels() * datum->height() * datum->width();
+                data_size_initialized = true;
+              }
+            else
+              {
+                const std::string &data = datum->data();
+                if (static_cast<int>(data.size()) != data_size)
+                  {
+                    _logger->error("incorrect data field size {}",
+                                   data.size());
+                    throw InputConnectorBadParamException(
+                        "incorrect data field size "
+                        + std::to_string(data.size()));
+                  }
+              }
+          }
 
-	// compute the mean
-	if (train)
-	  {
-	    if (_mean_values.empty())
-	      _mean_values = std::vector<float>(datum->channels(),0.0);
-	    std::vector<float> lmeanv(datum->channels(),0.0);
-	    std::vector<cv::Mat> channels;
-	    cv::Mat img = cv::imread(lines[line_id].first);
-	    cv::split(img, channels);
-	    for (int d=0;d<datum->channels();d++) {
-	      lmeanv[d] = cv::mean(channels[d])[0];
-	      _mean_values[d] += lmeanv[d];
-	    }
-	  }
-	
-	// sequential
-	string key_str = caffe::format_int(line_id, 8) + "_" + lines[line_id].first;
-	
-	// Put in db
-	string out;
-	CHECK(anno_datum.SerializeToString(&out));
-	if (!anno_datum.SerializeToString(&out))
-	  _logger->error("Failed serialization of annotated datum for db storage");
-	txn->Put(key_str, out);
-	
-	if (++count % 1000 == 0) {
-	  // Commit db
-	  txn->Commit();
-	  txn.reset(db->NewTransaction());
-	  LOG(INFO) << "Processed " << count << " files.";
-	}
+        // compute the mean
+        if (train)
+          {
+            if (_mean_values.empty())
+              _mean_values = std::vector<float>(datum->channels(), 0.0);
+            std::vector<float> lmeanv(datum->channels(), 0.0);
+            std::vector<cv::Mat> channels;
+            cv::Mat img = cv::imread(lines[line_id].first);
+            cv::split(img, channels);
+            for (int d = 0; d < datum->channels(); d++)
+              {
+                lmeanv[d] = cv::mean(channels[d])[0];
+                _mean_values[d] += lmeanv[d];
+              }
+          }
+
+        // sequential
+        string key_str
+            = caffe::format_int(line_id, 8) + "_" + lines[line_id].first;
+
+        // Put in db
+        string out;
+        CHECK(anno_datum.SerializeToString(&out));
+        if (!anno_datum.SerializeToString(&out))
+          _logger->error(
+              "Failed serialization of annotated datum for db storage");
+        txn->Put(key_str, out);
+
+        if (++count % 1000 == 0)
+          {
+            // Commit db
+            txn->Commit();
+            txn.reset(db->NewTransaction());
+            LOG(INFO) << "Processed " << count << " files.";
+          }
       }
-  
+
     // write the last batch
-    if (count % 1000 != 0) {
-      txn->Commit();
-      LOG(INFO) << "Processed " << count << " files.";
-    }
+    if (count % 1000 != 0)
+      {
+        txn->Commit();
+        LOG(INFO) << "Processed " << count << " files.";
+      }
 
     // average the mean
     if (train)
       {
-	std::ofstream fout_mean(_model_repo + "/mean_values.txt"); // since images are of various sizes
-	for (size_t i=0;i<_mean_values.size();i++)
-	  {
-	    _mean_values.at(i) /= static_cast<float>(count);
-	    fout_mean << _mean_values.at(i) << " ";
-	  }
-	fout_mean << std::endl;
-	fout_mean.close();
+        std::ofstream fout_mean(
+            _model_repo
+            + "/mean_values.txt"); // since images are of various sizes
+        for (size_t i = 0; i < _mean_values.size(); i++)
+          {
+            _mean_values.at(i) /= static_cast<float>(count);
+            fout_mean << _mean_values.at(i) << " ";
+          }
+        fout_mean << std::endl;
+        fout_mean.close();
       }
   }
-  
+
   int ImgCaffeInputFileConn::compute_images_mean(const std::string &dbname,
-						 const std::string &meanfile,
-						 const std::string &backend)
+                                                 const std::string &meanfile,
+                                                 const std::string &backend)
   {
     std::string dbfullname = dbname + "." + backend;
     if (fileops::file_exists(meanfile))
       {
-	_logger->warn("image mean file {} already exists, bypassing creation",meanfile);
-	BlobProto sum_blob;
-	ReadProtoFromBinaryFile(meanfile.c_str(),&sum_blob);
-	const int channels = sum_blob.channels();
-	const int dim = sum_blob.height() * sum_blob.width();
-	_mean_values = std::vector<float>(channels,0.0);
-	_logger->info("Number of channels: {}",channels);
-	for (int c = 0; c < channels; ++c) {
-	  for (int i = 0; i < dim; ++i) {
-	    _mean_values[c] += sum_blob.data(dim * c + i);
-	  }
-	  _logger->info("mean value channel [{}]:{}",c,_mean_values[c] / dim);
-	  _mean_values[c] /= dim;
-	}
-	return 0;
+        _logger->warn("image mean file {} already exists, bypassing creation",
+                      meanfile);
+        BlobProto sum_blob;
+        ReadProtoFromBinaryFile(meanfile.c_str(), &sum_blob);
+        const int channels = sum_blob.channels();
+        const int dim = sum_blob.height() * sum_blob.width();
+        _mean_values = std::vector<float>(channels, 0.0);
+        _logger->info("Number of channels: {}", channels);
+        for (int c = 0; c < channels; ++c)
+          {
+            for (int i = 0; i < dim; ++i)
+              {
+                _mean_values[c] += sum_blob.data(dim * c + i);
+              }
+            _logger->info("mean value channel [{}]:{}", c,
+                          _mean_values[c] / dim);
+            _mean_values[c] /= dim;
+          }
+        return 0;
       }
 
     std::unique_ptr<db::DB> db(db::GetDB(backend));
@@ -1008,72 +1108,87 @@ namespace dd
     Datum datum;
     datum.ParseFromString(cursor->value());
 
-    if (DecodeDatumNative(&datum)) {
-      //_logger->info("Decoding Datum");
-    }
-    
+    if (DecodeDatumNative(&datum))
+      {
+        //_logger->info("Decoding Datum");
+      }
+
     sum_blob.set_num(1);
     sum_blob.set_channels(datum.channels());
     sum_blob.set_height(datum.height());
     sum_blob.set_width(datum.width());
-    int size_in_datum = std::max<int>(datum.data().size(),
-				      datum.float_data_size());
-    for (int i = 0; i < size_in_datum; ++i) {
-      sum_blob.add_data(0.);
-    }
-    while (cursor->valid()) {
-      Datum datum;
-      datum.ParseFromString(cursor->value());
-      DecodeDatumNative(&datum);
-      
-      const std::string& data = datum.data();
-      size_in_datum = std::max<int>(datum.data().size(),
-				    datum.float_data_size());
-      if (data.size() != 0) {
-	for (int i = 0; i < size_in_datum; ++i) {
-	  sum_blob.set_data(i, sum_blob.data(i) + (uint8_t)data[i]);
-	}
-      } else {
-	for (int i = 0; i < size_in_datum; ++i) {
-	  sum_blob.set_data(i, sum_blob.data(i) +
-			    static_cast<float>(datum.float_data(i)));
-	}
+    int size_in_datum
+        = std::max<int>(datum.data().size(), datum.float_data_size());
+    for (int i = 0; i < size_in_datum; ++i)
+      {
+        sum_blob.add_data(0.);
       }
-      ++count;
-      if (count % 10000 == 0) {
-	_logger->info("Processed {} files",count);
+    while (cursor->valid())
+      {
+        Datum datum;
+        datum.ParseFromString(cursor->value());
+        DecodeDatumNative(&datum);
+
+        const std::string &data = datum.data();
+        size_in_datum
+            = std::max<int>(datum.data().size(), datum.float_data_size());
+        if (data.size() != 0)
+          {
+            for (int i = 0; i < size_in_datum; ++i)
+              {
+                sum_blob.set_data(i, sum_blob.data(i) + (uint8_t)data[i]);
+              }
+          }
+        else
+          {
+            for (int i = 0; i < size_in_datum; ++i)
+              {
+                sum_blob.set_data(
+                    i, sum_blob.data(i)
+                           + static_cast<float>(datum.float_data(i)));
+              }
+          }
+        ++count;
+        if (count % 10000 == 0)
+          {
+            _logger->info("Processed {} files", count);
+          }
+        cursor->Next();
       }
-      cursor->Next();
-    }
-    
-    if (count % 10000 != 0) {
-      _logger->info("Processed {} files",count);
-    }
-    for (int i = 0; i < sum_blob.data_size(); ++i) {
-      sum_blob.set_data(i, sum_blob.data(i) / count);
-    }
+
+    if (count % 10000 != 0)
+      {
+        _logger->info("Processed {} files", count);
+      }
+    for (int i = 0; i < sum_blob.data_size(); ++i)
+      {
+        sum_blob.set_data(i, sum_blob.data(i) / count);
+      }
     // Write to disk
-    _logger->info("Write to {}",meanfile);
+    _logger->info("Write to {}", meanfile);
     WriteProtoToBinaryFile(sum_blob, meanfile.c_str());
 
     // let's store the simpler mean values in case of image
     // size changes, e.g. cropping
     const int channels = sum_blob.channels();
     const int dim = sum_blob.height() * sum_blob.width();
-    _mean_values = std::vector<float>(channels,0.0);
-    _logger->info("Number of channels: {}",channels);
-    for (int c = 0; c < channels; ++c) {
-      for (int i = 0; i < dim; ++i) {
-	_mean_values[c] += sum_blob.data(dim * c + i);
+    _mean_values = std::vector<float>(channels, 0.0);
+    _logger->info("Number of channels: {}", channels);
+    for (int c = 0; c < channels; ++c)
+      {
+        for (int i = 0; i < dim; ++i)
+          {
+            _mean_values[c] += sum_blob.data(dim * c + i);
+          }
+        _logger->info("mean value channel [{}]:{}", c, _mean_values[c] / dim);
+        _mean_values[c] /= dim;
       }
-      _logger->info("mean value channel [{}]:{}",c,_mean_values[c] / dim);
-      _mean_values[c] /= dim;
-    }
     return 0;
   }
 
-  std::vector<caffe::Datum> ImgCaffeInputFileConn::get_dv_test_db(const int &num,
-							       const bool &has_mean_file)
+  std::vector<caffe::Datum>
+  ImgCaffeInputFileConn::get_dv_test_db(const int &num,
+                                        const bool &has_mean_file)
   {
     static Blob<float> data_mean;
     static float *mean = nullptr;
@@ -1082,117 +1197,130 @@ namespace dd
       tnum = -1;
     if (!_test_db_cursor)
       {
-	// open db and create cursor
-	if (!_test_db)
-	  {
-	    _test_db = std::unique_ptr<caffe::db::DB>(caffe::db::GetDB("lmdb"));
-	    _test_db->Open(_test_dbfullname.c_str(),caffe::db::READ);
-	  }
-	_test_db_cursor = std::unique_ptr<caffe::db::Cursor>(_test_db->NewCursor());
-	
-	// open mean file if any
-	std::string meanfullname = _model_repo + "/" + _meanfname;
-	if (has_mean_file && fileops::file_exists(meanfullname))
-	  {
-	    BlobProto blob_proto;
-	    ReadProtoFromBinaryFile(meanfullname.c_str(),&blob_proto);
-	    data_mean.FromProto(blob_proto);
-	    mean = data_mean.mutable_cpu_data();
-	  }
+        // open db and create cursor
+        if (!_test_db)
+          {
+            _test_db
+                = std::unique_ptr<caffe::db::DB>(caffe::db::GetDB("lmdb"));
+            _test_db->Open(_test_dbfullname.c_str(), caffe::db::READ);
+          }
+        _test_db_cursor
+            = std::unique_ptr<caffe::db::Cursor>(_test_db->NewCursor());
+
+        // open mean file if any
+        std::string meanfullname = _model_repo + "/" + _meanfname;
+        if (has_mean_file && fileops::file_exists(meanfullname))
+          {
+            BlobProto blob_proto;
+            ReadProtoFromBinaryFile(meanfullname.c_str(), &blob_proto);
+            data_mean.FromProto(blob_proto);
+            mean = data_mean.mutable_cpu_data();
+          }
       }
     std::vector<caffe::Datum> dv;
-    int i =0;
-    while(_test_db_cursor->valid())
+    int i = 0;
+    while (_test_db_cursor->valid())
       {
-	// fill up a vector up to 'num' elements.
-	if (i == tnum)
-	  break;
-	Datum datum;
-	datum.ParseFromString(_test_db_cursor->value());
-	std::vector<double> fd; // XXX: hack to work around removal of float_data in decoder
-	for (int s=0;s<datum.float_data_size();s++)
-	  fd.push_back(datum.float_data(s));
-	DecodeDatumNative(&datum);
-	for (auto s: fd)
-	  datum.add_float_data(s);
+        // fill up a vector up to 'num' elements.
+        if (i == tnum)
+          break;
+        Datum datum;
+        datum.ParseFromString(_test_db_cursor->value());
+        std::vector<double>
+            fd; // XXX: hack to work around removal of float_data in decoder
+        for (int s = 0; s < datum.float_data_size(); s++)
+          fd.push_back(datum.float_data(s));
+        DecodeDatumNative(&datum);
+        for (auto s : fd)
+          datum.add_float_data(s);
 
-	// deal with the mean image values, this forces to turn the datum
-	// data into an array of floats (as opposed to original bytes format)
-	// XXX: beware this is not compatible with imagedata layer with multi-labels as they are stored in float_data
-	if (mean)
-	  {
-	    int height = datum.height();
-	    int width = datum.width();
-	    for (int c=0;c<datum.channels();++c)
-	      for (int h=0;h<height;++h)
-		for (int w=0;w<width;++w)
-		  {
-		    int data_index = (c*height+h)*width+w;
-		    float datum_element;
-		    datum_element = static_cast<float>(static_cast<uint8_t>(datum.data()[data_index]));
-		    datum.add_float_data(datum_element - mean[data_index]);
-		  }
-	    datum.clear_data();
-	  }
-	dv.push_back(datum);
-	_ids.push_back(_test_db_cursor->key());
-	_test_db_cursor->Next();
-	++i;
+        // deal with the mean image values, this forces to turn the datum
+        // data into an array of floats (as opposed to original bytes format)
+        // XXX: beware this is not compatible with imagedata layer with
+        // multi-labels as they are stored in float_data
+        if (mean)
+          {
+            int height = datum.height();
+            int width = datum.width();
+            for (int c = 0; c < datum.channels(); ++c)
+              for (int h = 0; h < height; ++h)
+                for (int w = 0; w < width; ++w)
+                  {
+                    int data_index = (c * height + h) * width + w;
+                    float datum_element;
+                    datum_element = static_cast<float>(
+                        static_cast<uint8_t>(datum.data()[data_index]));
+                    datum.add_float_data(datum_element - mean[data_index]);
+                  }
+            datum.clear_data();
+          }
+        dv.push_back(datum);
+        _ids.push_back(_test_db_cursor->key());
+        _test_db_cursor->Next();
+        ++i;
       }
     return dv;
   }
 
-  std::vector<caffe::Datum> ImgCaffeInputFileConn::get_dv_test_segmentation(const int &num,
-									    const bool &has_mean_file)
+  std::vector<caffe::Datum>
+  ImgCaffeInputFileConn::get_dv_test_segmentation(const int &num,
+                                                  const bool &has_mean_file)
   {
-    (void) has_mean_file;
+    (void)has_mean_file;
     if (_segmentation_data_lines.empty())
       {
-	_logger->info("reading segmentation test file {}",_uris.at(1).c_str());
-	std::ifstream infile(_uris.at(1).c_str());
-	std::string filename, label_filename;
-	while(infile >> filename >> label_filename)
-	  {
-	    _segmentation_data_lines.push_back(std::make_pair(filename,label_filename));
-	  }
+        _logger->info("reading segmentation test file {}",
+                      _uris.at(1).c_str());
+        std::ifstream infile(_uris.at(1).c_str());
+        std::string filename, label_filename;
+        while (infile >> filename >> label_filename)
+          {
+            _segmentation_data_lines.push_back(
+                std::make_pair(filename, label_filename));
+          }
       }
 
     std::vector<caffe::Datum> dv;
     int j = 0;
-    for (int i=_dt_seg;i<static_cast<int>(_segmentation_data_lines.size());i++)
+    for (int i = _dt_seg;
+         i < static_cast<int>(_segmentation_data_lines.size()); i++)
       {
-	if (j == num)
-	  break;
-	std::string enc = guess_encoding(_segmentation_data_lines[i].first);
-	Datum datum_data, datum_labels;
-	bool status = ReadImageToDatum(_segmentation_data_lines[i].first,-1,
-				       _height,_width,0,0,!_bw,false,enc,&datum_data);
-	if (status == false)
-	  {
-	    _logger->error("reading segmentation image {} to datum",_segmentation_data_lines[i].first);
-	    continue;
-	  }
+        if (j == num)
+          break;
+        std::string enc = guess_encoding(_segmentation_data_lines[i].first);
+        Datum datum_data, datum_labels;
+        bool status
+            = ReadImageToDatum(_segmentation_data_lines[i].first, -1, _height,
+                               _width, 0, 0, !_bw, false, enc, &datum_data);
+        if (status == false)
+          {
+            _logger->error("reading segmentation image {} to datum",
+                           _segmentation_data_lines[i].first);
+            continue;
+          }
 
-	cv::Mat cv_lab = ReadImageToCVMat(_segmentation_data_lines[i].second,_height,_width,false,true);
-	datum_labels.set_height(_height);
-	datum_labels.set_width(_width);
-	datum_labels.set_channels(1);
-	for (int j=0;j<cv_lab.rows;j++) // height
-	  {
-	    for (int i=0;i<cv_lab.cols;i++) // width
-	      {
-		datum_labels.add_float_data(static_cast<float>(cv_lab.at<uchar>(j,i)));
-	      }
-	  }
-	dv.push_back(datum_data);
-	dv.push_back(datum_labels);
-	_ids.push_back(std::to_string(j));
-	++j;
+        cv::Mat cv_lab = ReadImageToCVMat(_segmentation_data_lines[i].second,
+                                          _height, _width, false, true);
+        datum_labels.set_height(_height);
+        datum_labels.set_width(_width);
+        datum_labels.set_channels(1);
+        for (int j = 0; j < cv_lab.rows; j++) // height
+          {
+            for (int i = 0; i < cv_lab.cols; i++) // width
+              {
+                datum_labels.add_float_data(
+                    static_cast<float>(cv_lab.at<uchar>(j, i)));
+              }
+          }
+        dv.push_back(datum_data);
+        dv.push_back(datum_labels);
+        _ids.push_back(std::to_string(j));
+        ++j;
       }
     _dt_seg += j;
     return dv;
   }
-  
+
   void ImgCaffeInputFileConn::reset_dv_test()
   {
     _dt_vit = _dv_test.begin();
@@ -1200,7 +1328,6 @@ namespace dd
     _test_db = std::unique_ptr<caffe::db::DB>();
     _dt_seg = 0;
   }
-
 
   /*- DDCCsv -*/
   int DDCCsv::read_file(const std::string &fname)
@@ -1210,7 +1337,8 @@ namespace dd
         _cifc->read_csv(fname);
         return 0;
       }
-    else return -1;
+    else
+      return -1;
   }
 
   int DDCCsv::read_db(const std::string &fname)
@@ -1218,7 +1346,7 @@ namespace dd
     _cifc->_db_fname = fname;
     return 0;
   }
-  
+
   int DDCCsv::read_mem(const std::string &content)
   {
     if (!_cifc)
@@ -1226,20 +1354,22 @@ namespace dd
     std::vector<double> vals;
     std::string cid;
     int nlines = 0;
-    _cifc->read_csv_line(content,_cifc->_delim,vals,cid,nlines);
+    _cifc->read_csv_line(content, _cifc->_delim, vals, cid, nlines);
     if (_cifc->_scale)
       _cifc->scale_vals(vals);
     if (!cid.empty())
-      _cifc->_csvdata.emplace_back(cid,vals);
-    else _cifc->_csvdata.emplace_back(std::to_string(_cifc->_csvdata.size()+1),vals);
+      _cifc->_csvdata.emplace_back(cid, vals);
+    else
+      _cifc->_csvdata.emplace_back(std::to_string(_cifc->_csvdata.size() + 1),
+                                   vals);
     return 0;
   }
 
   /*- CSVCaffeInputFileConn -*/
   int CSVCaffeInputFileConn::csv_to_db(const std::string &traindbname,
-				       const std::string &testdbname,
-				       const APIData &ad_input,
-				       const std::string &backend)
+                                       const std::string &testdbname,
+                                       const APIData &ad_input,
+                                       const std::string &backend)
   {
     std::string dbfullname = traindbname + "." + backend;
     std::string testdbfullname = testdbname + "." + backend;
@@ -1249,124 +1379,138 @@ namespace dd
     // in the model repository.
     if (fileops::file_exists(dbfullname))
       {
-	_logger->warn("CSV db file {} already exists, bypassing creation but checking on records",dbfullname);
-	std::unique_ptr<db::DB> db(db::GetDB(backend));
-	db->Open(dbfullname.c_str(), db::READ);
-	std::unique_ptr<db::Cursor> cursor(db->NewCursor());
-	while(cursor->valid())
-	  {
-	    if (_channels == 0)
-	      {
-		Datum datum;
-		datum.ParseFromString(cursor->value());
-		_channels = datum.channels();
-	      }
-	    break;
-	  }
-	_db_batchsize = db->Count();
-	_logger->info("CSV db train file {} with {} records",dbfullname,_db_batchsize);
-	if (!testdbname.empty() && fileops::file_exists(testdbfullname))
-	  {
-	    _logger->warn("CSV db file {} already exists, bypassing creation but checking on records",testdbfullname);
-	    std::unique_ptr<db::DB> tdb(db::GetDB(backend));
-	    tdb->Open(testdbfullname.c_str(), db::READ);
-	    _db_testbatchsize = tdb->Count();
-	    _logger->info("CSV db test file {} with {} records",testdbfullname,_db_testbatchsize);
-	  }	
-	return 0;
+        _logger->warn("CSV db file {} already exists, bypassing creation but "
+                      "checking on records",
+                      dbfullname);
+        std::unique_ptr<db::DB> db(db::GetDB(backend));
+        db->Open(dbfullname.c_str(), db::READ);
+        std::unique_ptr<db::Cursor> cursor(db->NewCursor());
+        while (cursor->valid())
+          {
+            if (_channels == 0)
+              {
+                Datum datum;
+                datum.ParseFromString(cursor->value());
+                _channels = datum.channels();
+              }
+            break;
+          }
+        _db_batchsize = db->Count();
+        _logger->info("CSV db train file {} with {} records", dbfullname,
+                      _db_batchsize);
+        if (!testdbname.empty() && fileops::file_exists(testdbfullname))
+          {
+            _logger->warn("CSV db file {} already exists, bypassing creation "
+                          "but checking on records",
+                          testdbfullname);
+            std::unique_ptr<db::DB> tdb(db::GetDB(backend));
+            tdb->Open(testdbfullname.c_str(), db::READ);
+            _db_testbatchsize = tdb->Count();
+            _logger->info("CSV db test file {} with {} records",
+                          testdbfullname, _db_testbatchsize);
+          }
+        return 0;
       }
-    
+
     // write files to dbs (i.e. train and possibly test)
     _db_batchsize = 0;
     _db_testbatchsize = 0;
-    write_csvline_to_db(dbfullname,testdbfullname,ad_input);
-        
+    write_csvline_to_db(dbfullname, testdbfullname, ad_input);
+
     return 0;
   }
 
   void CSVCaffeInputFileConn::add_train_csvline(const std::string &id,
-						std::vector<double> &vals)
+                                                std::vector<double> &vals)
   {
     if (!_db)
       {
-	CSVInputFileConn::add_train_csvline(id,vals);
-	return;
+        CSVInputFileConn::add_train_csvline(id, vals);
+        return;
       }
 
     static int count = 0;
-    
+
     const int kMaxKeyLength = 256;
     char key_cstr[kMaxKeyLength];
-    
+
     Datum d = to_datum(vals);
-    
+
     // sequential
-    int length = snprintf(key_cstr,kMaxKeyLength,"%s",std::to_string(count).c_str()); // XXX: using appeared to confuse the training (maybe because sorted)
-    
+    int length = snprintf(
+        key_cstr, kMaxKeyLength, "%s",
+        std::to_string(count).c_str()); // XXX: using appeared to confuse the
+                                        // training (maybe because sorted)
+
     // put in db
     std::string out;
-    if(!d.SerializeToString(&out))
+    if (!d.SerializeToString(&out))
       {
-	_logger->error("Failed serialization of datum for db storage");
-	return;
+        _logger->error("Failed serialization of datum for db storage");
+        return;
       }
     if (!_txn)
       {
-	_logger->error("db transaction cannot be executed, wrong db flag ?");
-	throw InputConnectorBadParamException("db transaction cannot be executed, wrong db flag ?");
+        _logger->error("db transaction cannot be executed, wrong db flag ?");
+        throw InputConnectorBadParamException(
+            "db transaction cannot be executed, wrong db flag ?");
       }
     _txn->Put(std::string(key_cstr, length), out);
     _db_batchsize++;
-    
-    if (++count % 10000 == 0) {
-      // commit db
-      _txn->Commit();
-      _txn.reset(_tdb->NewTransaction());
-      _logger->info("Processed {} records",count);
-    }
+
+    if (++count % 10000 == 0)
+      {
+        // commit db
+        _txn->Commit();
+        _txn.reset(_tdb->NewTransaction());
+        _logger->info("Processed {} records", count);
+      }
   }
 
   void CSVCaffeInputFileConn::add_test_csvline(const std::string &id,
-					       std::vector<double> &vals)
+                                               std::vector<double> &vals)
   {
     if (!_db)
       {
-	CSVInputFileConn::add_test_csvline(id,vals);
-	return;
+        CSVInputFileConn::add_test_csvline(id, vals);
+        return;
       }
-    
-      static int count = 0;
-    
+
+    static int count = 0;
+
     const int kMaxKeyLength = 256;
     char key_cstr[kMaxKeyLength];
-    
+
     Datum d = to_datum(vals);
-    
+
     // sequential
-    int length = snprintf(key_cstr,kMaxKeyLength,"%s",std::to_string(count).c_str()); // XXX: using id appeared to confuse the training (maybe because sorted)
-    
+    int length = snprintf(
+        key_cstr, kMaxKeyLength, "%s",
+        std::to_string(count).c_str()); // XXX: using id appeared to confuse
+                                        // the training (maybe because sorted)
+
     // put in db
     std::string out;
-    if(!d.SerializeToString(&out))
+    if (!d.SerializeToString(&out))
       {
-	_logger->error("Failed serialization of datum for db storage");
-	return;
+        _logger->error("Failed serialization of datum for db storage");
+        return;
       }
     _ttxn->Put(std::string(key_cstr, length), out);
     _db_testbatchsize++;
 
-    if (++count % 10000 == 0) {
-      // commit db
-      _ttxn->Commit();
-      _ttxn.reset(_ttdb->NewTransaction());
-      _logger->info("Processed {} records",count);
-    }
+    if (++count % 10000 == 0)
+      {
+        // commit db
+        _ttxn->Commit();
+        _ttxn.reset(_ttdb->NewTransaction());
+        _logger->info("Processed {} records", count);
+      }
   }
-  
-  void CSVCaffeInputFileConn::write_csvline_to_db(const std::string &dbfullname,
-						  const std::string &testdbfullname,
-						  const APIData &ad_input,
-						  const std::string &backend)
+
+  void CSVCaffeInputFileConn::write_csvline_to_db(
+      const std::string &dbfullname, const std::string &testdbfullname,
+      const APIData &ad_input, const std::string &backend)
   {
     // Create new DB
     _tdb = std::unique_ptr<caffe::db::DB>(caffe::db::GetDB(backend));
@@ -1378,55 +1522,60 @@ namespace dd
 
     _csv_fname = _uris.at(0); // training only from file
     if (!fileops::file_exists(_csv_fname))
-      throw InputConnectorBadParamException("training CSV file " + _csv_fname + " does not exist");
+      throw InputConnectorBadParamException("training CSV file " + _csv_fname
+                                            + " does not exist");
     if (_uris.size() > 1)
       _csv_test_fname = _uris.at(1);
     /*if (ad_input.has("label"))
       _label = ad_input.get("label").get<std::string>();
-    else if (_train && _label.empty()) throw InputConnectorBadParamException("missing label column parameter");
-    if (ad_input.has("label_offset"))
-    _label_offset = ad_input.get("label_offset").get<int>();*/
-    
+    else if (_train && _label.empty()) throw
+    InputConnectorBadParamException("missing label column parameter"); if
+    (ad_input.has("label_offset")) _label_offset =
+    ad_input.get("label_offset").get<int>();*/
+
     DataEl<DDCCsv> ddcsv(this->_input_timeout);
     ddcsv._ctype._cifc = this;
     ddcsv._ctype._adconf = ad_input;
-    ddcsv.read_element(_csv_fname,this->_logger);
+    ddcsv.read_element(_csv_fname, this->_logger);
 
     _txn->Commit();
     _ttxn->Commit();
-    
+
     _tdb->Close();
     _ttdb->Close();
   }
 
-  std::vector<caffe::Datum> CSVCaffeInputFileConn::get_dv_test_db(const int &num)
+  std::vector<caffe::Datum>
+  CSVCaffeInputFileConn::get_dv_test_db(const int &num)
   {
     int tnum = num;
     if (tnum == 0)
       tnum = -1;
     if (!_test_db_cursor)
       {
-	// open db and create cursor
-	if (!_test_db)
-	  {
-	    _test_db = std::unique_ptr<caffe::db::DB>(caffe::db::GetDB("lmdb"));
-	    _test_db->Open(_test_dbfullname.c_str(),caffe::db::READ);
-	  }
-	_test_db_cursor = std::unique_ptr<caffe::db::Cursor>(_test_db->NewCursor());
+        // open db and create cursor
+        if (!_test_db)
+          {
+            _test_db
+                = std::unique_ptr<caffe::db::DB>(caffe::db::GetDB("lmdb"));
+            _test_db->Open(_test_dbfullname.c_str(), caffe::db::READ);
+          }
+        _test_db_cursor
+            = std::unique_ptr<caffe::db::Cursor>(_test_db->NewCursor());
       }
     std::vector<caffe::Datum> dv;
-    int i =0;
-    while(_test_db_cursor->valid())
+    int i = 0;
+    while (_test_db_cursor->valid())
       {
-	// fill up a vector up to 'num' elements.
-	if (i == tnum)
-	  break;
-	Datum datum;
-	datum.ParseFromString(_test_db_cursor->value());
-	dv.push_back(datum);
-	_ids.push_back(_test_db_cursor->key());
-	_test_db_cursor->Next();
-	++i;
+        // fill up a vector up to 'num' elements.
+        if (i == tnum)
+          break;
+        Datum datum;
+        datum.ParseFromString(_test_db_cursor->value());
+        dv.push_back(datum);
+        _ids.push_back(_test_db_cursor->key());
+        _test_db_cursor->Next();
+        ++i;
       }
     return dv;
   }
@@ -1440,8 +1589,8 @@ namespace dd
 
   /*- TxtCaffeInputFileConn -*/
   int TxtCaffeInputFileConn::txt_to_db(const std::string &traindbname,
-				       const std::string &testdbname,
-				       const std::string &backend)
+                                       const std::string &testdbname,
+                                       const std::string &backend)
   {
     std::string dbfullname = traindbname + "." + backend;
     std::string testdbfullname = testdbname + "." + backend;
@@ -1451,60 +1600,67 @@ namespace dd
     // in the model repository.
     if (fileops::file_exists(dbfullname))
       {
-	_logger->warn("Txt db file {} already exists, bypassing creation but checking on records",dbfullname);
-	std::unique_ptr<db::DB> db(db::GetDB(backend));
-	db->Open(dbfullname.c_str(), db::READ);
-	std::unique_ptr<db::Cursor> cursor(db->NewCursor());
-	while(cursor->valid())
-	  {
-	    if (_channels == 0)
-	      {
-		Datum datum;
-		datum.ParseFromString(cursor->value());
-		_channels = datum.channels();
-	      }
-	    break;
-	  }
-	_db_batchsize = db->Count();
-	_logger->info("Txt db train file {} with {} records",dbfullname,_db_batchsize);
-	if (!testdbname.empty() && fileops::file_exists(testdbfullname))
-	  {
-	    _logger->warn("Txt db file {} already exists, bypassing creation but checking on records",testdbfullname);
-	    std::unique_ptr<db::DB> tdb(db::GetDB(backend));
-	    tdb->Open(testdbfullname.c_str(), db::READ);
-	    _db_testbatchsize = tdb->Count();
-	    _logger->info("Txt db test file {} with {} records",testdbfullname,_db_testbatchsize);
-	  }
-	// XXX: remove in-memory data, which pre-processing is useless and should be avoided
-	destroy_txt_entries(_txt);
-	destroy_txt_entries(_test_txt);
-	
-	return 0;
+        _logger->warn("Txt db file {} already exists, bypassing creation but "
+                      "checking on records",
+                      dbfullname);
+        std::unique_ptr<db::DB> db(db::GetDB(backend));
+        db->Open(dbfullname.c_str(), db::READ);
+        std::unique_ptr<db::Cursor> cursor(db->NewCursor());
+        while (cursor->valid())
+          {
+            if (_channels == 0)
+              {
+                Datum datum;
+                datum.ParseFromString(cursor->value());
+                _channels = datum.channels();
+              }
+            break;
+          }
+        _db_batchsize = db->Count();
+        _logger->info("Txt db train file {} with {} records", dbfullname,
+                      _db_batchsize);
+        if (!testdbname.empty() && fileops::file_exists(testdbfullname))
+          {
+            _logger->warn("Txt db file {} already exists, bypassing creation "
+                          "but checking on records",
+                          testdbfullname);
+            std::unique_ptr<db::DB> tdb(db::GetDB(backend));
+            tdb->Open(testdbfullname.c_str(), db::READ);
+            _db_testbatchsize = tdb->Count();
+            _logger->info("Txt db test file {} with {} records",
+                          testdbfullname, _db_testbatchsize);
+          }
+        // XXX: remove in-memory data, which pre-processing is useless and
+        // should be avoided
+        destroy_txt_entries(_txt);
+        destroy_txt_entries(_test_txt);
+
+        return 0;
       }
-    
+
     _db_batchsize = _txt.size();
     _db_testbatchsize = _test_txt.size();
 
-    _logger->info("db_batchsize={} / db_testbatchsize={}",_db_batchsize,_db_testbatchsize);
-    
+    _logger->info("db_batchsize={} / db_testbatchsize={}", _db_batchsize,
+                  _db_testbatchsize);
+
     // write to dbs (i.e. train and possibly test)
     if (!_sparse)
-      write_txt_to_db(dbfullname,_txt);
-    else write_sparse_txt_to_db(dbfullname,_txt);
+      write_txt_to_db(dbfullname, _txt);
+    else
+      write_sparse_txt_to_db(dbfullname, _txt);
     destroy_txt_entries(_txt);
     if (!_test_txt.empty())
       {
-	if (!_sparse)
-	  write_txt_to_db(testdbfullname,_test_txt);
-	else write_sparse_txt_to_db(testdbfullname,_test_txt);
-	destroy_txt_entries(_test_txt);
+        if (!_sparse)
+          write_txt_to_db(testdbfullname, _test_txt);
+        else
+          write_sparse_txt_to_db(testdbfullname, _test_txt);
+        destroy_txt_entries(_test_txt);
       }
-    
+
     return 0;
   }
-
-
-
 
   int DDCCsvTS::read_file(const std::string &fname, bool is_test_data)
   {
@@ -1518,8 +1674,8 @@ namespace dd
         _cifc->_ids.push_back(fname);
         return 0;
       }
-    else return -1;
-
+    else
+      return -1;
   }
 
   int DDCCsvTS::read_db(const std::string &fname)
@@ -1538,7 +1694,8 @@ namespace dd
     return 0;
   }
 
-  int DDCCsvTS::read_dir(const std::string &dir, bool is_test_data, bool update_bounds)
+  int DDCCsvTS::read_dir(const std::string &dir, bool is_test_data,
+                         bool update_bounds)
   {
     // first recursive list csv files
     std::unordered_set<std::string> allfiles;
@@ -1549,27 +1706,30 @@ namespace dd
     if (!_cifc)
       return -1;
 
-    if (update_bounds && _cifc->_scale && (_cifc->_min_vals.empty() || _cifc->_max_vals.empty() ))
+    if (update_bounds && _cifc->_scale
+        && (_cifc->_min_vals.empty() || _cifc->_max_vals.empty()))
       {
         std::unordered_set<std::string> reallyallfiles;
-        ret = fileops::list_directory(_cifc->_csv_test_fname, true, false, true, reallyallfiles);
+        ret = fileops::list_directory(_cifc->_csv_test_fname, true, false,
+                                      true, reallyallfiles);
         reallyallfiles.insert(allfiles.begin(), allfiles.end());
 
         std::vector<double> min_vals = _cifc->_min_vals;
         std::vector<double> max_vals = _cifc->_max_vals;
         for (auto fname : reallyallfiles)
           {
-            std::pair<std::vector<double>,std::vector<double>> mm = _cifc->get_min_max_vals(fname);
+            std::pair<std::vector<double>, std::vector<double>> mm
+                = _cifc->get_min_max_vals(fname);
             if (min_vals.empty())
               min_vals = mm.first;
             else
-              for (size_t j=0;j<mm.first.size();j++)
-                min_vals.at(j) = std::min(mm.first.at(j),min_vals.at(j));
+              for (size_t j = 0; j < mm.first.size(); j++)
+                min_vals.at(j) = std::min(mm.first.at(j), min_vals.at(j));
             if (max_vals.empty())
               max_vals = mm.second;
             else
-              for (size_t j=0;j<mm.first.size();j++)
-                max_vals.at(j) = std::max(mm.second.at(j),max_vals.at(j));
+              for (size_t j = 0; j < mm.first.size(); j++)
+                max_vals.at(j) = std::max(mm.second.at(j), max_vals.at(j));
           }
         _cifc->_min_vals = min_vals;
         _cifc->_max_vals = max_vals;
@@ -1592,17 +1752,17 @@ namespace dd
         read_file(fname, is_test_data);
 
     return 0;
-}
+  }
 
   void CSVTSCaffeInputFileConn::set_datadim(bool is_test_data)
   {
-	//+1 because of mandatory continuation indicator
+    //+1 because of mandatory continuation indicator
     if (_datadim != -1)
       return;
     if (is_test_data)
-      _datadim = _csvtsdata_test[0][0]._v.size() +1;
+      _datadim = _csvtsdata_test[0][0]._v.size() + 1;
     else
-      _datadim = _csvtsdata[0][0]._v.size() +1;
+      _datadim = _csvtsdata[0][0]._v.size() + 1;
   }
 
   void CSVTSCaffeInputFileConn::push_csv_to_csvts(bool is_test_data)
@@ -1614,7 +1774,8 @@ namespace dd
   }
 
   void CSVTSCaffeInputFileConn::transform(const APIData &ad)
-  {// calls CSVTSInputfileconn::transform and db stuff (in particular cvsts_to_db)
+  { // calls CSVTSInputfileconn::transform and db stuff (in particular
+    // cvsts_to_db)
     APIData ad_param = ad.getobj("parameters");
     APIData ad_input = ad_param.getobj("input");
     APIData ad_mllib = ad_param.getobj("mllib");
@@ -1628,70 +1789,70 @@ namespace dd
         _test_dbfullname = _model_repo + "/" + _test_dbfullname;
 
         _db = true;
-        csvts_to_db(_model_repo + "/" + _dbname,_model_repo + "/" + _test_dbname,
-		    ad_input);
-        write_class_weights(_model_repo,ad_mllib);
+        csvts_to_db(_model_repo + "/" + _dbname,
+                    _model_repo + "/" + _test_dbname, ad_input);
+        write_class_weights(_model_repo, ad_mllib);
 
         // enrich data object with db files location
         APIData dbad;
-        dbad.add("train_db",_dbfullname);
+        dbad.add("train_db", _dbfullname);
         if (_test_split > 0.0)
-          dbad.add("test_db",_test_dbfullname);
-        const_cast<APIData&>(ad).add("db",dbad);
-	}
-      else
-	{
-	  try
-	    {
-	      CSVTSInputFileConn::transform(ad);
-             set_datadim();
-             this->_ids=this->_fnames;
-	    }
-	  catch (std::exception &e)
-	    {
-	      throw;
-	    }
+          dbad.add("test_db", _test_dbfullname);
+        const_cast<APIData &>(ad).add("db", dbad);
+      }
+    else
+      {
+        try
+          {
+            CSVTSInputFileConn::transform(ad);
+            set_datadim();
+            this->_ids = this->_fnames;
+          }
+        catch (std::exception &e)
+          {
+            throw;
+          }
 
-	  // transform to datum by filling up float_data
-	  if (_train)
-	    {
-             csvts_to_dv(false,true,true,true,false);
-	    }
-	  if (!_train)
-	    {
-	      if (!_db_fname.empty())
-		{
-		  _test_dbfullname = _db_fname;
-		  _db = true;
-		  return; // done
-		}
-	      _csvtsdata_test = std::move(_csvtsdata);
-	    }
-	  else _csvtsdata.clear();
-         csvts_to_dv(true,true,true,false,_continuation);
-	  _csvtsdata_test.clear();
-	}
-      _csvtsdata_test.clear();
+        // transform to datum by filling up float_data
+        if (_train)
+          {
+            csvts_to_dv(false, true, true, true, false);
+          }
+        if (!_train)
+          {
+            if (!_db_fname.empty())
+              {
+                _test_dbfullname = _db_fname;
+                _db = true;
+                return; // done
+              }
+            _csvtsdata_test = std::move(_csvtsdata);
+          }
+        else
+          _csvtsdata.clear();
+        csvts_to_dv(true, true, true, false, _continuation);
+        _csvtsdata_test.clear();
+      }
+    _csvtsdata_test.clear();
   }
 
   void CSVTSCaffeInputFileConn::reset_dv_test()
   {
     _dt_vit = _dv_test.begin();
     _test_db_cursor = std::unique_ptr<caffe::db::Cursor>();
-    _test_db  = std::unique_ptr<caffe::db::DB>();
+    _test_db = std::unique_ptr<caffe::db::DB>();
   }
 
-
-  std::vector<caffe::Datum> CSVTSCaffeInputFileConn::get_dv_test(const int &num,
-                                                                 const bool &has_mean_file)
+  std::vector<caffe::Datum>
+  CSVTSCaffeInputFileConn::get_dv_test(const int &num,
+                                       const bool &has_mean_file)
   {
     (void)has_mean_file;
     if (!_db)
       {
         int i = 0;
         std::vector<caffe::Datum> dv;
-        while(_dt_vit!=_dv_test.end()
-              && i < num)
+        while (_dt_vit != _dv_test.end() && i < num)
           {
             dv.push_back((*_dt_vit));
             ++i;
@@ -1699,10 +1860,12 @@ namespace dd
           }
         return dv;
       }
-    else return get_dv_test_db(num);
+    else
+      return get_dv_test_db(num);
   }
 
-  std::vector<caffe::Datum> CSVTSCaffeInputFileConn::get_dv_test_db(const int &num)
+  std::vector<caffe::Datum>
+  CSVTSCaffeInputFileConn::get_dv_test_db(const int &num)
   {
     int tnum = num;
     if (tnum == 0)
@@ -1712,14 +1875,16 @@ namespace dd
         // open db and create cursor
         if (!_test_db)
           {
-            _test_db = std::unique_ptr<caffe::db::DB>(caffe::db::GetDB("lmdb"));
-            _test_db->Open(_test_dbfullname.c_str(),caffe::db::READ);
+            _test_db
+                = std::unique_ptr<caffe::db::DB>(caffe::db::GetDB("lmdb"));
+            _test_db->Open(_test_dbfullname.c_str(), caffe::db::READ);
           }
-        _test_db_cursor = std::unique_ptr<caffe::db::Cursor>(_test_db->NewCursor());
+        _test_db_cursor
+            = std::unique_ptr<caffe::db::Cursor>(_test_db->NewCursor());
       }
     std::vector<caffe::Datum> dv;
-    int i =0;
-    while(_test_db_cursor->valid())
+    int i = 0;
+    while (_test_db_cursor->valid())
       {
         // fill up a vector up to 'num' elements.
         if (i == tnum)
@@ -1734,12 +1899,10 @@ namespace dd
     return dv;
   }
 
-
-
-  int CSVTSCaffeInputFileConn::csvts_to_db(const std::string &traindbname,
-                                           const std::string &testdbname,
-                                           const APIData &ad_input,
-                                           const std::string &backend) // lmdb, leveldb
+  int CSVTSCaffeInputFileConn::csvts_to_db(
+      const std::string &traindbname, const std::string &testdbname,
+      const APIData &ad_input,
+      const std::string &backend) // lmdb, leveldb
   {
     std::string dbfullname = traindbname + "." + backend;
     std::string testdbfullname = testdbname + "." + backend;
@@ -1749,37 +1912,43 @@ namespace dd
     // in the model repository.
     if (fileops::file_exists(dbfullname))
       {
-	_logger->warn("CSV db file {} already exists, bypassing creation but checking on records",dbfullname);
-	std::unique_ptr<db::DB> db(db::GetDB(backend));
-	db->Open(dbfullname.c_str(), db::READ);
-	std::unique_ptr<db::Cursor> cursor(db->NewCursor());
-	while(cursor->valid())
-	  {
-	    if (_channels == 0 || _datadim == -1)
-	      {
-		Datum datum;
-		datum.ParseFromString(cursor->value());
-		_channels = datum.channels();
-              _datadim = datum.height();
-	      }
-	    break;
-	  }
-	_db_batchsize = db->Count();
-	_logger->info("CSV db train file {} with {} records",dbfullname,_db_batchsize);
-	if (!testdbname.empty() && fileops::file_exists(testdbfullname))
-	  {
-	    _logger->warn("CSV db file {} already exists, bypassing creation but checking on records",testdbfullname);
-	    std::unique_ptr<db::DB> tdb(db::GetDB(backend));
-	    tdb->Open(testdbfullname.c_str(), db::READ);
-	    _db_testbatchsize = tdb->Count();
-	    _logger->info("CSV db test file {} with {} records",testdbfullname,_db_testbatchsize);
-	  }
-	return 0;
+        _logger->warn("CSV db file {} already exists, bypassing creation but "
+                      "checking on records",
+                      dbfullname);
+        std::unique_ptr<db::DB> db(db::GetDB(backend));
+        db->Open(dbfullname.c_str(), db::READ);
+        std::unique_ptr<db::Cursor> cursor(db->NewCursor());
+        while (cursor->valid())
+          {
+            if (_channels == 0 || _datadim == -1)
+              {
+                Datum datum;
+                datum.ParseFromString(cursor->value());
+                _channels = datum.channels();
+                _datadim = datum.height();
+              }
+            break;
+          }
+        _db_batchsize = db->Count();
+        _logger->info("CSV db train file {} with {} records", dbfullname,
+                      _db_batchsize);
+        if (!testdbname.empty() && fileops::file_exists(testdbfullname))
+          {
+            _logger->warn("CSV db file {} already exists, bypassing creation "
+                          "but checking on records",
+                          testdbfullname);
+            std::unique_ptr<db::DB> tdb(db::GetDB(backend));
+            tdb->Open(testdbfullname.c_str(), db::READ);
+            _db_testbatchsize = tdb->Count();
+            _logger->info("CSV db test file {} with {} records",
+                          testdbfullname, _db_testbatchsize);
+          }
+        return 0;
       }
     // write files to dbs (i.e. train and possibly test)
     _db_batchsize = 0;
     _db_testbatchsize = 0;
-    write_csvts_to_db(dbfullname, testdbfullname, ad_input,backend);
+    write_csvts_to_db(dbfullname, testdbfullname, ad_input, backend);
     return 0;
   }
 
@@ -1787,12 +1956,12 @@ namespace dd
   {
     if (!_db)
       return;
-    std::vector<Datum>& dvtodump = _dv;
+    std::vector<Datum> &dvtodump = _dv;
     int &dv_index = _dv_index;
     std::unique_ptr<caffe::db::Transaction> *txn_ptr = &_txn;
     std::unique_ptr<caffe::db::DB> *tdb_ptr = &_tdb;
 
-    csvts_to_dv(is_test_data,true,true,true,_continuation);
+    csvts_to_dv(is_test_data, true, true, true, _continuation);
     if (is_test_data)
       {
         dvtodump = _dv_test;
@@ -1805,39 +1974,45 @@ namespace dd
     char key_cstr[kMaxKeyLength];
     int count = 0;
 
-    for (Datum d:dvtodump)
+    for (Datum d : dvtodump)
       {
         std::string out;
 
-        int length = snprintf(key_cstr,kMaxKeyLength,"%s",std::to_string(count).c_str()); // XXX: using appeared to confuse the training (maybe because sorted)
-        if(!d.SerializeToString(&out))
+        int length
+            = snprintf(key_cstr, kMaxKeyLength, "%s",
+                       std::to_string(count)
+                           .c_str()); // XXX: using appeared to confuse the
+                                      // training (maybe because sorted)
+        if (!d.SerializeToString(&out))
           {
             _logger->error("Failed serialization of datum for db storage");
             return;
           }
         if (!*txn_ptr)
           {
-            _logger->error("db transaction cannot be executed, wrong db flag ?");
-            throw InputConnectorBadParamException("db transaction cannot be executed, wrong db flag ?");
+            _logger->error(
+                "db transaction cannot be executed, wrong db flag ?");
+            throw InputConnectorBadParamException(
+                "db transaction cannot be executed, wrong db flag ?");
           }
         (*txn_ptr)->Put(std::string(key_cstr, length), out);
         _db_batchsize++;
 
-        if (++count % 10 == 0) {
-          // commit db
-          (*txn_ptr)->Commit();
-          (*txn_ptr).reset((*tdb_ptr)->NewTransaction());
-          _logger->info("Processed {} timeseries",count);
-        }
+        if (++count % 10 == 0)
+          {
+            // commit db
+            (*txn_ptr)->Commit();
+            (*txn_ptr).reset((*tdb_ptr)->NewTransaction());
+            _logger->info("Processed {} timeseries", count);
+          }
       }
     dvtodump.clear();
     dv_index = -1;
   }
 
-  void CSVTSCaffeInputFileConn::write_csvts_to_db(const std::string &dbfullname,
-                                                  const std::string &testdbfullname,
-                                                  const APIData &ad_input,
-                                                  const std::string &backend)
+  void CSVTSCaffeInputFileConn::write_csvts_to_db(
+      const std::string &dbfullname, const std::string &testdbfullname,
+      const APIData &ad_input, const std::string &backend)
   {
     // Create new DB
     _tdb = std::unique_ptr<caffe::db::DB>(caffe::db::GetDB(backend));
@@ -1849,34 +2024,35 @@ namespace dd
     _csv_fname = _uris.at(0); // training only from file
 
     if (!fileops::dir_exists(_csv_fname))
-      throw InputConnectorBadParamException("training CSV_TS dir " + _csv_fname + " does not exist");
+      throw InputConnectorBadParamException("training CSV_TS dir " + _csv_fname
+                                            + " does not exist");
     if (_uris.size() > 1)
       _csv_test_fname = _uris.at(1);
     DDCCsvTS ddccsvts;
     ddccsvts._cifc = this;
     ddccsvts._adconf = ad_input;
-    ddccsvts.read_dir(_csv_fname,false,true);
-    ddccsvts.read_dir(_csv_test_fname,true,false);
-
+    ddccsvts.read_dir(_csv_fname, false, true);
+    ddccsvts.read_dir(_csv_test_fname, true, false);
 
     _txn->Commit();
     _ttxn->Commit();
 
     _tdb->Close();
     _ttdb->Close();
-
   }
 
-
-  void CSVTSCaffeInputFileConn::csvts_to_dv(bool test, bool clear_dv_first, bool clear_csvts_after, bool split_seqs, bool first_is_cont)
+  void CSVTSCaffeInputFileConn::csvts_to_dv(bool test, bool clear_dv_first,
+                                            bool clear_csvts_after,
+                                            bool split_seqs,
+                                            bool first_is_cont)
   {
 
-    std::vector<Datum> * dv;
-    std::vector<std::vector<CSVline>> * data;
-    int* index;
+    std::vector<Datum> *dv;
+    std::vector<std::vector<CSVline>> *data;
+    int *index;
     if (test)
       {
-        dv = & _dv_test;
+        dv = &_dv_test;
         index = &_dv_test_index;
         data = &this->_csvtsdata_test;
       }
@@ -1901,7 +2077,7 @@ namespace dd
         dprim.set_channels(this->_timesteps);
         dprim.set_height(this->_datadim);
         dprim.set_width(1);
-        for (int i=0; i< this->_timesteps*this->_datadim; ++i)
+        for (int i = 0; i < this->_timesteps * this->_datadim; ++i)
           dprim.add_float_data(0.0);
         dv->push_back(dprim);
         d = &(dv->back());
@@ -1910,24 +2086,27 @@ namespace dd
     else
       d = &(dv->back());
 
-    for (unsigned int si=0; si< data->size(); ++si)
+    for (unsigned int si = 0; si < data->size(); ++si)
       {
         unsigned int offset = 0;
         unsigned int ti = 0;
         while (ti < data->at(si).size())
           {
             if ((ti == 0 && !first_is_cont) || ((*index == 0) && split_seqs))
-              d->set_float_data(*index*this->_datadim,0.0); // new sequence
+              d->set_float_data(*index * this->_datadim, 0.0); // new sequence
             else
-              d->set_float_data(*index*this->_datadim,1.0); // continue sequence
-            for (unsigned int di =0; di < _label_pos.size(); ++di)
-                d->set_float_data(*index*this->_datadim + di + 1,
-                                  data->at(si)[ti]._v[_label_pos[di]]);
-            int ii =0;
-            for (int di = 0; di<this->_datadim-1; ++di)
-              if (std::find(_label_pos.begin(),_label_pos.end(), di) == _label_pos.end())
-                  d->set_float_data(*index*this->_datadim + 1 + ii++ + _label_pos.size(),
-                                    data->at(si)[ti]._v[di]);
+              d->set_float_data(*index * this->_datadim,
+                                1.0); // continue sequence
+            for (unsigned int di = 0; di < _label_pos.size(); ++di)
+              d->set_float_data(*index * this->_datadim + di + 1,
+                                data->at(si)[ti]._v[_label_pos[di]]);
+            int ii = 0;
+            for (int di = 0; di < this->_datadim - 1; ++di)
+              if (std::find(_label_pos.begin(), _label_pos.end(), di)
+                  == _label_pos.end())
+                d->set_float_data(*index * this->_datadim + 1 + ii++
+                                      + _label_pos.size(),
+                                  data->at(si)[ti]._v[di]);
             (*index)++;
             ++ti;
             if ((*index) == _timesteps)
@@ -1938,27 +2117,33 @@ namespace dd
                 Datum dprim;
                 dprim.set_channels(this->_timesteps);
                 dprim.set_height(this->_datadim);
-                for (int i=0; i< this->_timesteps*this->_datadim; ++i)
+                for (int i = 0; i < this->_timesteps * this->_datadim; ++i)
                   dprim.add_float_data(0.0);
                 dprim.set_width(1);
                 dv->push_back(dprim);
                 d = &(dv->back());
-                if (ti + _timesteps >= data->at(si).size()+1)
+                if (ti + _timesteps >= data->at(si).size() + 1)
                   {
                     unsigned int tti = data->at(si).size() - _timesteps;
-                    for ( ; tti < data->at(si).size(); ++tti)
+                    for (; tti < data->at(si).size(); ++tti)
                       {
                         if (split_seqs)
-                          d->set_float_data(*index*this->_datadim,0.0); // continue sequence
+                          d->set_float_data(*index * this->_datadim,
+                                            0.0); // continue sequence
                         else
-                          d->set_float_data(*index*this->_datadim,1.0); // continue sequence
-                        for (unsigned int di =0; di < _label_pos.size(); ++di)
-                          d->set_float_data(*index*this->_datadim + di + 1,
-                                            data->at(si)[ti]._v[_label_pos[di]]);
-                        int ii =0;
-                        for (int di = 0; di<this->_datadim-1; ++di)
-                          if (std::find(_label_pos.begin(),_label_pos.end(), di) == _label_pos.end())
-                            d->set_float_data(*index*this->_datadim + 1 + ii++ + _label_pos.size(),
+                          d->set_float_data(*index * this->_datadim,
+                                            1.0); // continue sequence
+                        for (unsigned int di = 0; di < _label_pos.size(); ++di)
+                          d->set_float_data(
+                              *index * this->_datadim + di + 1,
+                              data->at(si)[ti]._v[_label_pos[di]]);
+                        int ii = 0;
+                        for (int di = 0; di < this->_datadim - 1; ++di)
+                          if (std::find(_label_pos.begin(), _label_pos.end(),
+                                        di)
+                              == _label_pos.end())
+                            d->set_float_data(*index * this->_datadim + 1
+                                                  + ii++ + _label_pos.size(),
                                               data->at(si)[ti]._v[di]);
                         (*index)++;
                       }
@@ -1970,14 +2155,16 @@ namespace dd
           }
 
         // at end of sequence start a new datum so that if the sequence
-        //is smaller than the number of timesteps,  then every datum contains an independant sequence
-        // is sequence is larger than timesteps, it will be splitted into independant sequences
-        if (si < data->size() -1)
+        // is smaller than the number of timesteps,  then every datum contains
+        // an independant sequence
+        // is sequence is larger than timesteps, it will be splitted into
+        // independant sequences
+        if (si < data->size() - 1)
           {
             Datum dprim;
             dprim.set_channels(this->_timesteps);
             dprim.set_height(this->_datadim);
-            for (int i=0; i< this->_timesteps*this->_datadim; ++i)
+            for (int i = 0; i < this->_timesteps * this->_datadim; ++i)
               dprim.add_float_data(0.0);
             dprim.set_width(1);
             dv->push_back(dprim);
@@ -1986,22 +2173,21 @@ namespace dd
           }
       }
     if (clear_csvts_after)
-        data->clear();
+      data->clear();
 
     if (!test && _shuffle)
       {
-        _logger->info("shuffling {} datum vectors",_dv.size());
+        _logger->info("shuffling {} datum vectors", _dv.size());
         std::random_device rd;
         std::mt19937 g(rd());
-        std::shuffle(_dv.begin(), _dv.end(),g);
+        std::shuffle(_dv.begin(), _dv.end(), g);
       }
-
   }
 
-
-  void TxtCaffeInputFileConn::write_txt_to_db(const std::string &dbfullname,
-					      std::vector<TxtEntry<double>*> &txt,
-					      const std::string &backend)
+  void
+  TxtCaffeInputFileConn::write_txt_to_db(const std::string &dbfullname,
+                                         std::vector<TxtEntry<double> *> &txt,
+                                         const std::string &backend)
   {
     // Create new DB
     std::unique_ptr<db::DB> db(db::GetDB(backend));
@@ -2015,44 +2201,48 @@ namespace dd
     char key_cstr[kMaxKeyLength];
     int n = 0;
     auto hit = txt.begin();
-    while(hit!=txt.end())
+    while (hit != txt.end())
       {
-	if (_characters)
-	  datum = to_datum<TxtCharEntry>(static_cast<TxtCharEntry*>((*hit)));
-	else datum = to_datum<TxtBowEntry>(static_cast<TxtBowEntry*>((*hit)));
-	if (_channels == 0)
-	  _channels = datum.channels();
-	int length = snprintf(key_cstr,kMaxKeyLength,"%s",std::to_string(n).c_str());
-	
-	// put in db
-	std::string out;
-	if (!datum.SerializeToString(&out))
-	  _logger->error("Failed serialization of datum for db storage");
-	txn->Put(string(key_cstr,length),out);
+        if (_characters)
+          datum = to_datum<TxtCharEntry>(static_cast<TxtCharEntry *>((*hit)));
+        else
+          datum = to_datum<TxtBowEntry>(static_cast<TxtBowEntry *>((*hit)));
+        if (_channels == 0)
+          _channels = datum.channels();
+        int length = snprintf(key_cstr, kMaxKeyLength, "%s",
+                              std::to_string(n).c_str());
 
-	if (++count % 1000 == 0) {
-	  // commit db
-	  txn->Commit();
-	  txn.reset(db->NewTransaction());
-	  _logger->info("Processed {} text entries",count);
-	}
-	
-	++hit;
-	++n;
+        // put in db
+        std::string out;
+        if (!datum.SerializeToString(&out))
+          _logger->error("Failed serialization of datum for db storage");
+        txn->Put(string(key_cstr, length), out);
+
+        if (++count % 1000 == 0)
+          {
+            // commit db
+            txn->Commit();
+            txn.reset(db->NewTransaction());
+            _logger->info("Processed {} text entries", count);
+          }
+
+        ++hit;
+        ++n;
       }
 
     // write the last batch
-    if (count % 1000 != 0) {
-      txn->Commit();
-      _logger->info("Processed {} text entries",count);
-    }
+    if (count % 1000 != 0)
+      {
+        txn->Commit();
+        _logger->info("Processed {} text entries", count);
+      }
 
     db->Close();
   }
 
-  void TxtCaffeInputFileConn::write_sparse_txt_to_db(const std::string &dbfullname,
-						     std::vector<TxtEntry<double>*> &txt,
-						     const std::string &backend)
+  void TxtCaffeInputFileConn::write_sparse_txt_to_db(
+      const std::string &dbfullname, std::vector<TxtEntry<double> *> &txt,
+      const std::string &backend)
   {
     // Create new DB
     std::unique_ptr<db::DB> db(db::GetDB(backend));
@@ -2066,109 +2256,118 @@ namespace dd
     char key_cstr[kMaxKeyLength];
     int n = 0;
     auto hit = txt.begin();
-    while(hit!=txt.end())
+    while (hit != txt.end())
       {
-	/*if (_characters)
-	  datum = to_datum<TxtCharEntry>(static_cast<TxtCharEntry*>((*hit)));
-	  else*/
-	datum = to_sparse_datum(static_cast<TxtBowEntry*>((*hit)));
-	int length = snprintf(key_cstr,kMaxKeyLength,"%s",std::to_string(n).c_str());
-	
-	// put in db
-	std::string out;
-	if (!datum.SerializeToString(&out))
-	  _logger->error("Failed serialization of datum for db storage");
-	txn->Put(string(key_cstr,length),out);
+        /*if (_characters)
+          datum = to_datum<TxtCharEntry>(static_cast<TxtCharEntry*>((*hit)));
+          else*/
+        datum = to_sparse_datum(static_cast<TxtBowEntry *>((*hit)));
+        int length = snprintf(key_cstr, kMaxKeyLength, "%s",
+                              std::to_string(n).c_str());
 
-	if (++count % 1000 == 0) {
-	  // commit db
-	  txn->Commit();
-	  txn.reset(db->NewTransaction());
-	  _logger->info("Processed {} text entries",count);
-	}
-	
-	++hit;
-	++n;
+        // put in db
+        std::string out;
+        if (!datum.SerializeToString(&out))
+          _logger->error("Failed serialization of datum for db storage");
+        txn->Put(string(key_cstr, length), out);
+
+        if (++count % 1000 == 0)
+          {
+            // commit db
+            txn->Commit();
+            txn.reset(db->NewTransaction());
+            _logger->info("Processed {} text entries", count);
+          }
+
+        ++hit;
+        ++n;
       }
 
     // write the last batch
-    if (count % 1000 != 0) {
-      txn->Commit();
-      _logger->info("Processed {} text entries",count);
-    }
+    if (count % 1000 != 0)
+      {
+        txn->Commit();
+        _logger->info("Processed {} text entries", count);
+      }
 
     db->Close();
   }
 
-  std::vector<caffe::Datum> TxtCaffeInputFileConn::get_dv_test_db(const int &num)
+  std::vector<caffe::Datum>
+  TxtCaffeInputFileConn::get_dv_test_db(const int &num)
   {
     int tnum = num;
     if (tnum == 0)
       tnum = -1;
     if (!_test_db_cursor)
       {
-	// open db and create cursor
-	if (!_test_db)
-	  {
-	    _test_db = std::unique_ptr<caffe::db::DB>(caffe::db::GetDB("lmdb"));
-	    _test_db->Open(_test_dbfullname.c_str(),caffe::db::READ);
-	  }
-	_test_db_cursor = std::unique_ptr<caffe::db::Cursor>(_test_db->NewCursor());
+        // open db and create cursor
+        if (!_test_db)
+          {
+            _test_db
+                = std::unique_ptr<caffe::db::DB>(caffe::db::GetDB("lmdb"));
+            _test_db->Open(_test_dbfullname.c_str(), caffe::db::READ);
+          }
+        _test_db_cursor
+            = std::unique_ptr<caffe::db::Cursor>(_test_db->NewCursor());
       }
-    int i =0;
+    int i = 0;
     std::vector<caffe::Datum> dv;
-    while(_test_db_cursor->valid())
+    while (_test_db_cursor->valid())
       {
-	// fill up a vector up to 'num' elements.
-	if (i == tnum)
-	  break;
-	Datum datum;
-	datum.ParseFromString(_test_db_cursor->value());
-	dv.push_back(datum);
-	_ids.push_back(_test_db_cursor->key());
-	_test_db_cursor->Next();
-	++i;
+        // fill up a vector up to 'num' elements.
+        if (i == tnum)
+          break;
+        Datum datum;
+        datum.ParseFromString(_test_db_cursor->value());
+        dv.push_back(datum);
+        _ids.push_back(_test_db_cursor->key());
+        _test_db_cursor->Next();
+        ++i;
       }
     return dv;
   }
-   
-  std::vector<caffe::SparseDatum> TxtCaffeInputFileConn::get_dv_test_sparse_db(const int &num)
+
+  std::vector<caffe::SparseDatum>
+  TxtCaffeInputFileConn::get_dv_test_sparse_db(const int &num)
   {
     int tnum = num;
     if (tnum == 0)
       tnum = -1;
     if (!_test_db_cursor)
       {
-	// open db and create cursor
-	if (!_test_db)
-	  {
-	    _test_db = std::unique_ptr<caffe::db::DB>(caffe::db::GetDB("lmdb"));
-	    _test_db->Open(_test_dbfullname.c_str(),caffe::db::READ);
-	  }
-	_test_db_cursor = std::unique_ptr<caffe::db::Cursor>(_test_db->NewCursor());
+        // open db and create cursor
+        if (!_test_db)
+          {
+            _test_db
+                = std::unique_ptr<caffe::db::DB>(caffe::db::GetDB("lmdb"));
+            _test_db->Open(_test_dbfullname.c_str(), caffe::db::READ);
+          }
+        _test_db_cursor
+            = std::unique_ptr<caffe::db::Cursor>(_test_db->NewCursor());
       }
-    int i =0;
+    int i = 0;
     std::vector<caffe::SparseDatum> dv;
-    while(_test_db_cursor->valid())
+    while (_test_db_cursor->valid())
       {
-	// fill up a vector up to 'num' elements.
-	if (i == tnum)
-	  break;
-	SparseDatum datum;
-	datum.ParseFromString(_test_db_cursor->value());
-	dv.push_back(datum);
-	_ids.push_back(_test_db_cursor->key());
-	_test_db_cursor->Next();
-	++i;
+        // fill up a vector up to 'num' elements.
+        if (i == tnum)
+          break;
+        SparseDatum datum;
+        datum.ParseFromString(_test_db_cursor->value());
+        dv.push_back(datum);
+        _ids.push_back(_test_db_cursor->key());
+        _test_db_cursor->Next();
+        ++i;
       }
     return dv;
   }
 
   /*- SVMCaffeInputFileConn -*/
   int SVMCaffeInputFileConn::svm_to_db(const std::string &traindbname,
-				       const std::string &testdbname,
-				       const APIData &ad_input,
-				       const std::string &backend)
+                                       const std::string &testdbname,
+                                       const APIData &ad_input,
+                                       const std::string &backend)
   {
     std::string dbfullname = traindbname + "." + backend;
     std::string testdbfullname = testdbname + "." + backend;
@@ -2178,120 +2377,133 @@ namespace dd
     // in the model repository.
     if (fileops::file_exists(dbfullname))
       {
-	_logger->warn("SVM db file {} already exists, bypassing creation but checking on records",dbfullname);
-	std::unique_ptr<db::DB> db(db::GetDB(backend));
-	db->Open(dbfullname.c_str(), db::READ);
-	std::unique_ptr<db::Cursor> cursor(db->NewCursor());
-	while(cursor->valid())
-	  {
-	    if (_channels == 0)
-	      {
-		SparseDatum datum;
-		datum.ParseFromString(cursor->value());
-		_channels = datum.size();
-	      }
-	    break;
-	  }
-	_db_batchsize = db->Count();
-	_logger->info("SVM db train file {} with {} records",dbfullname,_db_batchsize);
-	if (!testdbname.empty() && fileops::file_exists(testdbfullname))
-	  {
+        _logger->warn("SVM db file {} already exists, bypassing creation but "
+                      "checking on records",
+                      dbfullname);
+        std::unique_ptr<db::DB> db(db::GetDB(backend));
+        db->Open(dbfullname.c_str(), db::READ);
+        std::unique_ptr<db::Cursor> cursor(db->NewCursor());
+        while (cursor->valid())
+          {
+            if (_channels == 0)
+              {
+                SparseDatum datum;
+                datum.ParseFromString(cursor->value());
+                _channels = datum.size();
+              }
+            break;
+          }
+        _db_batchsize = db->Count();
+        _logger->info("SVM db train file {} with {} records", dbfullname,
+                      _db_batchsize);
+        if (!testdbname.empty() && fileops::file_exists(testdbfullname))
+          {
 
-	    _logger->warn("SVM db file {} already exists, bypassing creation but checking on records",testdbfullname);
-	    std::unique_ptr<db::DB> tdb(db::GetDB(backend));
-	    tdb->Open(testdbfullname.c_str(), db::READ);
-	    _db_testbatchsize = tdb->Count();
-	    _logger->info("SVM db test file {} with {} records",testdbfullname,_db_testbatchsize);
-	  }	
-	return 0;
+            _logger->warn("SVM db file {} already exists, bypassing creation "
+                          "but checking on records",
+                          testdbfullname);
+            std::unique_ptr<db::DB> tdb(db::GetDB(backend));
+            tdb->Open(testdbfullname.c_str(), db::READ);
+            _db_testbatchsize = tdb->Count();
+            _logger->info("SVM db test file {} with {} records",
+                          testdbfullname, _db_testbatchsize);
+          }
+        return 0;
       }
-    
+
     // write files to dbs (i.e. train and possibly test)
     _db_batchsize = 0;
     _db_testbatchsize = 0;
-    write_svmline_to_db(dbfullname,testdbfullname,ad_input);
-    
+    write_svmline_to_db(dbfullname, testdbfullname, ad_input);
+
     return 0;
   }
 
-  void SVMCaffeInputFileConn::add_train_svmline(const int &label,
-						const std::unordered_map<int,double> &vals,
-						const int &count)
+  void SVMCaffeInputFileConn::add_train_svmline(
+      const int &label, const std::unordered_map<int, double> &vals,
+      const int &count)
   {
     if (!_db || !_train)
       {
-	SVMInputFileConn::add_train_svmline(label,vals,count);
-	return;
+        SVMInputFileConn::add_train_svmline(label, vals, count);
+        return;
       }
 
     const int kMaxKeyLength = 256;
     char key_cstr[kMaxKeyLength];
-    
-    SparseDatum d = to_sparse_datum(SVMline(label,vals));
-    
+
+    SparseDatum d = to_sparse_datum(SVMline(label, vals));
+
     // sequential
-    int length = snprintf(key_cstr,kMaxKeyLength,"%s",std::to_string(count).c_str()); // XXX: using appeared to confuse the training (maybe because sorted)
-    
+    int length = snprintf(
+        key_cstr, kMaxKeyLength, "%s",
+        std::to_string(count).c_str()); // XXX: using appeared to confuse the
+                                        // training (maybe because sorted)
+
     // put in db
     std::string out;
-    if(!d.SerializeToString(&out))
+    if (!d.SerializeToString(&out))
       {
-	_logger->info("Failed serialization of datum for db storage");
-	return;
+        _logger->info("Failed serialization of datum for db storage");
+        return;
       }
     _txn->Put(std::string(key_cstr, length), out);
     _db_batchsize++;
-    
-    if (count % 10000 == 0) {
-      // commit db
-      _txn->Commit();
-      _txn.reset(_tdb->NewTransaction());
-      _logger->info("Processed {} records",count);
-    }
+
+    if (count % 10000 == 0)
+      {
+        // commit db
+        _txn->Commit();
+        _txn.reset(_tdb->NewTransaction());
+        _logger->info("Processed {} records", count);
+      }
   }
 
-  void SVMCaffeInputFileConn::add_test_svmline(const int &label,
-					       const std::unordered_map<int,double> &vals,
-					       const int &count)
+  void SVMCaffeInputFileConn::add_test_svmline(
+      const int &label, const std::unordered_map<int, double> &vals,
+      const int &count)
   {
     if (!_db)
       {
-	SVMInputFileConn::add_test_svmline(label,vals,count);
-	return;
+        SVMInputFileConn::add_test_svmline(label, vals, count);
+        return;
       }
 
     const int kMaxKeyLength = 256;
     char key_cstr[kMaxKeyLength];
-    
-    SparseDatum d = to_sparse_datum(SVMline(label,vals));
-    
+
+    SparseDatum d = to_sparse_datum(SVMline(label, vals));
+
     // sequential
-    int length = snprintf(key_cstr,kMaxKeyLength,"%s",std::to_string(count).c_str()); // XXX: using id appeared to confuse the training (maybe because sorted)
-    
+    int length = snprintf(
+        key_cstr, kMaxKeyLength, "%s",
+        std::to_string(count).c_str()); // XXX: using id appeared to confuse
+                                        // the training (maybe because sorted)
+
     // put in db
     std::string out;
-    if(!d.SerializeToString(&out))
+    if (!d.SerializeToString(&out))
       {
-	_logger->error("Failed serialization of datum for db storage");
-	return;
+        _logger->error("Failed serialization of datum for db storage");
+        return;
       }
     _ttxn->Put(std::string(key_cstr, length), out);
     _db_testbatchsize++;
 
-    if (count % 10000 == 0) {
-      // commit db
-      _ttxn->Commit();
-      _ttxn.reset(_ttdb->NewTransaction());
-      _logger->info("Processed {} records",count);
-    }
+    if (count % 10000 == 0)
+      {
+        // commit db
+        _ttxn->Commit();
+        _ttxn.reset(_ttdb->NewTransaction());
+        _logger->info("Processed {} records", count);
+      }
   }
-  
-  void SVMCaffeInputFileConn::write_svmline_to_db(const std::string &dbfullname,
-						  const std::string &testdbfullname,
-						  const APIData &ad_input,
-						  const std::string &backend)
+
+  void SVMCaffeInputFileConn::write_svmline_to_db(
+      const std::string &dbfullname, const std::string &testdbfullname,
+      const APIData &ad_input, const std::string &backend)
   {
-    _logger->info("SVM line to db / dbfullname={}",dbfullname);
+    _logger->info("SVM line to db / dbfullname={}", dbfullname);
 
     // Create new DB
     _tdb = std::unique_ptr<caffe::db::DB>(caffe::db::GetDB(backend));
@@ -2300,54 +2512,58 @@ namespace dd
     _ttdb = std::unique_ptr<caffe::db::DB>(caffe::db::GetDB(backend));
     _ttdb->Open(testdbfullname.c_str(), caffe::db::NEW);
     _ttxn = std::unique_ptr<caffe::db::Transaction>(_ttdb->NewTransaction());
-    _logger->info("dbs {} / {} opened",dbfullname,testdbfullname);
-    
+    _logger->info("dbs {} / {} opened", dbfullname, testdbfullname);
+
     _svm_fname = _uris.at(0); // training only from file
     if (!fileops::file_exists(_svm_fname))
-      throw InputConnectorBadParamException("training SVM file " + _svm_fname + " does not exist");
+      throw InputConnectorBadParamException("training SVM file " + _svm_fname
+                                            + " does not exist");
     if (_uris.size() > 1)
       _svm_test_fname = _uris.at(1);
 
     DataEl<DDSvm> ddsvm(this->_input_timeout);
     ddsvm._ctype._cifc = this;
     ddsvm._ctype._adconf = ad_input;
-    ddsvm.read_element(_svm_fname,this->_logger);
+    ddsvm.read_element(_svm_fname, this->_logger);
 
     _txn->Commit();
     _ttxn->Commit();
-    
+
     _tdb->Close();
     _ttdb->Close();
   }
 
-  std::vector<caffe::SparseDatum> SVMCaffeInputFileConn::get_dv_test_sparse_db(const int &num)
+  std::vector<caffe::SparseDatum>
+  SVMCaffeInputFileConn::get_dv_test_sparse_db(const int &num)
   {
     int tnum = num;
     if (tnum == 0)
       tnum = -1;
     if (!_test_db_cursor)
       {
-	// open db and create cursor
-	if (!_test_db)
-	  {
-	    _test_db = std::unique_ptr<caffe::db::DB>(caffe::db::GetDB("lmdb"));
-	    _test_db->Open(_test_dbfullname.c_str(),caffe::db::READ);
-	  }
-	_test_db_cursor = std::unique_ptr<caffe::db::Cursor>(_test_db->NewCursor());
+        // open db and create cursor
+        if (!_test_db)
+          {
+            _test_db
+                = std::unique_ptr<caffe::db::DB>(caffe::db::GetDB("lmdb"));
+            _test_db->Open(_test_dbfullname.c_str(), caffe::db::READ);
+          }
+        _test_db_cursor
+            = std::unique_ptr<caffe::db::Cursor>(_test_db->NewCursor());
       }
     std::vector<caffe::SparseDatum> dv;
-    int i =0;
-    while(_test_db_cursor->valid())
+    int i = 0;
+    while (_test_db_cursor->valid())
       {
-	// fill up a vector up to 'num' elements.
-	if (i == tnum)
-	  break;
-	SparseDatum datum;
-	datum.ParseFromString(_test_db_cursor->value());
-	dv.push_back(datum);
-	_ids.push_back(_test_db_cursor->key());
-	_test_db_cursor->Next();
-	++i;
+        // fill up a vector up to 'num' elements.
+        if (i == tnum)
+          break;
+        SparseDatum datum;
+        datum.ParseFromString(_test_db_cursor->value());
+        dv.push_back(datum);
+        _ids.push_back(_test_db_cursor->key());
+        _test_db_cursor->Next();
+        ++i;
       }
     return dv;
   }

--- a/src/backends/caffe/caffeinputconns.h
+++ b/src/backends/caffe/caffeinputconns.h
@@ -34,491 +34,548 @@
 namespace dd
 {
   /**
-   * \brief high-level data structure shared among Caffe-compatible connectors of DeepDetect
+   * \brief high-level data structure shared among Caffe-compatible connectors
+   * of DeepDetect
    */
   class CaffeInputInterface
   {
   public:
-    CaffeInputInterface() {}
+    CaffeInputInterface()
+    {
+    }
     CaffeInputInterface(const CaffeInputInterface &cii)
-      :_db(cii._db),_dv(cii._dv),_dv_test(cii._dv_test),_flat1dconv(cii._flat1dconv),_has_mean_file(cii._has_mean_file),_mean_values(cii._mean_values),_sparse(cii._sparse),_embed(cii._embed),_sequence_txt(cii._sequence_txt),_max_embed_id(cii._max_embed_id),_segmentation(cii._segmentation),_bbox(cii._bbox),_multi_label(cii._multi_label),_ctc(cii._ctc),_autoencoder(cii._autoencoder),_alphabet_size(cii._alphabet_size),_root_folder(cii._root_folder),_dbfullname(cii._dbfullname),_test_dbfullname(cii._test_dbfullname), _timesteps(cii._timesteps), _datadim(cii._datadim), _ntargets(cii._ntargets) {}
+        : _db(cii._db), _dv(cii._dv), _dv_test(cii._dv_test),
+          _flat1dconv(cii._flat1dconv), _has_mean_file(cii._has_mean_file),
+          _mean_values(cii._mean_values), _sparse(cii._sparse),
+          _embed(cii._embed), _sequence_txt(cii._sequence_txt),
+          _max_embed_id(cii._max_embed_id), _segmentation(cii._segmentation),
+          _bbox(cii._bbox), _multi_label(cii._multi_label), _ctc(cii._ctc),
+          _autoencoder(cii._autoencoder), _alphabet_size(cii._alphabet_size),
+          _root_folder(cii._root_folder), _dbfullname(cii._dbfullname),
+          _test_dbfullname(cii._test_dbfullname), _timesteps(cii._timesteps),
+          _datadim(cii._datadim), _ntargets(cii._ntargets)
+    {
+    }
 
-    ~CaffeInputInterface() {}
+    ~CaffeInputInterface()
+    {
+    }
 
     /**
      * \brief when using db, this provide a batch iterator to db data,
      *        used in measuring the output of the net
      * @param num the size of the data 'batch' to get from the db
-     * @param has_mean_file flag that tells whether the mean of images in the training set is removed from each image.
+     * @param has_mean_file flag that tells whether the mean of images in the
+     * training set is removed from each image.
      * @return a vector of Caffe Datum
      * @see ImgCaffeInputFileConn
      */
     std::vector<caffe::Datum> get_dv_test(const int &num,
-					  const bool &has_mean_file)
-      {
-	(void)has_mean_file;
-	  return std::vector<caffe::Datum>(num);
-      }
-    
-    std::vector<caffe::SparseDatum> get_dv_test_sparse(const int &num)
-      {
-	return std::vector<caffe::SparseDatum>(num);
-      }
+                                          const bool &has_mean_file)
+    {
+      (void)has_mean_file;
+      return std::vector<caffe::Datum>(num);
+    }
 
-    void reset_dv_test() {}
+    std::vector<caffe::SparseDatum> get_dv_test_sparse(const int &num)
+    {
+      return std::vector<caffe::SparseDatum>(num);
+    }
+
+    void reset_dv_test()
+    {
+    }
 
     // write class weights to binary proto
     void write_class_weights(const std::string &model_repo,
-			     const APIData &ad_mllib);
+                             const APIData &ad_mllib);
 
     bool _db = false; /**< whether to use a db. */
-    std::vector<caffe::Datum> _dv; /**< main input datum vector, used for training or prediction */
-    std::vector<caffe::Datum> _dv_test; /**< test input datum vector, when applicable in training mode */
+    std::vector<caffe::Datum>
+        _dv; /**< main input datum vector, used for training or prediction */
+    std::vector<caffe::Datum> _dv_test; /**< test input datum vector, when
+                                           applicable in training mode */
     std::vector<caffe::SparseDatum> _dv_sparse;
     std::vector<caffe::SparseDatum> _dv_test_sparse;
-    bool _flat1dconv = false; /**< whether a 1D convolution model. */
+    bool _flat1dconv = false;    /**< whether a 1D convolution model. */
     bool _has_mean_file = false; /**< image model mean.binaryproto. */
-    std::vector<float> _mean_values; /**< mean image values across a dataset. */
+    std::vector<float>
+        _mean_values;     /**< mean image values across a dataset. */
     bool _sparse = false; /**< whether to use sparse representation. */
-    bool _embed = false; /**< whether model is using an input embedding layer. */
-    int _sequence_txt = -1; /**< sequence of txt input connector. */
-    int _max_embed_id = -1; /**< in embeddings, the max index. */
+    bool _embed
+        = false; /**< whether model is using an input embedding layer. */
+    int _sequence_txt = -1;     /**< sequence of txt input connector. */
+    int _max_embed_id = -1;     /**< in embeddings, the max index. */
     bool _segmentation = false; /**< whether it is a segmentation service. */
     bool _bbox = false; /**< whether it is an object detection service. */
     bool _multi_label = false; /**< multi label setup */
-    bool _ctc = false; /**< whether it is a CTC / OCR service. */
+    bool _ctc = false;         /**< whether it is a CTC / OCR service. */
     bool _autoencoder = false; /**< whether an autoencoder. */
-    int _alphabet_size = 0; /**< for sequence to sequence models. */
-    std::string _root_folder; /**< root folder for image list layer. */
-    std::unordered_map<std::string,std::pair<int,int>> _imgs_size; /**< image sizes, used in detection. */
+    int _alphabet_size = 0;    /**< for sequence to sequence models. */
+    std::string _root_folder;  /**< root folder for image list layer. */
+    std::unordered_map<std::string, std::pair<int, int>>
+        _imgs_size; /**< image sizes, used in detection. */
     std::string _dbfullname = "train.lmdb";
     std::string _test_dbfullname = "test.lmdb";
-    int _timesteps = -1;  //default length for csv timeseries
-    int _datadim = -1; //default size of vector data for timeseries
-    int _ntargets = -1; // number of outputs for timeseries
+    int _timesteps = -1; // default length for csv timeseries
+    int _datadim = -1;   // default size of vector data for timeseries
+    int _ntargets = -1;  // number of outputs for timeseries
   };
 
   /**
-   * \brief Caffe image connector, supports both files and building of database for training
+   * \brief Caffe image connector, supports both files and building of database
+   * for training
    */
-  class ImgCaffeInputFileConn : public ImgInputFileConn, public CaffeInputInterface
+  class ImgCaffeInputFileConn : public ImgInputFileConn,
+                                public CaffeInputInterface
   {
   public:
-    ImgCaffeInputFileConn()
-      :ImgInputFileConn() {
+    ImgCaffeInputFileConn() : ImgInputFileConn()
+    {
       reset_dv_test();
     }
     ImgCaffeInputFileConn(const ImgCaffeInputFileConn &i)
-      :ImgInputFileConn(i),CaffeInputInterface(i) {/* _db = true;*/ }
-    ~ImgCaffeInputFileConn() {}
+        : ImgInputFileConn(i), CaffeInputInterface(i)
+    { /* _db = true;*/
+    }
+    ~ImgCaffeInputFileConn()
+    {
+    }
 
     // size of each element in Caffe jargon
     int channels() const
     {
-      if (_bw) return 1;
-      else return 3; // RGB
+      if (_bw)
+        return 1;
+      else
+        return 3; // RGB
     }
-    
+
     int height() const
     {
       return _height;
     }
-    
+
     int width() const
     {
       return _width;
-
     }
 
     int batch_size() const
     {
       if (_db_batchsize > 0)
-	return _db_batchsize;
+        return _db_batchsize;
       else if (!_dv.empty())
-	return _dv.size();
-      else return ImgInputFileConn::batch_size();
+        return _dv.size();
+      else
+        return ImgInputFileConn::batch_size();
     }
-    
+
     int test_batch_size() const
     {
       if (_db_testbatchsize > 0)
-	return _db_testbatchsize;
+        return _db_testbatchsize;
       else if (!_dv_test.empty())
-	return _dv_test.size();
-      else return ImgInputFileConn::test_batch_size();
+        return _dv_test.size();
+      else
+        return ImgInputFileConn::test_batch_size();
     }
 
     void init(const APIData &ad)
     {
       ImgInputFileConn::init(ad);
       if (ad.has("db"))
-	_db = ad.get("db").get<bool>();
+        _db = ad.get("db").get<bool>();
       if (ad.has("multi_label"))
-	_multi_label = ad.get("multi_label").get<bool>();
+        _multi_label = ad.get("multi_label").get<bool>();
       if (ad.has("root_folder"))
-	_root_folder = ad.get("root_folder").get<std::string>();
+        _root_folder = ad.get("root_folder").get<std::string>();
       if (ad.has("segmentation"))
-	_segmentation = ad.get("segmentation").get<bool>();
+        _segmentation = ad.get("segmentation").get<bool>();
       if (ad.has("bbox"))
-	_bbox = ad.get("bbox").get<bool>();
+        _bbox = ad.get("bbox").get<bool>();
       if (ad.has("ctc"))
-	_ctc = ad.get("ctc").get<bool>();
+        _ctc = ad.get("ctc").get<bool>();
     }
 
     void transform(const APIData &ad)
     {
-      // in prediction mode, convert the images to Datum, a Caffe data structure
+      // in prediction mode, convert the images to Datum, a Caffe data
+      // structure
       if (!_train)
-	{ 
-	  // if no img height x width, we assume 224x224 (works if user is lucky, i.e. the best we can do)
-	  if (_width == -1)
-	    _width = 224;
-	  if (_height == -1)
-	    _height = 224;
-	  
-	  if (ad.has("has_mean_file"))
-	    _has_mean_file = ad.get("has_mean_file").get<bool>();
-	  APIData ad_input = ad.getobj("parameters").getobj("input");
-	  if (ad_input.has("segmentation"))
-	    _segmentation = ad_input.get("segmentation").get<bool>();
-	  if (ad_input.has("bbox"))
-	    _bbox = ad_input.get("bbox").get<bool>();
-	  if (ad_input.has("multi_label"))
-	    _multi_label = ad_input.get("multi_label").get<bool>();
-	  if (ad.has("root_folder"))
-	    _root_folder = ad.get("root_folder").get<std::string>();
-	  try
-	    {
-	      ImgInputFileConn::transform(ad);
-	    }
-	  catch (InputConnectorBadParamException &e)
-	    {
-	      throw;
-	    }
-	  
-	  float *mean = nullptr;
-	  if (_data_mean.count() == 0 && _has_mean_file)
-	    {
-	      std::string meanfullname = _model_repo + "/" + _meanfname;
-	      caffe::BlobProto blob_proto;
-	      caffe::ReadProtoFromBinaryFile(meanfullname.c_str(),&blob_proto);
-	      _data_mean.FromProto(blob_proto);
-	      mean = _data_mean.mutable_cpu_data();
-	    }
-	  if (!_db_fname.empty())
-	    {
-	      _test_dbfullname = _db_fname;
-	      _db = true;
-	      return; // done
-	    }
-	  else _db = false;
-	  for (int i=0;i<(int)this->_images.size();i++)
-	    {      
-	      caffe::Datum datum;
-	      caffe::CVMatToDatum(this->_images.at(i),&datum);
-	      if (!_test_labels.empty())
-		datum.set_label(_test_labels.at(i));
-	      if (_data_mean.count() != 0)
-		{
-		  int height = datum.height();
-		  int width = datum.width();
-		  for (int c=0;c<datum.channels();++c)
-		    for (int h=0;h<height;++h)
-		      for (int w=0;w<width;++w)
-			{
-			  int data_index = (c*height+h)*width+w;
-			  float datum_element = static_cast<float>(static_cast<uint8_t>(datum.data()[data_index]));
-			  datum.add_float_data(datum_element - mean[data_index]);
-			}
-		  datum.clear_data();
-		}
-	      else if (_has_mean_scalar)
-		{
-		  int height = datum.height();
-		  int width = datum.width();
-		  for (int c=0;c<datum.channels();++c)
-		    for (int h=0;h<height;++h)
-		      for (int w=0;w<width;++w)
-			{
-			  int data_index = (c*height+h)*width+w;
-			  float datum_element = static_cast<float>(static_cast<uint8_t>(datum.data()[data_index]));
-			  datum.add_float_data(datum_element - _mean[c]);
-			}
-		  datum.clear_data();
-		}
-	      _dv_test.push_back(datum);
-	      _imgs_size.insert(std::pair<std::string,std::pair<int,int>>(this->_ids.at(i),this->_images_size.at(i)));
-	    }
-	  if (!ad.has("chain"))
-	    {
-	      this->_images.clear();
-	      this->_images_size.clear();
-	    }
-	}
+        {
+          // if no img height x width, we assume 224x224 (works if user is
+          // lucky, i.e. the best we can do)
+          if (_width == -1)
+            _width = 224;
+          if (_height == -1)
+            _height = 224;
+
+          if (ad.has("has_mean_file"))
+            _has_mean_file = ad.get("has_mean_file").get<bool>();
+          APIData ad_input = ad.getobj("parameters").getobj("input");
+          if (ad_input.has("segmentation"))
+            _segmentation = ad_input.get("segmentation").get<bool>();
+          if (ad_input.has("bbox"))
+            _bbox = ad_input.get("bbox").get<bool>();
+          if (ad_input.has("multi_label"))
+            _multi_label = ad_input.get("multi_label").get<bool>();
+          if (ad.has("root_folder"))
+            _root_folder = ad.get("root_folder").get<std::string>();
+          try
+            {
+              ImgInputFileConn::transform(ad);
+            }
+          catch (InputConnectorBadParamException &e)
+            {
+              throw;
+            }
+
+          float *mean = nullptr;
+          if (_data_mean.count() == 0 && _has_mean_file)
+            {
+              std::string meanfullname = _model_repo + "/" + _meanfname;
+              caffe::BlobProto blob_proto;
+              caffe::ReadProtoFromBinaryFile(meanfullname.c_str(),
+                                             &blob_proto);
+              _data_mean.FromProto(blob_proto);
+              mean = _data_mean.mutable_cpu_data();
+            }
+          if (!_db_fname.empty())
+            {
+              _test_dbfullname = _db_fname;
+              _db = true;
+              return; // done
+            }
+          else
+            _db = false;
+          for (int i = 0; i < (int)this->_images.size(); i++)
+            {
+              caffe::Datum datum;
+              caffe::CVMatToDatum(this->_images.at(i), &datum);
+              if (!_test_labels.empty())
+                datum.set_label(_test_labels.at(i));
+              if (_data_mean.count() != 0)
+                {
+                  int height = datum.height();
+                  int width = datum.width();
+                  for (int c = 0; c < datum.channels(); ++c)
+                    for (int h = 0; h < height; ++h)
+                      for (int w = 0; w < width; ++w)
+                        {
+                          int data_index = (c * height + h) * width + w;
+                          float datum_element = static_cast<float>(
+                              static_cast<uint8_t>(datum.data()[data_index]));
+                          datum.add_float_data(datum_element
+                                               - mean[data_index]);
+                        }
+                  datum.clear_data();
+                }
+              else if (_has_mean_scalar)
+                {
+                  int height = datum.height();
+                  int width = datum.width();
+                  for (int c = 0; c < datum.channels(); ++c)
+                    for (int h = 0; h < height; ++h)
+                      for (int w = 0; w < width; ++w)
+                        {
+                          int data_index = (c * height + h) * width + w;
+                          float datum_element = static_cast<float>(
+                              static_cast<uint8_t>(datum.data()[data_index]));
+                          datum.add_float_data(datum_element - _mean[c]);
+                        }
+                  datum.clear_data();
+                }
+              _dv_test.push_back(datum);
+              _imgs_size.insert(std::pair<std::string, std::pair<int, int>>(
+                  this->_ids.at(i), this->_images_size.at(i)));
+            }
+          if (!ad.has("chain"))
+            {
+              this->_images.clear();
+              this->_images_size.clear();
+            }
+        }
       else
-	{
-	  _shuffle = true;
-	  int db_height = 0;
-	  int db_width = 0;
-	  APIData ad_mllib;
-	  if (ad.has("parameters")) // hotplug of parameters, overriding the defaults
-	    {
-	      APIData ad_param = ad.getobj("parameters");
-	      if (ad_param.has("input"))
-		{
-		  APIData ad_input = ad_param.getobj("input");
-		  fillup_parameters(ad_param.getobj("input"));
-		  if (ad_input.has("db"))
-		    _db = ad_input.get("db").get<bool>();
-		  if (ad_input.has("segmentation"))
-		    _segmentation = ad_input.get("segmentation").get<bool>();
-		  if (ad_input.has("bbox"))
-		    _bbox = ad_input.get("bbox").get<bool>();
-		  if (ad_input.has("multi_label"))
-		    _multi_label = ad_input.get("multi_label").get<bool>();
-		  if (ad_input.has("root_folder"))
-		    _root_folder = ad_input.get("root_folder").get<std::string>();
-		  if (ad_input.has("align"))
-		    _align = ad_input.get("align").get<bool>();
-		  if (ad_input.has("db_height"))
-		    db_height = ad_input.get("db_height").get<int>();
-		  if (ad_input.has("db_width"))
-		    db_width = ad_input.get("db_width").get<int>();
-		  if (ad.has("autoencoder"))
-		    _autoencoder = ad.get("autoencoder").get<bool>();
-		}
-	      ad_mllib = ad_param.getobj("mllib");
-	    }
+        {
+          _shuffle = true;
+          int db_height = 0;
+          int db_width = 0;
+          APIData ad_mllib;
+          if (ad.has("parameters")) // hotplug of parameters, overriding the
+                                    // defaults
+            {
+              APIData ad_param = ad.getobj("parameters");
+              if (ad_param.has("input"))
+                {
+                  APIData ad_input = ad_param.getobj("input");
+                  fillup_parameters(ad_param.getobj("input"));
+                  if (ad_input.has("db"))
+                    _db = ad_input.get("db").get<bool>();
+                  if (ad_input.has("segmentation"))
+                    _segmentation = ad_input.get("segmentation").get<bool>();
+                  if (ad_input.has("bbox"))
+                    _bbox = ad_input.get("bbox").get<bool>();
+                  if (ad_input.has("multi_label"))
+                    _multi_label = ad_input.get("multi_label").get<bool>();
+                  if (ad_input.has("root_folder"))
+                    _root_folder
+                        = ad_input.get("root_folder").get<std::string>();
+                  if (ad_input.has("align"))
+                    _align = ad_input.get("align").get<bool>();
+                  if (ad_input.has("db_height"))
+                    db_height = ad_input.get("db_height").get<int>();
+                  if (ad_input.has("db_width"))
+                    db_width = ad_input.get("db_width").get<int>();
+                  if (ad.has("autoencoder"))
+                    _autoencoder = ad.get("autoencoder").get<bool>();
+                }
+              ad_mllib = ad_param.getobj("mllib");
+            }
 
-	  if (_segmentation)
-	    {
-	      try
-		{
-		  get_data(ad);
-		}
-	      catch(InputConnectorBadParamException &ex)
-		{
-		  throw ex;
-		}
-	      if (!fileops::file_exists(_uris.at(0)))
-		throw InputConnectorBadParamException("segmentation input train file " + _uris.at(0) + " not found");
-	      if (_uris.size() > 1)
-		{
-		  if (!fileops::file_exists(_uris.at(1)))
-		    throw InputConnectorBadParamException("segmentation input test file " + _uris.at(1) + " not found");
-		}
+          if (_segmentation)
+            {
+              try
+                {
+                  get_data(ad);
+                }
+              catch (InputConnectorBadParamException &ex)
+                {
+                  throw ex;
+                }
+              if (!fileops::file_exists(_uris.at(0)))
+                throw InputConnectorBadParamException(
+                    "segmentation input train file " + _uris.at(0)
+                    + " not found");
+              if (_uris.size() > 1)
+                {
+                  if (!fileops::file_exists(_uris.at(1)))
+                    throw InputConnectorBadParamException(
+                        "segmentation input test file " + _uris.at(1)
+                        + " not found");
+                }
 
-	      // class weights if any
-	      write_class_weights(_model_repo,ad_mllib);
-	      
-	      //TODO: if test split (+ optional shuffle)
-	      APIData sourcead;
-	      sourcead.add("source_train",_uris.at(0));
-	      if (_uris.size() > 1)
-            sourcead.add("source_test",_uris.at(1));
-	      const_cast<APIData&>(ad).add("source",sourcead);
-	    }
-	  else if (_bbox)
-	    {
-	      try
-		{
-		  get_data(ad);
-		}
-	      catch(InputConnectorBadParamException &ex)
-		{
-		  throw ex;
-		}
-	      if (!fileops::file_exists(_uris.at(0)))
-		throw InputConnectorBadParamException("object detection input train file " + _uris.at(0) + " not found");
-	      if (_uris.size() > 1)
-		{
-		  if (!fileops::file_exists(_uris.at(1)))
-		    throw InputConnectorBadParamException("object detection input test file " + _uris.at(1) + " not found");
-		}
+              // class weights if any
+              write_class_weights(_model_repo, ad_mllib);
 
-	      // - create lmdbs
-	      _dbfullname = _model_repo + "/" + _dbfullname;
-	      _test_dbfullname = _model_repo + "/" + _test_dbfullname;
-	      objects_to_db(_uris,db_height,db_width,_dbfullname,_test_dbfullname);
-	      
-	      // data object with db files location
-	      APIData dbad;
-	      dbad.add("train_db",_dbfullname);
-	      if (_test_split > 0.0 || _uris.size() > 1)
-		dbad.add("test_db",_test_dbfullname);
-	      const_cast<APIData&>(ad).add("db",dbad); 
-	    }
-	  else if (_ctc)
-	    {
-	      _dbfullname = _model_repo + "/train";
-	      _test_dbfullname = _model_repo + "/test.h5";
-	      try
-		{
-		  get_data(ad);
-		}
-	      catch(InputConnectorBadParamException &ex) // in case the db is in the net config
-		{
-		  throw ex;
-		}
+              // TODO: if test split (+ optional shuffle)
+              APIData sourcead;
+              sourcead.add("source_train", _uris.at(0));
+              if (_uris.size() > 1)
+                sourcead.add("source_test", _uris.at(1));
+              const_cast<APIData &>(ad).add("source", sourcead);
+            }
+          else if (_bbox)
+            {
+              try
+                {
+                  get_data(ad);
+                }
+              catch (InputConnectorBadParamException &ex)
+                {
+                  throw ex;
+                }
+              if (!fileops::file_exists(_uris.at(0)))
+                throw InputConnectorBadParamException(
+                    "object detection input train file " + _uris.at(0)
+                    + " not found");
+              if (_uris.size() > 1)
+                {
+                  if (!fileops::file_exists(_uris.at(1)))
+                    throw InputConnectorBadParamException(
+                        "object detection input test file " + _uris.at(1)
+                        + " not found");
+                }
 
-	      // read images list and create dbs
+              // - create lmdbs
+              _dbfullname = _model_repo + "/" + _dbfullname;
+              _test_dbfullname = _model_repo + "/" + _test_dbfullname;
+              objects_to_db(_uris, db_height, db_width, _dbfullname,
+                            _test_dbfullname);
+
+              // data object with db files location
+              APIData dbad;
+              dbad.add("train_db", _dbfullname);
+              if (_test_split > 0.0 || _uris.size() > 1)
+                dbad.add("test_db", _test_dbfullname);
+              const_cast<APIData &>(ad).add("db", dbad);
+            }
+          else if (_ctc)
+            {
+              _dbfullname = _model_repo + "/train";
+              _test_dbfullname = _model_repo + "/test.h5";
+              try
+                {
+                  get_data(ad);
+                }
+              catch (InputConnectorBadParamException
+                         &ex) // in case the db is in the net config
+                {
+                  throw ex;
+                }
+
+                // read images list and create dbs
 #ifdef USE_HDF5
-	      images_to_hdf5(_uris,_dbfullname,_test_dbfullname);
+              images_to_hdf5(_uris, _dbfullname, _test_dbfullname);
 #endif // USE_HDF5
-	      // enrich data object with db files location
-	      APIData dbad;
-	      dbad.add("train_db",_model_repo + "/training.txt");
-	      if (_uris.size() > 1 || _test_split > 0.0)
-		dbad.add("test_db",_model_repo + "/testing.txt");
-	      const_cast<APIData&>(ad).add("db",dbad);
-	    }
-	  else // more complicated, since images can be heavy, a db is built so that it is less costly to iterate than the filesystem, unless image data layer is used (e.g. multi-class image training)
-	    {
-	      _dbfullname = _model_repo + "/" + _dbfullname;
-	      _test_dbfullname = _model_repo + "/" + _test_dbfullname;
-	      try
-		{
-		  get_data(ad);
-		}
-	      catch(InputConnectorBadParamException &ex) // in case the db is in the net config
-		{
-		  // API defines no data as a user error (bad param).
-		  // However, Caffe does allow to specify the input database into the net's definition,
-		  // which makes it difficult to enforce the API here.
-		  // So for now, this check is kept disabled.
-		  /*if (!fileops::file_exists(_model_repo + "/" + _dbname))
-		    throw ex;*/
-		  return;
-		}
-	      if (!this->_db) {
-		// create test db for image data layer (no db of images)
-		create_test_db_for_imagedatalayer(_uris.at(1),_model_repo + "/" +_test_dbname);
-		return;
-	      }
-	      // create db
-	      // Check if the indicated uri is a folder
-	      bool dir_images = true;
-	      fileops::file_exists(_uris.at(0), dir_images);
-	      if (!this->_unchanged_data)
-	        images_to_db(_uris,_model_repo + "/" + _dbname,_model_repo + "/" + _test_dbname, dir_images);
-	      else 
-	        images_to_db(_uris,_model_repo + "/" + _dbname,_model_repo + "/" + _test_dbname, dir_images,
-					"lmdb",false,"");
+       // enrich data object with db files location
+              APIData dbad;
+              dbad.add("train_db", _model_repo + "/training.txt");
+              if (_uris.size() > 1 || _test_split > 0.0)
+                dbad.add("test_db", _model_repo + "/testing.txt");
+              const_cast<APIData &>(ad).add("db", dbad);
+            }
+          else // more complicated, since images can be heavy, a db is built so
+               // that it is less costly to iterate than the filesystem, unless
+               // image data layer is used (e.g. multi-class image training)
+            {
+              _dbfullname = _model_repo + "/" + _dbfullname;
+              _test_dbfullname = _model_repo + "/" + _test_dbfullname;
+              try
+                {
+                  get_data(ad);
+                }
+              catch (InputConnectorBadParamException
+                         &ex) // in case the db is in the net config
+                {
+                  // API defines no data as a user error (bad param).
+                  // However, Caffe does allow to specify the input database
+                  // into the net's definition, which makes it difficult to
+                  // enforce the API here. So for now, this check is kept
+                  // disabled.
+                  /*if (!fileops::file_exists(_model_repo + "/" + _dbname))
+                    throw ex;*/
+                  return;
+                }
+              if (!this->_db)
+                {
+                  // create test db for image data layer (no db of images)
+                  create_test_db_for_imagedatalayer(
+                      _uris.at(1), _model_repo + "/" + _test_dbname);
+                  return;
+                }
+              // create db
+              // Check if the indicated uri is a folder
+              bool dir_images = true;
+              fileops::file_exists(_uris.at(0), dir_images);
+              if (!this->_unchanged_data)
+                images_to_db(_uris, _model_repo + "/" + _dbname,
+                             _model_repo + "/" + _test_dbname, dir_images);
+              else
+                images_to_db(_uris, _model_repo + "/" + _dbname,
+                             _model_repo + "/" + _test_dbname, dir_images,
+                             "lmdb", false, "");
 
-	      // compute mean of images, not forcely used, depends on net, see has_mean_file
-	      if (!this->_unchanged_data)
-		compute_images_mean(_model_repo + "/" + _dbname,
-				    _model_repo + "/" + _meanfname);
-	      
-	      // class weights if any
-	      write_class_weights(_model_repo,ad_mllib);
-	      
-	      // enrich data object with db files location
-	      APIData dbad;
-	      dbad.add("train_db",_dbfullname);
-	      if (_test_split > 0.0)
-		dbad.add("test_db",_test_dbfullname);
-	      dbad.add("meanfile",_model_repo + "/" + _meanfname);
-	      const_cast<APIData&>(ad).add("db",dbad);
-	    }
-	}
+              // compute mean of images, not forcely used, depends on net, see
+              // has_mean_file
+              if (!this->_unchanged_data)
+                compute_images_mean(_model_repo + "/" + _dbname,
+                                    _model_repo + "/" + _meanfname);
+
+              // class weights if any
+              write_class_weights(_model_repo, ad_mllib);
+
+              // enrich data object with db files location
+              APIData dbad;
+              dbad.add("train_db", _dbfullname);
+              if (_test_split > 0.0)
+                dbad.add("test_db", _test_dbfullname);
+              dbad.add("meanfile", _model_repo + "/" + _meanfname);
+              const_cast<APIData &>(ad).add("db", dbad);
+            }
+        }
     }
 
     std::vector<caffe::Datum> get_dv_test(const int &num,
-					  const bool &has_mean_file)
-      {
-        if (_segmentation && _train)
-	  {
-	    return get_dv_test_segmentation(num,has_mean_file);
-	  }
-	else if (!_train && _db_fname.empty())
-	  {
-	    int i = 0;
-	    std::vector<caffe::Datum> dv;
-	    while(_dt_vit!=_dv_test.end()
-		  && i < num)
-	      {
-		dv.push_back((*_dt_vit));
-		++i;
-		++_dt_vit;
-	      }
-	    return dv;
-	  }
-	else return get_dv_test_db(num,has_mean_file);
-      }
-    
+                                          const bool &has_mean_file)
+    {
+      if (_segmentation && _train)
+        {
+          return get_dv_test_segmentation(num, has_mean_file);
+        }
+      else if (!_train && _db_fname.empty())
+        {
+          int i = 0;
+          std::vector<caffe::Datum> dv;
+          while (_dt_vit != _dv_test.end() && i < num)
+            {
+              dv.push_back((*_dt_vit));
+              ++i;
+              ++_dt_vit;
+            }
+          return dv;
+        }
+      else
+        return get_dv_test_db(num, has_mean_file);
+    }
+
     std::vector<caffe::Datum> get_dv_test_db(const int &num,
-					     const bool &has_mean_file);
+                                             const bool &has_mean_file);
 
-    std::vector<caffe::Datum> get_dv_test_segmentation(const int &num,
-						       const bool &has_mean_file);
-    
+    std::vector<caffe::Datum>
+    get_dv_test_segmentation(const int &num, const bool &has_mean_file);
+
     void reset_dv_test();
-    
-  private:
 
-    void create_test_db_for_imagedatalayer(const std::string &test_lst,
-                                           const std::string &testdbname,
-                                           const std::string &backend="lmdb", // lmdb, leveldb
-                                           const bool &encoded=true, // save the encoded image in datum
-                                           const std::string &encode_type=""); // 'png', 'jpg', ...
+  private:
+    void create_test_db_for_imagedatalayer(
+        const std::string &test_lst, const std::string &testdbname,
+        const std::string &backend = "lmdb", // lmdb, leveldb
+        const bool &encoded = true,          // save the encoded image in datum
+        const std::string &encode_type = ""); // 'png', 'jpg', ...
 
     int images_to_db(const std::vector<std::string> &rpaths,
-		     const std::string &traindbname,
-		     const std::string &testdbname,
-		     const bool &folders=true,						 
-		     const std::string &backend="lmdb", // lmdb, leveldb
-		     const bool &encoded=true, // save the encoded image in datum
-		     const std::string &encode_type=""); // 'png', 'jpg', ...
+                     const std::string &traindbname,
+                     const std::string &testdbname, const bool &folders = true,
+                     const std::string &backend = "lmdb", // lmdb, leveldb
+                     const bool &encoded
+                     = true, // save the encoded image in datum
+                     const std::string &encode_type = ""); // 'png', 'jpg', ...
 
-    void write_image_to_db(const std::string &dbfullname,
-			   const std::vector<std::pair<std::string,int>> &lfiles,
-			   const std::string &backend,
-			   const bool &encoded,
-			   const std::string &encode_type);
+    void
+    write_image_to_db(const std::string &dbfullname,
+                      const std::vector<std::pair<std::string, int>> &lfiles,
+                      const std::string &backend, const bool &encoded,
+                      const std::string &encode_type);
 
-    void write_image_to_db_multilabel(const std::string &dbfullname,
-				      const std::vector<std::pair<std::string,std::vector<float>>> &lfiles,
-				      const std::string &backend,
-				      const bool &encoded,
-				      const std::string &encode_type);
-		#ifdef USE_HDF5
+    void write_image_to_db_multilabel(
+        const std::string &dbfullname,
+        const std::vector<std::pair<std::string, std::vector<float>>> &lfiles,
+        const std::string &backend, const bool &encoded,
+        const std::string &encode_type);
+#ifdef USE_HDF5
     void images_to_hdf5(const std::vector<std::string> &img_lists,
-			const std::string &traindbname,
-			const std::string &testdbname);
+                        const std::string &traindbname,
+                        const std::string &testdbname);
 
     void write_images_to_hdf5(const std::string &inputfilename,
-			      const std::string &dbfullbame,
-			      const std::string &dblistfilename,
-			      std::unordered_map<uint32_t,int> &alphabet,
-			      int &max_ocr_length,
-			      const bool &train_db);
-		#endif // USE_HDF5
+                              const std::string &dbfullbame,
+                              const std::string &dblistfilename,
+                              std::unordered_map<uint32_t, int> &alphabet,
+                              int &max_ocr_length, const bool &train_db);
+#endif // USE_HDF5
 
     int objects_to_db(const std::vector<std::string> &rfolders,
-		      const int &db_height,
-		      const int &db_width,
-		      const std::string &traindbname,
-		      const std::string &testdbname,
-		      const bool &encoded=true,
-		      const std::string &encode_type="",
-		      const std::string &backend="lmdb");
+                      const int &db_height, const int &db_width,
+                      const std::string &traindbname,
+                      const std::string &testdbname,
+                      const bool &encoded = true,
+                      const std::string &encode_type = "",
+                      const std::string &backend = "lmdb");
 
-    void write_objects_to_db(const std::string &dbfullname,
-			     const int &db_height,
-			     const int &db_width,
-			     const std::vector<std::pair<std::string,std::string>> &lines,
-			     const bool &encoded,
-			     const std::string &encode_type,
-			     const std::string &backend,
-			     const bool &train);
-    
+    void write_objects_to_db(
+        const std::string &dbfullname, const int &db_height,
+        const int &db_width,
+        const std::vector<std::pair<std::string, std::string>> &lines,
+        const bool &encoded, const std::string &encode_type,
+        const std::string &backend, const bool &train);
+
     int compute_images_mean(const std::string &dbname,
-			    const std::string &meanfile,
-			    const std::string &backend="lmdb");
+                            const std::string &meanfile,
+                            const std::string &backend = "lmdb");
 
     std::string guess_encoding(const std::string &file);
-    
+
   public:
     int _db_batchsize = -1;
     int _db_testbatchsize = -1;
@@ -530,7 +587,7 @@ namespace dd
     std::string _correspname = "corresp.txt";
     caffe::Blob<float> _data_mean; // mean binary image if available.
     std::vector<caffe::Datum>::const_iterator _dt_vit;
-    std::vector<std::pair<std::string,std::string>> _segmentation_data_lines;
+    std::vector<std::pair<std::string, std::string>> _segmentation_data_lines;
     int _dt_seg = 0;
     bool _align = false;
   };
@@ -543,33 +600,42 @@ namespace dd
   class DDCCsv
   {
   public:
-    DDCCsv() {}
-    ~DDCCsv() {}
+    DDCCsv()
+    {
+    }
+    ~DDCCsv()
+    {
+    }
 
     int read_file(const std::string &fname);
     int read_db(const std::string &fname);
     int read_mem(const std::string &content);
     int read_dir(const std::string &dir)
     {
-      throw InputConnectorBadParamException("uri " + dir + " is a directory, requires a CSV file");
+      throw InputConnectorBadParamException(
+          "uri " + dir + " is a directory, requires a CSV file");
     }
-    
+
     CSVCaffeInputFileConn *_cifc = nullptr;
     APIData _adconf;
     std::shared_ptr<spdlog::logger> _logger;
   };
-  
-  class CSVCaffeInputFileConn : public CSVInputFileConn, public CaffeInputInterface
+
+  class CSVCaffeInputFileConn : public CSVInputFileConn,
+                                public CaffeInputInterface
   {
   public:
-    CSVCaffeInputFileConn()
-      :CSVInputFileConn() 
-      {
-	reset_dv_test();
-      }
+    CSVCaffeInputFileConn() : CSVInputFileConn()
+    {
+      reset_dv_test();
+    }
     CSVCaffeInputFileConn(const CSVCaffeInputFileConn &i)
-      :CSVInputFileConn(i),CaffeInputInterface(i) {}
-    ~CSVCaffeInputFileConn() {}
+        : CSVInputFileConn(i), CaffeInputInterface(i)
+    {
+    }
+    ~CSVCaffeInputFileConn()
+    {
+    }
 
     void init(const APIData &ad)
     {
@@ -580,15 +646,15 @@ namespace dd
     int channels() const
     {
       if (_channels > 0)
-	return _channels;
+        return _channels;
       return feature_size();
     }
-    
+
     int height() const
     {
       return 1;
     }
-    
+
     int width() const
     {
       return 1;
@@ -597,136 +663,143 @@ namespace dd
     int batch_size() const
     {
       if (_db_batchsize > 0)
-	return _db_batchsize;
-      else return _dv.size();
+        return _db_batchsize;
+      else
+        return _dv.size();
     }
 
     int test_batch_size() const
     {
       if (_db_testbatchsize > 0)
-	return _db_testbatchsize;
-      else return _dv_test.size();
+        return _db_testbatchsize;
+      else
+        return _dv_test.size();
     }
 
     virtual void add_train_csvline(const std::string &id,
-				   std::vector<double> &vals);
+                                   std::vector<double> &vals);
 
     virtual void add_test_csvline(const std::string &id,
-				  std::vector<double> &vals);
-    
+                                  std::vector<double> &vals);
+
     void transform(const APIData &ad)
     {
       APIData ad_param = ad.getobj("parameters");
       APIData ad_input = ad_param.getobj("input");
       APIData ad_mllib = ad_param.getobj("mllib");
-      
+
       if (_train && ad_input.has("db") && ad_input.get("db").get<bool>())
-	{
-	  _dbfullname = _model_repo + "/" + _dbfullname;
-	  _test_dbfullname = _model_repo + "/" + _test_dbfullname;
-	  fillup_parameters(ad_input);
-	  get_data(ad);
-	  _db = true;
-	  csv_to_db(_model_repo + "/" + _dbname,_model_repo + "/" + _test_dbname,
-		    ad_input);
-	  write_class_weights(_model_repo,ad_mllib);
-	  
-	  // enrich data object with db files location
-	  APIData dbad;
-	  dbad.add("train_db",_dbfullname);
-	  if (_test_split > 0.0)
-	    dbad.add("test_db",_test_dbfullname);
-	  const_cast<APIData&>(ad).add("db",dbad);
-	}
+        {
+          _dbfullname = _model_repo + "/" + _dbfullname;
+          _test_dbfullname = _model_repo + "/" + _test_dbfullname;
+          fillup_parameters(ad_input);
+          get_data(ad);
+          _db = true;
+          csv_to_db(_model_repo + "/" + _dbname,
+                    _model_repo + "/" + _test_dbname, ad_input);
+          write_class_weights(_model_repo, ad_mllib);
+
+          // enrich data object with db files location
+          APIData dbad;
+          dbad.add("train_db", _dbfullname);
+          if (_test_split > 0.0)
+            dbad.add("test_db", _test_dbfullname);
+          const_cast<APIData &>(ad).add("db", dbad);
+        }
       else
-	{
-	  try
-	    {
-	      CSVInputFileConn::transform(ad);
-	    }
-	  catch (std::exception &e)
-	    {
-	      throw;
-	    }
-	  
-	  // transform to datum by filling up float_data
-	  if (_train)
-	    {
-	      auto hit = _csvdata.begin();
-	      while(hit!=_csvdata.end())
-		{
-		  if (_label.size() == 1)
-		    _dv.push_back(to_datum((*hit)._v));
-		  else // multi labels or autoencoder
-		    {
-		      caffe::Datum dat = to_datum((*hit)._v,true);
-		      for (size_t i=0;i<_label_pos.size();i++) // concat labels and slice them out in the network itself
-			{
-			  dat.add_float_data(static_cast<float>((*hit)._v.at(_label_pos[i])));
-			}
-		      dat.set_channels(dat.channels()+_label.size());
-		      _dv.push_back(dat);
-		    }
-		  this->_ids.push_back((*hit)._str);
-		  ++hit;
-		}
-	    }
-	  if (!_train)
-	    {
-	      if (!_db_fname.empty())
-		{
-		  _test_dbfullname = _db_fname;
-		  _db = true;
-		  return; // done
-		}
-	      _csvdata_test = std::move(_csvdata);
-	    }
-	  else _csvdata.clear();
-	  auto hit = _csvdata_test.begin();
-	  while(hit!=_csvdata_test.end())
-	    {
-	      // no ids taken on the test set
-	      if (_label.size() == 1)
-		_dv_test.push_back(to_datum((*hit)._v));
-	      else
-		{
-		  caffe::Datum dat = to_datum((*hit)._v,true);
-		  for (size_t i=0;i<_label_pos.size();i++)
-		    {
-		      dat.add_float_data(static_cast<float>((*hit)._v.at(_label_pos[i])));
-		    }
-		  dat.set_channels(dat.channels()+_label.size());
-		  _dv_test.push_back(dat);
-		}
-	      if (!_train)
-		this->_ids.push_back((*hit)._str);
-	      ++hit;
-	    }
-	  _csvdata_test.clear();
-	}
+        {
+          try
+            {
+              CSVInputFileConn::transform(ad);
+            }
+          catch (std::exception &e)
+            {
+              throw;
+            }
+
+          // transform to datum by filling up float_data
+          if (_train)
+            {
+              auto hit = _csvdata.begin();
+              while (hit != _csvdata.end())
+                {
+                  if (_label.size() == 1)
+                    _dv.push_back(to_datum((*hit)._v));
+                  else // multi labels or autoencoder
+                    {
+                      caffe::Datum dat = to_datum((*hit)._v, true);
+                      for (size_t i = 0; i < _label_pos.size();
+                           i++) // concat labels and slice them out in the
+                                // network itself
+                        {
+                          dat.add_float_data(
+                              static_cast<float>((*hit)._v.at(_label_pos[i])));
+                        }
+                      dat.set_channels(dat.channels() + _label.size());
+                      _dv.push_back(dat);
+                    }
+                  this->_ids.push_back((*hit)._str);
+                  ++hit;
+                }
+            }
+          if (!_train)
+            {
+              if (!_db_fname.empty())
+                {
+                  _test_dbfullname = _db_fname;
+                  _db = true;
+                  return; // done
+                }
+              _csvdata_test = std::move(_csvdata);
+            }
+          else
+            _csvdata.clear();
+          auto hit = _csvdata_test.begin();
+          while (hit != _csvdata_test.end())
+            {
+              // no ids taken on the test set
+              if (_label.size() == 1)
+                _dv_test.push_back(to_datum((*hit)._v));
+              else
+                {
+                  caffe::Datum dat = to_datum((*hit)._v, true);
+                  for (size_t i = 0; i < _label_pos.size(); i++)
+                    {
+                      dat.add_float_data(
+                          static_cast<float>((*hit)._v.at(_label_pos[i])));
+                    }
+                  dat.set_channels(dat.channels() + _label.size());
+                  _dv_test.push_back(dat);
+                }
+              if (!_train)
+                this->_ids.push_back((*hit)._str);
+              ++hit;
+            }
+          _csvdata_test.clear();
+        }
       _csvdata_test.clear();
     }
 
     std::vector<caffe::Datum> get_dv_test(const int &num,
-					  const bool &has_mean_file)
-      {
-	(void)has_mean_file;
-	if (!_db)
-	  {
-	    int i = 0;
-	    std::vector<caffe::Datum> dv;
-	    while(_dt_vit!=_dv_test.end()
-		  && i < num)
-	      {
-		dv.push_back((*_dt_vit));
-		++i;
-		++_dt_vit;
-	      }
-	    return dv;
-	  }
-	  else return get_dv_test_db(num);
-      }
-    
+                                          const bool &has_mean_file)
+    {
+      (void)has_mean_file;
+      if (!_db)
+        {
+          int i = 0;
+          std::vector<caffe::Datum> dv;
+          while (_dt_vit != _dv_test.end() && i < num)
+            {
+              dv.push_back((*_dt_vit));
+              ++i;
+              ++_dt_vit;
+            }
+          return dv;
+        }
+      else
+        return get_dv_test_db(num);
+    }
+
     std::vector<caffe::Datum> get_dv_test_db(const int &num);
 
     void reset_dv_test();
@@ -737,52 +810,53 @@ namespace dd
      * @return datum
      */
     caffe::Datum to_datum(const std::vector<double> &vf,
-			  const bool &multi_label=false)
+                          const bool &multi_label = false)
     {
       caffe::Datum datum;
       int datum_channels = vf.size();
       if (!_label.empty())
-	datum_channels -= _label.size();
+        datum_channels -= _label.size();
       if (!_id.empty())
-	datum_channels--;
+        datum_channels--;
       datum.set_channels(datum_channels);
       datum.set_height(1);
       datum.set_width(1);
       auto lit = _columns.begin();
-      for (int i=0;i<(int)vf.size();i++)
-	{
-	  if (!multi_label && !this->_label.empty() && i == _label_pos[0])
-	    {
-	      datum.set_label(static_cast<float>(vf.at(i)+this->_label_offset[0]));
-	    }
-	  else if (i == _id_pos)
-	    {
-	      ++lit;
-	      continue;
-	    }
-	  else if (std::find(_label_pos.begin(),_label_pos.end(),i)==_label_pos.end()) // XXX: could do a faster lookup
-	  {
-	      datum.add_float_data(static_cast<float>(vf.at(i)));
-	    }
-	  ++lit;
-	}
+      for (int i = 0; i < (int)vf.size(); i++)
+        {
+          if (!multi_label && !this->_label.empty() && i == _label_pos[0])
+            {
+              datum.set_label(
+                  static_cast<float>(vf.at(i) + this->_label_offset[0]));
+            }
+          else if (i == _id_pos)
+            {
+              ++lit;
+              continue;
+            }
+          else if (std::find(_label_pos.begin(), _label_pos.end(), i)
+                   == _label_pos.end()) // XXX: could do a faster lookup
+            {
+              datum.add_float_data(static_cast<float>(vf.at(i)));
+            }
+          ++lit;
+        }
       return datum;
     }
 
   private:
     int csv_to_db(const std::string &traindbname,
-		  const std::string &testdbname,
-		  const APIData &ad_input,
-		  const std::string &backend="lmdb"); // lmdb, leveldb
+                  const std::string &testdbname, const APIData &ad_input,
+                  const std::string &backend = "lmdb"); // lmdb, leveldb
 
     void write_csvline_to_db(const std::string &dbfullname,
-			     const std::string &testdbfullname,
-			     const APIData &ad_input,
-			     const std::string &backend="lmdb");
-    
+                             const std::string &testdbfullname,
+                             const APIData &ad_input,
+                             const std::string &backend = "lmdb");
+
   public:
     std::vector<caffe::Datum>::const_iterator _dt_vit;
-    
+
     int _db_batchsize = -1;
     int _db_testbatchsize = -1;
     std::unique_ptr<caffe::db::DB> _test_db;
@@ -807,12 +881,17 @@ namespace dd
   class DDCCsvTS
   {
   public:
-  DDCCsvTS() {}
-    ~DDCCsvTS() {}
-    int read_file(const std::string &fname, bool is_test_data=false);
+    DDCCsvTS()
+    {
+    }
+    ~DDCCsvTS()
+    {
+    }
+    int read_file(const std::string &fname, bool is_test_data = false);
     int read_db(const std::string &fname);
     int read_mem(const std::string &content);
-    int read_dir(const std::string &dir, bool is_test_data=false, bool update_bounds = true);
+    int read_dir(const std::string &dir, bool is_test_data = false,
+                 bool update_bounds = true);
 
     DDCsvTS _ddcsvts;
     CSVTSCaffeInputFileConn *_cifc = nullptr;
@@ -820,21 +899,26 @@ namespace dd
     std::shared_ptr<spdlog::logger> _logger;
   };
 
-
-  class CSVTSCaffeInputFileConn : public CSVTSInputFileConn, public CaffeInputInterface
+  class CSVTSCaffeInputFileConn : public CSVTSInputFileConn,
+                                  public CaffeInputInterface
   {
   public:
-  CSVTSCaffeInputFileConn()
-    :CSVTSInputFileConn(), _dv_index(-1), _dv_test_index(-1), _continuation(false), _offset(100)
-      {
-        reset_dv_test();
-      }
-  CSVTSCaffeInputFileConn(const CSVTSCaffeInputFileConn &i)
-    :CSVTSInputFileConn(i), CaffeInputInterface(i), _dv_index(i._dv_index), _dv_test_index(i._dv_test_index), _continuation(i._continuation), _offset(i._offset)
-      {
-        this->_datadim = i._datadim;
-      }
-    ~CSVTSCaffeInputFileConn() {}
+    CSVTSCaffeInputFileConn()
+        : CSVTSInputFileConn(), _dv_index(-1), _dv_test_index(-1),
+          _continuation(false), _offset(100)
+    {
+      reset_dv_test();
+    }
+    CSVTSCaffeInputFileConn(const CSVTSCaffeInputFileConn &i)
+        : CSVTSInputFileConn(i), CaffeInputInterface(i),
+          _dv_index(i._dv_index), _dv_test_index(i._dv_test_index),
+          _continuation(i._continuation), _offset(i._offset)
+    {
+      this->_datadim = i._datadim;
+    }
+    ~CSVTSCaffeInputFileConn()
+    {
+    }
 
     void init(const APIData &ad)
     {
@@ -848,15 +932,14 @@ namespace dd
       _offset = _timesteps;
       if (ad_input.has("timesteps"))
         {
-          _timesteps= ad_input.get("timesteps").get<int>();
+          _timesteps = ad_input.get("timesteps").get<int>();
           _offset = _timesteps;
         }
       if (ad_input.has("continuation"))
-        _continuation= ad_input.get("continuation").get<bool>();
+        _continuation = ad_input.get("continuation").get<bool>();
       if (ad_input.has("offset"))
-        _offset= ad_input.get("offset").get<int>();
+        _offset = ad_input.get("offset").get<int>();
     }
-
 
     // size of each element in Caffe jargon
     int channels() const
@@ -877,9 +960,9 @@ namespace dd
     int batch_size() const
     {
       if (_db_batchsize > 0)
-	return _db_batchsize;
+        return _db_batchsize;
       else if (_dv.size() != 0)
-	return _dv.size();
+        return _dv.size();
       else
         return 1;
     }
@@ -887,27 +970,29 @@ namespace dd
     int test_batch_size() const
     {
       if (_db_testbatchsize > 0)
-	return _db_testbatchsize;
+        return _db_testbatchsize;
       else if (_dv_test.size() != 0)
-	return _dv_test.size();
+        return _dv_test.size();
       else
         return 1;
     }
 
-    void push_csv_to_csvts(bool is_test_data=false);
+    void push_csv_to_csvts(bool is_test_data = false);
     void set_datadim(bool is_test_data = false);
-    void transform(const APIData &ad); // calls CSVTSInputfileconn::transform and db stuff
+    void transform(
+        const APIData &ad); // calls CSVTSInputfileconn::transform and db stuff
     void reset_dv_test();
     std::vector<caffe::Datum> get_dv_test(const int &num,
                                           const bool &has_mean_file);
     std::vector<caffe::Datum> get_dv_test_db(const int &num);
 
     int csvts_to_db(const std::string &traindbname,
-                    const std::string &testdbname,
-                    const APIData &ad_input,
-                    const std::string &backend="lmdb"); // lmdb, leveldb
-    void csvts_to_dv(bool is_test_data=false, bool clear_dv_first = false, bool clear_csvts_after=false, bool split_seqs=true, bool first_is_cont = false);
-    void dv_to_db(bool is_test_data=false);
+                    const std::string &testdbname, const APIData &ad_input,
+                    const std::string &backend = "lmdb"); // lmdb, leveldb
+    void csvts_to_dv(bool is_test_data = false, bool clear_dv_first = false,
+                     bool clear_csvts_after = false, bool split_seqs = true,
+                     bool first_is_cont = false);
+    void dv_to_db(bool is_test_data = false);
 
     void write_csvts_to_db(const std::string &dbfullname,
                            const std::string &testdbfullname,
@@ -935,34 +1020,36 @@ namespace dd
     std::unique_ptr<caffe::db::Transaction> _ttxn;
     std::unique_ptr<caffe::db::DB> _ttdb;
     int _channels = 0;
-
-
   };
 
   /**
    * \brief Caffe text connector
    */
-  class TxtCaffeInputFileConn : public TxtInputFileConn, public CaffeInputInterface
+  class TxtCaffeInputFileConn : public TxtInputFileConn,
+                                public CaffeInputInterface
   {
   public:
-    TxtCaffeInputFileConn()
-      :TxtInputFileConn()
-      {
-	reset_dv_test();
-      }
+    TxtCaffeInputFileConn() : TxtInputFileConn()
+    {
+      reset_dv_test();
+    }
     TxtCaffeInputFileConn(const TxtCaffeInputFileConn &i)
-      :TxtInputFileConn(i),CaffeInputInterface(i) {}
-    ~TxtCaffeInputFileConn() {}
+        : TxtInputFileConn(i), CaffeInputInterface(i)
+    {
+    }
+    ~TxtCaffeInputFileConn()
+    {
+    }
 
     void init(const APIData &ad)
     {
       TxtInputFileConn::init(ad);
       if (_characters)
-	_flat1dconv = true;
+        _flat1dconv = true;
       if (ad.has("sparse") && ad.get("sparse").get<bool>())
-	_sparse = true;
+        _sparse = true;
       if (ad.has("embedding") && ad.get("embedding").get<bool>())
-	_embed = true;
+        _embed = true;
       _sequence_txt = _sequence;
       _max_embed_id = _alphabet.size() + 1; // +1 as offset to null index
     }
@@ -970,326 +1057,348 @@ namespace dd
     int channels() const
     {
       if (_characters)
-	return 1;
+        return 1;
       if (_embed)
-	{
-	  if (!_characters)
-	    return _sequence;
-	  else return 1;
-	}
+        {
+          if (!_characters)
+            return _sequence;
+          else
+            return 1;
+        }
       if (_channels > 0)
-	return _channels;
+        return _channels;
       return feature_size();
     }
 
     int height() const
     {
       if (_characters)
-	return _sequence;
-      else return 1;
+        return _sequence;
+      else
+        return 1;
     }
 
     int width() const
     {
       if (_characters && !_embed)
-	return _alphabet.size();
+        return _alphabet.size();
       return 1;
     }
 
     int batch_size() const
     {
       if (_db_batchsize > 0)
-	return _db_batchsize;
+        return _db_batchsize;
       else if (!_sparse)
-	return _dv.size();
-      else return _dv_sparse.size();
+        return _dv.size();
+      else
+        return _dv_sparse.size();
     }
 
     int test_batch_size() const
     {
       if (_db_testbatchsize > 0)
-	return _db_testbatchsize;
+        return _db_testbatchsize;
       else if (!_sparse)
-	return _dv_test.size();
-      else return _dv_test_sparse.size();
+        return _dv_test.size();
+      else
+        return _dv_test_sparse.size();
     }
-    
+
     int txt_to_db(const std::string &traindbname,
-		  const std::string &testdbname,
-		  const std::string &backend="lmdb");
+                  const std::string &testdbname,
+                  const std::string &backend = "lmdb");
 
     void write_txt_to_db(const std::string &dbname,
-			 std::vector<TxtEntry<double>*> &txt,
-			 const std::string &backend="lmdb");
-    
+                         std::vector<TxtEntry<double> *> &txt,
+                         const std::string &backend = "lmdb");
+
     void write_sparse_txt_to_db(const std::string &dbname,
-				std::vector<TxtEntry<double>*> &txt,
-				const std::string &backend="lmdb");
-    
+                                std::vector<TxtEntry<double> *> &txt,
+                                const std::string &backend = "lmdb");
+
     void transform(const APIData &ad)
     {
       APIData ad_param = ad.getobj("parameters");
       APIData ad_input = ad_param.getobj("input");
       APIData ad_mllib = ad_param.getobj("mllib");
       if (ad_input.has("db") && ad_input.get("db").get<bool>())
-	_db = true;
+        _db = true;
       if (ad_input.has("embedding") && ad_input.get("embedding").get<bool>())
-	{
-	  _embed = true;
-	}
-      
+        {
+          _embed = true;
+        }
+
       // transform to one-hot vector datum
       if (_train && _db)
-	{
-	  _dbfullname = _model_repo + "/" + _dbfullname;
-	  _test_dbfullname = _model_repo + "/" + _test_dbfullname;
-	  //std::string dbfullname = _model_repo + "/" + _dbname + ".lmdb";
-	  if (!fileops::file_exists(_dbfullname)) // if no existing db, preprocess from txt files
-	    TxtInputFileConn::transform(ad);
-	  txt_to_db(_model_repo + "/" + _dbname,_model_repo + "/" + _test_dbname);
-	  write_class_weights(_model_repo,ad_mllib);
+        {
+          _dbfullname = _model_repo + "/" + _dbfullname;
+          _test_dbfullname = _model_repo + "/" + _test_dbfullname;
+          // std::string dbfullname = _model_repo + "/" + _dbname + ".lmdb";
+          if (!fileops::file_exists(
+                  _dbfullname)) // if no existing db, preprocess from txt files
+            TxtInputFileConn::transform(ad);
+          txt_to_db(_model_repo + "/" + _dbname,
+                    _model_repo + "/" + _test_dbname);
+          write_class_weights(_model_repo, ad_mllib);
 
-	  
-	  // enrich data object with db files location
-	  APIData dbad;
-	  dbad.add("train_db",_dbfullname);
-	  if (_test_split > 0.0)
-	    dbad.add("test_db",_test_dbfullname);
-	  const_cast<APIData&>(ad).add("db",dbad);
-	}
+          // enrich data object with db files location
+          APIData dbad;
+          dbad.add("train_db", _dbfullname);
+          if (_test_split > 0.0)
+            dbad.add("test_db", _test_dbfullname);
+          const_cast<APIData &>(ad).add("db", dbad);
+        }
       else
-	{
-	  TxtInputFileConn::transform(ad);
-	  
-	  if (_train)
-	    {
-	      auto hit = _txt.begin();
-	      while(hit!=_txt.end())
-		{
-		  if (!_sparse)
-		    {
-		      if (_characters)
-			_dv.push_back(std::move(to_datum<TxtCharEntry>(static_cast<TxtCharEntry*>((*hit)))));
-		      else _dv.push_back(std::move(to_datum<TxtBowEntry>(static_cast<TxtBowEntry*>((*hit)))));
-		    }
-		  else
-		    {
-		      if (_characters)
-			{
-			  //TODO
-			}
-		      else _dv_sparse.push_back(std::move(to_sparse_datum(static_cast<TxtBowEntry*>((*hit)))));
-		    }
-		  this->_ids.push_back((*hit)->_uri);
-		  ++hit;
-		}
-	    }
-	  if (!_train)
-	    {
-	      if (!_db_fname.empty())
-		{
-		  _test_dbfullname = _db_fname;
-		  _db = true;
-		  return; // done
-		}
-	    _test_txt = std::move(_txt);
-	    }
+        {
+          TxtInputFileConn::transform(ad);
 
-	  int n = 0;
-	  auto hit = _test_txt.begin();
-	  while(hit!=_test_txt.end())
-	    {
-	      if (!_sparse)
-		{
-		  if (_characters)
-		    _dv_test.push_back(std::move(to_datum<TxtCharEntry>(static_cast<TxtCharEntry*>((*hit)))));
-		  else _dv_test.push_back(std::move(to_datum<TxtBowEntry>(static_cast<TxtBowEntry*>((*hit)))));
-		}
-	      else
-		{
-		  if (_characters)
-		    {
-		      //TODO
-		    }
-		  else _dv_test_sparse.push_back(std::move(to_sparse_datum(static_cast<TxtBowEntry*>((*hit)))));
-		}
-	      if (!_train)
-		this->_ids.push_back(std::to_string(n));
-	      ++hit;
-	      ++n;
-	    }
-	}
+          if (_train)
+            {
+              auto hit = _txt.begin();
+              while (hit != _txt.end())
+                {
+                  if (!_sparse)
+                    {
+                      if (_characters)
+                        _dv.push_back(std::move(to_datum<TxtCharEntry>(
+                            static_cast<TxtCharEntry *>((*hit)))));
+                      else
+                        _dv.push_back(std::move(to_datum<TxtBowEntry>(
+                            static_cast<TxtBowEntry *>((*hit)))));
+                    }
+                  else
+                    {
+                      if (_characters)
+                        {
+                          // TODO
+                        }
+                      else
+                        _dv_sparse.push_back(std::move(to_sparse_datum(
+                            static_cast<TxtBowEntry *>((*hit)))));
+                    }
+                  this->_ids.push_back((*hit)->_uri);
+                  ++hit;
+                }
+            }
+          if (!_train)
+            {
+              if (!_db_fname.empty())
+                {
+                  _test_dbfullname = _db_fname;
+                  _db = true;
+                  return; // done
+                }
+              _test_txt = std::move(_txt);
+            }
+
+          int n = 0;
+          auto hit = _test_txt.begin();
+          while (hit != _test_txt.end())
+            {
+              if (!_sparse)
+                {
+                  if (_characters)
+                    _dv_test.push_back(std::move(to_datum<TxtCharEntry>(
+                        static_cast<TxtCharEntry *>((*hit)))));
+                  else
+                    _dv_test.push_back(std::move(to_datum<TxtBowEntry>(
+                        static_cast<TxtBowEntry *>((*hit)))));
+                }
+              else
+                {
+                  if (_characters)
+                    {
+                      // TODO
+                    }
+                  else
+                    _dv_test_sparse.push_back(std::move(
+                        to_sparse_datum(static_cast<TxtBowEntry *>((*hit)))));
+                }
+              if (!_train)
+                this->_ids.push_back(std::to_string(n));
+              ++hit;
+              ++n;
+            }
+        }
     }
 
     std::vector<caffe::Datum> get_dv_test_db(const int &num);
     std::vector<caffe::SparseDatum> get_dv_test_sparse_db(const int &num);
-    
+
     std::vector<caffe::Datum> get_dv_test(const int &num,
-					  const bool &has_mean_file)
-      {
-	(void)has_mean_file;
-	if (!_db)
-	  {
-	    int i = 0;
-	    std::vector<caffe::Datum> dv;
-	    while(_dt_vit!=_dv_test.end()
-		  && i < num)
-	      {
-		dv.push_back((*_dt_vit));
-		++i;
-		++_dt_vit;
-	      }
-	    return dv;
-	  }
-	else return get_dv_test_db(num);
-      }
+                                          const bool &has_mean_file)
+    {
+      (void)has_mean_file;
+      if (!_db)
+        {
+          int i = 0;
+          std::vector<caffe::Datum> dv;
+          while (_dt_vit != _dv_test.end() && i < num)
+            {
+              dv.push_back((*_dt_vit));
+              ++i;
+              ++_dt_vit;
+            }
+          return dv;
+        }
+      else
+        return get_dv_test_db(num);
+    }
 
     std::vector<caffe::SparseDatum> get_dv_test_sparse(const int &num)
-      {
-	if (!_db)
-	  {
-	    int i = 0;
-	    std::vector<caffe::SparseDatum> dv;
-	    while(_dt_vit_sparse!=_dv_test_sparse.end()
-		  && i < num)
-	      {
-		dv.push_back((*_dt_vit_sparse));
-		++i;
-		++_dt_vit_sparse;
-	      }
-	    return dv;
-	  }
-      	else return get_dv_test_sparse_db(num);
-      }
+    {
+      if (!_db)
+        {
+          int i = 0;
+          std::vector<caffe::SparseDatum> dv;
+          while (_dt_vit_sparse != _dv_test_sparse.end() && i < num)
+            {
+              dv.push_back((*_dt_vit_sparse));
+              ++i;
+              ++_dt_vit_sparse;
+            }
+          return dv;
+        }
+      else
+        return get_dv_test_sparse_db(num);
+    }
 
     void reset_dv_test()
     {
       if (!_sparse)
-	_dt_vit = _dv_test.begin();
-      else _dt_vit_sparse = _dv_test_sparse.begin();
+        _dt_vit = _dv_test.begin();
+      else
+        _dt_vit_sparse = _dv_test_sparse.begin();
       _test_db_cursor = std::unique_ptr<caffe::db::Cursor>();
       _test_db = std::unique_ptr<caffe::db::DB>();
     }
-    
-    template<class TEntry> caffe::Datum to_datum(TEntry *tbe)
-      {
-	caffe::Datum datum;
-	int datum_channels;
-	if (_characters)
-	  datum_channels = 1;
-	else if (_embed && !_characters)
-	  datum_channels = _sequence;
-	else datum_channels = _vocab.size(); // XXX: may be very large
-	datum.set_channels(datum_channels);
-       	datum.set_height(1);
-	datum.set_width(1);
-	datum.set_label(tbe->_target);
-	if (!_characters)
-	  {
-	    std::unordered_map<std::string,Word>::const_iterator wit;
-	    if (!_embed)
-	      {
-		for (int i=0;i<datum_channels;i++) // XXX: expected to be slow
-		  datum.add_float_data(0.0);
-		tbe->reset();
-		while(tbe->has_elt())
-		  {
-		    std::string key;
-		    double val;
-		    tbe->get_next_elt(key,val);
-		    if ((wit = _vocab.find(key))!=_vocab.end())
-		      datum.set_float_data(_vocab[key]._pos,static_cast<float>(val));
-		  }
-	      }
-	    else
-	      {
-		tbe->reset();
-		int i = 0;
-		while(tbe->has_elt())
-		  {
-		    std::string key;
-		    double val;
-		    tbe->get_next_elt(key,val);
-		    if ((wit = _vocab.find(key))!=_vocab.end())
-		      datum.add_float_data(static_cast<float>(_vocab[key]._pos));
-		    ++i;
-		    if (i == _sequence) // tmp limit on sequence length
-		      break;
-		  }
-		while (datum.float_data_size() < _sequence)
-		  datum.add_float_data(0.0);
-	      }
-	  }
-	else // character-level features
-	  {
-	    tbe->reset();
-	    std::vector<int> vals;
-	    std::unordered_map<uint32_t,int>::const_iterator whit;
-	    while(tbe->has_elt())
-	      {
-		std::string key;
-		double val = -1.0;
-		tbe->get_next_elt(key,val);
-		uint32_t c = std::strtoul(key.c_str(),0,10);
-		if ((whit=_alphabet.find(c))!=_alphabet.end())
-		  vals.push_back((*whit).second);
-		else vals.push_back(-1);
-	      }
-	    /*if (vals.size() > _sequence)
-	      std::cerr << "more characters than sequence / " << vals.size() << " / sequence=" << _sequence << std::endl;*/
-	    if (!_embed)
-	      {
-		for (int c=0;c<_sequence;c++)
-		  {
-		    std::vector<float> v(_alphabet.size(),0.0);
-		    if (c<(int)vals.size() && vals[c] != -1)
-		      v[vals[c]] = 1.0;
-		    for (float f: v)
-		      datum.add_float_data(f);
-		  }
-		datum.set_height(_sequence);
-		datum.set_width(_alphabet.size());
-	      }
-	    else
-	      {
-		for (int c=0;c<_sequence;c++)
-		  {
-		    double val = 0.0;
-		    if (c<(int)vals.size() && vals[c] != -1)
-		      val = static_cast<float>(vals[c]+1.0); // +1 as offset to null index
-		    datum.add_float_data(val);
-		  }
-		datum.set_height(_sequence);
-		datum.set_width(1);
-	      }
-	  }
-	return datum;
-      }
+
+    template <class TEntry> caffe::Datum to_datum(TEntry *tbe)
+    {
+      caffe::Datum datum;
+      int datum_channels;
+      if (_characters)
+        datum_channels = 1;
+      else if (_embed && !_characters)
+        datum_channels = _sequence;
+      else
+        datum_channels = _vocab.size(); // XXX: may be very large
+      datum.set_channels(datum_channels);
+      datum.set_height(1);
+      datum.set_width(1);
+      datum.set_label(tbe->_target);
+      if (!_characters)
+        {
+          std::unordered_map<std::string, Word>::const_iterator wit;
+          if (!_embed)
+            {
+              for (int i = 0; i < datum_channels;
+                   i++) // XXX: expected to be slow
+                datum.add_float_data(0.0);
+              tbe->reset();
+              while (tbe->has_elt())
+                {
+                  std::string key;
+                  double val;
+                  tbe->get_next_elt(key, val);
+                  if ((wit = _vocab.find(key)) != _vocab.end())
+                    datum.set_float_data(_vocab[key]._pos,
+                                         static_cast<float>(val));
+                }
+            }
+          else
+            {
+              tbe->reset();
+              int i = 0;
+              while (tbe->has_elt())
+                {
+                  std::string key;
+                  double val;
+                  tbe->get_next_elt(key, val);
+                  if ((wit = _vocab.find(key)) != _vocab.end())
+                    datum.add_float_data(static_cast<float>(_vocab[key]._pos));
+                  ++i;
+                  if (i == _sequence) // tmp limit on sequence length
+                    break;
+                }
+              while (datum.float_data_size() < _sequence)
+                datum.add_float_data(0.0);
+            }
+        }
+      else // character-level features
+        {
+          tbe->reset();
+          std::vector<int> vals;
+          std::unordered_map<uint32_t, int>::const_iterator whit;
+          while (tbe->has_elt())
+            {
+              std::string key;
+              double val = -1.0;
+              tbe->get_next_elt(key, val);
+              uint32_t c = std::strtoul(key.c_str(), 0, 10);
+              if ((whit = _alphabet.find(c)) != _alphabet.end())
+                vals.push_back((*whit).second);
+              else
+                vals.push_back(-1);
+            }
+          /*if (vals.size() > _sequence)
+            std::cerr << "more characters than sequence / " << vals.size() << "
+            / sequence=" << _sequence << std::endl;*/
+          if (!_embed)
+            {
+              for (int c = 0; c < _sequence; c++)
+                {
+                  std::vector<float> v(_alphabet.size(), 0.0);
+                  if (c < (int)vals.size() && vals[c] != -1)
+                    v[vals[c]] = 1.0;
+                  for (float f : v)
+                    datum.add_float_data(f);
+                }
+              datum.set_height(_sequence);
+              datum.set_width(_alphabet.size());
+            }
+          else
+            {
+              for (int c = 0; c < _sequence; c++)
+                {
+                  double val = 0.0;
+                  if (c < (int)vals.size() && vals[c] != -1)
+                    val = static_cast<float>(
+                        vals[c] + 1.0); // +1 as offset to null index
+                  datum.add_float_data(val);
+                }
+              datum.set_height(_sequence);
+              datum.set_width(1);
+            }
+        }
+      return datum;
+    }
 
     caffe::SparseDatum to_sparse_datum(TxtBowEntry *tbe)
-      {
-	caffe::SparseDatum datum;
-	datum.set_label(tbe->_target);
-	std::unordered_map<std::string,Word>::const_iterator wit;
-	tbe->reset();
-	int nwords = 0;
-	while(tbe->has_elt())
-	  {
-	    std::string key;
-	    double val;
-	    tbe->get_next_elt(key,val);
-	    if ((wit = _vocab.find(key))!=_vocab.end())
-	      {
-		int word_pos = _vocab[key]._pos;
-		datum.add_data(static_cast<float>(val));
-		datum.add_indices(word_pos);
-		++nwords;
-	      }
-	  }
-	datum.set_nnz(nwords);
-	datum.set_size(_vocab.size());
-	return datum;
-      }
+    {
+      caffe::SparseDatum datum;
+      datum.set_label(tbe->_target);
+      std::unordered_map<std::string, Word>::const_iterator wit;
+      tbe->reset();
+      int nwords = 0;
+      while (tbe->has_elt())
+        {
+          std::string key;
+          double val;
+          tbe->get_next_elt(key, val);
+          if ((wit = _vocab.find(key)) != _vocab.end())
+            {
+              int word_pos = _vocab[key]._pos;
+              datum.add_data(static_cast<float>(val));
+              datum.add_indices(word_pos);
+              ++nwords;
+            }
+        }
+      datum.set_nnz(nwords);
+      datum.set_size(_vocab.size());
+      return datum;
+    }
 
     std::vector<caffe::Datum>::const_iterator _dt_vit;
     std::vector<caffe::SparseDatum>::const_iterator _dt_vit_sparse;
@@ -1307,18 +1416,22 @@ namespace dd
   /**
    * \brief Caffe SVM connector
    */
-  class SVMCaffeInputFileConn : public SVMInputFileConn, public CaffeInputInterface
+  class SVMCaffeInputFileConn : public SVMInputFileConn,
+                                public CaffeInputInterface
   {
   public:
-    SVMCaffeInputFileConn()
-      :SVMInputFileConn()
-      {
-	_sparse = true;
-	reset_dv_test();
-      }
+    SVMCaffeInputFileConn() : SVMInputFileConn()
+    {
+      _sparse = true;
+      reset_dv_test();
+    }
     SVMCaffeInputFileConn(const SVMCaffeInputFileConn &i)
-      :SVMInputFileConn(i),CaffeInputInterface(i) {}
-    ~SVMCaffeInputFileConn() {}
+        : SVMInputFileConn(i), CaffeInputInterface(i)
+    {
+    }
+    ~SVMCaffeInputFileConn()
+    {
+    }
 
     void init(const APIData &ad)
     {
@@ -1328,8 +1441,9 @@ namespace dd
     int channels() const
     {
       if (_channels > 0)
-	return _channels;
-      else return feature_size();
+        return _channels;
+      else
+        return feature_size();
     }
 
     int height() const
@@ -1345,23 +1459,25 @@ namespace dd
     int batch_size() const
     {
       if (_db_batchsize > 0)
-	return _db_batchsize;
-      else return _dv_sparse.size();
+        return _db_batchsize;
+      else
+        return _dv_sparse.size();
     }
 
     int test_batch_size() const
     {
       if (_db_testbatchsize > 0)
-	return _db_testbatchsize;
-      else return _dv_test_sparse.size();
+        return _db_testbatchsize;
+      else
+        return _dv_test_sparse.size();
     }
 
     virtual void add_train_svmline(const int &label,
-				   const std::unordered_map<int,double> &vals,
-				   const int &count);
+                                   const std::unordered_map<int, double> &vals,
+                                   const int &count);
     virtual void add_test_svmline(const int &label,
-				  const std::unordered_map<int,double> &vals,
-				  const int &count);
+                                  const std::unordered_map<int, double> &vals,
+                                  const int &count);
 
     void transform(const APIData &ad)
     {
@@ -1371,120 +1487,121 @@ namespace dd
 
       _test_dbfullname = "";
       if (_train && ad_input.has("db") && ad_input.get("db").get<bool>())
-	{
-	  _dbfullname = _model_repo + "/" + _dbfullname;
-	  _test_dbfullname = _model_repo + "/" + _test_dbfullname;
-	  fillup_parameters(ad_input);
-	  get_data(ad);
-	  _db = true;
-	  svm_to_db(_model_repo + "/" + _dbname,_model_repo + "/" + _test_dbname,ad_input);
-	  write_class_weights(_model_repo,ad_mllib);
-	  
-	  // enrich data object with db files location
-	  APIData dbad;
-	  dbad.add("train_db",_dbfullname);
-	  if (_test_split > 0.0)
-	    dbad.add("test_db",_test_dbfullname);
-	  const_cast<APIData&>(ad).add("db",dbad);
-	  serialize_vocab();
-	}
+        {
+          _dbfullname = _model_repo + "/" + _dbfullname;
+          _test_dbfullname = _model_repo + "/" + _test_dbfullname;
+          fillup_parameters(ad_input);
+          get_data(ad);
+          _db = true;
+          svm_to_db(_model_repo + "/" + _dbname,
+                    _model_repo + "/" + _test_dbname, ad_input);
+          write_class_weights(_model_repo, ad_mllib);
+
+          // enrich data object with db files location
+          APIData dbad;
+          dbad.add("train_db", _dbfullname);
+          if (_test_split > 0.0)
+            dbad.add("test_db", _test_dbfullname);
+          const_cast<APIData &>(ad).add("db", dbad);
+          serialize_vocab();
+        }
       else
-	{
-	  try
-	    {
-	      SVMInputFileConn::transform(ad);
-	    }
-	  catch(std::exception &e)
-	    {
-	      throw;
-	    }
-	
-	  if (_train)
-	    {
-	      write_class_weights(_model_repo,ad_mllib);
-	      int n = 0;
-	      auto hit = _svmdata.begin();
-	      while(hit!=_svmdata.end())
-		{
-		  _dv_sparse.push_back(to_sparse_datum((*hit)));
-		  this->_ids.push_back(std::to_string(n));
-		  ++n;
-		  ++hit;
-		}
-	    }
-	  if (!_train)
-	    {
-	      if (!_db_fname.empty())
-		{
-		  _test_dbfullname = _db_fname;
-		  _db = true;
-		  return; // done
-		}
-	      _svmdata_test = std::move(_svmdata);
-	    }
-	  else _svmdata.clear();
-	  int n = 0;
-	  auto hit = _svmdata_test.begin();
-	  while(hit!=_svmdata_test.end())
-	    {
-	      _dv_test_sparse.push_back(to_sparse_datum((*hit)));
-	      if (!_train)
-		this->_ids.push_back(std::to_string(n));
-	      ++n;
-	      ++hit;
-	    }
-	}
+        {
+          try
+            {
+              SVMInputFileConn::transform(ad);
+            }
+          catch (std::exception &e)
+            {
+              throw;
+            }
+
+          if (_train)
+            {
+              write_class_weights(_model_repo, ad_mllib);
+              int n = 0;
+              auto hit = _svmdata.begin();
+              while (hit != _svmdata.end())
+                {
+                  _dv_sparse.push_back(to_sparse_datum((*hit)));
+                  this->_ids.push_back(std::to_string(n));
+                  ++n;
+                  ++hit;
+                }
+            }
+          if (!_train)
+            {
+              if (!_db_fname.empty())
+                {
+                  _test_dbfullname = _db_fname;
+                  _db = true;
+                  return; // done
+                }
+              _svmdata_test = std::move(_svmdata);
+            }
+          else
+            _svmdata.clear();
+          int n = 0;
+          auto hit = _svmdata_test.begin();
+          while (hit != _svmdata_test.end())
+            {
+              _dv_test_sparse.push_back(to_sparse_datum((*hit)));
+              if (!_train)
+                this->_ids.push_back(std::to_string(n));
+              ++n;
+              ++hit;
+            }
+        }
     }
 
     caffe::SparseDatum to_sparse_datum(const SVMline &svml)
-      {
-	caffe::SparseDatum datum;
-	datum.set_label(svml._label);
-	auto hit = svml._v.begin();
-	int nelts = 0;
-	while(hit!=svml._v.end())
-	  {
-	    datum.add_data(static_cast<float>((*hit).second));
-	    datum.add_indices((*hit).first);
-	    ++nelts;
-	    ++hit;
-	  }
-	datum.set_nnz(nelts);
-	datum.set_size(channels());
-	return datum;
-      }
+    {
+      caffe::SparseDatum datum;
+      datum.set_label(svml._label);
+      auto hit = svml._v.begin();
+      int nelts = 0;
+      while (hit != svml._v.end())
+        {
+          datum.add_data(static_cast<float>((*hit).second));
+          datum.add_indices((*hit).first);
+          ++nelts;
+          ++hit;
+        }
+      datum.set_nnz(nelts);
+      datum.set_size(channels());
+      return datum;
+    }
 
     std::vector<caffe::SparseDatum> get_dv_test_sparse_db(const int &num);
     std::vector<caffe::SparseDatum> get_dv_test_sparse(const int &num)
-      {
-	if (_test_dbfullname.empty())
-	  {
-	    int i = 0;
-	    std::vector<caffe::SparseDatum> dv;
-	    while(_dt_vit!=_dv_test_sparse.end()
-		  && i < num)
-	      {
-		dv.push_back((*_dt_vit));
-		++i;
-		++_dt_vit;
-	      }
-	    return dv;
-	  }
-	  else return get_dv_test_sparse_db(num);
-      }
+    {
+      if (_test_dbfullname.empty())
+        {
+          int i = 0;
+          std::vector<caffe::SparseDatum> dv;
+          while (_dt_vit != _dv_test_sparse.end() && i < num)
+            {
+              dv.push_back((*_dt_vit));
+              ++i;
+              ++_dt_vit;
+            }
+          return dv;
+        }
+      else
+        return get_dv_test_sparse_db(num);
+    }
 
     void reset_dv_test();
 
   private:
     int svm_to_db(const std::string &traindbname,
-		  const std::string &testdbname,
-		  const APIData &ad_input,
-		  const std::string &backend="lmdb"); // lmdb, leveldb
+                  const std::string &testdbname, const APIData &ad_input,
+                  const std::string &backend = "lmdb"); // lmdb, leveldb
 
     void write_svmline_to_db(const std::string &dbfullname,
-			     const std::string &testdbfullname,
-			     const APIData &ad_input,
-			     const std::string &backend="lmdb");
+                             const std::string &testdbfullname,
+                             const APIData &ad_input,
+                             const std::string &backend = "lmdb");
 
   public:
     std::vector<caffe::SparseDatum>::const_iterator _dt_vit;
@@ -1494,7 +1611,7 @@ namespace dd
     std::unique_ptr<caffe::db::Cursor> _test_db_cursor;
     std::string _dbname = "train";
     std::string _test_dbname = "test";
- 
+
   private:
     std::unique_ptr<caffe::db::Transaction> _txn;
     std::unique_ptr<caffe::db::DB> _tdb;
@@ -1502,7 +1619,7 @@ namespace dd
     std::unique_ptr<caffe::db::DB> _ttdb;
     int _channels = 0;
   };
-  
+
 }
 
 #endif

--- a/src/backends/caffe/caffelib.cc
+++ b/src/backends/caffe/caffelib.cc
@@ -33,24 +33,30 @@
 #include <chrono>
 #include <iostream>
 
-using caffe::Caffe;
-using caffe::Net;
 using caffe::Blob;
+using caffe::Caffe;
 using caffe::Datum;
+using caffe::Net;
 
 namespace dd
 {
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::CaffeLib(const CaffeModel &cmodel)
-    :MLLib<TInputConnectorStrategy,TOutputConnectorStrategy,CaffeModel>(cmodel)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  CaffeLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+           TMLModel>::CaffeLib(const CaffeModel &cmodel)
+      : MLLib<TInputConnectorStrategy, TOutputConnectorStrategy, CaffeModel>(
+          cmodel)
   {
     this->_libname = "caffe";
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::CaffeLib(CaffeLib &&cl) noexcept
-    :MLLib<TInputConnectorStrategy,TOutputConnectorStrategy,CaffeModel>(std::move(cl))
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  CaffeLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+           TMLModel>::CaffeLib(CaffeLib &&cl) noexcept
+      : MLLib<TInputConnectorStrategy, TOutputConnectorStrategy, CaffeModel>(
+          std::move(cl))
   {
     this->_libname = "caffe";
     _gpu = cl._gpu;
@@ -69,386 +75,459 @@ namespace dd
     _best_metric_value = cl._best_metric_value;
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::~CaffeLib()
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  CaffeLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+           TMLModel>::~CaffeLib()
   {
     delete _net;
     _net = nullptr;
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::set_gpuid(const APIData &ad)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void CaffeLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+                TMLModel>::set_gpuid(const APIData &ad)
   {
 #if !defined(CPU_ONLY) && !defined(USE_CAFFE_CPU_ONLY)
     if (ad.has("gpuid"))
       {
-	try
-	  {
-	    int gpuid = ad.get("gpuid").get<int>();
-	    if (gpuid == -1)
-	      {
-		int count_gpus = 0;
-		cudaGetDeviceCount(&count_gpus);
-		for (int i =0;i<count_gpus;i++)
-		  _gpuid.push_back(i);
-	      }
-	    else _gpuid = {gpuid};
-	    _gpu = true;
-	  }
-	catch(std::exception &e)
-	  {
-	    std::vector<int> gpuid = ad.get("gpuid").get<std::vector<int>>();
-	    if (gpuid.size()== 1 && gpuid.at(0) == -1)
-	      {
-		int count_gpus = 0;
-		cudaGetDeviceCount(&count_gpus);
-		for (int i =0;i<count_gpus;i++)
-		  _gpuid.push_back(i);
-	      }
-	    else _gpuid = gpuid;
-	    _gpu = true;
-	  }
-	for (auto i: _gpuid)
-	  this->_logger->info("Using GPU {}",i);
+        try
+          {
+            int gpuid = ad.get("gpuid").get<int>();
+            if (gpuid == -1)
+              {
+                int count_gpus = 0;
+                cudaGetDeviceCount(&count_gpus);
+                for (int i = 0; i < count_gpus; i++)
+                  _gpuid.push_back(i);
+              }
+            else
+              _gpuid = { gpuid };
+            _gpu = true;
+          }
+        catch (std::exception &e)
+          {
+            std::vector<int> gpuid = ad.get("gpuid").get<std::vector<int>>();
+            if (gpuid.size() == 1 && gpuid.at(0) == -1)
+              {
+                int count_gpus = 0;
+                cudaGetDeviceCount(&count_gpus);
+                for (int i = 0; i < count_gpus; i++)
+                  _gpuid.push_back(i);
+              }
+            else
+              _gpuid = gpuid;
+            _gpu = true;
+          }
+        for (auto i : _gpuid)
+          this->_logger->info("Using GPU {}", i);
       }
 #else
     (void)ad;
 #endif
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::instantiate_template(const APIData &ad)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void CaffeLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+                TMLModel>::instantiate_template(const APIData &ad)
   {
     // - check whether there's a risk of erasing model files
-    if (this->_mlmodel.read_from_repository(this->_mlmodel._repo,this->_logger))
-      throw MLLibBadParamException("error reading or listing Caffe models in repository " + this->_mlmodel._repo);
+    if (this->_mlmodel.read_from_repository(this->_mlmodel._repo,
+                                            this->_logger))
+      throw MLLibBadParamException(
+          "error reading or listing Caffe models in repository "
+          + this->_mlmodel._repo);
     if (!this->_mlmodel._sstate.empty())
       {
-	// we assuming training with resume from solverstate, error is deferred to the training
-	// call assessing the resume is set to true
-	this->_logger->warn("ignoring template argument since .solverstate file exists, assuming a training job will resume, and deferring errors to potential future training call");
-	update_deploy_protofile_softmax(ad); // temperature scaling
-	create_model(true); // phase changed to train as needed later on
-	return;
+        // we assuming training with resume from solverstate, error is deferred
+        // to the training call assessing the resume is set to true
+        this->_logger->warn(
+            "ignoring template argument since .solverstate file exists, "
+            "assuming a training job will resume, and deferring errors to "
+            "potential future training call");
+        update_deploy_protofile_softmax(ad); // temperature scaling
+        create_model(true); // phase changed to train as needed later on
+        return;
       }
     if (!this->_mlmodel._weights.empty())
       {
-	if (ad.has("finetuning") && ad.get("finetuning").get<bool>()
-	    && !this->_mlmodel._trainf.empty()) // may want to finetune from a template only if no neural net definition present
-	  throw MLLibBadParamException("using template for finetuning but model prototxt already exists, remove 'template' from 'mllib', or remove existing 'prototxt' files ?");
-	/*else if (ad.has("resume") && ad.get("resume").get<bool>()) // resuming from state, may not want to override the existing network definition (e.g. after finetuning)
-	  throw MLLibBadParamException("using template while resuming from existing model, remove 'template' from 'mllib' ?");*/
-	else if (!this->_mlmodel._trainf.empty())
-	  throw MLLibBadParamException("using template while model prototxt and network weights exist, remove 'template' from 'mllib' or remove prototxt files instead instead ?");
+        if (ad.has("finetuning") && ad.get("finetuning").get<bool>()
+            && !this->_mlmodel._trainf
+                    .empty()) // may want to finetune from a template only if
+                              // no neural net definition present
+          throw MLLibBadParamException(
+              "using template for finetuning but model prototxt already "
+              "exists, remove 'template' from 'mllib', or remove existing "
+              "'prototxt' files ?");
+        /*else if (ad.has("resume") && ad.get("resume").get<bool>()) //
+          resuming from state, may not want to override the existing network
+          definition (e.g. after finetuning) throw
+          MLLibBadParamException("using template while resuming from existing
+          model, remove 'template' from 'mllib' ?");*/
+        else if (!this->_mlmodel._trainf.empty())
+          throw MLLibBadParamException(
+              "using template while model prototxt and network weights exist, "
+              "remove 'template' from 'mllib' or remove prototxt files "
+              "instead instead ?");
       }
-      
+
     // - locate template repository
     std::string model_tmpl = ad.get("template").get<std::string>();
     this->_mlmodel._model_template = model_tmpl;
-    this->_logger->info("instantiating model template {}",model_tmpl);
-    
+    this->_logger->info("instantiating model template {}", model_tmpl);
+
     // - copy files to model repository
-    std::string source = this->_mlmodel._mlmodel_template_repo + '/' + model_tmpl + "/";
-    this->_logger->info("source={}",source);
-    this->_logger->info("dest={}",this->_mlmodel._repo + '/' + model_tmpl + ".prototxt");
-    std::string dest_net = this->_mlmodel._repo + '/' + model_tmpl + ".prototxt";
+    std::string source
+        = this->_mlmodel._mlmodel_template_repo + '/' + model_tmpl + "/";
+    this->_logger->info("source={}", source);
+    this->_logger->info("dest={}",
+                        this->_mlmodel._repo + '/' + model_tmpl + ".prototxt");
+    std::string dest_net
+        = this->_mlmodel._repo + '/' + model_tmpl + ".prototxt";
     std::string dest_deploy_net = this->_mlmodel._repo + "/deploy.prototxt";
-    if (model_tmpl != "mlp" && model_tmpl != "convnet" && model_tmpl != "resnet" && model_tmpl != "recurrent")
+    if (model_tmpl != "mlp" && model_tmpl != "convnet"
+        && model_tmpl != "resnet" && model_tmpl != "recurrent")
       {
-	int err = fileops::copy_file(source + model_tmpl + ".prototxt", dest_net);
-	if (err == 1)
-	  throw MLLibBadParamException("failed to locate model template " + source + ".prototxt");
-	else if (err == 2)
-	  throw MLLibBadParamException("failed to create model template destination " + dest_net);
-	err = fileops::copy_file(source + "deploy.prototxt", dest_deploy_net);
-	if (err == 1)
-	  throw MLLibBadParamException("failed to locate deploy template " + source + "deploy.prototxt");
-	else if (err == 2)
-	  throw MLLibBadParamException("failed to create destination deploy solver file " + dest_deploy_net);
+        int err
+            = fileops::copy_file(source + model_tmpl + ".prototxt", dest_net);
+        if (err == 1)
+          throw MLLibBadParamException("failed to locate model template "
+                                       + source + ".prototxt");
+        else if (err == 2)
+          throw MLLibBadParamException(
+              "failed to create model template destination " + dest_net);
+        err = fileops::copy_file(source + "deploy.prototxt", dest_deploy_net);
+        if (err == 1)
+          throw MLLibBadParamException("failed to locate deploy template "
+                                       + source + "deploy.prototxt");
+        else if (err == 2)
+          throw MLLibBadParamException(
+              "failed to create destination deploy solver file "
+              + dest_deploy_net);
       }
     int err = fileops::copy_file(source + model_tmpl + "_solver.prototxt",
-				 this->_mlmodel._repo + '/' + model_tmpl + "_solver.prototxt");
+                                 this->_mlmodel._repo + '/' + model_tmpl
+                                     + "_solver.prototxt");
     if (err == 1)
-      throw MLLibBadParamException("failed to locate solver template " + source + model_tmpl + "_solver.prototxt");
+      throw MLLibBadParamException("failed to locate solver template " + source
+                                   + model_tmpl + "_solver.prototxt");
     else if (err == 2)
-      throw MLLibBadParamException("failed to create destination template solver file " + this->_mlmodel._repo + '/' + model_tmpl + "_solver.prototxt");
-    
+      throw MLLibBadParamException(
+          "failed to create destination template solver file "
+          + this->_mlmodel._repo + '/' + model_tmpl + "_solver.prototxt");
+
     // if mlp template, set the net structure as number of layers.
-    if (model_tmpl == "mlp" || model_tmpl == "mlp_db" || model_tmpl == "lregression")
+    if (model_tmpl == "mlp" || model_tmpl == "mlp_db"
+        || model_tmpl == "lregression")
       {
-	caffe::NetParameter net_param,deploy_net_param;
-	configure_mlp_template(ad,this->_inputc,net_param,deploy_net_param);
-	caffe::WriteProtoToTextFile(net_param,dest_net);
-	caffe::WriteProtoToTextFile(deploy_net_param,dest_deploy_net);
+        caffe::NetParameter net_param, deploy_net_param;
+        configure_mlp_template(ad, this->_inputc, net_param, deploy_net_param);
+        caffe::WriteProtoToTextFile(net_param, dest_net);
+        caffe::WriteProtoToTextFile(deploy_net_param, dest_deploy_net);
       }
     else if (model_tmpl == "convnet")
       {
-	caffe::NetParameter net_param,deploy_net_param;
-	configure_convnet_template(ad,this->_inputc,net_param,deploy_net_param);
-	if (typeid(this->_inputc) == typeid(ImgCaffeInputFileConn))
-	  configure_image_augmentation(ad,net_param);
-	caffe::WriteProtoToTextFile(net_param,dest_net);
-	caffe::WriteProtoToTextFile(deploy_net_param,dest_deploy_net);
+        caffe::NetParameter net_param, deploy_net_param;
+        configure_convnet_template(ad, this->_inputc, net_param,
+                                   deploy_net_param);
+        if (typeid(this->_inputc) == typeid(ImgCaffeInputFileConn))
+          configure_image_augmentation(ad, net_param);
+        caffe::WriteProtoToTextFile(net_param, dest_net);
+        caffe::WriteProtoToTextFile(deploy_net_param, dest_deploy_net);
       }
     else if (model_tmpl == "resnet")
       {
-	caffe::NetParameter net_param,deploy_net_param;
-	configure_resnet_template(ad,this->_inputc,net_param,deploy_net_param);
-	if (typeid(this->_inputc) == typeid(ImgCaffeInputFileConn))
-	  configure_image_augmentation(ad,net_param);
-	caffe::WriteProtoToTextFile(net_param,dest_net);
-	caffe::WriteProtoToTextFile(deploy_net_param,dest_deploy_net);
+        caffe::NetParameter net_param, deploy_net_param;
+        configure_resnet_template(ad, this->_inputc, net_param,
+                                  deploy_net_param);
+        if (typeid(this->_inputc) == typeid(ImgCaffeInputFileConn))
+          configure_image_augmentation(ad, net_param);
+        caffe::WriteProtoToTextFile(net_param, dest_net);
+        caffe::WriteProtoToTextFile(deploy_net_param, dest_deploy_net);
       }
-    else if (model_tmpl.find("ssd")!=std::string::npos
-	     || model_tmpl.find("refinedet")!=std::string::npos)
+    else if (model_tmpl.find("ssd") != std::string::npos
+             || model_tmpl.find("refinedet") != std::string::npos)
       {
-	bool refinedet = (model_tmpl.find("refinedet")!=std::string::npos);
-	configure_ssd_template(dest_net,dest_deploy_net,ad,this->_inputc,refinedet);
+        bool refinedet = (model_tmpl.find("refinedet") != std::string::npos);
+        configure_ssd_template(dest_net, dest_deploy_net, ad, this->_inputc,
+                               refinedet);
       }
     else if (model_tmpl.find("recurrent") != std::string::npos)
       {
-        caffe::NetParameter net_param,deploy_net_param;
-        configure_recurrent_template(ad,this->_inputc,net_param,deploy_net_param);
-        caffe::WriteProtoToTextFile(net_param,dest_net);
-        caffe::WriteProtoToTextFile(deploy_net_param,dest_deploy_net);
+        caffe::NetParameter net_param, deploy_net_param;
+        configure_recurrent_template(ad, this->_inputc, net_param,
+                                     deploy_net_param);
+        caffe::WriteProtoToTextFile(net_param, dest_net);
+        caffe::WriteProtoToTextFile(deploy_net_param, dest_deploy_net);
       }
     else
       {
-	caffe::NetParameter net_param,deploy_net_param;
-	caffe::ReadProtoFromTextFile(dest_net,&net_param); //TODO: catch parsing error (returns bool true on success)
-	caffe::ReadProtoFromTextFile(dest_deploy_net,&deploy_net_param);
+        caffe::NetParameter net_param, deploy_net_param;
+        caffe::ReadProtoFromTextFile(
+            dest_net, &net_param); // TODO: catch parsing error (returns bool
+                                   // true on success)
+        caffe::ReadProtoFromTextFile(dest_deploy_net, &deploy_net_param);
 
-       if (this->_loss == "dice")
-      // dice loss!!
-      {
-        if (net_param.name().compare("deeplab_vgg16")==0
-	    || net_param.name().compare("pspnet_vgg16")==0
-	    || net_param.name().compare("pspnet_50")==0
-	    || net_param.name().compare("pspnet_101")==0)
+        if (this->_loss == "dice")
+          // dice loss!!
           {
-            update_protofiles_dice_deeplab_vgg16(net_param, deploy_net_param, ad);
-	  }
-        else if (net_param.name().compare("unet") == 0)
-          {
-            update_protofiles_dice_unet(net_param,deploy_net_param, ad);
-	  }
-
-      }
-
-    // switch to imageDataLayer
-    //TODO: should apply to all templates with images
-    if (!this->_inputc._db && !this->_inputc._bbox && !this->_inputc._segmentation && !this->_inputc._ctc && typeid(this->_inputc) == typeid(ImgCaffeInputFileConn))
-      {
-        update_protofile_imageDataLayer(net_param);
-      }
-    
-    // input should be ok, now do the output
-    if (this->_inputc._multi_label)
-      {
-        int k = net_param.layer_size();
-        for (int l=k-1;l>0;l--)
-          {
-            caffe::LayerParameter *lparam = net_param.mutable_layer(l);
-            if (lparam->type() == "SoftmaxWithLoss")
+            if (net_param.name().compare("deeplab_vgg16") == 0
+                || net_param.name().compare("pspnet_vgg16") == 0
+                || net_param.name().compare("pspnet_50") == 0
+                || net_param.name().compare("pspnet_101") == 0)
               {
-                lparam->set_type("MultiLabelSigmoidLoss");
-                lparam->clear_include();
-                caffe::NetStateRule *nsr = lparam->add_include();
-                nsr->set_phase(caffe::TRAIN);
-                break;
+                update_protofiles_dice_deeplab_vgg16(net_param,
+                                                     deploy_net_param, ad);
               }
-	  }
-	// XXX: code below removes the softmax layer
-	// protobuf only allows to remove last element from repeated field.
-	int softm_pos = -1;
-	for (int l=k-1;l>0;l--)
-	  {
-            caffe::LayerParameter *lparam = net_param.mutable_layer(l);
+            else if (net_param.name().compare("unet") == 0)
+              {
+                update_protofiles_dice_unet(net_param, deploy_net_param, ad);
+              }
+          }
+
+        // switch to imageDataLayer
+        // TODO: should apply to all templates with images
+        if (!this->_inputc._db && !this->_inputc._bbox
+            && !this->_inputc._segmentation && !this->_inputc._ctc
+            && typeid(this->_inputc) == typeid(ImgCaffeInputFileConn))
+          {
+            update_protofile_imageDataLayer(net_param);
+          }
+
+        // input should be ok, now do the output
+        if (this->_inputc._multi_label)
+          {
+            int k = net_param.layer_size();
+            for (int l = k - 1; l > 0; l--)
+              {
+                caffe::LayerParameter *lparam = net_param.mutable_layer(l);
+                if (lparam->type() == "SoftmaxWithLoss")
+                  {
+                    lparam->set_type("MultiLabelSigmoidLoss");
+                    lparam->clear_include();
+                    caffe::NetStateRule *nsr = lparam->add_include();
+                    nsr->set_phase(caffe::TRAIN);
+                    break;
+                  }
+              }
+            // XXX: code below removes the softmax layer
+            // protobuf only allows to remove last element from repeated field.
+            int softm_pos = -1;
+            for (int l = k - 1; l > 0; l--)
+              {
+                caffe::LayerParameter *lparam = net_param.mutable_layer(l);
+                if (lparam->type() == "Softmax")
+                  {
+                    softm_pos = l;
+                    break;
+                  }
+              }
+            if (softm_pos > 0)
+              {
+                if (!_regression)
+                  {
+                    for (int l = softm_pos; l < net_param.layer_size() - 1;
+                         l++)
+                      {
+                        caffe::LayerParameter *lparam
+                            = net_param.mutable_layer(l);
+                        *lparam = net_param.layer(l + 1);
+                      }
+                    net_param.mutable_layer()->RemoveLast();
+                  }
+                else
+                  {
+                    caffe::LayerParameter *lparam
+                        = net_param.mutable_layer(softm_pos);
+                    lparam->set_type("Sigmoid");
+                    lparam->set_name("pred");
+                    *lparam->mutable_top(0) = "pred";
+
+                    // lparam->add_sigmoid_param();
+                    // lparam->sigmoid_param().set_engine(lparam->softmax_param().engine());
+                    // for doing so in a clean way, need to match
+                    // softmaxParameter::engine with sigmoidparameter::engine
+                    // for now, rewrite engine filed as is
+                    lparam->clear_softmax_param();
+                  }
+              }
+            else
+              throw MLLibInternalException("Couldn't find Softmax layer to "
+                                           "replace for multi-label training");
+
+            k = deploy_net_param.layer_size();
+            caffe::LayerParameter *lparam
+                = deploy_net_param.mutable_layer(k - 1);
             if (lparam->type() == "Softmax")
               {
-                softm_pos = l;
-                break;
-              }
-	  }
-	if (softm_pos > 0)
-	  {
-            if (!_regression)
-              {
-                for (int l=softm_pos;l<net_param.layer_size()-1;l++)
+                if (!_regression)
+                  deploy_net_param.mutable_layer()->RemoveLast();
+                else
                   {
-                    caffe::LayerParameter *lparam = net_param.mutable_layer(l);
-                    *lparam = net_param.layer(l+1);
+                    lparam->set_type("Sigmoid");
+                    lparam->set_name("pred");
+                    *lparam->mutable_top(0) = "pred";
+                    // lparam->add_sigmoid_param();
+                    // lparam->sigmoid_param().set_engine(lparam->softmax_param().engine());
+                    // see 20 lines above for comment
+                    lparam->clear_softmax_param();
                   }
-                net_param.mutable_layer()->RemoveLast();
               }
-            else
-              {
-                caffe::LayerParameter *lparam = net_param.mutable_layer(softm_pos);
-                lparam->set_type("Sigmoid");
-                lparam->set_name("pred");
-                *lparam->mutable_top(0) = "pred";
-		
-                //lparam->add_sigmoid_param();
-                //lparam->sigmoid_param().set_engine(lparam->softmax_param().engine());
-                // for doing so in a clean way, need to match softmaxParameter::engine
-                // with sigmoidparameter::engine
-                // for now, rewrite engine filed as is
-                lparam->clear_softmax_param();
-              }
-	    
-	  }
-	else throw MLLibInternalException("Couldn't find Softmax layer to replace for multi-label training");
-      
-	k = deploy_net_param.layer_size();
-	caffe::LayerParameter *lparam = deploy_net_param.mutable_layer(k-1);
-	if (lparam->type() == "Softmax")
-	  {
-            if (!_regression)
-              deploy_net_param.mutable_layer()->RemoveLast();
-            else
-              {
-                lparam->set_type("Sigmoid");
-                lparam->set_name("pred");
-                *lparam->mutable_top(0) = "pred";
-		//lparam->add_sigmoid_param();
-                //lparam->sigmoid_param().set_engine(lparam->softmax_param().engine());
-                // see 20 lines above for comment
-                lparam->clear_softmax_param();
-              }
-	  }
-      } // end multi_label
-    else if (_regression)
-      {
-		int k = net_param.layer_size();
-        for (int l=k-1;l>0;l--)
+          } // end multi_label
+        else if (_regression)
           {
-            caffe::LayerParameter *lparam = net_param.mutable_layer(l);
-            if (lparam->type() == "SoftmaxWithLoss")
+            int k = net_param.layer_size();
+            for (int l = k - 1; l > 0; l--)
               {
-				if ( _loss.empty() || _loss == "L2")
-				  {
-					lparam->set_type("EuclideanLoss");
-				  }
-				else if (_loss == "L1")
-				  {
-					lparam->set_type("SmoothL1Loss");
-					lparam->mutable_smooth_l1_loss_param()->set_sigma(10.0);
-				  }
-				else if (_loss == "sigmoid")
-				  {
-					lparam->set_type("SigmoidCrossEntropyLoss");
-				  }
-				lparam->clear_include();
-                caffe::NetStateRule *nsr = lparam->add_include();
-                nsr->set_phase(caffe::TRAIN);
-                break;
+                caffe::LayerParameter *lparam = net_param.mutable_layer(l);
+                if (lparam->type() == "SoftmaxWithLoss")
+                  {
+                    if (_loss.empty() || _loss == "L2")
+                      {
+                        lparam->set_type("EuclideanLoss");
+                      }
+                    else if (_loss == "L1")
+                      {
+                        lparam->set_type("SmoothL1Loss");
+                        lparam->mutable_smooth_l1_loss_param()->set_sigma(
+                            10.0);
+                      }
+                    else if (_loss == "sigmoid")
+                      {
+                        lparam->set_type("SigmoidCrossEntropyLoss");
+                      }
+                    lparam->clear_include();
+                    caffe::NetStateRule *nsr = lparam->add_include();
+                    nsr->set_phase(caffe::TRAIN);
+                    break;
+                  }
+                else if (lparam->type() == "Softmax")
+                  {
+                    lparam->set_name("pred");
+                    *lparam->mutable_top(0) = "pred";
+                    if (_loss.empty() || _loss == "L1" || _loss == "L2")
+                      lparam->set_type("Flatten");
+                    else if (_loss == "sigmoid")
+                      lparam->set_type("Sigmoid");
+                    lparam->clear_include();
+                    caffe::NetStateRule *nsr = lparam->add_include();
+                    nsr->set_phase(caffe::TEST);
+                  }
               }
-			else if (lparam->type() == "Softmax")
-			  {
-				lparam->set_name("pred");
-                *lparam->mutable_top(0) = "pred";
-				if (_loss.empty() || _loss == "L1" || _loss == "L2")
-				  lparam->set_type("Flatten");
-				else if (_loss == "sigmoid")
-				  lparam->set_type("Sigmoid");
-				lparam->clear_include();
-				caffe::NetStateRule *nsr = lparam->add_include();
-				nsr->set_phase(caffe::TEST);
-			  }
-		  }
 
-		k = deploy_net_param.layer_size();
-		for (int l=k-1;l>0;l--)
-		  {
-            caffe::LayerParameter *lparam = deploy_net_param.mutable_layer(l);
-			if (lparam->type() == "Softmax")
-			  {
-				lparam->set_name("pred");
-                *lparam->mutable_top(0) = "pred";
-				if (_loss.empty() || _loss == "L1" || _loss == "L2")
-				  lparam->set_type("Flatten");
-				else if (_loss == "sigmoid")
-				  lparam->set_type("Sigmoid");
-				lparam->clear_include();
-				caffe::NetStateRule *nsr = lparam->add_include();
-				nsr->set_phase(caffe::TEST);
-				break;
-			  }
-		  }
-	  }
-          
-	// input size
-	caffe::LayerParameter *lparam = net_param.mutable_layer(1); // test
-	caffe::LayerParameter *dlparam = deploy_net_param.mutable_layer(0);
-	if (!this->_inputc._bbox && !this->_inputc._ctc &&(_crop_size > 0 || (this->_inputc.width() != -1 && this->_inputc.height() != -1))) // forced width & height
-	  {
-	    int width = this->_inputc.width();
-	    int height = this->_inputc.height();
-	    if (_crop_size > 0)
-	      width = height = _crop_size;
-	    lparam->mutable_memory_data_param()->set_channels(this->_inputc.channels());
-	    lparam->mutable_memory_data_param()->set_height(height);
-	    lparam->mutable_memory_data_param()->set_width(width);
-	    dlparam->mutable_memory_data_param()->set_channels(this->_inputc.channels());
-	    dlparam->mutable_memory_data_param()->set_height(height);
-	    dlparam->mutable_memory_data_param()->set_width(width);
-	  }
-		
-	// image data augmentation
-	if (typeid(this->_inputc) == typeid(ImgCaffeInputFileConn))
-	  configure_image_augmentation(ad,net_param);
+            k = deploy_net_param.layer_size();
+            for (int l = k - 1; l > 0; l--)
+              {
+                caffe::LayerParameter *lparam
+                    = deploy_net_param.mutable_layer(l);
+                if (lparam->type() == "Softmax")
+                  {
+                    lparam->set_name("pred");
+                    *lparam->mutable_top(0) = "pred";
+                    if (_loss.empty() || _loss == "L1" || _loss == "L2")
+                      lparam->set_type("Flatten");
+                    else if (_loss == "sigmoid")
+                      lparam->set_type("Sigmoid");
+                    lparam->clear_include();
+                    caffe::NetStateRule *nsr = lparam->add_include();
+                    nsr->set_phase(caffe::TEST);
+                    break;
+                  }
+              }
+          }
+
+        // input size
+        caffe::LayerParameter *lparam = net_param.mutable_layer(1); // test
+        caffe::LayerParameter *dlparam = deploy_net_param.mutable_layer(0);
+        if (!this->_inputc._bbox && !this->_inputc._ctc
+            && (_crop_size > 0
+                || (this->_inputc.width() != -1
+                    && this->_inputc.height() != -1))) // forced width & height
+          {
+            int width = this->_inputc.width();
+            int height = this->_inputc.height();
+            if (_crop_size > 0)
+              width = height = _crop_size;
+            lparam->mutable_memory_data_param()->set_channels(
+                this->_inputc.channels());
+            lparam->mutable_memory_data_param()->set_height(height);
+            lparam->mutable_memory_data_param()->set_width(width);
+            dlparam->mutable_memory_data_param()->set_channels(
+                this->_inputc.channels());
+            dlparam->mutable_memory_data_param()->set_height(height);
+            dlparam->mutable_memory_data_param()->set_width(width);
+          }
+
+        // image data augmentation
+        if (typeid(this->_inputc) == typeid(ImgCaffeInputFileConn))
+          configure_image_augmentation(ad, net_param);
 
 #ifdef USE_CUDNN
-	update_protofile_engine(net_param, ad);
-	update_protofile_engine(deploy_net_param, ad);
+        update_protofile_engine(net_param, ad);
+        update_protofile_engine(deploy_net_param, ad);
 #endif
 
-	// adapt number of neuron output
-	update_protofile_classes(net_param);
-	update_protofile_classes(deploy_net_param);
-	caffe::WriteProtoToTextFile(net_param,dest_net);
-	caffe::WriteProtoToTextFile(deploy_net_param,dest_deploy_net);
-  }
+        // adapt number of neuron output
+        update_protofile_classes(net_param);
+        update_protofile_classes(deploy_net_param);
+        caffe::WriteProtoToTextFile(net_param, dest_net);
+        caffe::WriteProtoToTextFile(deploy_net_param, dest_deploy_net);
+      }
     if (ad.has("finetuning") && ad.get("finetuning").get<bool>())
       {
-	if (this->_mlmodel._weights.empty()) // weights should have been specified or detected on the first pass into the model repository
-	  throw MLLibBadParamException("finetuning requires specifying an existing weights file");	
-	caffe::NetParameter net_param,deploy_net_param;
-	caffe::ReadProtoFromTextFile(dest_net,&net_param); //TODO: catch parsing error (returns bool true on success)
-	caffe::ReadProtoFromTextFile(dest_deploy_net,&deploy_net_param);
-	update_protofile_finetune(net_param);
-	update_protofile_finetune(deploy_net_param);
-	caffe::WriteProtoToTextFile(net_param,dest_net);
-	caffe::WriteProtoToTextFile(deploy_net_param,dest_deploy_net);
+        if (this->_mlmodel._weights
+                .empty()) // weights should have been specified or detected on
+                          // the first pass into the model repository
+          throw MLLibBadParamException(
+              "finetuning requires specifying an existing weights file");
+        caffe::NetParameter net_param, deploy_net_param;
+        caffe::ReadProtoFromTextFile(
+            dest_net, &net_param); // TODO: catch parsing error (returns bool
+                                   // true on success)
+        caffe::ReadProtoFromTextFile(dest_deploy_net, &deploy_net_param);
+        update_protofile_finetune(net_param);
+        update_protofile_finetune(deploy_net_param);
+        caffe::WriteProtoToTextFile(net_param, dest_net);
+        caffe::WriteProtoToTextFile(deploy_net_param, dest_deploy_net);
       }
-    
-    if (this->_mlmodel.read_from_repository(this->_mlmodel._repo,this->_logger))
-      throw MLLibBadParamException("error reading or listing Caffe models in repository " + this->_mlmodel._repo);
+
+    if (this->_mlmodel.read_from_repository(this->_mlmodel._repo,
+                                            this->_logger))
+      throw MLLibBadParamException(
+          "error reading or listing Caffe models in repository "
+          + this->_mlmodel._repo);
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  caffe::LayerParameter*
-  CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::insert_layer_before(caffe::NetParameter &net_param, int layer_number)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  caffe::LayerParameter *
+  CaffeLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+           TMLModel>::insert_layer_before(caffe::NetParameter &net_param,
+                                          int layer_number)
   {
-    
+
     net_param.add_layer();
 
-    for (int i=net_param.layer_size()-1; i>layer_number; --i)
+    for (int i = net_param.layer_size() - 1; i > layer_number; --i)
       {
         caffe::LayerParameter *lparam = net_param.mutable_layer(i);
-        *lparam = net_param.layer(i-1);
+        *lparam = net_param.layer(i - 1);
       }
     net_param.mutable_layer(layer_number)->Clear();
-    return  net_param.mutable_layer(layer_number);
+    return net_param.mutable_layer(layer_number);
   }
 
-
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  caffe::LayerParameter*
-  CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::find_layer_by_name(caffe::NetParameter &net_param, std::string name)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  caffe::LayerParameter *
+  CaffeLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+           TMLModel>::find_layer_by_name(caffe::NetParameter &net_param,
+                                         std::string name)
   {
     int k = net_param.layer_size();
-    for (int l=k-1;l>0;l--)
+    for (int l = k - 1; l > 0; l--)
       {
         caffe::LayerParameter *lparam = net_param.mutable_layer(l);
         if (lparam->name().compare(name) == 0)
@@ -457,12 +536,15 @@ namespace dd
     return NULL;
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  caffe::LayerParameter*
-  CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::find_layer_by_type(caffe::NetParameter &net_param, std::string type)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  caffe::LayerParameter *
+  CaffeLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+           TMLModel>::find_layer_by_type(caffe::NetParameter &net_param,
+                                         std::string type)
   {
     int k = net_param.layer_size();
-    for (int l=k-1; l>=0; l--)
+    for (int l = k - 1; l >= 0; l--)
       {
         caffe::LayerParameter *lparam = net_param.mutable_layer(l);
         if (lparam->type() == type)
@@ -471,13 +553,15 @@ namespace dd
     return NULL;
   }
 
-
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  int
-  CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::find_index_layer_by_type(caffe::NetParameter &net_param, std::string type)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  int CaffeLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+               TMLModel>::find_index_layer_by_type(caffe::NetParameter
+                                                       &net_param,
+                                                   std::string type)
   {
     int k = net_param.layer_size();
-    for (int l=k-1;l>0;l--)
+    for (int l = k - 1; l > 0; l--)
       {
         caffe::LayerParameter *lparam = net_param.mutable_layer(l);
         if (lparam->type() == type)
@@ -486,12 +570,15 @@ namespace dd
     return -1;
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  int
-  CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::find_index_layer_by_name(caffe::NetParameter &net_param, std::string name)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  int CaffeLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+               TMLModel>::find_index_layer_by_name(caffe::NetParameter
+                                                       &net_param,
+                                                   std::string name)
   {
     int k = net_param.layer_size();
-    for (int l=k-1;l>0;l--)
+    for (int l = k - 1; l > 0; l--)
       {
         caffe::LayerParameter *lparam = net_param.mutable_layer(l);
         if (lparam->name() == name)
@@ -500,206 +587,243 @@ namespace dd
     return -1;
   }
 
-
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::configure_image_augmentation(const APIData &ad,
-													 caffe::NetParameter &net_param)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void CaffeLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+                TMLModel>::configure_image_augmentation(const APIData &ad,
+                                                        caffe::NetParameter
+                                                            &net_param)
   {
-    if ((ad.has("rotate") && ad.get("rotate").get<bool>()) 
-	|| (ad.has("mirror") && ad.get("mirror").get<bool>())
-	|| ad.has("crop_size") || _scale != 1.0)
+    if ((ad.has("rotate") && ad.get("rotate").get<bool>())
+        || (ad.has("mirror") && ad.get("mirror").get<bool>())
+        || ad.has("crop_size") || _scale != 1.0)
       {
-	caffe::LayerParameter *lparam = net_param.mutable_layer(0); // data input layer
-	if (lparam->type() != "DenseImageData")
-	  {
-	    if (ad.has("mirror"))
-	      lparam->mutable_transform_param()->set_mirror(ad.get("mirror").get<bool>());
-	    if (ad.has("rotate"))
-	      lparam->mutable_transform_param()->set_rotate(ad.get("rotate").get<bool>());
-	    if (ad.has("crop_size"))
-	      {
-		_crop_size = ad.get("crop_size").get<int>();
-		lparam->mutable_transform_param()->set_crop_size(_crop_size);
-		caffe::LayerParameter *dlparam = net_param.mutable_layer(1); // test input layer
-		dlparam->mutable_transform_param()->set_crop_size(_crop_size);
-	      }
-	    else lparam->mutable_transform_param()->clear_crop_size();
-	    if (_scale != 1.0)
-	      {
-		lparam->mutable_transform_param()->set_scale(_scale);
-		caffe::LayerParameter *dlparam = net_param.mutable_layer(1); // test input layer
-		dlparam->mutable_transform_param()->set_scale(_scale);
-	      }
-	  }
-	else
-	  {
-	    if (ad.has("mirror"))
-	      lparam->mutable_dense_image_data_param()->set_mirror(ad.get("mirror").get<bool>());
-	    if (ad.has("rotate"))
-	      lparam->mutable_dense_image_data_param()->set_rotate(ad.get("rotate").get<bool>());
-	    lparam->mutable_dense_image_data_param()->set_new_height(this->_inputc.height());
-	    lparam->mutable_dense_image_data_param()->set_new_width(this->_inputc.width());
-	    // XXX: DenseImageData supports crop_height and crop_width
-	  }
+        caffe::LayerParameter *lparam
+            = net_param.mutable_layer(0); // data input layer
+        if (lparam->type() != "DenseImageData")
+          {
+            if (ad.has("mirror"))
+              lparam->mutable_transform_param()->set_mirror(
+                  ad.get("mirror").get<bool>());
+            if (ad.has("rotate"))
+              lparam->mutable_transform_param()->set_rotate(
+                  ad.get("rotate").get<bool>());
+            if (ad.has("crop_size"))
+              {
+                _crop_size = ad.get("crop_size").get<int>();
+                lparam->mutable_transform_param()->set_crop_size(_crop_size);
+                caffe::LayerParameter *dlparam
+                    = net_param.mutable_layer(1); // test input layer
+                dlparam->mutable_transform_param()->set_crop_size(_crop_size);
+              }
+            else
+              lparam->mutable_transform_param()->clear_crop_size();
+            if (_scale != 1.0)
+              {
+                lparam->mutable_transform_param()->set_scale(_scale);
+                caffe::LayerParameter *dlparam
+                    = net_param.mutable_layer(1); // test input layer
+                dlparam->mutable_transform_param()->set_scale(_scale);
+              }
+          }
+        else
+          {
+            if (ad.has("mirror"))
+              lparam->mutable_dense_image_data_param()->set_mirror(
+                  ad.get("mirror").get<bool>());
+            if (ad.has("rotate"))
+              lparam->mutable_dense_image_data_param()->set_rotate(
+                  ad.get("rotate").get<bool>());
+            lparam->mutable_dense_image_data_param()->set_new_height(
+                this->_inputc.height());
+            lparam->mutable_dense_image_data_param()->set_new_width(
+                this->_inputc.width());
+            // XXX: DenseImageData supports crop_height and crop_width
+          }
       }
     if (ad.has("noise"))
       {
-	std::vector<std::string> noise_options = {
-	  "decolorize","hist_eq","inverse","gauss_blur","posterize","erode",
-	  "saltpepper","clahe","convert_to_hsv","convert_to_lab"
-	};
-	APIData ad_noise = ad.getobj("noise");
-	caffe::LayerParameter *lparam = net_param.mutable_layer(0); // data input layer
-	caffe::TransformationParameter *trparam = lparam->mutable_transform_param();
-	caffe::NoiseParameter *nparam = trparam->mutable_noise_param();
-	if (ad_noise.has("all_effects") && ad_noise.get("all_effects").get<bool>())
-	  nparam->set_all_effects(true);
-	else
-	  {
-	    for (auto s: noise_options)
-	      {
-		if (ad_noise.has(s))
-		  {
-		    if (s == "decolorize")
-		      nparam->set_decolorize(ad_noise.get(s).get<bool>());
-		    else if (s == "hist_eq")
-		      nparam->set_hist_eq(ad_noise.get(s).get<bool>());
-		    else if (s == "inverse")
-		      nparam->set_inverse(ad_noise.get(s).get<bool>());
-		    else if (s == "gauss_blur")
-		      nparam->set_gauss_blur(ad_noise.get(s).get<bool>());
-		    else if (s == "posterize")
-		      nparam->set_hist_eq(ad_noise.get(s).get<bool>());
-		    else if (s == "erode")
-		      nparam->set_erode(ad_noise.get(s).get<bool>());
-		    else if (s == "saltpepper")
-			  nparam->set_saltpepper(ad_noise.get(s).get<bool>());
-		    else if (s == "clahe")
-		      nparam->set_clahe(ad_noise.get(s).get<bool>());
-		    else if (s == "convert_to_hsv")
-		      nparam->set_convert_to_hsv(ad_noise.get(s).get<bool>());
-		    else if (s == "convert_to_lab")
-		      nparam->set_convert_to_lab(ad_noise.get(s).get<bool>());
-		  }
-	      }
-	  }
-	if (ad_noise.has("prob"))
-	  nparam->set_prob(ad_noise.get("prob").get<double>());
+        std::vector<std::string> noise_options
+            = { "decolorize",     "hist_eq",       "inverse",    "gauss_blur",
+                "posterize",      "erode",         "saltpepper", "clahe",
+                "convert_to_hsv", "convert_to_lab" };
+        APIData ad_noise = ad.getobj("noise");
+        caffe::LayerParameter *lparam
+            = net_param.mutable_layer(0); // data input layer
+        caffe::TransformationParameter *trparam
+            = lparam->mutable_transform_param();
+        caffe::NoiseParameter *nparam = trparam->mutable_noise_param();
+        if (ad_noise.has("all_effects")
+            && ad_noise.get("all_effects").get<bool>())
+          nparam->set_all_effects(true);
+        else
+          {
+            for (auto s : noise_options)
+              {
+                if (ad_noise.has(s))
+                  {
+                    if (s == "decolorize")
+                      nparam->set_decolorize(ad_noise.get(s).get<bool>());
+                    else if (s == "hist_eq")
+                      nparam->set_hist_eq(ad_noise.get(s).get<bool>());
+                    else if (s == "inverse")
+                      nparam->set_inverse(ad_noise.get(s).get<bool>());
+                    else if (s == "gauss_blur")
+                      nparam->set_gauss_blur(ad_noise.get(s).get<bool>());
+                    else if (s == "posterize")
+                      nparam->set_hist_eq(ad_noise.get(s).get<bool>());
+                    else if (s == "erode")
+                      nparam->set_erode(ad_noise.get(s).get<bool>());
+                    else if (s == "saltpepper")
+                      nparam->set_saltpepper(ad_noise.get(s).get<bool>());
+                    else if (s == "clahe")
+                      nparam->set_clahe(ad_noise.get(s).get<bool>());
+                    else if (s == "convert_to_hsv")
+                      nparam->set_convert_to_hsv(ad_noise.get(s).get<bool>());
+                    else if (s == "convert_to_lab")
+                      nparam->set_convert_to_lab(ad_noise.get(s).get<bool>());
+                  }
+              }
+          }
+        if (ad_noise.has("prob"))
+          nparam->set_prob(ad_noise.get("prob").get<double>());
       }
     if (ad.has("distort"))
       {
-	std::vector<std::string> distort_options = {
-	  "brightness","contrast","saturation","hue","random_order"
-	};
-	APIData ad_distort = ad.getobj("distort");
-	caffe::LayerParameter *lparam = net_param.mutable_layer(0); // data input layer
-	caffe::TransformationParameter *trparam = lparam->mutable_transform_param();
-	caffe::DistortionParameter *nparam = trparam->mutable_distort_param();
-	if (ad_distort.has("all_effects") && ad_distort.get("all_effects").get<bool>())
-	  nparam->set_all_effects(true);
-	else
-	  {
-	    for (auto s: distort_options)
-	      {
-		if (ad_distort.has(s))
-		  {
-		    if (s == "brightness")
-		      nparam->set_brightness(ad_distort.get(s).get<bool>());
-		    else if (s == "contrast")
-		      nparam->set_contrast(ad_distort.get(s).get<bool>());
-		    else if (s == "saturation")
-		      nparam->set_saturation(ad_distort.get(s).get<bool>());
-		    else if (s == "hue")
-		      nparam->set_hue(ad_distort.get(s).get<bool>());
-		    else if (s == "random_order")
-		      nparam->set_random_order(ad_distort.get(s).get<bool>());
-		  }
-	      }
-	  }
-	if (ad_distort.has("prob"))
-	  nparam->set_prob(ad_distort.get("prob").get<double>());
+        std::vector<std::string> distort_options
+            = { "brightness", "contrast", "saturation", "hue",
+                "random_order" };
+        APIData ad_distort = ad.getobj("distort");
+        caffe::LayerParameter *lparam
+            = net_param.mutable_layer(0); // data input layer
+        caffe::TransformationParameter *trparam
+            = lparam->mutable_transform_param();
+        caffe::DistortionParameter *nparam = trparam->mutable_distort_param();
+        if (ad_distort.has("all_effects")
+            && ad_distort.get("all_effects").get<bool>())
+          nparam->set_all_effects(true);
+        else
+          {
+            for (auto s : distort_options)
+              {
+                if (ad_distort.has(s))
+                  {
+                    if (s == "brightness")
+                      nparam->set_brightness(ad_distort.get(s).get<bool>());
+                    else if (s == "contrast")
+                      nparam->set_contrast(ad_distort.get(s).get<bool>());
+                    else if (s == "saturation")
+                      nparam->set_saturation(ad_distort.get(s).get<bool>());
+                    else if (s == "hue")
+                      nparam->set_hue(ad_distort.get(s).get<bool>());
+                    else if (s == "random_order")
+                      nparam->set_random_order(ad_distort.get(s).get<bool>());
+                  }
+              }
+          }
+        if (ad_distort.has("prob"))
+          nparam->set_prob(ad_distort.get("prob").get<double>());
       }
 
-    configure_geometry_augmentation(ad,net_param.mutable_layer(0)->mutable_transform_param());
+    configure_geometry_augmentation(
+        ad, net_param.mutable_layer(0)->mutable_transform_param());
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::configure_mlp_template(const APIData &ad,
-												   const TInputConnectorStrategy &inputc,
-												   caffe::NetParameter &net_param,
-												   caffe::NetParameter &dnet_param)
-    {
-      NetCaffe<NetInputCaffe<TInputConnectorStrategy>,NetLayersCaffeMLP,NetLossCaffe> netcaffe(&net_param,&dnet_param,this->_logger);
-	netcaffe._nic.configure_inputs(ad,inputc);
-	if (inputc._sparse)
-	  const_cast<APIData&>(ad).add("sparse",true);
-	if (_regression)
-	  const_cast<APIData&>(ad).add("regression",true);
-	if (_autoencoder)
-	  {
-	    const_cast<APIData&>(ad).add("autoencoder",true);
-	    const_cast<APIData&>(ad).add("ntargets",inputc.width()*inputc.height());
-	  }
-	netcaffe._nlac.configure_net(ad);
-    }
-
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::configure_convnet_template(const APIData &ad,
-												       const TInputConnectorStrategy &inputc,
-												       caffe::NetParameter &net_param,
-												       caffe::NetParameter &dnet_param)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void CaffeLib<TInputConnectorStrategy, TOutputConnectorStrategy, TMLModel>::
+      configure_mlp_template(const APIData &ad,
+                             const TInputConnectorStrategy &inputc,
+                             caffe::NetParameter &net_param,
+                             caffe::NetParameter &dnet_param)
   {
-    NetCaffe<NetInputCaffe<TInputConnectorStrategy>,NetLayersCaffeConvnet,NetLossCaffe> netcaffe(&net_param,&dnet_param,this->_logger);
-    netcaffe._nic.configure_inputs(ad,inputc);
-    if (inputc._flat1dconv)
-      const_cast<APIData&>(ad).add("flat1dconv",static_cast<bool>(inputc._flat1dconv));
+    NetCaffe<NetInputCaffe<TInputConnectorStrategy>, NetLayersCaffeMLP,
+             NetLossCaffe>
+        netcaffe(&net_param, &dnet_param, this->_logger);
+    netcaffe._nic.configure_inputs(ad, inputc);
+    if (inputc._sparse)
+      const_cast<APIData &>(ad).add("sparse", true);
     if (_regression)
-      const_cast<APIData&>(ad).add("regression",true);
+      const_cast<APIData &>(ad).add("regression", true);
     if (_autoencoder)
       {
-	const_cast<APIData&>(ad).add("autoencoder",true);
-	const_cast<APIData&>(ad).add("ntargets",inputc.channels());
-	const_cast<APIData&>(ad).add("width",inputc.width());
-	const_cast<APIData&>(ad).add("height",inputc.height());
+        const_cast<APIData &>(ad).add("autoencoder", true);
+        const_cast<APIData &>(ad).add("ntargets",
+                                      inputc.width() * inputc.height());
       }
     netcaffe._nlac.configure_net(ad);
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::configure_resnet_template(const APIData &ad,
-												      const TInputConnectorStrategy &inputc,
-												      caffe::NetParameter &net_param,
-												      caffe::NetParameter &dnet_param)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void CaffeLib<TInputConnectorStrategy, TOutputConnectorStrategy, TMLModel>::
+      configure_convnet_template(const APIData &ad,
+                                 const TInputConnectorStrategy &inputc,
+                                 caffe::NetParameter &net_param,
+                                 caffe::NetParameter &dnet_param)
   {
-    NetCaffe<NetInputCaffe<TInputConnectorStrategy>,NetLayersCaffeResnet,NetLossCaffe> netcaffe(&net_param,&dnet_param,this->_logger);
-    netcaffe._nic.configure_inputs(ad,inputc);
-    if (inputc._sparse)
-      const_cast<APIData&>(ad).add("sparse",true);
+    NetCaffe<NetInputCaffe<TInputConnectorStrategy>, NetLayersCaffeConvnet,
+             NetLossCaffe>
+        netcaffe(&net_param, &dnet_param, this->_logger);
+    netcaffe._nic.configure_inputs(ad, inputc);
     if (inputc._flat1dconv)
-      const_cast<APIData&>(ad).add("flat1dconv",static_cast<bool>(inputc._flat1dconv));
+      const_cast<APIData &>(ad).add("flat1dconv",
+                                    static_cast<bool>(inputc._flat1dconv));
     if (_regression)
-      const_cast<APIData&>(ad).add("regression",true);
+      const_cast<APIData &>(ad).add("regression", true);
+    if (_autoencoder)
+      {
+        const_cast<APIData &>(ad).add("autoencoder", true);
+        const_cast<APIData &>(ad).add("ntargets", inputc.channels());
+        const_cast<APIData &>(ad).add("width", inputc.width());
+        const_cast<APIData &>(ad).add("height", inputc.height());
+      }
     netcaffe._nlac.configure_net(ad);
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::configure_geometry_augmentation(const APIData&ad, caffe::TransformationParameter * trparam)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void CaffeLib<TInputConnectorStrategy, TOutputConnectorStrategy, TMLModel>::
+      configure_resnet_template(const APIData &ad,
+                                const TInputConnectorStrategy &inputc,
+                                caffe::NetParameter &net_param,
+                                caffe::NetParameter &dnet_param)
   {
-    if(!ad.has("geometry"))
+    NetCaffe<NetInputCaffe<TInputConnectorStrategy>, NetLayersCaffeResnet,
+             NetLossCaffe>
+        netcaffe(&net_param, &dnet_param, this->_logger);
+    netcaffe._nic.configure_inputs(ad, inputc);
+    if (inputc._sparse)
+      const_cast<APIData &>(ad).add("sparse", true);
+    if (inputc._flat1dconv)
+      const_cast<APIData &>(ad).add("flat1dconv",
+                                    static_cast<bool>(inputc._flat1dconv));
+    if (_regression)
+      const_cast<APIData &>(ad).add("regression", true);
+    netcaffe._nlac.configure_net(ad);
+  }
+
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void CaffeLib<TInputConnectorStrategy, TOutputConnectorStrategy, TMLModel>::
+      configure_geometry_augmentation(const APIData &ad,
+                                      caffe::TransformationParameter *trparam)
+  {
+    if (!ad.has("geometry"))
       return;
 
-    std::vector<std::string> geometry_options = {
-      "persp_horizontal", "persp_vertical", "zoom_out", "zoom_in"
-    };
+    std::vector<std::string> geometry_options
+        = { "persp_horizontal", "persp_vertical", "zoom_out", "zoom_in" };
 
     APIData ad_geometry = ad.getobj("geometry");
     caffe::GeometryParameter *gparam = trparam->mutable_geometry_param();
 
-    if (ad_geometry.has("all_effects") && ad_geometry.get("all_effects").get<bool>())
+    if (ad_geometry.has("all_effects")
+        && ad_geometry.get("all_effects").get<bool>())
       gparam->set_all_effects(true);
     else
       {
-        for (auto s: geometry_options)
+        for (auto s : geometry_options)
           {
             if (ad_geometry.has(s))
               {
@@ -714,42 +838,50 @@ namespace dd
               }
           }
         if (ad_geometry.has("persp_factor"))
-          gparam->set_persp_factor(ad_geometry.get("persp_factor").get<double>());
+          gparam->set_persp_factor(
+              ad_geometry.get("persp_factor").get<double>());
         if (ad_geometry.has("zoom_factor"))
-          gparam->set_zoom_factor(ad_geometry.get("zoom_factor").get<double>());
+          gparam->set_zoom_factor(
+              ad_geometry.get("zoom_factor").get<double>());
         if (ad_geometry.has("pad_mode"))
           {
             std::string pmode = ad_geometry.get("pad_mode").get<std::string>();
             if (pmode == "constant")
-              gparam->set_pad_mode(::caffe::GeometryParameter_Pad_mode_CONSTANT);
+              gparam->set_pad_mode(
+                  ::caffe::GeometryParameter_Pad_mode_CONSTANT);
             else if (pmode == "mirrored")
-              gparam->set_pad_mode(::caffe::GeometryParameter_Pad_mode_MIRRORED);
+              gparam->set_pad_mode(
+                  ::caffe::GeometryParameter_Pad_mode_MIRRORED);
             else if (pmode == "repeat_nearest")
-              gparam->set_pad_mode(::caffe::GeometryParameter_Pad_mode_REPEAT_NEAREST);
+              gparam->set_pad_mode(
+                  ::caffe::GeometryParameter_Pad_mode_REPEAT_NEAREST);
           }
       }
     if (ad_geometry.has("prob"))
       gparam->set_prob(ad_geometry.get("prob").get<double>());
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::configure_ssd_template(const std::string &dest_net,
-												   const std::string &dest_deploy_net,
-												   const APIData &ad,
-												   TInputConnectorStrategy &inputc,
-												   const bool &refinedet)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void CaffeLib<TInputConnectorStrategy, TOutputConnectorStrategy, TMLModel>::
+      configure_ssd_template(const std::string &dest_net,
+                             const std::string &dest_deploy_net,
+                             const APIData &ad,
+                             TInputConnectorStrategy &inputc,
+                             const bool &refinedet)
   {
     //- load prototxt
-    caffe::NetParameter net_param,deploy_net_param;
-    caffe::ReadProtoFromTextFile(dest_net,&net_param);
-    caffe::ReadProtoFromTextFile(dest_deploy_net,&deploy_net_param);
+    caffe::NetParameter net_param, deploy_net_param;
+    caffe::ReadProtoFromTextFile(dest_net, &net_param);
+    caffe::ReadProtoFromTextFile(dest_deploy_net, &deploy_net_param);
 
     // image augmentation
-    configure_image_augmentation(ad,net_param);
-    
+    configure_image_augmentation(ad, net_param);
+
     // get image input connector
-    ImgCaffeInputFileConn *timg = reinterpret_cast<ImgCaffeInputFileConn*>(&inputc);
-    
+    ImgCaffeInputFileConn *timg
+        = reinterpret_cast<ImgCaffeInputFileConn *>(&inputc);
+
     // get ssd detailed params, if any.
     double ssd_expand_prob = -1.0;
     double ssd_max_expand_ratio = -1.0;
@@ -769,254 +901,294 @@ namespace dd
       ssd_neg_overlap = ad.get("ssd_neg_overlap").get<double>();
     if (ad.has("ssd_keep_top_k"))
       ssd_keep_top_k = ad.get("ssd_keep_top_k").get<int>();
-    
+
     //- if finetuning, change the proper layer names
     std::string postfix = "_ftune";
-    const bool finetune = (ad.has("finetuning") && ad.get("finetuning").get<bool>());
+    const bool finetune
+        = (ad.has("finetuning") && ad.get("finetuning").get<bool>());
     int k = net_param.layer_size();
-    for (int l=0;l<k;l++)
+    for (int l = 0; l < k; l++)
       {
-	caffe::LayerParameter *lparam = net_param.mutable_layer(l);
-	
- 	if ((l==0 || l==1) && lparam->type() == "AnnotatedData")
-	  {
-	    caffe::TransformationParameter *trparam = lparam->mutable_transform_param();
-	    if (timg->_bw)
-	      {
-		trparam->set_force_gray(true);
-		trparam->set_force_color(false);
-	      }
+        caffe::LayerParameter *lparam = net_param.mutable_layer(l);
 
-	    if (l==0)
-	      {
-		if (ssd_expand_prob >= 0.0 || ssd_max_expand_ratio >= 0.0)
-		  {
-		    caffe::ExpansionParameter *exparam = trparam->mutable_expand_param();
-		    if (ssd_expand_prob >= 0.0)
-		      exparam->set_prob(ssd_expand_prob);
-		    if (ssd_max_expand_ratio >= 0.0)
-		      exparam->set_max_expand_ratio(ssd_max_expand_ratio);
-		  }
-		configure_geometry_augmentation(ad,trparam);
-	      }
-	  }
-	
-	if (finetune)
-	  {
-	    if (lparam->name().find("mbox_conf") != std::string::npos
-		|| lparam->name().find("mbox_loc") != std::string::npos)
-	      {
-		lparam->set_name(lparam->name() + postfix);
-	      }
-	    for (int t=0;t<lparam->top_size();t++)
-	      {
-		if (lparam->top(t).find("_conf") != std::string::npos
-		    || lparam->top(t).find("_loc") != std::string::npos)
-		  {
-		    lparam->set_top(t,lparam->top(t) + postfix);
-		  }
-	      }
-	    for (int t=0;t<lparam->bottom_size();t++)
-	      {
-		if (lparam->bottom(t).find("_conf") != std::string::npos
-		    || lparam->bottom(t).find("_loc") != std::string::npos)
-		  {
-		    lparam->set_bottom(t,lparam->bottom(t) + postfix);
-		  }
-	      }
-	  }
-	//- set correct layer parameters based on nclasses
-	if (lparam->name() == "mbox_loss" || lparam->name() == "odm_loss")
-	  {
-	    lparam->mutable_multibox_loss_param()->set_num_classes(_nclasses);
-	    if (ssd_mining_type == "MAX_NEGATIVE")
-	      lparam->mutable_multibox_loss_param()->set_mining_type(caffe::MultiBoxLossParameter::MAX_NEGATIVE);
-	    else if (ssd_mining_type == "HARD_EXAMPLE")
-	      lparam->mutable_multibox_loss_param()->set_mining_type(caffe::MultiBoxLossParameter::HARD_EXAMPLE);
-	    if (ssd_neg_pos_ratio >= 1.0)
-	      lparam->mutable_multibox_loss_param()->set_neg_pos_ratio(ssd_neg_pos_ratio);
-	    if (ssd_neg_overlap >= 0.0)
-	      lparam->mutable_multibox_loss_param()->set_neg_overlap(ssd_neg_overlap);
-	  }
-	else if (lparam->name() == "arm_loss")
-	  {
-	    if (ssd_mining_type == "MAX_NEGATIVE")
-	      lparam->mutable_multibox_loss_param()->set_mining_type(caffe::MultiBoxLossParameter::MAX_NEGATIVE);
-	    else if (ssd_mining_type == "HARD_EXAMPLE")
-	      lparam->mutable_multibox_loss_param()->set_mining_type(caffe::MultiBoxLossParameter::HARD_EXAMPLE);
-	    if (ssd_neg_pos_ratio >= 1.0)
-	      lparam->mutable_multibox_loss_param()->set_neg_pos_ratio(ssd_neg_pos_ratio);
-	    if (ssd_neg_overlap >= 0.0)
-	      lparam->mutable_multibox_loss_param()->set_neg_overlap(ssd_neg_overlap);
-	  }
-	else if (lparam->name() == "detection_out")
-	  {
-	    lparam->mutable_detection_output_param()->set_num_classes(_nclasses);
-	    if (ssd_keep_top_k >= 1.0)
-	      lparam->mutable_detection_output_param()->set_keep_top_k(ssd_keep_top_k);
-	  }
-	else if (lparam->name() == "detection_eval")
-	  {
-	    lparam->mutable_detection_evaluate_param()->set_num_classes(_nclasses);
-	  }
-	else if (lparam->name().find("mbox_conf_reshape") != std::string::npos
-		 || lparam->name().find("odm_conf_reshape") != std::string::npos)
-	  {
-	    lparam->mutable_reshape_param()->mutable_shape()->set_dim(2,_nclasses);
-	  }
+        if ((l == 0 || l == 1) && lparam->type() == "AnnotatedData")
+          {
+            caffe::TransformationParameter *trparam
+                = lparam->mutable_transform_param();
+            if (timg->_bw)
+              {
+                trparam->set_force_gray(true);
+                trparam->set_force_color(false);
+              }
+
+            if (l == 0)
+              {
+                if (ssd_expand_prob >= 0.0 || ssd_max_expand_ratio >= 0.0)
+                  {
+                    caffe::ExpansionParameter *exparam
+                        = trparam->mutable_expand_param();
+                    if (ssd_expand_prob >= 0.0)
+                      exparam->set_prob(ssd_expand_prob);
+                    if (ssd_max_expand_ratio >= 0.0)
+                      exparam->set_max_expand_ratio(ssd_max_expand_ratio);
+                  }
+                configure_geometry_augmentation(ad, trparam);
+              }
+          }
+
+        if (finetune)
+          {
+            if (lparam->name().find("mbox_conf") != std::string::npos
+                || lparam->name().find("mbox_loc") != std::string::npos)
+              {
+                lparam->set_name(lparam->name() + postfix);
+              }
+            for (int t = 0; t < lparam->top_size(); t++)
+              {
+                if (lparam->top(t).find("_conf") != std::string::npos
+                    || lparam->top(t).find("_loc") != std::string::npos)
+                  {
+                    lparam->set_top(t, lparam->top(t) + postfix);
+                  }
+              }
+            for (int t = 0; t < lparam->bottom_size(); t++)
+              {
+                if (lparam->bottom(t).find("_conf") != std::string::npos
+                    || lparam->bottom(t).find("_loc") != std::string::npos)
+                  {
+                    lparam->set_bottom(t, lparam->bottom(t) + postfix);
+                  }
+              }
+          }
+        //- set correct layer parameters based on nclasses
+        if (lparam->name() == "mbox_loss" || lparam->name() == "odm_loss")
+          {
+            lparam->mutable_multibox_loss_param()->set_num_classes(_nclasses);
+            if (ssd_mining_type == "MAX_NEGATIVE")
+              lparam->mutable_multibox_loss_param()->set_mining_type(
+                  caffe::MultiBoxLossParameter::MAX_NEGATIVE);
+            else if (ssd_mining_type == "HARD_EXAMPLE")
+              lparam->mutable_multibox_loss_param()->set_mining_type(
+                  caffe::MultiBoxLossParameter::HARD_EXAMPLE);
+            if (ssd_neg_pos_ratio >= 1.0)
+              lparam->mutable_multibox_loss_param()->set_neg_pos_ratio(
+                  ssd_neg_pos_ratio);
+            if (ssd_neg_overlap >= 0.0)
+              lparam->mutable_multibox_loss_param()->set_neg_overlap(
+                  ssd_neg_overlap);
+          }
+        else if (lparam->name() == "arm_loss")
+          {
+            if (ssd_mining_type == "MAX_NEGATIVE")
+              lparam->mutable_multibox_loss_param()->set_mining_type(
+                  caffe::MultiBoxLossParameter::MAX_NEGATIVE);
+            else if (ssd_mining_type == "HARD_EXAMPLE")
+              lparam->mutable_multibox_loss_param()->set_mining_type(
+                  caffe::MultiBoxLossParameter::HARD_EXAMPLE);
+            if (ssd_neg_pos_ratio >= 1.0)
+              lparam->mutable_multibox_loss_param()->set_neg_pos_ratio(
+                  ssd_neg_pos_ratio);
+            if (ssd_neg_overlap >= 0.0)
+              lparam->mutable_multibox_loss_param()->set_neg_overlap(
+                  ssd_neg_overlap);
+          }
+        else if (lparam->name() == "detection_out")
+          {
+            lparam->mutable_detection_output_param()->set_num_classes(
+                _nclasses);
+            if (ssd_keep_top_k >= 1.0)
+              lparam->mutable_detection_output_param()->set_keep_top_k(
+                  ssd_keep_top_k);
+          }
+        else if (lparam->name() == "detection_eval")
+          {
+            lparam->mutable_detection_evaluate_param()->set_num_classes(
+                _nclasses);
+          }
+        else if (lparam->name().find("mbox_conf_reshape") != std::string::npos
+                 || lparam->name().find("odm_conf_reshape")
+                        != std::string::npos)
+          {
+            lparam->mutable_reshape_param()->mutable_shape()->set_dim(
+                2, _nclasses);
+          }
       }
-	
+
     // fix other layer parameters
-    for (int l=0;l<k;l++)
+    for (int l = 0; l < k; l++)
       {
-	caffe::LayerParameter *lparam = net_param.mutable_layer(l);
-	if (!refinedet && lparam->name().find("mbox_conf") != std::string::npos
-	    && lparam->type() == "Convolution")
-	  {
-	    int num_priors_per_location = lparam->mutable_convolution_param()->num_output() / 2;
-	    lparam->mutable_convolution_param()->set_num_output(num_priors_per_location * _nclasses);
-	  }
-	else if (refinedet && lparam->name().find("mbox_conf") != std::string::npos
-		 && (lparam->name()[0] == 'P' && lparam->type() == "Convolution"
-		     || lparam->name().substr(0,4) == "resP" && lparam->type() == "Convolution"))
-		 
-	  {
-	    int num_priors_per_location = lparam->mutable_convolution_param()->num_output() / 2;
-	    lparam->mutable_convolution_param()->set_num_output(num_priors_per_location * _nclasses);
-	  }
+        caffe::LayerParameter *lparam = net_param.mutable_layer(l);
+        if (!refinedet && lparam->name().find("mbox_conf") != std::string::npos
+            && lparam->type() == "Convolution")
+          {
+            int num_priors_per_location
+                = lparam->mutable_convolution_param()->num_output() / 2;
+            lparam->mutable_convolution_param()->set_num_output(
+                num_priors_per_location * _nclasses);
+          }
+        else if (refinedet
+                 && lparam->name().find("mbox_conf") != std::string::npos
+                 && (lparam->name()[0] == 'P'
+                         && lparam->type() == "Convolution"
+                     || lparam->name().substr(0, 4) == "resP"
+                            && lparam->type() == "Convolution"))
+
+          {
+            int num_priors_per_location
+                = lparam->mutable_convolution_param()->num_output() / 2;
+            lparam->mutable_convolution_param()->set_num_output(
+                num_priors_per_location * _nclasses);
+          }
       }
 
     k = deploy_net_param.layer_size();
-    for (int l=0;l<k;l++)
+    for (int l = 0; l < k; l++)
       {
-	caffe::LayerParameter *lparam = deploy_net_param.mutable_layer(l);
-	if (lparam->type() == "MemoryData" && timg->_bw)
-	  {
-	    lparam->mutable_memory_data_param()->set_channels(timg->channels());
-	  }
-	if (finetune)
-	  {
-	    if (lparam->name().find("mbox_conf") != std::string::npos
-		|| lparam->name().find("mbox_loc") != std::string::npos)
-	      {
-		lparam->set_name(lparam->name() + postfix);
-	      }
-	    for (int t=0;t<lparam->top_size();t++)
-	      {
-		if (lparam->top(t).find("_conf") != std::string::npos
-		    || lparam->top(t).find("_loc") != std::string::npos)
-		  {
-		    lparam->set_top(t,lparam->top(t) + postfix);
-		  }
-	      }
-	    for (int t=0;t<lparam->bottom_size();t++)
-	      {
-		if (lparam->bottom(t).find("_conf") != std::string::npos
-		    || lparam->bottom(t).find("_loc") != std::string::npos)
-		  {
-		    lparam->set_bottom(t,lparam->bottom(t) + postfix);
-		  }
-	      }
-	  }
-	//- set correct layer parameters based on nclasses
-	if (!refinedet && lparam->name().find("mbox_conf") != std::string::npos
-	    && lparam->type() == "Convolution")
-	  {
-	    int num_priors_per_location = lparam->mutable_convolution_param()->num_output() / 2;
-	    lparam->mutable_convolution_param()->set_num_output(num_priors_per_location * _nclasses);
-	  }
-	else if (refinedet && lparam->name().find("mbox_conf") != std::string::npos
-		 && lparam->name()[0] == 'P' && lparam->type() == "Convolution")
-	  {
-	    int num_priors_per_location = lparam->mutable_convolution_param()->num_output() / 2;
-	    lparam->mutable_convolution_param()->set_num_output(num_priors_per_location * _nclasses);
-	  }
-	else if (lparam->name() == "detection_out")
-	  {
-	    lparam->mutable_detection_output_param()->set_num_classes(_nclasses);
-	    if (ssd_keep_top_k >= 1.0)
-	      lparam->mutable_detection_output_param()->set_keep_top_k(ssd_keep_top_k);
-	  }
-	else if (lparam->name().find("mbox_conf_reshape") != std::string::npos
-		 || lparam->name().find("odm_conf_reshape") != std::string::npos)
-	  {
-	    lparam->mutable_reshape_param()->mutable_shape()->set_dim(2,_nclasses);
-	  }
+        caffe::LayerParameter *lparam = deploy_net_param.mutable_layer(l);
+        if (lparam->type() == "MemoryData" && timg->_bw)
+          {
+            lparam->mutable_memory_data_param()->set_channels(
+                timg->channels());
+          }
+        if (finetune)
+          {
+            if (lparam->name().find("mbox_conf") != std::string::npos
+                || lparam->name().find("mbox_loc") != std::string::npos)
+              {
+                lparam->set_name(lparam->name() + postfix);
+              }
+            for (int t = 0; t < lparam->top_size(); t++)
+              {
+                if (lparam->top(t).find("_conf") != std::string::npos
+                    || lparam->top(t).find("_loc") != std::string::npos)
+                  {
+                    lparam->set_top(t, lparam->top(t) + postfix);
+                  }
+              }
+            for (int t = 0; t < lparam->bottom_size(); t++)
+              {
+                if (lparam->bottom(t).find("_conf") != std::string::npos
+                    || lparam->bottom(t).find("_loc") != std::string::npos)
+                  {
+                    lparam->set_bottom(t, lparam->bottom(t) + postfix);
+                  }
+              }
+          }
+        //- set correct layer parameters based on nclasses
+        if (!refinedet && lparam->name().find("mbox_conf") != std::string::npos
+            && lparam->type() == "Convolution")
+          {
+            int num_priors_per_location
+                = lparam->mutable_convolution_param()->num_output() / 2;
+            lparam->mutable_convolution_param()->set_num_output(
+                num_priors_per_location * _nclasses);
+          }
+        else if (refinedet
+                 && lparam->name().find("mbox_conf") != std::string::npos
+                 && lparam->name()[0] == 'P'
+                 && lparam->type() == "Convolution")
+          {
+            int num_priors_per_location
+                = lparam->mutable_convolution_param()->num_output() / 2;
+            lparam->mutable_convolution_param()->set_num_output(
+                num_priors_per_location * _nclasses);
+          }
+        else if (lparam->name() == "detection_out")
+          {
+            lparam->mutable_detection_output_param()->set_num_classes(
+                _nclasses);
+            if (ssd_keep_top_k >= 1.0)
+              lparam->mutable_detection_output_param()->set_keep_top_k(
+                  ssd_keep_top_k);
+          }
+        else if (lparam->name().find("mbox_conf_reshape") != std::string::npos
+                 || lparam->name().find("odm_conf_reshape")
+                        != std::string::npos)
+          {
+            lparam->mutable_reshape_param()->mutable_shape()->set_dim(
+                2, _nclasses);
+          }
       }
-    
+
     //- write it down
-    caffe::WriteProtoToTextFile(net_param,dest_net);
-    caffe::WriteProtoToTextFile(deploy_net_param,dest_deploy_net);
+    caffe::WriteProtoToTextFile(net_param, dest_net);
+    caffe::WriteProtoToTextFile(deploy_net_param, dest_deploy_net);
   }
 
-
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::configure_recurrent_template(const APIData &ad,
-                                                                                                   const TInputConnectorStrategy &inputc,
-                                                                                                   caffe::NetParameter &net_param,
-                                                                                                         caffe::NetParameter &dnet_param)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void CaffeLib<TInputConnectorStrategy, TOutputConnectorStrategy, TMLModel>::
+      configure_recurrent_template(const APIData &ad,
+                                   const TInputConnectorStrategy &inputc,
+                                   caffe::NetParameter &net_param,
+                                   caffe::NetParameter &dnet_param)
   {
 
-    NetCaffe<NetInputCaffe<TInputConnectorStrategy>,NetLayersCaffeRecurrent,NetLossCaffe> netcaffe(&net_param,&dnet_param,this->_logger);
-    netcaffe._nic.configure_inputs(ad,inputc);
+    NetCaffe<NetInputCaffe<TInputConnectorStrategy>, NetLayersCaffeRecurrent,
+             NetLossCaffe>
+        netcaffe(&net_param, &dnet_param, this->_logger);
+    netcaffe._nic.configure_inputs(ad, inputc);
     // add ntargets to ad.
-    const_cast<APIData&>(ad).add("ntargets",this->_ntargets);
+    const_cast<APIData &>(ad).add("ntargets", this->_ntargets);
     netcaffe._nlac.configure_net(ad);
     // will be changed at predict time
     // small default for debug
     dnet_param.mutable_layer(0)->mutable_memory_data_param()->set_channels(10);
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  int CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::create_model(const bool &test)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  int CaffeLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+               TMLModel>::create_model(const bool &test)
   {
     // create net and fill it up
     if (!this->_mlmodel._def.empty() && !this->_mlmodel._weights.empty())
       {
-	delete _net;
-	_net = nullptr;	
-	try
-	  {
-	    if (!test)
-	      _net = new Net<float>(this->_mlmodel._def,caffe::TRAIN);
-	    else
-	      _net = new Net<float>(this->_mlmodel._def,caffe::TEST);
-	  }
-	catch (std::exception &e)
-	  {
-	    this->_logger->error("Error creating network");
-	    throw;
-	  }
-	this->_logger->info("Using pre-trained weights from {}",this->_mlmodel._weights);
-	try
-	  {
-	    _net->CopyTrainedLayersFrom(this->_mlmodel._weights);
-	  }
-	catch (std::exception &e)
-	  {
-	    this->_logger->error("Error copying pre-trained weights");
-	    delete _net;
-	    _net = nullptr;
-	    throw;
-	  }
-	try
-	  {
-             model_complexity(this->_model_flops,this->_model_params);
-	  }
-	catch(std::exception &e)
-	  {
-	    // nets can be exotic, let's make sure we don't get killed here
-	    this->_logger->error("failed computing net's complexity");
-	  }
-	try
-	  {
-	    model_type(_net,this->_mltype);
-	  }
-	catch (std::exception &e)
-	  {
-	    this->_logger->error("failed determining mltype");
-	  }
-	return 0;
+        delete _net;
+        _net = nullptr;
+        try
+          {
+            if (!test)
+              _net = new Net<float>(this->_mlmodel._def, caffe::TRAIN);
+            else
+              _net = new Net<float>(this->_mlmodel._def, caffe::TEST);
+          }
+        catch (std::exception &e)
+          {
+            this->_logger->error("Error creating network");
+            throw;
+          }
+        this->_logger->info("Using pre-trained weights from {}",
+                            this->_mlmodel._weights);
+        try
+          {
+            _net->CopyTrainedLayersFrom(this->_mlmodel._weights);
+          }
+        catch (std::exception &e)
+          {
+            this->_logger->error("Error copying pre-trained weights");
+            delete _net;
+            _net = nullptr;
+            throw;
+          }
+        try
+          {
+            model_complexity(this->_model_flops, this->_model_params);
+          }
+        catch (std::exception &e)
+          {
+            // nets can be exotic, let's make sure we don't get killed here
+            this->_logger->error("failed computing net's complexity");
+          }
+        try
+          {
+            model_type(_net, this->_mltype);
+          }
+        catch (std::exception &e)
+          {
+            this->_logger->error("failed determining mltype");
+          }
+        return 0;
       }
     // net definition is missing
     else if (this->_mlmodel._def.empty())
@@ -1024,8 +1196,10 @@ namespace dd
     return 1;
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::init_mllib(const APIData &ad)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void CaffeLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+                TMLModel>::init_mllib(const APIData &ad)
   {
     if (ad.has("gpu"))
       _gpu = ad.get("gpu").get<bool>();
@@ -1033,14 +1207,15 @@ namespace dd
 #if !defined(CPU_ONLY) && !defined(USE_CAFFE_CPU_ONLY)
     if (_gpu)
       {
-	for (auto i: _gpuid)
-	  {
-	    Caffe::SetDevice(i);
-	    Caffe::DeviceQuery();
-	  }
-	Caffe::set_mode(Caffe::GPU);
+        for (auto i : _gpuid)
+          {
+            Caffe::SetDevice(i);
+            Caffe::DeviceQuery();
+          }
+        Caffe::set_mode(Caffe::GPU);
       }
-    else Caffe::set_mode(Caffe::CPU);
+    else
+      Caffe::set_mode(Caffe::CPU);
 #else
     Caffe::set_mode(Caffe::CPU);
 #endif
@@ -1048,14 +1223,17 @@ namespace dd
     if (ad.has(scale_key))
       apitools::get_float(ad, scale_key, _scale);
     if (ad.has("db"))
-      this->_inputc._db = ad.get("db").get<bool>(); // XXX: API backward compatibility, if db is in mllib, assume it applies to input as well
+      this->_inputc._db
+          = ad.get("db")
+                .get<bool>(); // XXX: API backward compatibility, if db is in
+                              // mllib, assume it applies to input as well
     if (ad.has("nclasses"))
       _nclasses = ad.get("nclasses").get<int>();
     if (ad.has("regression") && ad.get("regression").get<bool>())
       {
-	_regression = true;
-    	_nclasses = 1;
-	this->_mltype = "regression";
+        _regression = true;
+        _nclasses = 1;
+        this->_mltype = "regression";
       }
     if (this->_inputc._timeserie)
       this->_mltype = "timeserie";
@@ -1064,8 +1242,9 @@ namespace dd
       {
         _loss = ad.get("loss").get<std::string>();
         if (this->_loss == "dice")
-          if (! this->_inputc._segmentation)
-            throw MLLibBadParamException("asked for  dice loss without segmentation");
+          if (!this->_inputc._segmentation)
+            throw MLLibBadParamException(
+                "asked for  dice loss without segmentation");
       }
 
     if (ad.has("ntargets"))
@@ -1075,67 +1254,79 @@ namespace dd
     if (ad.has("autoencoder") && ad.get("autoencoder").get<bool>())
       _autoencoder = true;
     if (!_autoencoder && _nclasses == 0)
-      throw MLLibBadParamException("number of classes is unknown (nclasses == 0)");
-    bool multi =
-      this->_inputc._multi_label &&  !(this->_inputc._db)
-      && typeid(this->_inputc) == typeid(ImgCaffeInputFileConn);
+      throw MLLibBadParamException(
+          "number of classes is unknown (nclasses == 0)");
+    bool multi = this->_inputc._multi_label && !(this->_inputc._db)
+                 && typeid(this->_inputc) == typeid(ImgCaffeInputFileConn);
     if (_regression && _ntargets == 0 && !multi)
-      throw MLLibBadParamException("number of regression targets is unknown (ntargets == 0)");
+      throw MLLibBadParamException(
+          "number of regression targets is unknown (ntargets == 0)");
     if (_regression && multi) // multisoft case
       if (ad.has("nclasses"))
         _nclasses = ad.get("nclasses").get<int>();
 
     // import model from existing directory upon request
     if (ad.has("from_repository"))
-      this->_mlmodel.copy_to_target(ad.get("from_repository").get<std::string>(),
-				    this->_mlmodel._repo,
-				    this->_logger);
-    
+      this->_mlmodel.copy_to_target(
+          ad.get("from_repository").get<std::string>(), this->_mlmodel._repo,
+          this->_logger);
+
     // instantiate model template here, if any
     if (ad.has("template") && ad.get("template").get<std::string>() != "")
-	  {
-		instantiate_template(ad);
-	  }
+      {
+        instantiate_template(ad);
+      }
     else // model template instantiation is defered until training call
       {
         create_model(true);
       }
 
     // the first present measure will be used to snapshot best model
-    _best_metrics = {"map", "meaniou", "mlacc", "delta_score_0.1", "bacc", "f1", "net_meas", "acc", "L1_mean_error", "eucll"};
+    _best_metrics = { "map", "meaniou",  "mlacc", "delta_score_0.1", "bacc",
+                      "f1",  "net_meas", "acc",   "L1_mean_error",   "eucll" };
     _best_metric_value = std::numeric_limits<double>::infinity();
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::clear_mllib(const APIData &ad)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void CaffeLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+                TMLModel>::clear_mllib(const APIData &ad)
   {
     (void)ad;
-    std::vector<std::string> extensions = {".solverstate",".caffemodel",".json"};
+    std::vector<std::string> extensions
+        = { ".solverstate", ".caffemodel", ".json" };
     if (!this->_inputc._db)
-      extensions.push_back(".dat"); // e.g., for txt input connector and db, do not delete the vocab.dat since the db is not deleted
-    fileops::remove_directory_files(this->_mlmodel._repo,extensions);
+      extensions.push_back(
+          ".dat"); // e.g., for txt input connector and db, do not delete the
+                   // vocab.dat since the db is not deleted
+    fileops::remove_directory_files(this->_mlmodel._repo, extensions);
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  int CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::train(const APIData &ad,
-										 APIData &out)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  int CaffeLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+               TMLModel>::train(const APIData &ad, APIData &out)
   {
     if (this->_mlmodel._solver.empty())
       {
-	throw MLLibBadParamException("missing solver file in " + this->_mlmodel._repo);
+        throw MLLibBadParamException("missing solver file in "
+                                     + this->_mlmodel._repo);
       }
-
 
     APIData ad_mllib = ad.getobj("parameters").getobj("mllib");
     int timesteps = 0;
     if (ad_mllib.has("timesteps"))
       timesteps = ad_mllib.get("timesteps").get<int>();
     if (timesteps <= 0 && this->_inputc._ctc)
-      throw MLLibBadParamException("Need to specify timesteps > 0 with sequence (e.g. OCR / CTC) models");
-    if  (timesteps <= 0 && this->_inputc._timeserie)
-      throw MLLibBadParamException("Need to specify timesteps > 0 with recurrent  models");
+      throw MLLibBadParamException("Need to specify timesteps > 0 with "
+                                   "sequence (e.g. OCR / CTC) models");
+    if (timesteps <= 0 && this->_inputc._timeserie)
+      throw MLLibBadParamException(
+          "Need to specify timesteps > 0 with recurrent  models");
 
-    std::lock_guard<std::mutex> lock(_net_mutex); // XXX: not mandatory as train calls are locking resources from above
+    std::lock_guard<std::mutex> lock(
+        _net_mutex); // XXX: not mandatory as train calls are locking resources
+                     // from above
     TInputConnectorStrategy inputc(this->_inputc);
     this->_inputc._dv.clear();
     this->_inputc._dv_test.clear();
@@ -1144,309 +1335,379 @@ namespace dd
     this->_inputc._ids.clear();
     inputc._train = true;
     APIData cad = ad;
-    cad.add("has_mean_file",this->_mlmodel._has_mean_file);
+    cad.add("has_mean_file", this->_mlmodel._has_mean_file);
     if (_crop_size > 0)
-      cad.add("crop_size",_crop_size);
+      cad.add("crop_size", _crop_size);
     if (_autoencoder)
-      cad.add("autoencoder",_autoencoder);
+      cad.add("autoencoder", _autoencoder);
     if (this->_inputc._timeserie)
       inputc._timesteps = timesteps;
     try
       {
-	inputc.transform(cad);
+        inputc.transform(cad);
       }
     catch (...)
       {
-	throw;
+        throw;
       }
-    
-    // instantiate model template here, as a defered from service initialization
-    // since inputs are necessary in order to fit the inner net input dimension.
+
+    // instantiate model template here, as a defered from service
+    // initialization since inputs are necessary in order to fit the inner net
+    // input dimension.
     if (!this->_mlmodel._model_template.empty())
       {
-	// modifies model structure, template must have been copied at service creation with instantiate_template
-	bool has_class_weights = ad_mllib.has("class_weights");
-	int ignore_label = -1;
-	if (ad_mllib.has("ignore_label"))
-	  ignore_label = ad_mllib.get("ignore_label").get<int>();
-	update_protofile_net(this->_mlmodel._repo + '/' + this->_mlmodel._model_template + ".prototxt",
-                            this->_mlmodel._repo + "/deploy.prototxt",
-                         inputc, has_class_weights, ignore_label, timesteps,ad_mllib);
+        // modifies model structure, template must have been copied at service
+        // creation with instantiate_template
+        bool has_class_weights = ad_mllib.has("class_weights");
+        int ignore_label = -1;
+        if (ad_mllib.has("ignore_label"))
+          ignore_label = ad_mllib.get("ignore_label").get<int>();
+        update_protofile_net(
+            this->_mlmodel._repo + '/' + this->_mlmodel._model_template
+                + ".prototxt",
+            this->_mlmodel._repo + "/deploy.prototxt", inputc,
+            has_class_weights, ignore_label, timesteps, ad_mllib);
       }
 
 #ifdef USE_CUDNN
     caffe::NetParameter net_param;
-    caffe::ReadProtoFromTextFile(this->_mlmodel._trainf,&net_param); //TODO: catch parsing error (returns bool true on success)
+    caffe::ReadProtoFromTextFile(this->_mlmodel._trainf,
+                                 &net_param); // TODO: catch parsing error
+                                              // (returns bool true on success)
     update_protofile_engine(net_param, ad_mllib);
-    caffe::WriteProtoToTextFile(net_param,this->_mlmodel._trainf);
+    caffe::WriteProtoToTextFile(net_param, this->_mlmodel._trainf);
 #endif
 
     create_model(); // creates initial net.
 
     caffe::SolverParameter solver_param;
-    if (!caffe::ReadProtoFromTextFile(this->_mlmodel._solver,&solver_param))
-      throw MLLibInternalException("failed opening solver file " + this->_mlmodel._solver);
+    if (!caffe::ReadProtoFromTextFile(this->_mlmodel._solver, &solver_param))
+      throw MLLibInternalException("failed opening solver file "
+                                   + this->_mlmodel._solver);
     bool has_mean_file = false;
     int user_batch_size, batch_size, test_batch_size, test_iter;
-    update_in_memory_net_and_solver(solver_param,cad,inputc,has_mean_file,user_batch_size,batch_size,test_batch_size,test_iter);
-    //caffe::ReadProtoFromTextFile(this->_mlmodel._solver,&solver_param);
+    update_in_memory_net_and_solver(solver_param, cad, inputc, has_mean_file,
+                                    user_batch_size, batch_size,
+                                    test_batch_size, test_iter);
+    // caffe::ReadProtoFromTextFile(this->_mlmodel._solver,&solver_param);
 
     // parameters
 #if !defined(CPU_ONLY) && !defined(USE_CAFFE_CPU_ONLY)
     bool gpu = _gpu;
     if (ad_mllib.has("gpu"))
       {
-	gpu = ad_mllib.get("gpu").get<bool>();
-	if (gpu)
-	  set_gpuid(ad_mllib);
+        gpu = ad_mllib.get("gpu").get<bool>();
+        if (gpu)
+          set_gpuid(ad_mllib);
       }
     if (gpu)
       {
-	solver_param.set_device_id(_gpuid.at(0));
-	Caffe::SetDevice(_gpuid.at(0));
-	Caffe::set_mode(Caffe::GPU);
-	Caffe::set_solver_count(_gpuid.size());
+        solver_param.set_device_id(_gpuid.at(0));
+        Caffe::SetDevice(_gpuid.at(0));
+        Caffe::set_mode(Caffe::GPU);
+        Caffe::set_solver_count(_gpuid.size());
       }
-    else Caffe::set_mode(Caffe::CPU);
+    else
+      Caffe::set_mode(Caffe::CPU);
 #else
     Caffe::set_mode(Caffe::CPU);
 #endif
-    
+
     // solver's parameters
     APIData ad_solver = ad_mllib.getobj("solver");
     if (ad_solver.size())
       {
         int max_iter = -1;
         if (ad_solver.has("iterations"))
-	  {
-	    max_iter = ad_solver.get("iterations").get<int>();
-	    solver_param.set_max_iter(max_iter);
-	  }
-	if (ad_solver.has("snapshot")) // iterations between snapshots
-	  {
-	    int snapshot = ad_solver.get("snapshot").get<int>();
-	    solver_param.set_snapshot(snapshot);
-	  }
-	if (ad_solver.has("snapshot_prefix")) // overrides default internal dd prefix which is model repo
-	  {
-	    std::string snapshot_prefix = ad_solver.get("snapshot_prefix").get<std::string>();
-	    solver_param.set_snapshot_prefix(snapshot_prefix);
-	  }
-	if (ad_solver.has("solver_type"))
-	  {
-	    std::string solver_type = ad_solver.get("solver_type").get<std::string>();
-	    if (strcasecmp(solver_type.c_str(),"SGD") == 0)
-	      solver_param.set_solver_type(caffe::SolverParameter_SolverType_SGD);
-	    else if (strcasecmp(solver_type.c_str(),"ADAGRAD") == 0)
-	      {
-		solver_param.set_solver_type(caffe::SolverParameter_SolverType_ADAGRAD);
-		solver_param.set_momentum(0.0); // cannot be used with adagrad
-	      }
-	    else if (strcasecmp(solver_type.c_str(),"NESTEROV") == 0)
-	      solver_param.set_solver_type(caffe::SolverParameter_SolverType_NESTEROV);
-	    else if (strcasecmp(solver_type.c_str(),"RMSPROP") == 0)
-	      {
-		solver_param.set_solver_type(caffe::SolverParameter_SolverType_RMSPROP);
-		solver_param.set_momentum(0.0); // not supported by Caffe PR
-	      }
-	    else if (strcasecmp(solver_type.c_str(),"ADADELTA") == 0)
-	      solver_param.set_solver_type(caffe::SolverParameter_SolverType_ADADELTA);
-	    else if (strcasecmp(solver_type.c_str(),"ADAM") == 0)
-	      solver_param.set_solver_type(caffe::SolverParameter_SolverType_ADAM);
-	    else if (strcasecmp(solver_type.c_str(),"AMSGRAD") == 0)
-	      {
-		solver_param.set_solver_type(caffe::SolverParameter_SolverType_ADAM);
-        solver_param.set_amsgrad(true);
-	      }
-        else if (strcasecmp(solver_type.c_str(),"ADAMW") == 0)
           {
-            solver_param.set_solver_type(caffe::SolverParameter_SolverType_ADAM);
-            solver_param.set_regularization_type("decoupled");
-            int periods = 4;
-            int mult = 2;
-            if (ad_solver.has("decoupled_wd_mult"))
-              solver_param.set_decoupled_wd_t0(ad_solver.get("decoupled_wd_mult").get<double>());
-            if (ad_solver.has("decoupled_wd_periods"))
-              periods = ad_solver.get("decoupled_wd_periods").get<int>();
-            if (max_iter > 0)
-              solver_param.set_decoupled_wd_t0(max_iter/ (pow(mult,periods)-1));
-            else
-              throw MLLibBadParamException("decoupled weight decay requires iterations to be set");
-
+            max_iter = ad_solver.get("iterations").get<int>();
+            solver_param.set_max_iter(max_iter);
           }
-        else if (strcasecmp(solver_type.c_str(),"SGDW") == 0)
+        if (ad_solver.has("snapshot")) // iterations between snapshots
           {
-            solver_param.set_solver_type(caffe::SolverParameter_SolverType_SGD);
-            solver_param.set_regularization_type("decoupled");
-            int periods = 4;
-            int mult = 2;
-            if (ad_solver.has("decoupled_wd_mult"))
-              solver_param.set_decoupled_wd_t0(ad_solver.get("decoupled_wd_mult").get<double>());
-            if (ad_solver.has("decoupled_wd_periods"))
-              periods = ad_solver.get("decoupled_wd_periods").get<int>();
-            if (max_iter > 0)
-              solver_param.set_decoupled_wd_t0(max_iter /  (pow(mult,periods)-1));
-            else
-              throw MLLibBadParamException("decoupled weight decay requires iterations to be set");
+            int snapshot = ad_solver.get("snapshot").get<int>();
+            solver_param.set_snapshot(snapshot);
           }
-        else if (strcasecmp(solver_type.c_str(),"AMSGRADW") == 0)
+        if (ad_solver.has("snapshot_prefix")) // overrides default internal dd
+                                              // prefix which is model repo
           {
-            solver_param.set_solver_type(caffe::SolverParameter_SolverType_ADAM);
-            solver_param.set_amsgrad(true);
-            solver_param.set_regularization_type("decoupled");
-            int periods = 4;
-            int mult = 2;
-            if (ad_solver.has("decoupled_wd_mult"))
-              solver_param.set_decoupled_wd_t0(ad_solver.get("decoupled_wd_mult").get<double>());
-            if (ad_solver.has("decoupled_wd_periods"))
-              periods = ad_solver.get("decoupled_wd_periods").get<int>();
-            if (max_iter > 0)
-              solver_param.set_decoupled_wd_t0(max_iter/ (pow(mult,periods)-1));
-            else
-              throw MLLibBadParamException("decoupled weight decay requires iterations to be set");
+            std::string snapshot_prefix
+                = ad_solver.get("snapshot_prefix").get<std::string>();
+            solver_param.set_snapshot_prefix(snapshot_prefix);
           }
-        if (ad_solver.has("rectified") && ad_solver.get("rectified").get<bool>())
-          solver_param.set_rectified(true);
+        if (ad_solver.has("solver_type"))
+          {
+            std::string solver_type
+                = ad_solver.get("solver_type").get<std::string>();
+            if (strcasecmp(solver_type.c_str(), "SGD") == 0)
+              solver_param.set_solver_type(
+                  caffe::SolverParameter_SolverType_SGD);
+            else if (strcasecmp(solver_type.c_str(), "ADAGRAD") == 0)
+              {
+                solver_param.set_solver_type(
+                    caffe::SolverParameter_SolverType_ADAGRAD);
+                solver_param.set_momentum(0.0); // cannot be used with adagrad
+              }
+            else if (strcasecmp(solver_type.c_str(), "NESTEROV") == 0)
+              solver_param.set_solver_type(
+                  caffe::SolverParameter_SolverType_NESTEROV);
+            else if (strcasecmp(solver_type.c_str(), "RMSPROP") == 0)
+              {
+                solver_param.set_solver_type(
+                    caffe::SolverParameter_SolverType_RMSPROP);
+                solver_param.set_momentum(0.0); // not supported by Caffe PR
+              }
+            else if (strcasecmp(solver_type.c_str(), "ADADELTA") == 0)
+              solver_param.set_solver_type(
+                  caffe::SolverParameter_SolverType_ADADELTA);
+            else if (strcasecmp(solver_type.c_str(), "ADAM") == 0)
+              solver_param.set_solver_type(
+                  caffe::SolverParameter_SolverType_ADAM);
+            else if (strcasecmp(solver_type.c_str(), "AMSGRAD") == 0)
+              {
+                solver_param.set_solver_type(
+                    caffe::SolverParameter_SolverType_ADAM);
+                solver_param.set_amsgrad(true);
+              }
+            else if (strcasecmp(solver_type.c_str(), "ADAMW") == 0)
+              {
+                solver_param.set_solver_type(
+                    caffe::SolverParameter_SolverType_ADAM);
+                solver_param.set_regularization_type("decoupled");
+                int periods = 4;
+                int mult = 2;
+                if (ad_solver.has("decoupled_wd_mult"))
+                  solver_param.set_decoupled_wd_t0(
+                      ad_solver.get("decoupled_wd_mult").get<double>());
+                if (ad_solver.has("decoupled_wd_periods"))
+                  periods = ad_solver.get("decoupled_wd_periods").get<int>();
+                if (max_iter > 0)
+                  solver_param.set_decoupled_wd_t0(max_iter
+                                                   / (pow(mult, periods) - 1));
+                else
+                  throw MLLibBadParamException(
+                      "decoupled weight decay requires iterations to be set");
+              }
+            else if (strcasecmp(solver_type.c_str(), "SGDW") == 0)
+              {
+                solver_param.set_solver_type(
+                    caffe::SolverParameter_SolverType_SGD);
+                solver_param.set_regularization_type("decoupled");
+                int periods = 4;
+                int mult = 2;
+                if (ad_solver.has("decoupled_wd_mult"))
+                  solver_param.set_decoupled_wd_t0(
+                      ad_solver.get("decoupled_wd_mult").get<double>());
+                if (ad_solver.has("decoupled_wd_periods"))
+                  periods = ad_solver.get("decoupled_wd_periods").get<int>();
+                if (max_iter > 0)
+                  solver_param.set_decoupled_wd_t0(max_iter
+                                                   / (pow(mult, periods) - 1));
+                else
+                  throw MLLibBadParamException(
+                      "decoupled weight decay requires iterations to be set");
+              }
+            else if (strcasecmp(solver_type.c_str(), "AMSGRADW") == 0)
+              {
+                solver_param.set_solver_type(
+                    caffe::SolverParameter_SolverType_ADAM);
+                solver_param.set_amsgrad(true);
+                solver_param.set_regularization_type("decoupled");
+                int periods = 4;
+                int mult = 2;
+                if (ad_solver.has("decoupled_wd_mult"))
+                  solver_param.set_decoupled_wd_t0(
+                      ad_solver.get("decoupled_wd_mult").get<double>());
+                if (ad_solver.has("decoupled_wd_periods"))
+                  periods = ad_solver.get("decoupled_wd_periods").get<int>();
+                if (max_iter > 0)
+                  solver_param.set_decoupled_wd_t0(max_iter
+                                                   / (pow(mult, periods) - 1));
+                else
+                  throw MLLibBadParamException(
+                      "decoupled weight decay requires iterations to be set");
+              }
+            if (ad_solver.has("rectified")
+                && ad_solver.get("rectified").get<bool>())
+              solver_param.set_rectified(true);
 
-
-        caffe::UpgradeSolverType(&solver_param);
-	  }
-	if (ad_solver.has("test_interval"))
-	  solver_param.set_test_interval(ad_solver.get("test_interval").get<int>());
-	if (ad_solver.has("test_initialization"))
-	  solver_param.set_test_initialization(ad_solver.get("test_initialization").get<bool>());
-	if (ad_solver.has("lr_policy"))
-	  solver_param.set_lr_policy(ad_solver.get("lr_policy").get<std::string>());
-	if (ad_solver.has("base_lr"))
-	  solver_param.set_base_lr(ad_solver.get("base_lr").get<double>());
-	if (ad_solver.has("warmup_lr"))
-	  solver_param.set_warmup_start_lr(ad_solver.get("warmup_lr").get<double>());
-	if (ad_solver.has("warmup_iter"))
-	  solver_param.set_warmup_iter(ad_solver.get("warmup_iter").get<int>());
-	if (ad_solver.has("gamma"))
-	  solver_param.set_gamma(ad_solver.get("gamma").get<double>());
-	if (ad_solver.has("stepsize"))
-	  solver_param.set_stepsize(ad_solver.get("stepsize").get<int>());
-	if (ad_solver.has("stepvalue"))
-	  {
-	    std::vector<int> stepvalues = ad_solver.get("stepvalue").get<std::vector<int>>();
-	    for (auto sv: stepvalues)
-	      solver_param.add_stepvalue(sv);
-	  }
-	if (ad_solver.has("momentum") && solver_param.solver_type() != caffe::SolverParameter_SolverType_ADAGRAD)
-	  solver_param.set_momentum(ad_solver.get("momentum").get<double>());
-	if (ad_solver.has("weight_decay"))
-	  solver_param.set_weight_decay(ad_solver.get("weight_decay").get<double>());
-	if (ad_solver.has("power"))
-	  solver_param.set_power(ad_solver.get("power").get<double>());
-	if (ad_solver.has("rms_decay"))
-	  solver_param.set_rms_decay(ad_solver.get("rms_decay").get<double>());
-	if (ad_solver.has("iter_size"))
-	  solver_param.set_iter_size(ad_solver.get("iter_size").get<int>());
-	if (ad_solver.has("lookahead"))
-	  solver_param.set_lookahead(ad_solver.get("lookahead").get<bool>());
-	if (ad_solver.has("lookahead_steps"))
-	  solver_param.set_lookahead_steps(ad_solver.get("lookahead_steps").get<int>());
-	if (ad_solver.has("lookahead_alpha"))
-	  solver_param.set_lookahead_alpha(ad_solver.get("lookahead_alpha").get<double>());
-	if (ad_solver.has("lr_dropout"))
-	  solver_param.set_lr_dropout(ad_solver.get("lr_dropout").get<double>());
-	if (ad_solver.has("min_lr"))
-	  solver_param.set_min_lr(ad_solver.get("min_lr").get<double>());
-	if (ad_solver.has("lr_mult"))
-	  solver_param.set_lr_mult(ad_solver.get("lr_mult").get<double>());
-	double p_mult = -1;
-	if (ad_solver.has("p_mult")) {
-	  p_mult = ad_solver.get("p_mult").get<double>();
-	  solver_param.set_p_mult(p_mult);
-	}
-	if (ad_solver.has("period"))
-	  solver_param.set_period(ad_solver.get("period").get<int>());
-	else if (ad_solver.has("ncycles")) {
-	  // compute initial period length in order to have num_period cycle until max_iter
-	  int ncycles = ad_solver.get("ncycles").get<int>();
-	  if (p_mult < 0) {
-	    p_mult = 2.0;
-	    solver_param.set_p_mult(p_mult);
-	  }
-	  if (max_iter > 0) {
-	    int period = ((float) max_iter)  / ( pow(p_mult, ncycles) - 1.0);
-	    solver_param.set_period(period);
-	  } else
-	    throw MLLibBadParamException("sgdr + ncycles  requires iterations to be set");
-	}
+            caffe::UpgradeSolverType(&solver_param);
+          }
+        if (ad_solver.has("test_interval"))
+          solver_param.set_test_interval(
+              ad_solver.get("test_interval").get<int>());
+        if (ad_solver.has("test_initialization"))
+          solver_param.set_test_initialization(
+              ad_solver.get("test_initialization").get<bool>());
+        if (ad_solver.has("lr_policy"))
+          solver_param.set_lr_policy(
+              ad_solver.get("lr_policy").get<std::string>());
+        if (ad_solver.has("base_lr"))
+          solver_param.set_base_lr(ad_solver.get("base_lr").get<double>());
+        if (ad_solver.has("warmup_lr"))
+          solver_param.set_warmup_start_lr(
+              ad_solver.get("warmup_lr").get<double>());
+        if (ad_solver.has("warmup_iter"))
+          solver_param.set_warmup_iter(
+              ad_solver.get("warmup_iter").get<int>());
+        if (ad_solver.has("gamma"))
+          solver_param.set_gamma(ad_solver.get("gamma").get<double>());
+        if (ad_solver.has("stepsize"))
+          solver_param.set_stepsize(ad_solver.get("stepsize").get<int>());
+        if (ad_solver.has("stepvalue"))
+          {
+            std::vector<int> stepvalues
+                = ad_solver.get("stepvalue").get<std::vector<int>>();
+            for (auto sv : stepvalues)
+              solver_param.add_stepvalue(sv);
+          }
+        if (ad_solver.has("momentum")
+            && solver_param.solver_type()
+                   != caffe::SolverParameter_SolverType_ADAGRAD)
+          solver_param.set_momentum(ad_solver.get("momentum").get<double>());
+        if (ad_solver.has("weight_decay"))
+          solver_param.set_weight_decay(
+              ad_solver.get("weight_decay").get<double>());
+        if (ad_solver.has("power"))
+          solver_param.set_power(ad_solver.get("power").get<double>());
+        if (ad_solver.has("rms_decay"))
+          solver_param.set_rms_decay(ad_solver.get("rms_decay").get<double>());
+        if (ad_solver.has("iter_size"))
+          solver_param.set_iter_size(ad_solver.get("iter_size").get<int>());
+        if (ad_solver.has("lookahead"))
+          solver_param.set_lookahead(ad_solver.get("lookahead").get<bool>());
+        if (ad_solver.has("lookahead_steps"))
+          solver_param.set_lookahead_steps(
+              ad_solver.get("lookahead_steps").get<int>());
+        if (ad_solver.has("lookahead_alpha"))
+          solver_param.set_lookahead_alpha(
+              ad_solver.get("lookahead_alpha").get<double>());
+        if (ad_solver.has("lr_dropout"))
+          solver_param.set_lr_dropout(
+              ad_solver.get("lr_dropout").get<double>());
+        if (ad_solver.has("min_lr"))
+          solver_param.set_min_lr(ad_solver.get("min_lr").get<double>());
+        if (ad_solver.has("lr_mult"))
+          solver_param.set_lr_mult(ad_solver.get("lr_mult").get<double>());
+        double p_mult = -1;
+        if (ad_solver.has("p_mult"))
+          {
+            p_mult = ad_solver.get("p_mult").get<double>();
+            solver_param.set_p_mult(p_mult);
+          }
+        if (ad_solver.has("period"))
+          solver_param.set_period(ad_solver.get("period").get<int>());
+        else if (ad_solver.has("ncycles"))
+          {
+            // compute initial period length in order to have num_period cycle
+            // until max_iter
+            int ncycles = ad_solver.get("ncycles").get<int>();
+            if (p_mult < 0)
+              {
+                p_mult = 2.0;
+                solver_param.set_p_mult(p_mult);
+              }
+            if (max_iter > 0)
+              {
+                int period = ((float)max_iter) / (pow(p_mult, ncycles) - 1.0);
+                solver_param.set_period(period);
+              }
+            else
+              throw MLLibBadParamException(
+                  "sgdr + ncycles  requires iterations to be set");
+          }
       }
-    
+
     // optimize
     this->_tjob_running = true;
     boost::shared_ptr<caffe::Solver<float>> solver;
     try
       {
-	solver.reset(caffe::SolverRegistry<float>::CreateSolver(solver_param));
-    this->_logger->info("selected solver: " + solver_param.type());
-    if (solver_param.amsgrad())
-    this->_logger->info("solver flavor : AMSGRAD ");
-    if (solver_param.rectified())
-      this->_logger->info("solver flavor : rectified ");
-    if (solver_param.regularization_type() == "decoupled")
-      this->_logger->info("solver flavor: decoupled weight decay ");
-    if (solver_param.lookahead())
-      this->_logger->info("solver flavor: lookahead ");
-    if (solver_param.lr_dropout() != 1.0)
-      this->_logger->info("solver flavor: lr dropout " + std::to_string(solver_param.lr_dropout()));
+        solver.reset(caffe::SolverRegistry<float>::CreateSolver(solver_param));
+        this->_logger->info("selected solver: " + solver_param.type());
+        if (solver_param.amsgrad())
+          this->_logger->info("solver flavor : AMSGRAD ");
+        if (solver_param.rectified())
+          this->_logger->info("solver flavor : rectified ");
+        if (solver_param.regularization_type() == "decoupled")
+          this->_logger->info("solver flavor: decoupled weight decay ");
+        if (solver_param.lookahead())
+          this->_logger->info("solver flavor: lookahead ");
+        if (solver_param.lr_dropout() != 1.0)
+          this->_logger->info("solver flavor: lr dropout "
+                              + std::to_string(solver_param.lr_dropout()));
       }
-    catch(...)
+    catch (...)
       {
-	throw MLLibInternalException("solver creation exception");
+        throw MLLibInternalException("solver creation exception");
       }
     try
       {
-	model_type(solver->net().get(),this->_mltype);
+        model_type(solver->net().get(), this->_mltype);
       }
     catch (std::exception &e)
       {
-	this->_logger->error("failed determining mltype");
+        this->_logger->error("failed determining mltype");
       }
     if (!inputc._dv.empty() || !inputc._dv_sparse.empty())
       {
-	this->_logger->info("filling up net prior to training");
-	try {
-	  if (!inputc._sparse)
-	    {
-	      if (boost::dynamic_pointer_cast<caffe::MemoryDataLayer<float>>(solver->net()->layers()[0]) == 0)
-		{
-		  throw MLLibBadParamException("solver's net's first layer is required to be of MemoryData type");
-		}
-	      boost::dynamic_pointer_cast<caffe::MemoryDataLayer<float>>(solver->net()->layers()[0])->AddDatumVector(inputc._dv);
-	    }
-	  else
-	    {
-	      if (boost::dynamic_pointer_cast<caffe::MemorySparseDataLayer<float>>(solver->net()->layers()[0]) == 0)
-		{
-		  throw MLLibBadParamException("solver's net's first layer is required to be of MemorySparseData type");
-		}
-	      boost::dynamic_pointer_cast<caffe::MemorySparseDataLayer<float>>(solver->net()->layers()[0])->AddDatumVector(inputc._dv_sparse);
-	    }
-	}
-	catch(std::exception &e)
-	  {
-	    throw;
-	  }
-	inputc._dv.clear();
-	inputc._dv_sparse.clear();
-	inputc._ids.clear();
+        this->_logger->info("filling up net prior to training");
+        try
+          {
+            if (!inputc._sparse)
+              {
+                if (boost::dynamic_pointer_cast<caffe::MemoryDataLayer<float>>(
+                        solver->net()->layers()[0])
+                    == 0)
+                  {
+                    throw MLLibBadParamException(
+                        "solver's net's first layer is required to be of "
+                        "MemoryData type");
+                  }
+                boost::dynamic_pointer_cast<caffe::MemoryDataLayer<float>>(
+                    solver->net()->layers()[0])
+                    ->AddDatumVector(inputc._dv);
+              }
+            else
+              {
+                if (boost::dynamic_pointer_cast<
+                        caffe::MemorySparseDataLayer<float>>(
+                        solver->net()->layers()[0])
+                    == 0)
+                  {
+                    throw MLLibBadParamException(
+                        "solver's net's first layer is required to be of "
+                        "MemorySparseData type");
+                  }
+                boost::dynamic_pointer_cast<
+                    caffe::MemorySparseDataLayer<float>>(
+                    solver->net()->layers()[0])
+                    ->AddDatumVector(inputc._dv_sparse);
+              }
+          }
+        catch (std::exception &e)
+          {
+            throw;
+          }
+        inputc._dv.clear();
+        inputc._dv_sparse.clear();
+        inputc._ids.clear();
       }
-    if (this->_mlmodel.read_from_repository(this->_mlmodel._repo,this->_logger))
-      throw MLLibBadParamException("error reading or listing Caffe models in repository " + this->_mlmodel._repo);
+    if (this->_mlmodel.read_from_repository(this->_mlmodel._repo,
+                                            this->_logger))
+      throw MLLibBadParamException(
+          "error reading or listing Caffe models in repository "
+          + this->_mlmodel._repo);
     this->_mlmodel.read_corresp_file();
     if (ad_mllib.has("resume") && ad_mllib.get("resume").get<bool>())
       {
-        std::string bestfilename = this->_mlmodel._repo + this->_mlmodel._best_model_filename;
+        std::string bestfilename
+            = this->_mlmodel._repo + this->_mlmodel._best_model_filename;
         std::ifstream bestfile;
         try
           {
             std::string tmp;
-            bestfile.open(bestfilename,std::ios::in);
+            bestfile.open(bestfilename, std::ios::in);
             // first three fields are thrown away
             bestfile >> tmp >> tmp >> tmp >> tmp;
             bestfile.close();
@@ -1455,60 +1716,68 @@ namespace dd
         catch (std::exception &e)
           {
             this->_logger->info("no previous best model file");
-	  }
+          }
 
-	if (this->_mlmodel._sstate.empty())
-	  {
-	    this->_logger->error("resuming a model requires a .solverstate file in model repository");
-	    throw MLLibBadParamException("resuming a model requires a .solverstate file in model repository");
-	  }
-	else 
-	  {
-	    try
-	      {
-		solver->Restore(this->_mlmodel._sstate.c_str());
-	      }
-	    catch(std::exception &e)
-	      {
-		this->_logger->error("Failed restoring network state");
-		throw;
-	      }
-	  }
+        if (this->_mlmodel._sstate.empty())
+          {
+            this->_logger->error("resuming a model requires a .solverstate "
+                                 "file in model repository");
+            throw MLLibBadParamException(
+                "resuming a model requires a .solverstate file in model "
+                "repository");
+          }
+        else
+          {
+            try
+              {
+                solver->Restore(this->_mlmodel._sstate.c_str());
+              }
+            catch (std::exception &e)
+              {
+                this->_logger->error("Failed restoring network state");
+                throw;
+              }
+          }
       }
     else if (!this->_mlmodel._sstate.empty())
       {
-	this->_logger->error("not resuming while a .solverstate file remains in model repository");
-	throw MLLibBadParamException("a .solverstate file requires a resume argument for training, otherwise delete existing training state files (with clear=lib) to cleanup the model repository");
+        this->_logger->error("not resuming while a .solverstate file remains "
+                             "in model repository");
+        throw MLLibBadParamException(
+            "a .solverstate file requires a resume argument for training, "
+            "otherwise delete existing training state files (with clear=lib) "
+            "to cleanup the model repository");
       }
     else if (!this->_mlmodel._weights.empty())
       {
-	try
-	  {
-	    solver->net()->CopyTrainedLayersFrom(this->_mlmodel._weights);
-	  }
-	catch(std::exception &e)
-	  {
-	    throw;
-	  }
+        try
+          {
+            solver->net()->CopyTrainedLayersFrom(this->_mlmodel._weights);
+          }
+        catch (std::exception &e)
+          {
+            throw;
+          }
       }
     else
       {
-	solver->iter_ = 0;
-	solver->current_step_ = 0;
+        solver->iter_ = 0;
+        solver->current_step_ = 0;
       }
-    
+
     if (_gpuid.size() > 1)
       {
-	_sync = new caffe::P2PSync<float>(solver,nullptr,solver->param());
-	_syncs = std::vector<boost::shared_ptr<caffe::P2PSync<float>>>(_gpuid.size());
-	_sync->Prepare(_gpuid, &_syncs); 
-	for (size_t i=1;i<_syncs.size();++i)
-	  _syncs[i]->StartInternalThread();
+        _sync = new caffe::P2PSync<float>(solver, nullptr, solver->param());
+        _syncs = std::vector<boost::shared_ptr<caffe::P2PSync<float>>>(
+            _gpuid.size());
+        _sync->Prepare(_gpuid, &_syncs);
+        for (size_t i = 1; i < _syncs.size(); ++i)
+          _syncs[i]->StartInternalThread();
       }
 
     this->_mem_used_train = solver->net_->memory_used();
-    for (caffe::shared_ptr<caffe::Net<float > > n: solver->test_nets())
-      this->_mem_used_test+= n->memory_used();
+    for (caffe::shared_ptr<caffe::Net<float>> n : solver->test_nets())
+      this->_mem_used_test += n->memory_used();
 
     const int start_iter = solver->iter_;
     int average_loss = solver->param_.average_loss();
@@ -1516,142 +1785,170 @@ namespace dd
     if (!ad_mllib.has("resume") || !ad_mllib.get("resume").get<bool>())
       this->clear_all_meas_per_iter();
     float smoothed_loss = 0.0;
-    while(solver->iter_ < solver->param_.max_iter()
-	  && this->_tjob_running.load())
+    while (solver->iter_ < solver->param_.max_iter()
+           && this->_tjob_running.load())
       {
-	this->add_meas("iteration",solver->iter_);
+        this->add_meas("iteration", solver->iter_);
 
-	solver->net_->ClearParamDiffs();
-	
-	// Save a snapshot if needed.
-       bool already_snapshoted = false;
-	if (solver->param_.snapshot() && solver->iter_ > start_iter &&
-	    solver->iter_ % solver->param_.snapshot() == 0) {
-	  solver->Snapshot();
-         already_snapshoted = true;
-	}
-	if (solver->param_.test_interval() && solver->iter_ % solver->param_.test_interval() == 0
-	    && (solver->iter_ > 0 || solver->param_.test_initialization())) 
-	  {
-	    APIData meas_out;
-	    solver->test_nets().at(0).get()->ShareTrainedLayersWith(solver->net().get());
-	    test(solver->test_nets().at(0).get(),ad,inputc,test_batch_size,has_mean_file,test_iter,meas_out);
-           APIData meas_obj = meas_out.getobj("measure");
+        solver->net_->ClearParamDiffs();
 
-	    // save best iteration snapshot
-	    save_if_best(meas_obj, solver, already_snapshoted);
+        // Save a snapshot if needed.
+        bool already_snapshoted = false;
+        if (solver->param_.snapshot() && solver->iter_ > start_iter
+            && solver->iter_ % solver->param_.snapshot() == 0)
+          {
+            solver->Snapshot();
+            already_snapshoted = true;
+          }
+        if (solver->param_.test_interval()
+            && solver->iter_ % solver->param_.test_interval() == 0
+            && (solver->iter_ > 0 || solver->param_.test_initialization()))
+          {
+            APIData meas_out;
+            solver->test_nets().at(0).get()->ShareTrainedLayersWith(
+                solver->net().get());
+            test(solver->test_nets().at(0).get(), ad, inputc, test_batch_size,
+                 has_mean_file, test_iter, meas_out);
+            APIData meas_obj = meas_out.getobj("measure");
 
-	    std::vector<std::string> meas_str = meas_obj.list_keys();
-	    this->_logger->info("batch size={}",batch_size);
-	    
-	    for (auto m: meas_str)
-	      {
+            // save best iteration snapshot
+            save_if_best(meas_obj, solver, already_snapshoted);
 
-			if (m != "cmdiag" && m != "cmfull" && m != "clacc" && m != "labels" && m!= "cliou"
-				&& m != "precisions" && m != "recalls" && m != "f1s")
-			  // do not report confusion matrix in server logs
-		  {
-		    double mval = meas_obj.get(m).get<double>();
-		    this->_logger->info("{}={}",m,mval);
-		    this->add_meas(m,mval);
-		    this->add_meas_per_iter(m,mval);
-		  }
-		else if (m == "cmdiag" || m == "clacc" || m == "cliou"
-				 || m == "precisions" || m == "recalls" || m == "f1s")
-		  {
-		    std::vector<double> mdiag = meas_obj.get(m).get<std::vector<double>>();
-		    std::vector<std::string> cnames;
-		    std::string mdiag_str;
-		    for (size_t i=0;i<mdiag.size();i++)
-		      {
-			mdiag_str += this->_mlmodel.get_hcorresp(i) + ":" + std::to_string(mdiag.at(i)) + " ";
-			this->add_meas_per_iter(m+'_'+this->_mlmodel.get_hcorresp(i),mdiag.at(i));
-			cnames.push_back(this->_mlmodel.get_hcorresp(i));
-		      }
-		    this->_logger->info("{}=[{}]",m,mdiag_str);
-		    this->add_meas(m,mdiag,cnames);
-		  }
-	      }
-	  }
-	
-	float loss = 0.0;
-	float avg_fb_time = 0.0;
-	float est_remain_time = 0.0;
-	std::string est_remain_time_str;
-	try
-	  {
-	    for (size_t i = 0; i < solver->callbacks().size(); ++i) {
-	      solver->callbacks()[i]->on_start();
-	    }
-	    for (int i = 0; i < solver->param_.iter_size(); ++i)
-	      {
-		std::chrono::time_point<std::chrono::system_clock> tstart = std::chrono::system_clock::now();
-		loss += solver->net_->ForwardBackward();
-		std::chrono::time_point<std::chrono::system_clock> tstop = std::chrono::system_clock::now();
-		avg_fb_time += std::chrono::duration_cast<std::chrono::milliseconds>(tstop-tstart).count();
-	      }
-	    loss /= solver->param_.iter_size();
-	    avg_fb_time /= solver->param_.iter_size();
-	    est_remain_time = avg_fb_time * solver->param_.iter_size() * (solver->param_.max_iter() - solver->iter_) / 1000.0;
-	  }
-	catch(std::exception &e)
-	  {
-	    this->_logger->error("exception while forward/backward pass through the network");
-	    if (_sync)
-	      {
-		for (size_t i=1;i<_syncs.size();++i)
-		  _syncs[i]->StopInternalThread();
-	      }
-	    delete _sync;
-	    throw;
-	  }
-	if (static_cast<int>(losses.size()) < average_loss) 
-	  {
-	    losses.push_back(loss);
-	    int size = losses.size();
-	    smoothed_loss = (smoothed_loss * (size - 1) + loss) / size;
-	  } 
-	else 
-	  {
-	    int idx = (solver->iter_ - start_iter) % average_loss;
-	    smoothed_loss += (loss - losses[idx]) / average_loss;
-	    losses[idx] = loss;
-	  }
-	this->add_meas("train_loss",smoothed_loss);
-	this->add_meas_per_iter("train_loss",smoothed_loss);
-	this->add_meas("iter_time",avg_fb_time);
-	this->add_meas("remain_time",est_remain_time);
+            std::vector<std::string> meas_str = meas_obj.list_keys();
+            this->_logger->info("batch size={}", batch_size);
 
-    caffe::SGDSolver<float> *sgd_solver = static_cast<caffe::SGDSolver<float>*>(solver.get());
-    this->add_meas("learning_rate", sgd_solver->GetLearningRate());
-    this->add_meas_per_iter("learning_rate", sgd_solver->GetLearningRate());
-	
-	if ((solver->param_.display() && solver->iter_ % solver->param_.display() == 0)
-	    || (solver->param_.test_interval() && solver->iter_ % solver->param_.test_interval() == 0))
-	  {
-	    this->_logger->info("Iteration {}, lr = {}, smoothed_loss={}",solver->iter_,sgd_solver->GetLearningRate(),this->get_meas("train_loss"));
-        if (sgd_solver->param_.warmup_iter() > 0)
-          this->_logger->info("[doing warmup (start_lr = {}, iter = {})]",solver->param_.warmup_start_lr(),solver->param_.warmup_iter());
-	  }
-	try
-	  {
-	    for (size_t i = 0; i < solver->callbacks().size(); ++i) {
-	      solver->callbacks()[i]->on_gradients_ready();
-	    }
-	    solver->iter_++;
-	    solver->ApplyUpdate(false); // no iteration logging from within caffe
-	  }
-	catch (std::exception &e)
-	  {
-	    this->_logger->error("exception while updating network");
-	    if (_sync)
-	      {
-		for (size_t i=1;i<_syncs.size();++i)
-		  _syncs[i]->StopInternalThread();
-	      }
-	    delete _sync;
-	    throw;
-	  }
+            for (auto m : meas_str)
+              {
+
+                if (m != "cmdiag" && m != "cmfull" && m != "clacc"
+                    && m != "labels" && m != "cliou" && m != "precisions"
+                    && m != "recalls" && m != "f1s")
+                  // do not report confusion matrix in server logs
+                  {
+                    double mval = meas_obj.get(m).get<double>();
+                    this->_logger->info("{}={}", m, mval);
+                    this->add_meas(m, mval);
+                    this->add_meas_per_iter(m, mval);
+                  }
+                else if (m == "cmdiag" || m == "clacc" || m == "cliou"
+                         || m == "precisions" || m == "recalls" || m == "f1s")
+                  {
+                    std::vector<double> mdiag
+                        = meas_obj.get(m).get<std::vector<double>>();
+                    std::vector<std::string> cnames;
+                    std::string mdiag_str;
+                    for (size_t i = 0; i < mdiag.size(); i++)
+                      {
+                        mdiag_str += this->_mlmodel.get_hcorresp(i) + ":"
+                                     + std::to_string(mdiag.at(i)) + " ";
+                        this->add_meas_per_iter(
+                            m + '_' + this->_mlmodel.get_hcorresp(i),
+                            mdiag.at(i));
+                        cnames.push_back(this->_mlmodel.get_hcorresp(i));
+                      }
+                    this->_logger->info("{}=[{}]", m, mdiag_str);
+                    this->add_meas(m, mdiag, cnames);
+                  }
+              }
+          }
+
+        float loss = 0.0;
+        float avg_fb_time = 0.0;
+        float est_remain_time = 0.0;
+        std::string est_remain_time_str;
+        try
+          {
+            for (size_t i = 0; i < solver->callbacks().size(); ++i)
+              {
+                solver->callbacks()[i]->on_start();
+              }
+            for (int i = 0; i < solver->param_.iter_size(); ++i)
+              {
+                std::chrono::time_point<std::chrono::system_clock> tstart
+                    = std::chrono::system_clock::now();
+                loss += solver->net_->ForwardBackward();
+                std::chrono::time_point<std::chrono::system_clock> tstop
+                    = std::chrono::system_clock::now();
+                avg_fb_time
+                    += std::chrono::duration_cast<std::chrono::milliseconds>(
+                           tstop - tstart)
+                           .count();
+              }
+            loss /= solver->param_.iter_size();
+            avg_fb_time /= solver->param_.iter_size();
+            est_remain_time = avg_fb_time * solver->param_.iter_size()
+                              * (solver->param_.max_iter() - solver->iter_)
+                              / 1000.0;
+          }
+        catch (std::exception &e)
+          {
+            this->_logger->error(
+                "exception while forward/backward pass through the network");
+            if (_sync)
+              {
+                for (size_t i = 1; i < _syncs.size(); ++i)
+                  _syncs[i]->StopInternalThread();
+              }
+            delete _sync;
+            throw;
+          }
+        if (static_cast<int>(losses.size()) < average_loss)
+          {
+            losses.push_back(loss);
+            int size = losses.size();
+            smoothed_loss = (smoothed_loss * (size - 1) + loss) / size;
+          }
+        else
+          {
+            int idx = (solver->iter_ - start_iter) % average_loss;
+            smoothed_loss += (loss - losses[idx]) / average_loss;
+            losses[idx] = loss;
+          }
+        this->add_meas("train_loss", smoothed_loss);
+        this->add_meas_per_iter("train_loss", smoothed_loss);
+        this->add_meas("iter_time", avg_fb_time);
+        this->add_meas("remain_time", est_remain_time);
+
+        caffe::SGDSolver<float> *sgd_solver
+            = static_cast<caffe::SGDSolver<float> *>(solver.get());
+        this->add_meas("learning_rate", sgd_solver->GetLearningRate());
+        this->add_meas_per_iter("learning_rate",
+                                sgd_solver->GetLearningRate());
+
+        if ((solver->param_.display()
+             && solver->iter_ % solver->param_.display() == 0)
+            || (solver->param_.test_interval()
+                && solver->iter_ % solver->param_.test_interval() == 0))
+          {
+            this->_logger->info("Iteration {}, lr = {}, smoothed_loss={}",
+                                solver->iter_, sgd_solver->GetLearningRate(),
+                                this->get_meas("train_loss"));
+            if (sgd_solver->param_.warmup_iter() > 0)
+              this->_logger->info("[doing warmup (start_lr = {}, iter = {})]",
+                                  solver->param_.warmup_start_lr(),
+                                  solver->param_.warmup_iter());
+          }
+        try
+          {
+            for (size_t i = 0; i < solver->callbacks().size(); ++i)
+              {
+                solver->callbacks()[i]->on_gradients_ready();
+              }
+            solver->iter_++;
+            solver->ApplyUpdate(
+                false); // no iteration logging from within caffe
+          }
+        catch (std::exception &e)
+          {
+            this->_logger->error("exception while updating network");
+            if (_sync)
+              {
+                for (size_t i = 1; i < _syncs.size(); ++i)
+                  _syncs[i]->StopInternalThread();
+              }
+            delete _sync;
+            throw;
+          }
       }
 
     // always save final snapshot.
@@ -1664,31 +1961,39 @@ namespace dd
 
     if (_sync)
       {
-	for (size_t i=1;i<_syncs.size();++i)
-	  _syncs[i]->StopInternalThread();
-	delete _sync;
+        for (size_t i = 1; i < _syncs.size(); ++i)
+          _syncs[i]->StopInternalThread();
+        delete _sync;
       }
 
     // bail on forced stop, i.e. not testing the net further.
     if (!this->_tjob_running.load())
       {
-	inputc._dv_test.clear();
-	inputc._dv_test_sparse.clear();
-	return 0;
+        inputc._dv_test.clear();
+        inputc._dv_test_sparse.clear();
+        return 0;
       }
-    
+
     solver_param = caffe::SolverParameter();
-    if (this->_mlmodel.read_from_repository(this->_mlmodel._repo,this->_logger,true))
-      throw MLLibBadParamException("error reading or listing Caffe models in repository " + this->_mlmodel._repo);
+    if (this->_mlmodel.read_from_repository(this->_mlmodel._repo,
+                                            this->_logger, true))
+      throw MLLibBadParamException(
+          "error reading or listing Caffe models in repository "
+          + this->_mlmodel._repo);
     int cm = create_model();
     if (cm == 1)
-      throw MLLibInternalException("no model in " + this->_mlmodel._repo + " for initializing the net");
+      throw MLLibInternalException("no model in " + this->_mlmodel._repo
+                                   + " for initializing the net");
     else if (cm == 2)
-      throw MLLibBadParamException("no deploy file in " + this->_mlmodel._repo + " for initializing the net");
-    
+      throw MLLibBadParamException("no deploy file in " + this->_mlmodel._repo
+                                   + " for initializing the net");
+
     // test
-    if (!inputc._ctc && !inputc._bbox) // ctc uses the accuracy computed from within the net, and bbox models use special layer as well, can't run test with deploy
-      test(_net,ad,inputc,test_batch_size,has_mean_file,test_iter,out);
+    if (!inputc._ctc
+        && !inputc._bbox) // ctc uses the accuracy computed from within the
+                          // net, and bbox models use special layer as well,
+                          // can't run test with deploy
+      test(_net, ad, inputc, test_batch_size, has_mean_file, test_iter, out);
     inputc._dv_test.clear();
     inputc._dv_test_sparse.clear();
 
@@ -1698,20 +2003,20 @@ namespace dd
     // if batch_size has been recomputed, let the user know
     if (user_batch_size != batch_size)
       {
-	APIData advb;
-	advb.add("batch_size",batch_size);
-	if (!out.has("parameters"))
-	  {
-	    APIData adparams;
-	    adparams.add("mllib",advb);
-	    out.add("parameters",adparams);
-	  }
-	else
-	  {
-	    APIData adparams = out.getobj("parameters");
-	    adparams.add("mllib",advb);
-	    out.add("parameters",adparams);
-	  }
+        APIData advb;
+        advb.add("batch_size", batch_size);
+        if (!out.has("parameters"))
+          {
+            APIData adparams;
+            adparams.add("mllib", advb);
+            out.add("parameters", adparams);
+          }
+        else
+          {
+            APIData adparams = out.getobj("parameters");
+            adparams.add("mllib", advb);
+            out.add("parameters", adparams);
+          }
       }
 
     // reset db input connector, ready for in-memory prediction
@@ -1721,26 +2026,25 @@ namespace dd
     // if there's target repository, copy relevant data there
     APIData ad_out = ad.getobj("parameters").getobj("output");
     if (ad_out.has("target_repository"))
-      this->_mlmodel.copy_to_target(this->_mlmodel._repo,
-				    ad_out.get("target_repository").get<std::string>(),
-				    this->_logger);
-    
+      this->_mlmodel.copy_to_target(
+          this->_mlmodel._repo,
+          ad_out.get("target_repository").get<std::string>(), this->_logger);
+
     return 0;
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::test(caffe::Net<float> *net,
-										 const APIData &ad,
-										 TInputConnectorStrategy &inputc,
-										 const int &test_batch_size,
-										 const bool &has_mean_file,
-										 const int &test_iter,
-										 APIData &out)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void
+  CaffeLib<TInputConnectorStrategy, TOutputConnectorStrategy, TMLModel>::test(
+      caffe::Net<float> *net, const APIData &ad,
+      TInputConnectorStrategy &inputc, const int &test_batch_size,
+      const bool &has_mean_file, const int &test_iter, APIData &out)
   {
     APIData ad_res;
-    ad_res.add("iteration",this->get_meas("iteration"));
-    ad_res.add("train_loss",this->get_meas("train_loss"));
-    ad_res.add("learning_rate",this->get_meas("learning_rate"));
+    ad_res.add("iteration", this->get_meas("iteration"));
+    ad_res.add("train_loss", this->get_meas("train_loss"));
+    ad_res.add("learning_rate", this->get_meas("learning_rate"));
     APIData ad_out = ad.getobj("parameters").getobj("output");
 
     bool output_logits = false;
@@ -1748,539 +2052,653 @@ namespace dd
       output_logits = ad_out.get("logits").get<bool>();
 
     boost::shared_ptr<Blob<float>> logits_blob;
-    if (ad_out.has("logits_blob")) {
-      std::string logits_blob_name = ad_out.get("logits_blob").get<std::string>();
-      logits_blob = findBlobByName(net,logits_blob_name);
-      output_logits = true;
-    }
-
+    if (ad_out.has("logits_blob"))
+      {
+        std::string logits_blob_name
+            = ad_out.get("logits_blob").get<std::string>();
+        logits_blob = findBlobByName(net, logits_blob_name);
+        output_logits = true;
+      }
 
     if (ad.getobj("parameters").getobj("mllib").has("ignore_label"))
       {
-        int ignore_label = ad.getobj("parameters").getobj("mllib").get("ignore_label").get<int>();
+        int ignore_label = ad.getobj("parameters")
+                               .getobj("mllib")
+                               .get("ignore_label")
+                               .get<int>();
         ad_res.add("ignore_label", ignore_label);
       }
 
     if (ad_out.has("measure"))
       {
-	float mean_loss = 0.0;
-	int tresults = 0;
-	int nout = _nclasses;
-	int inner_meas_iter = 0;
-	float net_meas = 0.0;
-	if (_regression && _ntargets > 1)
-	  nout = _ntargets;
-	if (_autoencoder)
-	  {
-	    if (typeid(inputc) == typeid(ImgCaffeInputFileConn))
-	      nout = inputc.channels() * inputc.width() * inputc.height();
-	    else nout = inputc.channels();
-	  }
-	ad_res.add("nclasses",_nclasses);
-	inputc.reset_dv_test();
-	std::map<int,std::map<int,std::vector<std::pair<float,int>>>> all_true_pos;
-	std::map<int,std::map<int,std::vector<std::pair<float,int>>>> all_false_pos;
-	std::map<int,std::map<int,std::vector<std::vector<float>>>> all_logits_pos;
-	std::map<int,std::map<int,int>> all_num_pos;
-	while(true)
-	  {
-	    size_t dv_size = 0;
-	    std::vector<float> dv_labels;
-	    std::vector<std::vector<double>> dv_float_data;
-	    try
-	      {
-               if (inputc._ctc || inputc._bbox)
-		  {
-		    // do nothing, db input
-		    dv_size = test_batch_size;
-		  }
-		else if (!inputc._sparse)
-		  {
-		    std::vector<caffe::Datum> seg_dv;
-		    std::vector<caffe::Datum> dv = inputc.get_dv_test(test_batch_size,!_autoencoder ? has_mean_file : false);
-		    if (dv.empty())
-		      break;
-		    dv_size = dv.size();
-		    for (size_t s=0;s<dv_size;s++)
-		      {
-			if (inputc._segmentation)
-			  {
-			    // dv_labels will need to be of size width x height x batch size -> use dv_float_data
-			    // -> read datum 2 by 2 -> skip s (read s 2 by 2)
-			    if (!(s % 2))
-			      {
-				std::vector<double> vals;
-				for (int k=0;k<dv.at(s+1).float_data_size();k++)
-				  vals.push_back(dv.at(s+1).float_data(k));
-				dv_float_data.push_back(vals);
-				seg_dv.push_back(dv.at(s));
-			      }
-			  }
-			// imagedata layer
-			//- store labels in float_data
-			//- similar to segmentation for computing multi-label accuracy
-			else if ((inputc._multi_label || _regression) && !(inputc._db) && typeid(inputc) == typeid(ImgCaffeInputFileConn)
-				 && (_nclasses > 1 || _ntargets > 1))
-			  {
-			    std::vector<double> vals;
-			    for (int k=0;k<dv.at(s).float_data_size();k++)
-			      vals.push_back(dv.at(s).float_data(k));
-			    dv_float_data.push_back(vals);
-			  }
-                     else if (inputc._timeserie)  // timeseries case
-                       {
-			    std::vector<double> vals;
-                         for (int t=0; t<inputc._timesteps; ++t)
-                           {
-                             for (int k=0; k<_ntargets; ++k)
-                               {
-                                 vals.push_back(dv.at(s).float_data(t*inputc._datadim+k+1));
-                               }
-                           }
-			    dv_float_data.push_back(vals);
-                       }
-			else if (!_autoencoder)
-			  {
-			    dv_labels.push_back(dv.at(s).label());
-			    if (_ntargets > 1)
-			      {
-				std::vector<double> vals;
-				for (int k=inputc.channels();k<dv.at(s).float_data_size();k++)
-				  vals.push_back(dv.at(s).float_data(k));
-				dv_float_data.push_back(vals);
-			      }
-			  }
-			else if (_autoencoder && (typeid(inputc) == typeid(ImgCaffeInputFileConn)))
-			  {
-			    Datum datum = dv.at(s);
-			    int height = datum.height();
-			    int width = datum.width();
-			    std::vector<double> vals;
-			    for (int c=0;c<datum.channels();++c) //TODO: store for each channel or flatten before sigmoid
-			      for (int h=0;h<height;++h)
-				for (int w=0;w<width;++w)
-				  {
-				    int data_index = (c*height+h)*width+w;
-				    double datum_element;
-				    datum_element = static_cast<double>(static_cast<uint8_t>(datum.data()[data_index]));
-				    datum_element *= _scale;
-				    vals.push_back(datum_element);
-				  }
-			    dv_float_data.push_back(vals);
-			  }
-			else
-			  {
-			    std::vector<double> vals;
-			    for (int k=0;k<inputc.channels();k++)
-			      {
-				vals.push_back(dv.at(s).float_data(k));
-			      }
-			    dv_float_data.push_back(vals);
-			  }
-		      }
-		    if (boost::dynamic_pointer_cast<caffe::MemoryDataLayer<float>>(net->layers()[0]) == 0)
-		      throw MLLibBadParamException("test net's first layer is required to be of MemoryData type");
-		    if (inputc._segmentation)
-		      {
-			dv = seg_dv;
-			dv_size = dv.size();
-			seg_dv.clear();
-		      }
-		    boost::dynamic_pointer_cast<caffe::MemoryDataLayer<float>>(net->layers()[0])->set_batch_size(dv.size());
-		    boost::dynamic_pointer_cast<caffe::MemoryDataLayer<float>>(net->layers()[0])->AddDatumVector(dv);
-		  }
-		else // sparse
-		  {
-		    std::vector<caffe::SparseDatum> dv = inputc.get_dv_test_sparse(test_batch_size);
-		    if (dv.empty())
-		      break;
-		    dv_size = dv.size();
-		    for (size_t s=0;s<dv_size;s++)
-		      {
-			dv_labels.push_back(dv.at(s).label());
-			if (_ntargets > 1)
-			  {
-			    // SparseDatum has no float_data and source cannot be sliced
-			    throw MLLibBadParamException("sparse inputs cannot accomodate multi-target objectives, use single target instead");
-			  }
-		      }
-		    if (boost::dynamic_pointer_cast<caffe::MemorySparseDataLayer<float>>(net->layers()[0]) == 0)
-		      throw MLLibBadParamException("test net's first layer is required to be of MemorySparseData type");
-		    boost::dynamic_pointer_cast<caffe::MemorySparseDataLayer<float>>(net->layers()[0])->set_batch_size(dv.size());
-		    boost::dynamic_pointer_cast<caffe::MemorySparseDataLayer<float>>(net->layers()[0])->AddDatumVector(dv);
-		  }
-	      }
-	    catch(std::exception &e)
-	      {
-		this->_logger->error("Error while filling up network for testing");
-		// XXX: might want to clean up here...
-		throw;
-	      }
-	    float loss = 0.0;
-	    std::vector<Blob<float>*> lresults;
-	    try
-	      {
-		lresults = net->Forward(&loss);
-	      }
-	    catch(std::exception &e)
-	      {
-		this->_logger->error("Error while proceeding with test forward pass");
-		// XXX: might want to clean up here...
-		throw;
-	      }
-	    int slot = lresults.size() - 1;
-	    
-	    if (_regression && _ntargets > 1
-		&& typeid(inputc) != typeid(ImgCaffeInputFileConn)) // slicing is involved
-	      slot--; // labels appear to be last
-	    else if (inputc._multi_label && ( inputc._db || ! (typeid(inputc) == typeid(ImgCaffeInputFileConn))
-                                           ||  _nclasses <= 1))
-	      slot--;
-	    else if (_autoencoder && typeid(inputc) == typeid(ImgCaffeInputFileConn))
-	      slot = 0; // flatten output
-           else if (_regression && _ntargets == 1 && typeid(inputc) == typeid(CSVCaffeInputFileConn))
-             {
-               slot = findOutputSlotNumberByBlobName(net, "ip_loss");
-             }
-
-           if (inputc._timeserie)
-             {
-               slot = findOutputSlotNumberByBlobName(net,"rnn_pred");
-             }
-
-	    int scount = lresults[slot]->count();
-	    int scperel = scount / dv_size;
-
-	    if (inputc._ctc) // special case, we're using the accuracy computed from within the network
-	      {
-		slot = 0;
-		net_meas += lresults[slot]->cpu_data()[0];
-		if (inner_meas_iter >= test_iter)
-		  {
-		    net_meas /= static_cast<float>(test_iter);
-		    std::vector<double> predictions;
-		    predictions.push_back(net_meas);
-		    APIData bad;
-		    bad.add("pred",predictions);
-		    ad_res.add("0",bad);
-		    break;
-		  }
-		++inner_meas_iter;
-	      }
-	    else if (inputc._bbox)
-	      {
-            boost::shared_ptr<Blob<float>> detection_eval = findBlobByName(net,"detection_eval");
-            int evalWidth = 5;
-
-		    if ((detection_eval->width() != 5 && !output_logits)
-                || ((detection_eval->width() != 5 + _nclasses) && output_logits))
-		      throw MLLibBadParamException("wrong width in bbox result");
-            if (output_logits && (detection_eval->width() == 5 + _nclasses))
+        float mean_loss = 0.0;
+        int tresults = 0;
+        int nout = _nclasses;
+        int inner_meas_iter = 0;
+        float net_meas = 0.0;
+        if (_regression && _ntargets > 1)
+          nout = _ntargets;
+        if (_autoencoder)
+          {
+            if (typeid(inputc) == typeid(ImgCaffeInputFileConn))
+              nout = inputc.channels() * inputc.width() * inputc.height();
+            else
+              nout = inputc.channels();
+          }
+        ad_res.add("nclasses", _nclasses);
+        inputc.reset_dv_test();
+        std::map<int, std::map<int, std::vector<std::pair<float, int>>>>
+            all_true_pos;
+        std::map<int, std::map<int, std::vector<std::pair<float, int>>>>
+            all_false_pos;
+        std::map<int, std::map<int, std::vector<std::vector<float>>>>
+            all_logits_pos;
+        std::map<int, std::map<int, int>> all_num_pos;
+        while (true)
+          {
+            size_t dv_size = 0;
+            std::vector<float> dv_labels;
+            std::vector<std::vector<double>> dv_float_data;
+            try
               {
-                this->_logger->info("will ouput raw logits");
-                evalWidth = 5 + _nclasses;
-              }
-
-		    int pos = tresults;
-		    const float *result_vec = detection_eval->cpu_data();
-		    int num_det = detection_eval->height();
-		    for (int k=0;k<num_det;k++)
-		      {
-			int item_id = static_cast<int>(result_vec[k * evalWidth]);
-			int label = static_cast<int>(result_vec[k * evalWidth + 1]);
-			if (item_id == -1) {
-			  // Special row of storing number of positives for a label.
-			  if (all_num_pos[pos].find(label) == all_num_pos[pos].end()) {
-			    all_num_pos[pos][label] = static_cast<int>(result_vec[k * evalWidth + 2]);
-			  } else {
-			    all_num_pos[pos][label] += static_cast<int>(result_vec[k * evalWidth + 2]);
-			  }
-			} else {
-			  // Normal row storing detection status.
-			  float score = result_vec[k * evalWidth + 2];
-			  int tp = static_cast<int>(result_vec[k * evalWidth + 3]);
-			  int fp = static_cast<int>(result_vec[k * evalWidth + 4]);
-			  if (tp == 0 && fp == 0) {
-			    // Ignore such case. It happens when a detection bbox is matched to
-			    // a difficult gt bbox and we don't evaluate on difficult gt bbox.
-			    this->_logger->warn("skipping bbox");
-			    continue;
-			  }
-              if (output_logits)
-                {
-                  std::vector<float> logits;
-                  for (int l = 0; l< _nclasses; ++l)
-                      logits.push_back(result_vec[k*evalWidth + 5 + l]);
-                  all_logits_pos[pos][label].push_back(logits);
-                }
-			  all_true_pos[pos][label].push_back(std::make_pair(score, tp));
-			  all_false_pos[pos][label].push_back(std::make_pair(score, fp));
-			}
-		  }
-
-		// wrapping up
-		if (inner_meas_iter >= test_iter)
-		  {
-		    APIData bad;
-		    int pos_count = 0;
-		    for (size_t i=0;i<all_true_pos.size();i++)
-		      {
-			if (all_true_pos.find(i) == all_true_pos.end())
-			  throw MLLibInternalException("Missing output_blob true_pos: " + std::to_string(i));
-
-			const std::map<int, std::vector<std::pair<float, int> > >& true_pos =
-			  all_true_pos.find(i)->second;
-			if (all_false_pos.find(i) == all_false_pos.end())
-			  throw MLLibInternalException("Missing output_blob false_pos: " + std::to_string(i));
-			const std::map<int, std::vector<std::pair<float, int> > >& false_pos =
-			  all_false_pos.find(i)->second;
-			if (all_num_pos.find(i) == all_num_pos.end())
-			  throw MLLibInternalException("Missing output_blob num_pos: " + std::to_string(i));
-			const std::map<int, int>& num_pos = all_num_pos.find(i)->second;
-
-            std::map<int, std::vector<std::vector<float>>> logits_pos;
-            if (output_logits)
-              {
-                if (all_logits_pos.find(i) == all_logits_pos.end())
-                  throw MLLibInternalException("Missing output_blob logits_pos: " + std::to_string(i));
-                logits_pos = all_logits_pos.find(i)->second;
-              }
-
-			// Sort true_pos and false_pos with descend scores.
-			std::vector<APIData> vbad;
-			for (std::map<int, int>::const_iterator it = num_pos.begin();
-			     it != num_pos.end(); ++it)
-			  {
-			    APIData lbad;
-			    int label = it->first;
-			    int label_num_pos = it->second;
-			    if (true_pos.find(label) == true_pos.end()) {
-			      this->_logger->error("Missing true_pos for label: {}",label);
-			      continue;
-			    }
-			    const std::vector<std::pair<float, int> >& label_true_pos =
-			      true_pos.find(label)->second;
-			    if (false_pos.find(label) == false_pos.end()) {
-			      this->_logger->error("Missing false_pos for label: {}",label);
-			      continue;
-			    }
-			    const std::vector<std::pair<float, int> >& label_false_pos =
-			      false_pos.find(label)->second;
-
-                if (output_logits)
+                if (inputc._ctc || inputc._bbox)
                   {
-                    const std::vector<std::vector<float>> & label_logits =
-                      logits_pos.find(label)->second;
-
-                    std::vector<APIData> ll;
-                    for (size_t v = 0; v< label_logits.size(); ++v)
+                    // do nothing, db input
+                    dv_size = test_batch_size;
+                  }
+                else if (!inputc._sparse)
+                  {
+                    std::vector<caffe::Datum> seg_dv;
+                    std::vector<caffe::Datum> dv = inputc.get_dv_test(
+                        test_batch_size,
+                        !_autoencoder ? has_mean_file : false);
+                    if (dv.empty())
+                      break;
+                    dv_size = dv.size();
+                    for (size_t s = 0; s < dv_size; s++)
                       {
-                        APIData l;
-                        std::vector<double> lldbl;
-                        lldbl.insert(lldbl.end(), label_logits[v].begin(), label_logits[v].end());
-                        l.add("logits", lldbl);
-                        ll.push_back(l);
+                        if (inputc._segmentation)
+                          {
+                            // dv_labels will need to be of size width x height
+                            // x batch size -> use dv_float_data
+                            // -> read datum 2 by 2 -> skip s (read s 2 by 2)
+                            if (!(s % 2))
+                              {
+                                std::vector<double> vals;
+                                for (int k = 0;
+                                     k < dv.at(s + 1).float_data_size(); k++)
+                                  vals.push_back(dv.at(s + 1).float_data(k));
+                                dv_float_data.push_back(vals);
+                                seg_dv.push_back(dv.at(s));
+                              }
+                          }
+                        // imagedata layer
+                        //- store labels in float_data
+                        //- similar to segmentation for computing multi-label
+                        // accuracy
+                        else if ((inputc._multi_label || _regression)
+                                 && !(inputc._db)
+                                 && typeid(inputc)
+                                        == typeid(ImgCaffeInputFileConn)
+                                 && (_nclasses > 1 || _ntargets > 1))
+                          {
+                            std::vector<double> vals;
+                            for (int k = 0; k < dv.at(s).float_data_size();
+                                 k++)
+                              vals.push_back(dv.at(s).float_data(k));
+                            dv_float_data.push_back(vals);
+                          }
+                        else if (inputc._timeserie) // timeseries case
+                          {
+                            std::vector<double> vals;
+                            for (int t = 0; t < inputc._timesteps; ++t)
+                              {
+                                for (int k = 0; k < _ntargets; ++k)
+                                  {
+                                    vals.push_back(dv.at(s).float_data(
+                                        t * inputc._datadim + k + 1));
+                                  }
+                              }
+                            dv_float_data.push_back(vals);
+                          }
+                        else if (!_autoencoder)
+                          {
+                            dv_labels.push_back(dv.at(s).label());
+                            if (_ntargets > 1)
+                              {
+                                std::vector<double> vals;
+                                for (int k = inputc.channels();
+                                     k < dv.at(s).float_data_size(); k++)
+                                  vals.push_back(dv.at(s).float_data(k));
+                                dv_float_data.push_back(vals);
+                              }
+                          }
+                        else if (_autoencoder
+                                 && (typeid(inputc)
+                                     == typeid(ImgCaffeInputFileConn)))
+                          {
+                            Datum datum = dv.at(s);
+                            int height = datum.height();
+                            int width = datum.width();
+                            std::vector<double> vals;
+                            for (int c = 0; c < datum.channels();
+                                 ++c) // TODO: store for each channel or
+                                      // flatten before sigmoid
+                              for (int h = 0; h < height; ++h)
+                                for (int w = 0; w < width; ++w)
+                                  {
+                                    int data_index
+                                        = (c * height + h) * width + w;
+                                    double datum_element;
+                                    datum_element = static_cast<double>(
+                                        static_cast<uint8_t>(
+                                            datum.data()[data_index]));
+                                    datum_element *= _scale;
+                                    vals.push_back(datum_element);
+                                  }
+                            dv_float_data.push_back(vals);
+                          }
+                        else
+                          {
+                            std::vector<double> vals;
+                            for (int k = 0; k < inputc.channels(); k++)
+                              {
+                                vals.push_back(dv.at(s).float_data(k));
+                              }
+                            dv_float_data.push_back(vals);
+                          }
                       }
-                    lbad.add("all_logits", ll);
+                    if (boost::dynamic_pointer_cast<
+                            caffe::MemoryDataLayer<float>>(net->layers()[0])
+                        == 0)
+                      throw MLLibBadParamException(
+                          "test net's first layer is required to be of "
+                          "MemoryData type");
+                    if (inputc._segmentation)
+                      {
+                        dv = seg_dv;
+                        dv_size = dv.size();
+                        seg_dv.clear();
+                      }
+                    boost::dynamic_pointer_cast<caffe::MemoryDataLayer<float>>(
+                        net->layers()[0])
+                        ->set_batch_size(dv.size());
+                    boost::dynamic_pointer_cast<caffe::MemoryDataLayer<float>>(
+                        net->layers()[0])
+                        ->AddDatumVector(dv);
+                  }
+                else // sparse
+                  {
+                    std::vector<caffe::SparseDatum> dv
+                        = inputc.get_dv_test_sparse(test_batch_size);
+                    if (dv.empty())
+                      break;
+                    dv_size = dv.size();
+                    for (size_t s = 0; s < dv_size; s++)
+                      {
+                        dv_labels.push_back(dv.at(s).label());
+                        if (_ntargets > 1)
+                          {
+                            // SparseDatum has no float_data and source cannot
+                            // be sliced
+                            throw MLLibBadParamException(
+                                "sparse inputs cannot accomodate multi-target "
+                                "objectives, use single target instead");
+                          }
+                      }
+                    if (boost::dynamic_pointer_cast<
+                            caffe::MemorySparseDataLayer<float>>(
+                            net->layers()[0])
+                        == 0)
+                      throw MLLibBadParamException(
+                          "test net's first layer is required to be of "
+                          "MemorySparseData type");
+                    boost::dynamic_pointer_cast<
+                        caffe::MemorySparseDataLayer<float>>(net->layers()[0])
+                        ->set_batch_size(dv.size());
+                    boost::dynamic_pointer_cast<
+                        caffe::MemorySparseDataLayer<float>>(net->layers()[0])
+                        ->AddDatumVector(dv);
+                  }
+              }
+            catch (std::exception &e)
+              {
+                this->_logger->error(
+                    "Error while filling up network for testing");
+                // XXX: might want to clean up here...
+                throw;
+              }
+            float loss = 0.0;
+            std::vector<Blob<float> *> lresults;
+            try
+              {
+                lresults = net->Forward(&loss);
+              }
+            catch (std::exception &e)
+              {
+                this->_logger->error(
+                    "Error while proceeding with test forward pass");
+                // XXX: might want to clean up here...
+                throw;
+              }
+            int slot = lresults.size() - 1;
+
+            if (_regression && _ntargets > 1
+                && typeid(inputc)
+                       != typeid(ImgCaffeInputFileConn)) // slicing is involved
+              slot--; // labels appear to be last
+            else if (inputc._multi_label
+                     && (inputc._db
+                         || !(typeid(inputc) == typeid(ImgCaffeInputFileConn))
+                         || _nclasses <= 1))
+              slot--;
+            else if (_autoencoder
+                     && typeid(inputc) == typeid(ImgCaffeInputFileConn))
+              slot = 0; // flatten output
+            else if (_regression && _ntargets == 1
+                     && typeid(inputc) == typeid(CSVCaffeInputFileConn))
+              {
+                slot = findOutputSlotNumberByBlobName(net, "ip_loss");
+              }
+
+            if (inputc._timeserie)
+              {
+                slot = findOutputSlotNumberByBlobName(net, "rnn_pred");
+              }
+
+            int scount = lresults[slot]->count();
+            int scperel = scount / dv_size;
+
+            if (inputc._ctc) // special case, we're using the accuracy computed
+                             // from within the network
+              {
+                slot = 0;
+                net_meas += lresults[slot]->cpu_data()[0];
+                if (inner_meas_iter >= test_iter)
+                  {
+                    net_meas /= static_cast<float>(test_iter);
+                    std::vector<double> predictions;
+                    predictions.push_back(net_meas);
+                    APIData bad;
+                    bad.add("pred", predictions);
+                    ad_res.add("0", bad);
+                    break;
+                  }
+                ++inner_meas_iter;
+              }
+            else if (inputc._bbox)
+              {
+                boost::shared_ptr<Blob<float>> detection_eval
+                    = findBlobByName(net, "detection_eval");
+                int evalWidth = 5;
+
+                if ((detection_eval->width() != 5 && !output_logits)
+                    || ((detection_eval->width() != 5 + _nclasses)
+                        && output_logits))
+                  throw MLLibBadParamException("wrong width in bbox result");
+                if (output_logits
+                    && (detection_eval->width() == 5 + _nclasses))
+                  {
+                    this->_logger->info("will ouput raw logits");
+                    evalWidth = 5 + _nclasses;
                   }
 
+                int pos = tresults;
+                const float *result_vec = detection_eval->cpu_data();
+                int num_det = detection_eval->height();
+                for (int k = 0; k < num_det; k++)
+                  {
+                    int item_id = static_cast<int>(result_vec[k * evalWidth]);
+                    int label
+                        = static_cast<int>(result_vec[k * evalWidth + 1]);
+                    if (item_id == -1)
+                      {
+                        // Special row of storing number of positives for a
+                        // label.
+                        if (all_num_pos[pos].find(label)
+                            == all_num_pos[pos].end())
+                          {
+                            all_num_pos[pos][label] = static_cast<int>(
+                                result_vec[k * evalWidth + 2]);
+                          }
+                        else
+                          {
+                            all_num_pos[pos][label] += static_cast<int>(
+                                result_vec[k * evalWidth + 2]);
+                          }
+                      }
+                    else
+                      {
+                        // Normal row storing detection status.
+                        float score = result_vec[k * evalWidth + 2];
+                        int tp
+                            = static_cast<int>(result_vec[k * evalWidth + 3]);
+                        int fp
+                            = static_cast<int>(result_vec[k * evalWidth + 4]);
+                        if (tp == 0 && fp == 0)
+                          {
+                            // Ignore such case. It happens when a detection
+                            // bbox is matched to a difficult gt bbox and we
+                            // don't evaluate on difficult gt bbox.
+                            this->_logger->warn("skipping bbox");
+                            continue;
+                          }
+                        if (output_logits)
+                          {
+                            std::vector<float> logits;
+                            for (int l = 0; l < _nclasses; ++l)
+                              logits.push_back(
+                                  result_vec[k * evalWidth + 5 + l]);
+                            all_logits_pos[pos][label].push_back(logits);
+                          }
+                        all_true_pos[pos][label].push_back(
+                            std::make_pair(score, tp));
+                        all_false_pos[pos][label].push_back(
+                            std::make_pair(score, fp));
+                      }
+                  }
 
-			    
-			    //XXX: AP computed here, store in apidata instead
-			    std::vector<double> tp_d;
-			    std::vector<int> tp_i;
-			    for (size_t v=0;v<label_true_pos.size();v++)
-			      {
-				tp_d.push_back(label_true_pos.at(v).first);
-				tp_i.push_back(label_true_pos.at(v).second);
-			      }
+                // wrapping up
+                if (inner_meas_iter >= test_iter)
+                  {
+                    APIData bad;
+                    int pos_count = 0;
+                    for (size_t i = 0; i < all_true_pos.size(); i++)
+                      {
+                        if (all_true_pos.find(i) == all_true_pos.end())
+                          throw MLLibInternalException(
+                              "Missing output_blob true_pos: "
+                              + std::to_string(i));
 
-			    std::vector<double> fp_d;
-			    std::vector<int> fp_i;
-			    for (size_t v=0;v<label_false_pos.size();v++)
-			      {
-				fp_d.push_back(label_false_pos.at(v).first);
-				fp_i.push_back(label_false_pos.at(v).second);
-			      }
-			    
-			    lbad.add("tp_d",tp_d);
-			    lbad.add("tp_i",tp_i);
-			    lbad.add("fp_d",fp_d);
-			    lbad.add("fp_i",fp_i);
-			    lbad.add("num_pos",label_num_pos);
-			    lbad.add("label",label);
-			    vbad.push_back(lbad);
-			  }
-			bad.add(std::to_string(pos_count),vbad);
-			++pos_count;
-		      }
-		    ad_res.add("0",bad);
-		    ad_res.add("pos_count",pos_count);
-		    break;
-		  }
-		++inner_meas_iter;
-	      }
-	    else
-	      {
-		for (int j=0;j<(int)dv_size;j++)
-		  {
-		    APIData bad;
-		    std::vector<double> predictions;
-		    if (inputc._segmentation)
-		      {
-			APIData bad2;
-			std::vector<double> preds, targets;
-			for (size_t l=0;l<dv_float_data.at(j).size();l++)
-			  {
-			    double target = dv_float_data.at(j).at(l);
-			    double best_prob = -1.0;
-			    double best_cat = -1.0;
-			    if (lresults[slot]->shape(1) != 1)
-			      {
-				for (int k=0;k<nout;k++)
-				  {
-				    double prob = lresults[slot]->cpu_data()[l+(nout*j+k)*dv_float_data.at(j).size()];
-				    if (prob >= best_prob)
-				      {
-					best_prob = prob;
-					best_cat = k;
-				      }
-				  }
-			      }
-			    else
-			      {
-				// in case of dice loss + deeplab_vgg16, predictions are at pos 0
-				double res = lresults[slot]->cpu_data()[l+j*dv_float_data.at(j).size()];
-				if (res > 0.5)
-				  {
-				    best_cat = 1;
-				  }
-				else
-				  {
-				    best_cat = 0;
-				  }
-			      }
-			    preds.push_back(best_cat);
-			    targets.push_back(target);
-			  }
-			bad2.add("target",targets);
-			bad2.add("pred",preds);
-			ad_res.add(std::to_string(tresults+j),bad2);
-		      }
-		    // multilabel image  => also covers soft labels
-		    else if (inputc._multi_label && !inputc._db && typeid(inputc) == typeid(ImgCaffeInputFileConn)
-			     && _nclasses > 1)
-		      {
-			// grab multi-label prediction from last layer
-			std::vector<double> targets;
-			for (int k=0;k<nout;k++)
-			  {
-			    double target = dv_float_data.at(j).at(k);
-			    targets.push_back(target);
-			    predictions.push_back(lresults[slot]->cpu_data()[j*scperel+k]);
-			  }
-			bad.add("target",targets);
-			bad.add("pred",predictions);
-		      }
-                  else if (inputc._timeserie)
-                    {
-                      std::vector<double> target;
-                      for (size_t k=0;k<dv_float_data.at(j).size();k++)
-                        {
+                        const std::map<int, std::vector<std::pair<float, int>>>
+                            &true_pos = all_true_pos.find(i)->second;
+                        if (all_false_pos.find(i) == all_false_pos.end())
+                          throw MLLibInternalException(
+                              "Missing output_blob false_pos: "
+                              + std::to_string(i));
+                        const std::map<int, std::vector<std::pair<float, int>>>
+                            &false_pos = all_false_pos.find(i)->second;
+                        if (all_num_pos.find(i) == all_num_pos.end())
+                          throw MLLibInternalException(
+                              "Missing output_blob num_pos: "
+                              + std::to_string(i));
+                        const std::map<int, int> &num_pos
+                            = all_num_pos.find(i)->second;
+
+                        std::map<int, std::vector<std::vector<float>>>
+                            logits_pos;
+                        if (output_logits)
+                          {
+                            if (all_logits_pos.find(i) == all_logits_pos.end())
+                              throw MLLibInternalException(
+                                  "Missing output_blob logits_pos: "
+                                  + std::to_string(i));
+                            logits_pos = all_logits_pos.find(i)->second;
+                          }
+
+                        // Sort true_pos and false_pos with descend scores.
+                        std::vector<APIData> vbad;
+                        for (std::map<int, int>::const_iterator it
+                             = num_pos.begin();
+                             it != num_pos.end(); ++it)
+                          {
+                            APIData lbad;
+                            int label = it->first;
+                            int label_num_pos = it->second;
+                            if (true_pos.find(label) == true_pos.end())
+                              {
+                                this->_logger->error(
+                                    "Missing true_pos for label: {}", label);
+                                continue;
+                              }
+                            const std::vector<std::pair<float, int>>
+                                &label_true_pos = true_pos.find(label)->second;
+                            if (false_pos.find(label) == false_pos.end())
+                              {
+                                this->_logger->error(
+                                    "Missing false_pos for label: {}", label);
+                                continue;
+                              }
+                            const std::vector<std::pair<float, int>>
+                                &label_false_pos
+                                = false_pos.find(label)->second;
+
+                            if (output_logits)
+                              {
+                                const std::vector<std::vector<float>>
+                                    &label_logits
+                                    = logits_pos.find(label)->second;
+
+                                std::vector<APIData> ll;
+                                for (size_t v = 0; v < label_logits.size();
+                                     ++v)
+                                  {
+                                    APIData l;
+                                    std::vector<double> lldbl;
+                                    lldbl.insert(lldbl.end(),
+                                                 label_logits[v].begin(),
+                                                 label_logits[v].end());
+                                    l.add("logits", lldbl);
+                                    ll.push_back(l);
+                                  }
+                                lbad.add("all_logits", ll);
+                              }
+
+                            // XXX: AP computed here, store in apidata instead
+                            std::vector<double> tp_d;
+                            std::vector<int> tp_i;
+                            for (size_t v = 0; v < label_true_pos.size(); v++)
+                              {
+                                tp_d.push_back(label_true_pos.at(v).first);
+                                tp_i.push_back(label_true_pos.at(v).second);
+                              }
+
+                            std::vector<double> fp_d;
+                            std::vector<int> fp_i;
+                            for (size_t v = 0; v < label_false_pos.size(); v++)
+                              {
+                                fp_d.push_back(label_false_pos.at(v).first);
+                                fp_i.push_back(label_false_pos.at(v).second);
+                              }
+
+                            lbad.add("tp_d", tp_d);
+                            lbad.add("tp_i", tp_i);
+                            lbad.add("fp_d", fp_d);
+                            lbad.add("fp_i", fp_i);
+                            lbad.add("num_pos", label_num_pos);
+                            lbad.add("label", label);
+                            vbad.push_back(lbad);
+                          }
+                        bad.add(std::to_string(pos_count), vbad);
+                        ++pos_count;
+                      }
+                    ad_res.add("0", bad);
+                    ad_res.add("pos_count", pos_count);
+                    break;
+                  }
+                ++inner_meas_iter;
+              }
+            else
+              {
+                for (int j = 0; j < (int)dv_size; j++)
+                  {
+                    APIData bad;
+                    std::vector<double> predictions;
+                    if (inputc._segmentation)
+                      {
+                        APIData bad2;
+                        std::vector<double> preds, targets;
+                        for (size_t l = 0; l < dv_float_data.at(j).size(); l++)
+                          {
+                            double target = dv_float_data.at(j).at(l);
+                            double best_prob = -1.0;
+                            double best_cat = -1.0;
+                            if (lresults[slot]->shape(1) != 1)
+                              {
+                                for (int k = 0; k < nout; k++)
+                                  {
+                                    double prob
+                                        = lresults[slot]->cpu_data()
+                                              [l
+                                               + (nout * j + k)
+                                                     * dv_float_data.at(j)
+                                                           .size()];
+                                    if (prob >= best_prob)
+                                      {
+                                        best_prob = prob;
+                                        best_cat = k;
+                                      }
+                                  }
+                              }
+                            else
+                              {
+                                // in case of dice loss + deeplab_vgg16,
+                                // predictions are at pos 0
+                                double res
+                                    = lresults[slot]->cpu_data()
+                                          [l + j * dv_float_data.at(j).size()];
+                                if (res > 0.5)
+                                  {
+                                    best_cat = 1;
+                                  }
+                                else
+                                  {
+                                    best_cat = 0;
+                                  }
+                              }
+                            preds.push_back(best_cat);
+                            targets.push_back(target);
+                          }
+                        bad2.add("target", targets);
+                        bad2.add("pred", preds);
+                        ad_res.add(std::to_string(tresults + j), bad2);
+                      }
+                    // multilabel image  => also covers soft labels
+                    else if (inputc._multi_label && !inputc._db
+                             && typeid(inputc) == typeid(ImgCaffeInputFileConn)
+                             && _nclasses > 1)
+                      {
+                        // grab multi-label prediction from last layer
+                        std::vector<double> targets;
+                        for (int k = 0; k < nout; k++)
+                          {
+                            double target = dv_float_data.at(j).at(k);
+                            targets.push_back(target);
+                            predictions.push_back(
+                                lresults[slot]->cpu_data()[j * scperel + k]);
+                          }
+                        bad.add("target", targets);
+                        bad.add("pred", predictions);
+                      }
+                    else if (inputc._timeserie)
+                      {
+                        std::vector<double> target;
+                        for (size_t k = 0; k < dv_float_data.at(j).size(); k++)
+                          {
+                            target.push_back(dv_float_data.at(j).at(k));
+                          }
+                        bad.add("target", target);
+
+                        for (int t = 0; t < inputc._timesteps; ++t)
+                          {
+                            for (int k = 0; k < nout; k++)
+                              {
+                                std::vector<int> loc = { t, j, k };
+                                predictions.push_back(
+                                    lresults[slot]->data_at(loc));
+                              }
+                          }
+                      }
+                    else if ((!_regression && !_autoencoder) || _ntargets == 1)
+                      {
+                        double target = dv_labels.at(j);
+                        if (output_logits)
+                          {
+                            std::vector<double> logits;
+                            for (int k = 0; k < nout; k++)
+                              {
+                                logits.push_back(
+                                    logits_blob->cpu_data()[j * scperel + k]);
+                              }
+                            bad.add("logits", logits);
+                          }
+                        std::vector<double> logits;
+                        for (int k = 0; k < nout; k++)
+                          {
+                            predictions.push_back(
+                                lresults[slot]->cpu_data()[j * scperel + k]);
+                          }
+                        bad.add("target", target);
+                      }
+                    else // regression with ntargets > 1 or autoencoder
+                      {
+                        std::vector<double> target;
+                        for (size_t k = 0; k < dv_float_data.at(j).size(); k++)
                           target.push_back(dv_float_data.at(j).at(k));
-                        }
-                      bad.add("target", target);
-
-                      for (int t=0; t<inputc._timesteps; ++t)
-                        {
-                          for (int k=0;k<nout;k++)
-                            {
-                              std::vector<int> loc = {t,j,k};
-                              predictions.push_back(lresults[slot]->data_at(loc));
-                            }
-                        }
-                    }
-		    else if ((!_regression && !_autoencoder)|| _ntargets == 1)
-		      {
-			double target = dv_labels.at(j);
-			if (output_logits)
-			  {
-			    std::vector<double> logits;
-			    for (int k=0;k<nout;k++)
-			      {
-				logits.push_back(logits_blob->cpu_data()[j*scperel+k]);
-			      }
-			    bad.add("logits",logits);
-			  }
-			std::vector<double> logits;
-			for (int k=0;k<nout;k++)
-			  {
-			    predictions.push_back(lresults[slot]->cpu_data()[j*scperel+k]);
-			  }
-			bad.add("target",target);
-		      }
-		    else // regression with ntargets > 1 or autoencoder
-		      {
-			std::vector<double> target;
-			for (size_t k=0;k<dv_float_data.at(j).size();k++)
-			  target.push_back(dv_float_data.at(j).at(k));
-			for (int k=0;k<nout;k++)
-			  predictions.push_back(lresults[slot]->cpu_data()[j*scperel+k]);
-			bad.add("target",target);
-		      }
-		    if (!inputc._segmentation)
-		      {
-			bad.add("pred",predictions);
-			ad_res.add(std::to_string(tresults+j),bad);
-		      }
-		  }
-	      }
-	    if (inputc._bbox)
-	      tresults += 1;
-	    else tresults += dv_size;
-	    mean_loss += loss;
-	  }
-	std::vector<std::string> clnames;
-	for (int i=0;i<nout;i++)
-	  clnames.push_back(this->_mlmodel.get_hcorresp(i));
-	ad_res.add("clnames",clnames);
-	if (inputc._segmentation)
-	  ad_res.add("segmentation",true);
-	if (inputc._multi_label)
-	  ad_res.add("multilabel",true);
-	if (inputc._bbox)
-	  ad_res.add("bbox",true);
-	ad_res.add("batch_size",tresults);
-	if (_regression)
-	  ad_res.add("regression",_regression);
-	if (inputc._ctc)
-	  ad_res.add("net_meas",true);
-       if (inputc._timeserie)
-         {
-           ad_res.add("timeserie",true);
-           ad_res.add("timeseries",nout);
-         }
+                        for (int k = 0; k < nout; k++)
+                          predictions.push_back(
+                              lresults[slot]->cpu_data()[j * scperel + k]);
+                        bad.add("target", target);
+                      }
+                    if (!inputc._segmentation)
+                      {
+                        bad.add("pred", predictions);
+                        ad_res.add(std::to_string(tresults + j), bad);
+                      }
+                  }
+              }
+            if (inputc._bbox)
+              tresults += 1;
+            else
+              tresults += dv_size;
+            mean_loss += loss;
+          }
+        std::vector<std::string> clnames;
+        for (int i = 0; i < nout; i++)
+          clnames.push_back(this->_mlmodel.get_hcorresp(i));
+        ad_res.add("clnames", clnames);
+        if (inputc._segmentation)
+          ad_res.add("segmentation", true);
+        if (inputc._multi_label)
+          ad_res.add("multilabel", true);
+        if (inputc._bbox)
+          ad_res.add("bbox", true);
+        ad_res.add("batch_size", tresults);
+        if (_regression)
+          ad_res.add("regression", _regression);
+        if (inputc._ctc)
+          ad_res.add("net_meas", true);
+        if (inputc._timeserie)
+          {
+            ad_res.add("timeserie", true);
+            ad_res.add("timeseries", nout);
+          }
       }
-    SupervisedOutput::measure(ad_res,ad_out,out);
+    SupervisedOutput::measure(ad_res, ad_out, out);
   }
-  
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  int CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::predict(const APIData &ad,
-										   APIData &out)
-  {
-    std::lock_guard<std::mutex> lock(_net_mutex); // no concurrent calls since the net is not re-instantiated
 
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  int CaffeLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+               TMLModel>::predict(const APIData &ad, APIData &out)
+  {
+    std::lock_guard<std::mutex> lock(
+        _net_mutex); // no concurrent calls since the net is not
+                     // re-instantiated
 
     // check for net
     if (!_net || _net->phase() == caffe::TRAIN)
       {
-	int cm = create_model(true);
-	if (cm != 0)
-	  this->_logger->error("Error creating model for prediction");
-	if (cm == 1)
-	  throw MLLibInternalException("no model in " + this->_mlmodel._repo + " for initializing the net");
-	else if (cm == 2)
-	  throw MLLibBadParamException("no deploy file in " + this->_mlmodel._repo + " for initializing the net");
+        int cm = create_model(true);
+        if (cm != 0)
+          this->_logger->error("Error creating model for prediction");
+        if (cm == 1)
+          throw MLLibInternalException("no model in " + this->_mlmodel._repo
+                                       + " for initializing the net");
+        else if (cm == 2)
+          throw MLLibBadParamException("no deploy file in "
+                                       + this->_mlmodel._repo
+                                       + " for initializing the net");
       }
 
     TInputConnectorStrategy inputc(this->_inputc);
@@ -2296,22 +2714,26 @@ namespace dd
     double confidence_threshold = 0.0;
     if (ad_output.has("confidence_threshold"))
       {
-	try
-	  {
-	    confidence_threshold = ad_output.get("confidence_threshold").get<double>();
-	  }
-	catch(std::exception &e)
-	  {
-	    // try from int
-	    confidence_threshold = static_cast<double>(ad_output.get("confidence_threshold").get<int>());
-	  }
+        try
+          {
+            confidence_threshold
+                = ad_output.get("confidence_threshold").get<double>();
+          }
+        catch (std::exception &e)
+          {
+            // try from int
+            confidence_threshold = static_cast<double>(
+                ad_output.get("confidence_threshold").get<int>());
+          }
       }
-
 
     if (inputc._timeserie
         && ad.getobj("parameters").getobj("input").has("timesteps"))
       {
-        int timesteps = ad.getobj("parameters").getobj("input").get("timesteps").get<int>();
+        int timesteps = ad.getobj("parameters")
+                            .getobj("input")
+                            .get("timesteps")
+                            .get<int>();
 
         bool changed = update_timesteps(timesteps);
         if (changed)
@@ -2320,50 +2742,55 @@ namespace dd
             if (cm != 0)
               this->_logger->error("Error creating model for prediction");
             if (cm == 1)
-              throw MLLibInternalException("no model in " + this->_mlmodel._repo + " for initializing the net");
+              throw MLLibInternalException("no model in "
+                                           + this->_mlmodel._repo
+                                           + " for initializing the net");
             else if (cm == 2)
-              throw MLLibBadParamException("no deploy file in " + this->_mlmodel._repo + " for initializing the net");
+              throw MLLibBadParamException("no deploy file in "
+                                           + this->_mlmodel._repo
+                                           + " for initializing the net");
           }
       }
 
-
     if (ad_output.has("bbox") && ad_output.get("bbox").get<bool>())
       bbox = true;
-    if (ad_output.has("rois")) {
-      roi_layer =  ad_output.get("rois").get<std::string>();
-      rois = true;
-      if (ad_output.has("multibox_rois"))
-	multibox_rois = ad_output.get("multibox_rois").get<bool>();
-    }
+    if (ad_output.has("rois"))
+      {
+        roi_layer = ad_output.get("rois").get<std::string>();
+        rois = true;
+        if (ad_output.has("multibox_rois"))
+          multibox_rois = ad_output.get("multibox_rois").get<bool>();
+      }
     if (ad_output.has("ctc"))
       {
-	ctc = ad_output.get("ctc").get<bool>();
-	if (ad_output.has("blank_label"))
-	  blank_label = ad_output.get("blank_label").get<int>();
+        ctc = ad_output.get("ctc").get<bool>();
+        if (ad_output.has("blank_label"))
+          blank_label = ad_output.get("blank_label").get<int>();
       }
 
-    // gpu
+      // gpu
 #if !defined(CPU_ONLY) && !defined(USE_CAFFE_CPU_ONLY)
     bool gpu = _gpu;
     if (ad_mllib.has("gpu"))
       {
-	gpu = ad_mllib.get("gpu").get<bool>();
-	if (gpu)
-	  {
-	    set_gpuid(ad_mllib);
-	  }
+        gpu = ad_mllib.get("gpu").get<bool>();
+        if (gpu)
+          {
+            set_gpuid(ad_mllib);
+          }
       }
     if (gpu)
       {
-	for (auto i: _gpuid)
-	  {
-	    Caffe::SetDevice(i);
-	    if (gpu != _gpu)
-	      Caffe::DeviceQuery();
-	  }
-	Caffe::set_mode(Caffe::GPU);
+        for (auto i : _gpuid)
+          {
+            Caffe::SetDevice(i);
+            if (gpu != _gpu)
+              Caffe::DeviceQuery();
+          }
+        Caffe::set_mode(Caffe::GPU);
       }
-    else Caffe::set_mode(Caffe::CPU);
+    else
+      Caffe::set_mode(Caffe::CPU);
 #else
     Caffe::set_mode(Caffe::CPU);
 #endif
@@ -2372,41 +2799,41 @@ namespace dd
     bool has_mean_file = this->_mlmodel._has_mean_file;
     if (_autoencoder)
       has_mean_file = false;
-    cad.add("has_mean_file",has_mean_file);
+    cad.add("has_mean_file", has_mean_file);
     if (ad_output.has("measure"))
       {
-	try
-	  {
-	    inputc.transform(cad);
-	  }
-	catch (std::exception &e)
-	  {
-	    throw;
-	  }
+        try
+          {
+            inputc.transform(cad);
+          }
+        catch (std::exception &e)
+          {
+            throw;
+          }
 
-	int batch_size = inputc.test_batch_size();
-	if (ad_mllib.has("net"))
-	  {
-	    APIData ad_net = ad_mllib.getobj("net");
-	    if (ad_net.has("test_batch_size"))
-	      batch_size = ad_net.get("test_batch_size").get<int>();
-	  }
+        int batch_size = inputc.test_batch_size();
+        if (ad_mllib.has("net"))
+          {
+            APIData ad_net = ad_mllib.getobj("net");
+            if (ad_net.has("test_batch_size"))
+              batch_size = ad_net.get("test_batch_size").get<int>();
+          }
 
-	bool has_mean_file = this->_mlmodel._has_mean_file;
-	test(_net,ad,inputc,batch_size,has_mean_file,1,out);
-	APIData out_meas = out.getobj("measure");
-	out_meas.erase("train_loss");
-	out_meas.erase("iteration");
-	out.add("measure",out_meas);
-	return 0;
+        bool has_mean_file = this->_mlmodel._has_mean_file;
+        test(_net, ad, inputc, batch_size, has_mean_file, 1, out);
+        APIData out_meas = out.getobj("measure");
+        out_meas.erase("train_loss");
+        out_meas.erase("iteration");
+        out.add("measure", out_meas);
+        return 0;
       }
-    
+
     std::string extract_layer;
     if (ad_mllib.has("extract_layer"))
       extract_layer = ad_mllib.get("extract_layer").get<std::string>();
     if (ad.has("chain") && ad.get("chain").get<bool>())
-      cad.add("chain",true);
-    
+      cad.add("chain", true);
+
     try
       {
         inputc.transform(cad);
@@ -2418,9 +2845,9 @@ namespace dd
     int batch_size = inputc.test_batch_size();
     if (ad_mllib.has("net"))
       {
-	APIData ad_net = ad_mllib.getobj("net");
-	if (ad_net.has("test_batch_size"))
-	  batch_size = ad_net.get("test_batch_size").get<int>();
+        APIData ad_net = ad_mllib.getobj("net");
+        if (ad_net.has("test_batch_size"))
+          batch_size = ad_net.get("test_batch_size").get<int>();
       }
     inputc.reset_dv_test();
     std::vector<APIData> vrad;
@@ -2429,1243 +2856,1513 @@ namespace dd
     std::vector<APIData> series;
     int serieNum = 0;
 
-    while(true)
+    while (true)
       {
-	try
-	  {
-           if (!inputc._sparse)
-	      {
-		std::vector<Datum> dv = inputc.get_dv_test(batch_size,has_mean_file);
-		if (dv.empty())
-                {
-                  if (inputc._timeserie) // timeseries
-                    // in case of time series, need to output data of last serie at end
-                    {
-                      if (series.size() > 0)
-                        {
-                          APIData out;
-                          if (!inputc._ids.empty())
-                            out.add("uri",inputc._ids.at(serieNum++));
-                          else out.add("uri",std::to_string(serieNum++));
-                          out.add("series", series);
-                          out.add("probs",std::vector<double>(series.size(),1.0));
-                          out.add("loss",0.0);
-                          vrad.push_back(out);
-                        }
-                      series.clear();
-                    }
+        try
+          {
+            if (!inputc._sparse)
+              {
+                std::vector<Datum> dv
+                    = inputc.get_dv_test(batch_size, has_mean_file);
+                if (dv.empty())
+                  {
+                    if (inputc._timeserie) // timeseries
+                      // in case of time series, need to output data of last
+                      // serie at end
+                      {
+                        if (series.size() > 0)
+                          {
+                            APIData out;
+                            if (!inputc._ids.empty())
+                              out.add("uri", inputc._ids.at(serieNum++));
+                            else
+                              out.add("uri", std::to_string(serieNum++));
+                            out.add("series", series);
+                            out.add("probs",
+                                    std::vector<double>(series.size(), 1.0));
+                            out.add("loss", 0.0);
+                            vrad.push_back(out);
+                          }
+                        series.clear();
+                      }
+                    break;
+                  }
+                batch_size = dv.size();
+                if (boost::dynamic_pointer_cast<caffe::MemoryDataLayer<float>>(
+                        _net->layers()[0])
+                    == 0)
+                  {
+                    this->_logger->info("deploy net's first layer is required "
+                                        "to be of MemoryData type (predict)");
+                    delete _net;
+                    _net = nullptr;
+                    throw MLLibBadParamException(
+                        "deploy net's first layer is required to be of "
+                        "MemoryData type");
+                  }
+                boost::dynamic_pointer_cast<caffe::MemoryDataLayer<float>>(
+                    _net->layers()[0])
+                    ->set_batch_size(batch_size);
+                boost::dynamic_pointer_cast<caffe::MemoryDataLayer<float>>(
+                    _net->layers()[0])
+                    ->AddDatumVector(dv);
+              }
+            else
+              {
+                std::vector<caffe::SparseDatum> dv
+                    = inputc.get_dv_test_sparse(batch_size);
+                if (dv.empty())
                   break;
-                }
-		batch_size = dv.size();
-		if (boost::dynamic_pointer_cast<caffe::MemoryDataLayer<float>>(_net->layers()[0]) == 0)
-		    {
-		      this->_logger->info("deploy net's first layer is required to be of MemoryData type (predict)");
-		      delete _net;
-		      _net = nullptr;
-		      throw MLLibBadParamException("deploy net's first layer is required to be of MemoryData type");
-		    }
-		boost::dynamic_pointer_cast<caffe::MemoryDataLayer<float>>(_net->layers()[0])->set_batch_size(batch_size);
-		boost::dynamic_pointer_cast<caffe::MemoryDataLayer<float>>(_net->layers()[0])->AddDatumVector(dv);
-	      }
-	    else
-	      {
-		std::vector<caffe::SparseDatum> dv = inputc.get_dv_test_sparse(batch_size);
-		if (dv.empty())
-		  break;
-		batch_size = dv.size();
-		if (boost::dynamic_pointer_cast<caffe::MemorySparseDataLayer<float>>(_net->layers()[0]) == 0)
-		  {
-		    this->_logger->error("deploy net's first layer is required to be of MemoryData type (predict)");
-		    delete _net;
-		    _net = nullptr;
-		    throw MLLibBadParamException("deploy net's first layer is required to be of MemorySparseData type");
-		  }
-		boost::dynamic_pointer_cast<caffe::MemorySparseDataLayer<float>>(_net->layers()[0])->set_batch_size(batch_size);
-		boost::dynamic_pointer_cast<caffe::MemorySparseDataLayer<float>>(_net->layers()[0])->AddDatumVector(dv);
-	      }
-	  }
-	catch(std::exception &e)
-	  {
-	    this->_logger->error("exception while filling up network for prediction");
-	    delete _net;
-	    _net = nullptr;
-	    throw;
-	  }
+                batch_size = dv.size();
+                if (boost::dynamic_pointer_cast<
+                        caffe::MemorySparseDataLayer<float>>(_net->layers()[0])
+                    == 0)
+                  {
+                    this->_logger->error(
+                        "deploy net's first layer is required to be of "
+                        "MemoryData type (predict)");
+                    delete _net;
+                    _net = nullptr;
+                    throw MLLibBadParamException(
+                        "deploy net's first layer is required to be of "
+                        "MemorySparseData type");
+                  }
+                boost::dynamic_pointer_cast<
+                    caffe::MemorySparseDataLayer<float>>(_net->layers()[0])
+                    ->set_batch_size(batch_size);
+                boost::dynamic_pointer_cast<
+                    caffe::MemorySparseDataLayer<float>>(_net->layers()[0])
+                    ->AddDatumVector(dv);
+              }
+          }
+        catch (std::exception &e)
+          {
+            this->_logger->error(
+                "exception while filling up network for prediction");
+            delete _net;
+            _net = nullptr;
+            throw;
+          }
 
-	this->_mem_used_test = _net->memory_used();
+        this->_mem_used_test = _net->memory_used();
 
-	float loss = 0.0;
-	if (extract_layer.empty() || inputc._segmentation) // supervised or segmentation
-	  {
-	    std::vector<Blob<float>*> results;
-	    
-	    if (rois)
-	      {
-		std::map<std::string,int> n_layer_names_index = _net->layer_names_index();
-		std::map<std::string,int>::const_iterator lit;
-		if ((lit=n_layer_names_index.find(roi_layer))==n_layer_names_index.end())
-		  throw MLLibBadParamException("unknown rois layer " + roi_layer);
-		int li = (*lit).second;
-		try
-		  {
-		    loss = _net->ForwardFromTo(0,li);
-		  }
-		catch(std::exception &e)
-		  {
-		    this->_logger->error("Error while proceeding with supervised prediction forward pass, not enough memory? {}",e.what());
-		    delete _net;
-		    _net = nullptr;
-		    throw;
-		  }
-		const std::vector<std::vector<Blob<float>*>>& rresults = _net->top_vecs();
-		results = rresults.at(li);
-	      }
-	    else
-	      {
-		try
-		  {
-		    results = _net->Forward(&loss);
-		  }
-		catch(std::exception &e)
-		  {
-		    this->_logger->error("Error while proceeding with supervised prediction forward pass, not enough memory? {}",e.what());
-		    delete _net;
-		    _net = nullptr;
-		    throw;
-		  }
-	      }
-	    
-	    if (inputc._segmentation)
-	      {
-               int slot = results.size() - 1;
-               nclasses = _nclasses;
+        float loss = 0.0;
+        if (extract_layer.empty()
+            || inputc._segmentation) // supervised or segmentation
+          {
+            std::vector<Blob<float> *> results;
 
-               bool conf_best = false;
-               std::vector<bool> confidences;
-               if (_nclasses == 1)
-                 confidences = std::vector<bool>(2,false);
-               else
-                 confidences = std::vector<bool>(_nclasses,false);
-               if (ad_output.has("confidences"))
-                 {
-                   std::vector<std::string> smaps =
-                     ad_output.get("confidences").get<std::vector<std::string>>();
-                   for (std::string s: smaps)
-                     if (s == "all")
-                       for (int ci = 0; ci<_nclasses; ++ci)
-                         confidences[ci] = true;
-                     else if (s=="best")
-                       conf_best = true;
-                     else
-                       confidences[std::stoi(s)]= true;
-                 }
+            if (rois)
+              {
+                std::map<std::string, int> n_layer_names_index
+                    = _net->layer_names_index();
+                std::map<std::string, int>::const_iterator lit;
+                if ((lit = n_layer_names_index.find(roi_layer))
+                    == n_layer_names_index.end())
+                  throw MLLibBadParamException("unknown rois layer "
+                                               + roi_layer);
+                int li = (*lit).second;
+                try
+                  {
+                    loss = _net->ForwardFromTo(0, li);
+                  }
+                catch (std::exception &e)
+                  {
+                    this->_logger->error(
+                        "Error while proceeding with supervised prediction "
+                        "forward pass, not enough memory? {}",
+                        e.what());
+                    delete _net;
+                    _net = nullptr;
+                    throw;
+                  }
+                const std::vector<std::vector<Blob<float> *>> &rresults
+                    = _net->top_vecs();
+                results = rresults.at(li);
+              }
+            else
+              {
+                try
+                  {
+                    results = _net->Forward(&loss);
+                  }
+                catch (std::exception &e)
+                  {
+                    this->_logger->error(
+                        "Error while proceeding with supervised prediction "
+                        "forward pass, not enough memory? {}",
+                        e.what());
+                    delete _net;
+                    _net = nullptr;
+                    throw;
+                  }
+              }
 
-		for (int j=0;j<batch_size;j++)
-		  {
-		    APIData rad;
-		    std::string uri;
-		    if (!inputc._ids.empty())
-		      {
-			uri = inputc._ids.at(idoffset+j);
-			rad.add("uri",uri);
-		      }
-		    else
-		      {
-			uri = std::to_string(idoffset+j);
-			rad.add("uri",uri);
-		      }
-		    rad.add("loss",static_cast<double>(loss));
-		    std::vector<double> vals;
-                  std::map<int,std::vector<double>> confidence_maps;
-                  std::vector<double> conf_map_best;
-		    int imgsize = inputc.width()*inputc.height();
-		    for (int i=0;i<imgsize;i++)
-		      {
-			double max_prob = -1.0;
-			double best_cat = -1.0;
-			if (results[slot]->shape(1) != 1)
-			  {
-			    for (int k=0;k<nclasses;k++)
-			      {
-				double prob = results[slot]->cpu_data()[(j*nclasses+k)*imgsize+i];
-                            if (confidences[k])
-                              confidence_maps[k].push_back(prob);
-				if (prob > max_prob)
-				  {
-				    max_prob = prob;
-				    best_cat = static_cast<double>(k);
-				  }
-			      }
-                         if (conf_best)
-                           conf_map_best.push_back(max_prob);
-			  }
-			else
-			  {
-			    double prob = results[slot]->cpu_data()[(j)*imgsize+i];
-                         if (confidences[1])
-                           confidence_maps[1].push_back(prob);
-                         if (confidences[0])
-                           confidence_maps[0].push_back(1.0-prob);
-			    if (prob > 0.5)
-                           {
-                             if (conf_best)
-                               conf_map_best.push_back(prob);
-                             best_cat = 1;
-                           }
-			    else
-                           {
-                             if (conf_best)
-                               conf_map_best.push_back(1.0-prob);
-                             best_cat = 0;
-                           }
-			  }
-			vals.push_back(best_cat);
-		      }
-		    auto bit = inputc._imgs_size.find(uri);
-		    APIData ad_imgsize;
-		    ad_imgsize.add("height",(*bit).second.first);
-		    ad_imgsize.add("width",(*bit).second.second);
-		    rad.add("imgsize",ad_imgsize);
-		    if (imgsize != (*bit).second.first*(*bit).second.second) // resizing output segmentation array
-		      {
-                      vals =img_resize(vals,inputc.height(),inputc.width(),(*bit).second.first, (*bit).second.second,true);
-                     if (conf_best)
-                       conf_map_best = img_resize(conf_map_best, inputc.height(), inputc.width(),
-                                                  (*bit).second.first, (*bit).second.second,false);
-                     for (int ci=0; ci <_nclasses; ++ci)
-                       if (confidences[ci])
-                       confidence_maps[ci] =
-                         img_resize(confidence_maps[ci],
-                                    inputc.height(), inputc.width(),
-                                     (*bit).second.first, (*bit).second.second, false);
-		      }
-		    rad.add("vals",vals);
-                  if (conf_best || !confidence_maps.empty())
-                    {
-                      APIData confs;
-                      if (conf_best)
-                        confs.add("best", conf_map_best);
-                      for (int ci=0; ci < _nclasses; ++ci)
-                        if (confidences[ci])
-                          confs.add(std::to_string(ci), confidence_maps[ci]);
-                      rad.add("confidences",confs);
-                    }
-		    vrad.push_back(rad);
-		  }
-	      }
-	    else if (bbox) // in-image object detection
-	      {
-		int results_height = results[0]->height();
-		const int det_size = 7;
-		const float *outr = results[0]->cpu_data();
-		for (int j=0;j<batch_size;j++)
-		  {
-		    int k = 0;
-		    std::vector<double> probs;
-		    std::vector<std::string> cats;
-		    std::vector<APIData> bboxes;
-		    APIData rad;
-		    std::string uri = inputc._ids.at(idoffset+j);
-		    auto bit = inputc._imgs_size.find(uri);
-		    int rows = 1;
-		    int cols = 1;
-		    if (bit != inputc._imgs_size.end())
-		      {
-			// original image size
-			rows = (*bit).second.first;
-			cols = (*bit).second.second;
-		      }
-		    else
-		      {
-			this->_logger->error("couldn't find original image size for {}",uri);
-		      }
-		    bool leave = false;
-		    int curi = -1;
-		    while(true && k<results_height)
-		      {
-			if (outr[0] == -1)
-			  {
-			    // skipping invalid detection
-			    this->_logger->error("skipping invalid detection");
-			    outr += det_size;
-			    leave = true;
-			    break;
-			  }
-			std::vector<float> detection(outr, outr + det_size);
-			if (curi == -1)
-			  curi = detection[0]; // first pass
-			else if (curi != detection[0])
-			  break; // this belongs to next image
-			++k;
-			outr += det_size;
-			if (detection[2] < confidence_threshold)
-			  continue;
-			// Fix border of bboxes
-			detection[3] = std::max(((float) detection[3]), 0.0f);
-			detection[4] = std::max(((float) detection[4]), 0.0f);
-			detection[5] = std::min(((float) detection[5]), 1.0f);
-			detection[6] = std::min(((float) detection[6]), 1.0f);
+            if (inputc._segmentation)
+              {
+                int slot = results.size() - 1;
+                nclasses = _nclasses;
 
-			probs.push_back(detection[2]);
-			cats.push_back(this->_mlmodel.get_hcorresp(detection[1]));
-			APIData ad_bbox;
-			ad_bbox.add("xmin",static_cast<double>(detection[3]*(cols-1)));
-			ad_bbox.add("ymin",static_cast<double>(detection[4]*(rows-1)));
-			ad_bbox.add("xmax",static_cast<double>(detection[5]*(cols-1)));
-			ad_bbox.add("ymax",static_cast<double>(detection[6]*(rows-1)));
-			bboxes.push_back(ad_bbox);
-		      }
-		    if (leave)
-		      continue;
-		    rad.add("uri",uri);
-		    if (!inputc._index_uris.empty())
-		      rad.add("index_uri",inputc._index_uris.at(idoffset+j));
-		    rad.add("loss",0.0); // XXX: unused
-		    rad.add("probs",probs);
-		    rad.add("cats",cats);
-		    rad.add("bboxes",bboxes); 
-		    vrad.push_back(rad);
-		  }
-	      }
-	    else if (rois) {
-	      // adhoc code for roi extractions
-	      // nblobs should be 5: 0 is id (in batch)
-	      // 1 is label
-	      // 2 is confidence
-	      // 3 is coord
-	      // 4 is pooled_data
-	      int nroi = results[0]->shape(0);
-	      // 1 et un seul val par reply
-	      int max_id = -1;
-	      for (int iroi=0; iroi<nroi; ++iroi)
-		if (std::round(results[0]->cpu_data()[iroi]) > max_id)
-		  max_id = std::round(results[0]->cpu_data()[iroi]);
-	      
-	      // loop over images
-	      for (int iid=0; iid<=max_id; ++iid) {
-		APIData rad;
-		std::vector<APIData> rois;
-		// loop overs rois
-		std::vector<double> probs;
-		std::vector<std::string> cats;
-		std::vector<APIData> bboxes;
-		std::vector<APIData> vals;
-		std::string uri = inputc._ids.at(idoffset+iid);
-		auto bit = inputc._imgs_size.find(uri);
-		int rows = 1;
-		int cols = 1;
-		if (bit != inputc._imgs_size.end())
-		  {
-		    // original image size
-		    rows = (*bit).second.first;
-		    cols = (*bit).second.second;
-		  }
-		else
-		  {
-		    this->_logger->error("couldn't find original image size for {}",uri);
-		  }
-		
-		for (int iroi=0; iroi<nroi; ++iroi) {
-		  // if cat == -1 no detection has been done on image
-		  if (results[1]->cpu_data()[iroi] == -1)
-		    continue;
-		  // check if current roi belongs to current image
-		  if (std::round(results[0]->cpu_data()[iroi]) == iid) {
-		    if (results[2]->cpu_data()[iroi] < confidence_threshold)
-		      continue;
-		    APIData roi;
-		    //roi.add("cat",results[1]->cpu_data()[iroi]);
-		    cats.push_back(this->_mlmodel.get_hcorresp(results[1]->cpu_data()[iroi]));
-		    probs.push_back(results[2]->cpu_data()[iroi]);
-		    APIData ad_bbox;
-		    ad_bbox.add("xmin",static_cast<double>(results[3]->cpu_data()[iroi*4]*cols));
-		    ad_bbox.add("ymax",static_cast<double>(results[3]->cpu_data()[iroi*4+1]*rows));
-		    ad_bbox.add("xmax",static_cast<double>(results[3]->cpu_data()[iroi*4+2]*cols));
-		    ad_bbox.add("ymin",static_cast<double>(results[3]->cpu_data()[iroi*4+3]*rows));
-		    bboxes.push_back(ad_bbox);
-		    std::vector<double> pooled_data;
-		    int poolsize = results.at(4)->count()/nroi;
-		    for (int idata = 0; idata < poolsize; ++idata)
-		      pooled_data.push_back(results.at(4)->cpu_data()[iroi*poolsize+idata]);
-		    APIData rval;
-		    rval.add("vals",pooled_data);
-		    vals.push_back(rval);
-		  }//end if roi in image
-		} // end loop over all rois
-		rad.add("vals",vals);
-		rad.add("bboxes", bboxes);
-		rad.add("uri",inputc._ids.at(idoffset+iid));
-		if (!inputc._index_uris.empty())
-		  rad.add("index_uri",inputc._index_uris.at(idoffset+iid));
-		rad.add("loss",0.0); // XXX: unused
-		rad.add("probs",probs);
-		rad.add("cats",cats);
-		vrad.push_back(rad);
-	      }
-	    }
-	    else if (ctc)
-	    {
-	      // input is time_step x batch_size x alphabet_size
-	      int slot = results.size() - 1;
-	      const int alphabet_size = results[slot]->shape(2);
-	      const int time_step = results[slot]->shape(0);
-	      const float *pred_data = results[slot]->cpu_data();
-	      for (int j=0;j<batch_size;j++)
-		{
-		  std::vector<int> pred_label_seq_with_blank(time_step);
-		  std::vector<double> pred_conf_seq(time_step);
-		  std::vector<std::vector<float>> pred_sample;
+                bool conf_best = false;
+                std::vector<bool> confidences;
+                if (_nclasses == 1)
+                  confidences = std::vector<bool>(2, false);
+                else
+                  confidences = std::vector<bool>(_nclasses, false);
+                if (ad_output.has("confidences"))
+                  {
+                    std::vector<std::string> smaps
+                        = ad_output.get("confidences")
+                              .get<std::vector<std::string>>();
+                    for (std::string s : smaps)
+                      if (s == "all")
+                        for (int ci = 0; ci < _nclasses; ++ci)
+                          confidences[ci] = true;
+                      else if (s == "best")
+                        conf_best = true;
+                      else
+                        confidences[std::stoi(s)] = true;
+                  }
 
-		  const float *pred_cur = pred_data;
-		  pred_cur += j*alphabet_size;
-		  for (int t=0;t<time_step;t++)
-		    {
-		      pred_label_seq_with_blank[t] = std::max_element(pred_cur, pred_cur + alphabet_size) - pred_cur;
-		      pred_conf_seq[t] = static_cast<double>(pred_cur[pred_label_seq_with_blank[t]]);
-		      pred_cur += batch_size * alphabet_size;
-		    }
+                for (int j = 0; j < batch_size; j++)
+                  {
+                    APIData rad;
+                    std::string uri;
+                    if (!inputc._ids.empty())
+                      {
+                        uri = inputc._ids.at(idoffset + j);
+                        rad.add("uri", uri);
+                      }
+                    else
+                      {
+                        uri = std::to_string(idoffset + j);
+                        rad.add("uri", uri);
+                      }
+                    rad.add("loss", static_cast<double>(loss));
+                    std::vector<double> vals;
+                    std::map<int, std::vector<double>> confidence_maps;
+                    std::vector<double> conf_map_best;
+                    int imgsize = inputc.width() * inputc.height();
+                    for (int i = 0; i < imgsize; i++)
+                      {
+                        double max_prob = -1.0;
+                        double best_cat = -1.0;
+                        if (results[slot]->shape(1) != 1)
+                          {
+                            for (int k = 0; k < nclasses; k++)
+                              {
+                                double prob
+                                    = results[slot]->cpu_data()
+                                          [(j * nclasses + k) * imgsize + i];
+                                if (confidences[k])
+                                  confidence_maps[k].push_back(prob);
+                                if (prob > max_prob)
+                                  {
+                                    max_prob = prob;
+                                    best_cat = static_cast<double>(k);
+                                  }
+                              }
+                            if (conf_best)
+                              conf_map_best.push_back(max_prob);
+                          }
+                        else
+                          {
+                            double prob
+                                = results[slot]->cpu_data()[(j)*imgsize + i];
+                            if (confidences[1])
+                              confidence_maps[1].push_back(prob);
+                            if (confidences[0])
+                              confidence_maps[0].push_back(1.0 - prob);
+                            if (prob > 0.5)
+                              {
+                                if (conf_best)
+                                  conf_map_best.push_back(prob);
+                                best_cat = 1;
+                              }
+                            else
+                              {
+                                if (conf_best)
+                                  conf_map_best.push_back(1.0 - prob);
+                                best_cat = 0;
+                              }
+                          }
+                        vals.push_back(best_cat);
+                      }
+                    auto bit = inputc._imgs_size.find(uri);
+                    APIData ad_imgsize;
+                    ad_imgsize.add("height", (*bit).second.first);
+                    ad_imgsize.add("width", (*bit).second.second);
+                    rad.add("imgsize", ad_imgsize);
+                    if (imgsize
+                        != (*bit).second.first
+                               * (*bit).second.second) // resizing output
+                                                       // segmentation array
+                      {
+                        vals = img_resize(vals, inputc.height(),
+                                          inputc.width(), (*bit).second.first,
+                                          (*bit).second.second, true);
+                        if (conf_best)
+                          conf_map_best
+                              = img_resize(conf_map_best, inputc.height(),
+                                           inputc.width(), (*bit).second.first,
+                                           (*bit).second.second, false);
+                        for (int ci = 0; ci < _nclasses; ++ci)
+                          if (confidences[ci])
+                            confidence_maps[ci] = img_resize(
+                                confidence_maps[ci], inputc.height(),
+                                inputc.width(), (*bit).second.first,
+                                (*bit).second.second, false);
+                      }
+                    rad.add("vals", vals);
+                    if (conf_best || !confidence_maps.empty())
+                      {
+                        APIData confs;
+                        if (conf_best)
+                          confs.add("best", conf_map_best);
+                        for (int ci = 0; ci < _nclasses; ++ci)
+                          if (confidences[ci])
+                            confs.add(std::to_string(ci), confidence_maps[ci]);
+                        rad.add("confidences", confs);
+                      }
+                    vrad.push_back(rad);
+                  }
+              }
+            else if (bbox) // in-image object detection
+              {
+                int results_height = results[0]->height();
+                const int det_size = 7;
+                const float *outr = results[0]->cpu_data();
+                for (int j = 0; j < batch_size; j++)
+                  {
+                    int k = 0;
+                    std::vector<double> probs;
+                    std::vector<std::string> cats;
+                    std::vector<APIData> bboxes;
+                    APIData rad;
+                    std::string uri = inputc._ids.at(idoffset + j);
+                    auto bit = inputc._imgs_size.find(uri);
+                    int rows = 1;
+                    int cols = 1;
+                    if (bit != inputc._imgs_size.end())
+                      {
+                        // original image size
+                        rows = (*bit).second.first;
+                        cols = (*bit).second.second;
+                      }
+                    else
+                      {
+                        this->_logger->error(
+                            "couldn't find original image size for {}", uri);
+                      }
+                    bool leave = false;
+                    int curi = -1;
+                    while (true && k < results_height)
+                      {
+                        if (outr[0] == -1)
+                          {
+                            // skipping invalid detection
+                            this->_logger->error("skipping invalid detection");
+                            outr += det_size;
+                            leave = true;
+                            break;
+                          }
+                        std::vector<float> detection(outr, outr + det_size);
+                        if (curi == -1)
+                          curi = detection[0]; // first pass
+                        else if (curi != detection[0])
+                          break; // this belongs to next image
+                        ++k;
+                        outr += det_size;
+                        if (detection[2] < confidence_threshold)
+                          continue;
+                        // Fix border of bboxes
+                        detection[3] = std::max(((float)detection[3]), 0.0f);
+                        detection[4] = std::max(((float)detection[4]), 0.0f);
+                        detection[5] = std::min(((float)detection[5]), 1.0f);
+                        detection[6] = std::min(((float)detection[6]), 1.0f);
 
-		  // get labels seq
-		  std::vector<int> pred_label_seq;
-		  int prev = blank_label;
-		  for(int l = 0; l < time_step; ++l)
-		    {
-		      int cur = pred_label_seq_with_blank[l];
-		      if(cur != prev && cur != blank_label)
-			pred_label_seq.push_back(cur);
-		      prev = cur;
-		    }
-		  APIData outseq;
-		  std::string outstr;
-		  std::ostringstream oss;
-		  for (auto l: pred_label_seq)
-		    {
-		      outstr += char(std::atoi(this->_mlmodel.get_hcorresp(l).c_str()));
-		      //utf8::append(this->_mlmodel.get_hcorresp(l),outstr);
-		    }
-		  std::vector<std::string> cats;
-		  cats.push_back(outstr);
-		  if (!inputc._ids.empty())
-		    outseq.add("uri",inputc._ids.at(idoffset+j));
-		  else outseq.add("uri",std::to_string(idoffset+j));
-		  outseq.add("cats",cats);
-		  outseq.add("probs",std::vector<double>(1,std::accumulate(pred_conf_seq.begin(),pred_conf_seq.end(), 0.0) / static_cast<double>(pred_conf_seq.size()))); // average confidence over all characters
-		  outseq.add("loss",0.0);
-		  vrad.push_back(outseq);
-		}
-	    }
-           else if (inputc._timeserie) // timeseries
-             {
-               int slot = findOutputSlotNumberByBlobName(_net,"rnn_pred");
-               //results[slot] is TxNxDataDim , N is batchsize ...
-               int nout = _ntargets;
+                        probs.push_back(detection[2]);
+                        cats.push_back(
+                            this->_mlmodel.get_hcorresp(detection[1]));
+                        APIData ad_bbox;
+                        ad_bbox.add("xmin", static_cast<double>(detection[3]
+                                                                * (cols - 1)));
+                        ad_bbox.add("ymin", static_cast<double>(detection[4]
+                                                                * (rows - 1)));
+                        ad_bbox.add("xmax", static_cast<double>(detection[5]
+                                                                * (cols - 1)));
+                        ad_bbox.add("ymax", static_cast<double>(detection[6]
+                                                                * (rows - 1)));
+                        bboxes.push_back(ad_bbox);
+                      }
+                    if (leave)
+                      continue;
+                    rad.add("uri", uri);
+                    if (!inputc._index_uris.empty())
+                      rad.add("index_uri",
+                              inputc._index_uris.at(idoffset + j));
+                    rad.add("loss", 0.0); // XXX: unused
+                    rad.add("probs", probs);
+                    rad.add("cats", cats);
+                    rad.add("bboxes", bboxes);
+                    vrad.push_back(rad);
+                  }
+              }
+            else if (rois)
+              {
+                // adhoc code for roi extractions
+                // nblobs should be 5: 0 is id (in batch)
+                // 1 is label
+                // 2 is confidence
+                // 3 is coord
+                // 4 is pooled_data
+                int nroi = results[0]->shape(0);
+                // 1 et un seul val par reply
+                int max_id = -1;
+                for (int iroi = 0; iroi < nroi; ++iroi)
+                  if (std::round(results[0]->cpu_data()[iroi]) > max_id)
+                    max_id = std::round(results[0]->cpu_data()[iroi]);
 
-               const boost::shared_ptr<Blob<float>> contseq = _net->blob_by_name("cont_seq");
-               //cont_seq is TxN
+                // loop over images
+                for (int iid = 0; iid <= max_id; ++iid)
+                  {
+                    APIData rad;
+                    std::vector<APIData> rois;
+                    // loop overs rois
+                    std::vector<double> probs;
+                    std::vector<std::string> cats;
+                    std::vector<APIData> bboxes;
+                    std::vector<APIData> vals;
+                    std::string uri = inputc._ids.at(idoffset + iid);
+                    auto bit = inputc._imgs_size.find(uri);
+                    int rows = 1;
+                    int cols = 1;
+                    if (bit != inputc._imgs_size.end())
+                      {
+                        // original image size
+                        rows = (*bit).second.first;
+                        cols = (*bit).second.second;
+                      }
+                    else
+                      {
+                        this->_logger->error(
+                            "couldn't find original image size for {}", uri);
+                      }
 
-               CSVTSCaffeInputFileConn* ic =
-                 reinterpret_cast<CSVTSCaffeInputFileConn*>(&inputc);
+                    for (int iroi = 0; iroi < nroi; ++iroi)
+                      {
+                        // if cat == -1 no detection has been done on image
+                        if (results[1]->cpu_data()[iroi] == -1)
+                          continue;
+                        // check if current roi belongs to current image
+                        if (std::round(results[0]->cpu_data()[iroi]) == iid)
+                          {
+                            if (results[2]->cpu_data()[iroi]
+                                < confidence_threshold)
+                              continue;
+                            APIData roi;
+                            // roi.add("cat",results[1]->cpu_data()[iroi]);
+                            cats.push_back(this->_mlmodel.get_hcorresp(
+                                results[1]->cpu_data()[iroi]));
+                            probs.push_back(results[2]->cpu_data()[iroi]);
+                            APIData ad_bbox;
+                            ad_bbox.add(
+                                "xmin",
+                                static_cast<double>(
+                                    results[3]->cpu_data()[iroi * 4] * cols));
+                            ad_bbox.add(
+                                "ymax",
+                                static_cast<double>(
+                                    results[3]->cpu_data()[iroi * 4 + 1]
+                                    * rows));
+                            ad_bbox.add(
+                                "xmax",
+                                static_cast<double>(
+                                    results[3]->cpu_data()[iroi * 4 + 2]
+                                    * cols));
+                            ad_bbox.add(
+                                "ymin",
+                                static_cast<double>(
+                                    results[3]->cpu_data()[iroi * 4 + 3]
+                                    * rows));
+                            bboxes.push_back(ad_bbox);
+                            std::vector<double> pooled_data;
+                            int poolsize = results.at(4)->count() / nroi;
+                            for (int idata = 0; idata < poolsize; ++idata)
+                              pooled_data.push_back(
+                                  results.at(4)
+                                      ->cpu_data()[iroi * poolsize + idata]);
+                            APIData rval;
+                            rval.add("vals", pooled_data);
+                            vals.push_back(rval);
+                          } // end if roi in image
+                      }     // end loop over all rois
+                    rad.add("vals", vals);
+                    rad.add("bboxes", bboxes);
+                    rad.add("uri", inputc._ids.at(idoffset + iid));
+                    if (!inputc._index_uris.empty())
+                      rad.add("index_uri",
+                              inputc._index_uris.at(idoffset + iid));
+                    rad.add("loss", 0.0); // XXX: unused
+                    rad.add("probs", probs);
+                    rad.add("cats", cats);
+                    vrad.push_back(rad);
+                  }
+              }
+            else if (ctc)
+              {
+                // input is time_step x batch_size x alphabet_size
+                int slot = results.size() - 1;
+                const int alphabet_size = results[slot]->shape(2);
+                const int time_step = results[slot]->shape(0);
+                const float *pred_data = results[slot]->cpu_data();
+                for (int j = 0; j < batch_size; j++)
+                  {
+                    std::vector<int> pred_label_seq_with_blank(time_step);
+                    std::vector<double> pred_conf_seq(time_step);
+                    std::vector<std::vector<float>> pred_sample;
 
-               for (int j=0; j<batch_size; ++j)
-                 {
-                   for (int t=0; t<ic->_timesteps; ++t)
-                     {
-                       std::vector<int> loc0 = {t,j};
-                       if (contseq->data_at(loc0) == 0 && series.size() != 0)
-                         // new seq -> push old one
-                         {
-                           if (series.size() > 0)
-                             {
-                               APIData out;
-                               if (!inputc._ids.empty())
-                                 out.add("uri",inputc._ids.at(serieNum++));
-                               else out.add("uri",std::to_string(serieNum++));
-                               out.add("series", series);
-                               out.add("probs",std::vector<double>(series.size(),1.0));
-                               out.add("loss",0.0);
-                               vrad.push_back(out);
-                             }
-                           series.clear();
-                         }
+                    const float *pred_cur = pred_data;
+                    pred_cur += j * alphabet_size;
+                    for (int t = 0; t < time_step; t++)
+                      {
+                        pred_label_seq_with_blank[t]
+                            = std::max_element(pred_cur,
+                                               pred_cur + alphabet_size)
+                              - pred_cur;
+                        pred_conf_seq[t] = static_cast<double>(
+                            pred_cur[pred_label_seq_with_blank[t]]);
+                        pred_cur += batch_size * alphabet_size;
+                      }
 
-                       std::vector<double> predictions;
-                       for (int k=0; k<nout; ++k)
-                         {
-                           std::vector<int> loc = {t,j,k};
-                           if (ic->_min_vals.empty() || ic->_max_vals.empty())
-                             {
-                               this->_logger->info("not unscaling output because no bounds data found");
-                               predictions.push_back(results[slot]->data_at(loc));
-                             }
-                           else
-                             {
-                               double res = results[slot]->data_at(loc);
-                               if (!ic->_dont_scale_labels)
-                                 {
-                                   double max = ic->_max_vals[ic->_label_pos[k]];
-                                   double min = ic->_min_vals[ic->_label_pos[k]];
-                                   if (ic->_scale_between_minus1_and_1)
-                                     res +=  0.5;
-                                   res = res * (max -min) + min;
-                                 }
-                               predictions.push_back(res);
-                             }
-                         }
-                       APIData ts;
-                       ts.add("out", predictions);
-                       series.push_back(ts);
-                     }
-                 }
-             }
-	    else // classification
-	      {
-		int slot = results.size() - 1;
-		if (_regression)
-		  {
-		    if (_ntargets > 1 || typeid(this->_inputc) == typeid(ImgCaffeInputFileConn))
-		      slot = 1;
-		    else slot = 0; // XXX: more in-depth testing required
-		  }
-		int scount = results[slot]->count();
-		int scperel = scount / batch_size;
-		nclasses = scperel;
-		if (_autoencoder)
-		  nclasses = scperel = 1;
-		for (int j=0;j<batch_size;j++)
-		  {
-		    APIData rad;
-		    if (!inputc._ids.empty())
-		      rad.add("uri",inputc._ids.at(idoffset+j));
-		    else rad.add("uri",std::to_string(idoffset+j));
-		    rad.add("loss",static_cast<double>(loss));
-		    std::vector<double> probs;
-		    std::vector<std::string> cats;
-		    for (int i=0;i<nclasses;i++)
-		      {
-			double prob = results[slot]->cpu_data()[j*scperel+i];
-			if (prob < confidence_threshold && !_regression)
-			  continue;
-			probs.push_back(prob);
-			cats.push_back(this->_mlmodel.get_hcorresp(i));
-		      }
-		    rad.add("probs",probs);
-		    rad.add("cats",cats);
-		    vrad.push_back(rad);
-		  }
-	      }
-	  }
-	else // unsupervised
-	  {
-	    std::map<std::string,int> n_layer_names_index = _net->layer_names_index();
-	    std::map<std::string,int>::const_iterator lit;
-	    if ((lit=n_layer_names_index.find(extract_layer))==n_layer_names_index.end())
-	      throw MLLibBadParamException("unknown extract layer " + extract_layer);
-	    int li = (*lit).second;
-	    try
-	      {
-		loss = _net->ForwardFromTo(0,li);
-	      }
-	    catch(std::exception &e)
-	      {
-		this->_logger->error("Error while proceeding with unsupervised prediction forward pass, not enough memory? {}",e.what());
-		delete _net;
-		_net = nullptr;
-		throw;
-	      }
+                    // get labels seq
+                    std::vector<int> pred_label_seq;
+                    int prev = blank_label;
+                    for (int l = 0; l < time_step; ++l)
+                      {
+                        int cur = pred_label_seq_with_blank[l];
+                        if (cur != prev && cur != blank_label)
+                          pred_label_seq.push_back(cur);
+                        prev = cur;
+                      }
+                    APIData outseq;
+                    std::string outstr;
+                    std::ostringstream oss;
+                    for (auto l : pred_label_seq)
+                      {
+                        outstr += char(
+                            std::atoi(this->_mlmodel.get_hcorresp(l).c_str()));
+                        // utf8::append(this->_mlmodel.get_hcorresp(l),outstr);
+                      }
+                    std::vector<std::string> cats;
+                    cats.push_back(outstr);
+                    if (!inputc._ids.empty())
+                      outseq.add("uri", inputc._ids.at(idoffset + j));
+                    else
+                      outseq.add("uri", std::to_string(idoffset + j));
+                    outseq.add("cats", cats);
+                    outseq.add(
+                        "probs",
+                        std::vector<double>(
+                            1, std::accumulate(pred_conf_seq.begin(),
+                                               pred_conf_seq.end(), 0.0)
+                                   / static_cast<double>(
+                                       pred_conf_seq
+                                           .size()))); // average confidence
+                                                       // over all characters
+                    outseq.add("loss", 0.0);
+                    vrad.push_back(outseq);
+                  }
+              }
+            else if (inputc._timeserie) // timeseries
+              {
+                int slot = findOutputSlotNumberByBlobName(_net, "rnn_pred");
+                // results[slot] is TxNxDataDim , N is batchsize ...
+                int nout = _ntargets;
 
-	    const std::vector<std::vector<Blob<float>*>>& rresults = _net->top_vecs();
-	    std::vector<Blob<float>*> results = rresults.at(li);
+                const boost::shared_ptr<Blob<float>> contseq
+                    = _net->blob_by_name("cont_seq");
+                // cont_seq is TxN
 
-	    int slot = 0;
-	    int scount = results[slot]->count();
-	    int scperel = scount / batch_size;
-	    std::vector<int> vshape = {batch_size,scperel};
-	    results[slot]->Reshape(vshape); // reshaping into a rectangle, first side = batch size
-	    for (int j=0;j<batch_size;j++)
-	      {
-		APIData rad;
-		rad.add("uri",inputc._ids.at(idoffset+j));
-		if (!inputc._meta_uris.empty())
-		  rad.add("meta_uri",inputc._meta_uris.at(idoffset+j));
-		if (!inputc._index_uris.empty())
-		  rad.add("index_uri",inputc._index_uris.at(idoffset+j));
-		rad.add("loss",static_cast<double>(loss));
-		std::vector<double> vals;
-		int cpos = 0;
-		for (int c=0;c<results.at(slot)->shape(1);c++)
-		  {
-		    vals.push_back(results.at(slot)->cpu_data()[j*scperel+cpos]);
-		    ++cpos;
-		  }
-		rad.add("vals",vals);
-		vrad.push_back(rad);
-	      }
-	  }
-	idoffset += batch_size;
+                CSVTSCaffeInputFileConn *ic
+                    = reinterpret_cast<CSVTSCaffeInputFileConn *>(&inputc);
+
+                for (int j = 0; j < batch_size; ++j)
+                  {
+                    for (int t = 0; t < ic->_timesteps; ++t)
+                      {
+                        std::vector<int> loc0 = { t, j };
+                        if (contseq->data_at(loc0) == 0 && series.size() != 0)
+                          // new seq -> push old one
+                          {
+                            if (series.size() > 0)
+                              {
+                                APIData out;
+                                if (!inputc._ids.empty())
+                                  out.add("uri", inputc._ids.at(serieNum++));
+                                else
+                                  out.add("uri", std::to_string(serieNum++));
+                                out.add("series", series);
+                                out.add("probs", std::vector<double>(
+                                                     series.size(), 1.0));
+                                out.add("loss", 0.0);
+                                vrad.push_back(out);
+                              }
+                            series.clear();
+                          }
+
+                        std::vector<double> predictions;
+                        for (int k = 0; k < nout; ++k)
+                          {
+                            std::vector<int> loc = { t, j, k };
+                            if (ic->_min_vals.empty() || ic->_max_vals.empty())
+                              {
+                                this->_logger->info(
+                                    "not unscaling output because no bounds "
+                                    "data found");
+                                predictions.push_back(
+                                    results[slot]->data_at(loc));
+                              }
+                            else
+                              {
+                                double res = results[slot]->data_at(loc);
+                                if (!ic->_dont_scale_labels)
+                                  {
+                                    double max
+                                        = ic->_max_vals[ic->_label_pos[k]];
+                                    double min
+                                        = ic->_min_vals[ic->_label_pos[k]];
+                                    if (ic->_scale_between_minus1_and_1)
+                                      res += 0.5;
+                                    res = res * (max - min) + min;
+                                  }
+                                predictions.push_back(res);
+                              }
+                          }
+                        APIData ts;
+                        ts.add("out", predictions);
+                        series.push_back(ts);
+                      }
+                  }
+              }
+            else // classification
+              {
+                int slot = results.size() - 1;
+                if (_regression)
+                  {
+                    if (_ntargets > 1
+                        || typeid(this->_inputc)
+                               == typeid(ImgCaffeInputFileConn))
+                      slot = 1;
+                    else
+                      slot = 0; // XXX: more in-depth testing required
+                  }
+                int scount = results[slot]->count();
+                int scperel = scount / batch_size;
+                nclasses = scperel;
+                if (_autoencoder)
+                  nclasses = scperel = 1;
+                for (int j = 0; j < batch_size; j++)
+                  {
+                    APIData rad;
+                    if (!inputc._ids.empty())
+                      rad.add("uri", inputc._ids.at(idoffset + j));
+                    else
+                      rad.add("uri", std::to_string(idoffset + j));
+                    rad.add("loss", static_cast<double>(loss));
+                    std::vector<double> probs;
+                    std::vector<std::string> cats;
+                    for (int i = 0; i < nclasses; i++)
+                      {
+                        double prob
+                            = results[slot]->cpu_data()[j * scperel + i];
+                        if (prob < confidence_threshold && !_regression)
+                          continue;
+                        probs.push_back(prob);
+                        cats.push_back(this->_mlmodel.get_hcorresp(i));
+                      }
+                    rad.add("probs", probs);
+                    rad.add("cats", cats);
+                    vrad.push_back(rad);
+                  }
+              }
+          }
+        else // unsupervised
+          {
+            std::map<std::string, int> n_layer_names_index
+                = _net->layer_names_index();
+            std::map<std::string, int>::const_iterator lit;
+            if ((lit = n_layer_names_index.find(extract_layer))
+                == n_layer_names_index.end())
+              throw MLLibBadParamException("unknown extract layer "
+                                           + extract_layer);
+            int li = (*lit).second;
+            try
+              {
+                loss = _net->ForwardFromTo(0, li);
+              }
+            catch (std::exception &e)
+              {
+                this->_logger->error(
+                    "Error while proceeding with unsupervised prediction "
+                    "forward pass, not enough memory? {}",
+                    e.what());
+                delete _net;
+                _net = nullptr;
+                throw;
+              }
+
+            const std::vector<std::vector<Blob<float> *>> &rresults
+                = _net->top_vecs();
+            std::vector<Blob<float> *> results = rresults.at(li);
+
+            int slot = 0;
+            int scount = results[slot]->count();
+            int scperel = scount / batch_size;
+            std::vector<int> vshape = { batch_size, scperel };
+            results[slot]->Reshape(
+                vshape); // reshaping into a rectangle, first side = batch size
+            for (int j = 0; j < batch_size; j++)
+              {
+                APIData rad;
+                rad.add("uri", inputc._ids.at(idoffset + j));
+                if (!inputc._meta_uris.empty())
+                  rad.add("meta_uri", inputc._meta_uris.at(idoffset + j));
+                if (!inputc._index_uris.empty())
+                  rad.add("index_uri", inputc._index_uris.at(idoffset + j));
+                rad.add("loss", static_cast<double>(loss));
+                std::vector<double> vals;
+                int cpos = 0;
+                for (int c = 0; c < results.at(slot)->shape(1); c++)
+                  {
+                    vals.push_back(
+                        results.at(slot)->cpu_data()[j * scperel + cpos]);
+                    ++cpos;
+                  }
+                rad.add("vals", vals);
+                vrad.push_back(rad);
+              }
+          }
+        idoffset += batch_size;
       } // end prediction loop over batches
 
     if (!inputc._segmentation)
       tout.add_results(vrad);
     if (extract_layer.empty())
       {
-	if (_regression)
-	  {
-	    out.add("regression",true);
-	  }
-	else if (_autoencoder)
-	  {
-	    out.add("autoencoder",true);
-	  }
-    if (inputc._timeserie)
-      {
-        out.add("timeseries",true);
+        if (_regression)
+          {
+            out.add("regression", true);
+          }
+        else if (_autoencoder)
+          {
+            out.add("autoencoder", true);
+          }
+        if (inputc._timeserie)
+          {
+            out.add("timeseries", true);
+          }
       }
-      }
-    
-    out.add("nclasses",nclasses);
-    out.add("bbox",bbox);
-    out.add("roi",rois);
-    out.add("multibox_rois",multibox_rois);
+
+    out.add("nclasses", nclasses);
+    out.add("bbox", bbox);
+    out.add("roi", rois);
+    out.add("multibox_rois", multibox_rois);
     if (!inputc._segmentation)
-      tout.finalize(ad.getobj("parameters").getobj("output"),out,static_cast<MLModel*>(&this->_mlmodel));
-    else // segmentation returns an array, best dealt with an unsupervised connector
+      tout.finalize(ad.getobj("parameters").getobj("output"), out,
+                    static_cast<MLModel *>(&this->_mlmodel));
+    else // segmentation returns an array, best dealt with an unsupervised
+         // connector
       {
-	UnsupervisedOutput unsupo;
-	unsupo.add_results(vrad);
-	unsupo.finalize(ad.getobj("parameters").getobj("output"),out,static_cast<MLModel*>(&this->_mlmodel));
+        UnsupervisedOutput unsupo;
+        unsupo.add_results(vrad);
+        unsupo.finalize(ad.getobj("parameters").getobj("output"), out,
+                        static_cast<MLModel *>(&this->_mlmodel));
       }
     if (ad.has("chain") && ad.get("chain").get<bool>())
       {
-	if (typeid(inputc) == typeid(ImgCaffeInputFileConn))
-	  {
-	    APIData chain_input;
-	    if (!reinterpret_cast<ImgCaffeInputFileConn*>(&inputc)->_orig_images.empty())
-	      chain_input.add("imgs",reinterpret_cast<ImgCaffeInputFileConn*>(&inputc)->_orig_images);
-	    else chain_input.add("imgs",reinterpret_cast<ImgCaffeInputFileConn*>(&inputc)->_images);
-	    chain_input.add("imgs_size",reinterpret_cast<ImgCaffeInputFileConn*>(&inputc)->_images_size);
-	    out.add("input",chain_input);
-	  }
+        if (typeid(inputc) == typeid(ImgCaffeInputFileConn))
+          {
+            APIData chain_input;
+            if (!reinterpret_cast<ImgCaffeInputFileConn *>(&inputc)
+                     ->_orig_images.empty())
+              chain_input.add(
+                  "imgs", reinterpret_cast<ImgCaffeInputFileConn *>(&inputc)
+                              ->_orig_images);
+            else
+              chain_input.add(
+                  "imgs",
+                  reinterpret_cast<ImgCaffeInputFileConn *>(&inputc)->_images);
+            chain_input.add("imgs_size",
+                            reinterpret_cast<ImgCaffeInputFileConn *>(&inputc)
+                                ->_images_size);
+            out.add("input", chain_input);
+          }
       }
-    
-    out.add("status",0);
-    
+
+    out.add("status", 0);
+
     return 0;
   }
-  
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::update_in_memory_net_and_solver(caffe::SolverParameter &sp,
-													    const APIData &ad,
-													    const TInputConnectorStrategy &inputc,
-													    bool &has_mean_file,
-													    int &user_batch_size,
-													    int &batch_size,
-													    int &test_batch_size,
-													    int &test_iter)
+
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void CaffeLib<TInputConnectorStrategy, TOutputConnectorStrategy, TMLModel>::
+      update_in_memory_net_and_solver(caffe::SolverParameter &sp,
+                                      const APIData &ad,
+                                      const TInputConnectorStrategy &inputc,
+                                      bool &has_mean_file,
+                                      int &user_batch_size, int &batch_size,
+                                      int &test_batch_size, int &test_iter)
   {
     // fix net model path.
     sp.set_net(this->_mlmodel._repo + "/" + sp.net());
-    
+
     // fix net snapshot path.
     sp.set_snapshot_prefix(this->_mlmodel._repo + "/model");
-    
+
     // acquire custom batch size if any
     user_batch_size = batch_size = inputc.batch_size();
     test_batch_size = inputc.test_batch_size();
     test_iter = -1;
-    fix_batch_size(ad,inputc,user_batch_size,batch_size,test_batch_size,test_iter);
+    fix_batch_size(ad, inputc, user_batch_size, batch_size, test_batch_size,
+                   test_iter);
     if (test_iter != -1) // has changed
-	sp.set_test_iter(0,test_iter);
-    
+      sp.set_test_iter(0, test_iter);
+
     // fix source paths in the model.
     caffe::NetParameter *np = sp.mutable_net_param();
-    if (!caffe::ReadProtoFromTextFile(sp.net().c_str(),np))
-      throw MLLibInternalException("failed opening train prototxt file " + sp.net());
+    if (!caffe::ReadProtoFromTextFile(sp.net().c_str(), np))
+      throw MLLibInternalException("failed opening train prototxt file "
+                                   + sp.net());
 
-    this->_logger->info("input db = {}",inputc._db);
+    this->_logger->info("input db = {}", inputc._db);
     APIData ad_mllib = ad.getobj("parameters").getobj("mllib");
-    if (!inputc._db && !inputc._bbox && typeid(inputc) == typeid(ImgCaffeInputFileConn))
+    if (!inputc._db && !inputc._bbox
+        && typeid(inputc) == typeid(ImgCaffeInputFileConn))
       {
-	caffe::LayerParameter *lparam = np->mutable_layer(0);
-        caffe::ImageDataParameter* image_data_parameter = lparam->mutable_image_data_param();
+        caffe::LayerParameter *lparam = np->mutable_layer(0);
+        caffe::ImageDataParameter *image_data_parameter
+            = lparam->mutable_image_data_param();
         image_data_parameter->set_batch_size(user_batch_size);
-	if (ad_mllib.has("resume") && ad_mllib.get("resume").get<bool>())
-	  {
-	    if (ad_mllib.getobj("solver").has("rand_skip"))
-	      {
-		image_data_parameter->set_rand_skip(ad_mllib.getobj("solver").get("rand_skip").get<int>());
-	      }
-	  }
+        if (ad_mllib.has("resume") && ad_mllib.get("resume").get<bool>())
+          {
+            if (ad_mllib.getobj("solver").has("rand_skip"))
+              {
+                image_data_parameter->set_rand_skip(
+                    ad_mllib.getobj("solver").get("rand_skip").get<int>());
+              }
+          }
       }
 
-    for (int i=0;i<2;i++)
+    for (int i = 0; i < 2; i++)
       {
-	caffe::LayerParameter *lp = np->mutable_layer(i);
-	if (lp->has_data_param())
-	  {
-	    caffe::DataParameter *dp = lp->mutable_data_param();
-	    if (dp->has_source())
-	      {
-		if (i == 0 && ad.has("db")) // training
-		  {
-		    dp->set_source(ad.getobj("db").get("train_db").get<std::string>());
-		  }
-		else if (i == 1 && ad.has("db"))
-		  {
-		    dp->set_source(ad.getobj("db").get("test_db").get<std::string>());
-		  }
-		else 
-		  {
-		    dp->set_source(this->_mlmodel._repo + "/" + dp->source()); // this updates in-memory net
-		  }
-	      }
-	    if (dp->has_batch_size() && batch_size != inputc.batch_size() && batch_size > 0)
-	      {
-		dp->set_batch_size(user_batch_size); // data params seem to handle batch_size that are no multiple of the training set
-		batch_size = user_batch_size;
-	      }
-	  }
-	#ifdef USE_HDF5
-	else if (lp->has_hdf5_data_param())
-	  {
-	    caffe::HDF5DataParameter *dp = lp->mutable_hdf5_data_param();
-	    if (dp->has_source())
-	      {
-		if (i == 0)
-		  {
-		    dp->set_source(ad.getobj("db").get("train_db").get<std::string>());
-		    if (dp->has_batch_size() && batch_size != inputc.batch_size() && batch_size > 0)
-		      dp->set_batch_size(user_batch_size);
-		  }
-		else if (i == 1)
-		  {
-		    dp->set_source(ad.getobj("db").get("test_db").get<std::string>());
-		    dp->set_batch_size(test_batch_size);
-		  }
-	      }
-	    dp->set_image(true);
-	  }
-	#endif // USE_HDF5
-	else if (lp->has_dense_image_data_param())
-	  {
-	    caffe::DenseImageDataParameter *dp = lp->mutable_dense_image_data_param();
-	    if (dp->has_source())
-	      {
-		if (i == 0)
-		  dp->set_source(ad.getobj("source").get("source_train").get<std::string>());
-		else dp->set_source(ad.getobj("source").get("source_test").get<std::string>());
-	      }
-	    if (dp->has_batch_size() && batch_size != inputc.batch_size() && batch_size > 0)
-	      {
-		dp->set_batch_size(user_batch_size);
-		batch_size = user_batch_size;
-	      }
-	    if (ad_mllib.has("resume") && ad_mllib.get("resume").get<bool>())
-	      {
-		if (ad_mllib.getobj("solver").has("rand_skip"))
-		  {
-		    dp->set_rand_skip(ad_mllib.getobj("solver").get("rand_skip").get<int>());
-		  }
-	      }
-	  }
-	else if (lp->has_memory_data_param())
-	  {
-	    caffe::MemoryDataParameter *mdp = lp->mutable_memory_data_param();
-	    if (mdp->has_batch_size() && batch_size > 0 &&
-            ( (batch_size != inputc.batch_size()) || inputc._timeserie ))
-	      {
-		if (i == 0) // training
-		  mdp->set_batch_size(batch_size);
-		else mdp->set_batch_size(test_batch_size);
-	      }
-	  }
-	if (!_autoencoder && (lp->has_transform_param() || inputc._has_mean_file || !inputc._mean_values.empty()))
-	  {
-	    caffe::TransformationParameter *tp = lp->mutable_transform_param();
-	    has_mean_file = tp->has_mean_file();
-	    if (tp->has_mean_file() || !inputc._mean_values.empty())
-	      {
-		if (tp->crop_size() == 0) // beware if no mean file available, though should not happen
-		  {
-		    if (inputc._mean_values.empty())
-		      {
-			if (ad.has("db"))
-			  tp->set_mean_file(ad.getobj("db").get("meanfile").get<std::string>());
-			else tp->set_mean_file(this->_mlmodel._repo + "/" + tp->mean_file());
-		      }
-		    else
-		      {
-			for (size_t d=0;d<inputc._mean_values.size();d++)
-			  tp->add_mean_value(inputc._mean_values.at(d));
-			tp->clear_mean_file();
-		      }
-		  }
-		else
-		  {
-		    for (size_t d=0;d<inputc._mean_values.size();d++)
-		      tp->add_mean_value(inputc._mean_values.at(d));
-		    tp->clear_mean_file();
-		  }
-	      }
-	  }
+        caffe::LayerParameter *lp = np->mutable_layer(i);
+        if (lp->has_data_param())
+          {
+            caffe::DataParameter *dp = lp->mutable_data_param();
+            if (dp->has_source())
+              {
+                if (i == 0 && ad.has("db")) // training
+                  {
+                    dp->set_source(
+                        ad.getobj("db").get("train_db").get<std::string>());
+                  }
+                else if (i == 1 && ad.has("db"))
+                  {
+                    dp->set_source(
+                        ad.getobj("db").get("test_db").get<std::string>());
+                  }
+                else
+                  {
+                    dp->set_source(
+                        this->_mlmodel._repo + "/"
+                        + dp->source()); // this updates in-memory net
+                  }
+              }
+            if (dp->has_batch_size() && batch_size != inputc.batch_size()
+                && batch_size > 0)
+              {
+                dp->set_batch_size(
+                    user_batch_size); // data params seem to handle batch_size
+                                      // that are no multiple of the training
+                                      // set
+                batch_size = user_batch_size;
+              }
+          }
+#ifdef USE_HDF5
+        else if (lp->has_hdf5_data_param())
+          {
+            caffe::HDF5DataParameter *dp = lp->mutable_hdf5_data_param();
+            if (dp->has_source())
+              {
+                if (i == 0)
+                  {
+                    dp->set_source(
+                        ad.getobj("db").get("train_db").get<std::string>());
+                    if (dp->has_batch_size()
+                        && batch_size != inputc.batch_size() && batch_size > 0)
+                      dp->set_batch_size(user_batch_size);
+                  }
+                else if (i == 1)
+                  {
+                    dp->set_source(
+                        ad.getobj("db").get("test_db").get<std::string>());
+                    dp->set_batch_size(test_batch_size);
+                  }
+              }
+            dp->set_image(true);
+          }
+#endif // USE_HDF5
+        else if (lp->has_dense_image_data_param())
+          {
+            caffe::DenseImageDataParameter *dp
+                = lp->mutable_dense_image_data_param();
+            if (dp->has_source())
+              {
+                if (i == 0)
+                  dp->set_source(ad.getobj("source")
+                                     .get("source_train")
+                                     .get<std::string>());
+                else
+                  dp->set_source(ad.getobj("source")
+                                     .get("source_test")
+                                     .get<std::string>());
+              }
+            if (dp->has_batch_size() && batch_size != inputc.batch_size()
+                && batch_size > 0)
+              {
+                dp->set_batch_size(user_batch_size);
+                batch_size = user_batch_size;
+              }
+            if (ad_mllib.has("resume") && ad_mllib.get("resume").get<bool>())
+              {
+                if (ad_mllib.getobj("solver").has("rand_skip"))
+                  {
+                    dp->set_rand_skip(
+                        ad_mllib.getobj("solver").get("rand_skip").get<int>());
+                  }
+              }
+          }
+        else if (lp->has_memory_data_param())
+          {
+            caffe::MemoryDataParameter *mdp = lp->mutable_memory_data_param();
+            if (mdp->has_batch_size() && batch_size > 0
+                && ((batch_size != inputc.batch_size()) || inputc._timeserie))
+              {
+                if (i == 0) // training
+                  mdp->set_batch_size(batch_size);
+                else
+                  mdp->set_batch_size(test_batch_size);
+              }
+          }
+        if (!_autoencoder
+            && (lp->has_transform_param() || inputc._has_mean_file
+                || !inputc._mean_values.empty()))
+          {
+            caffe::TransformationParameter *tp = lp->mutable_transform_param();
+            has_mean_file = tp->has_mean_file();
+            if (tp->has_mean_file() || !inputc._mean_values.empty())
+              {
+                if (tp->crop_size() == 0) // beware if no mean file available,
+                                          // though should not happen
+                  {
+                    if (inputc._mean_values.empty())
+                      {
+                        if (ad.has("db"))
+                          tp->set_mean_file(ad.getobj("db")
+                                                .get("meanfile")
+                                                .get<std::string>());
+                        else
+                          tp->set_mean_file(this->_mlmodel._repo + "/"
+                                            + tp->mean_file());
+                      }
+                    else
+                      {
+                        for (size_t d = 0; d < inputc._mean_values.size(); d++)
+                          tp->add_mean_value(inputc._mean_values.at(d));
+                        tp->clear_mean_file();
+                      }
+                  }
+                else
+                  {
+                    for (size_t d = 0; d < inputc._mean_values.size(); d++)
+                      tp->add_mean_value(inputc._mean_values.at(d));
+                    tp->clear_mean_file();
+                  }
+              }
+          }
       }
 
     if (inputc._timeserie)
       {
-        caffe::LayerParameter *loss_scale_layer_param = find_layer_by_name(*np,"Loss_Scale");
+        caffe::LayerParameter *loss_scale_layer_param
+            = find_layer_by_name(*np, "Loss_Scale");
         if (loss_scale_layer_param != NULL)
           {
-            loss_scale_layer_param->mutable_scale_param()->mutable_filler()->
-              set_value(1.0/(float)_ntargets/(float)batch_size);
+            loss_scale_layer_param->mutable_scale_param()
+                ->mutable_filler()
+                ->set_value(1.0 / (float)_ntargets / (float)batch_size);
           }
       }
 
-
-    //caffe::WriteProtoToTextFile(*np,sp.net().c_str());
+    // caffe::WriteProtoToTextFile(*np,sp.net().c_str());
     sp.clear_net();
   }
 
-
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  bool CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::update_timesteps(int timesteps)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  bool CaffeLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+                TMLModel>::update_timesteps(int timesteps)
   {
     std::string deploy_file = this->_mlmodel._repo + "/deploy.prototxt";
     caffe::NetParameter deploy_net_param;
-    caffe::ReadProtoFromTextFile(deploy_file,&deploy_net_param);
+    caffe::ReadProtoFromTextFile(deploy_file, &deploy_net_param);
 
     caffe::LayerParameter *lparam = deploy_net_param.mutable_layer(0);
     int orig_timesteps = lparam->memory_data_param().channels();
     if (orig_timesteps == timesteps)
       return false;
     lparam->mutable_memory_data_param()->set_channels(timesteps);
-    caffe::WriteProtoToTextFile(deploy_net_param,deploy_file);
+    caffe::WriteProtoToTextFile(deploy_net_param, deploy_file);
     return true;
   }
 
-
-
-
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::update_deploy_protofile_softmax(const APIData &ad)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void CaffeLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+                TMLModel>::update_deploy_protofile_softmax(const APIData &ad)
   {
     if (ad.has("scaling_temperature"))
       {
-	double temperature = ad.get("scaling_temperature").get<double>();
-	std::string deploy_file = this->_mlmodel._repo + "/deploy.prototxt";
-	caffe::NetParameter deploy_net_param;
-	caffe::ReadProtoFromTextFile(deploy_file,&deploy_net_param);
-	int k = deploy_net_param.layer_size();
-	for (int l=k-1;l>0;l--)
-	  {
-	    caffe::LayerParameter *lparam = deploy_net_param.mutable_layer(l);
-	    if (lparam->type() == "Softmax")
-	      {
-		lparam->mutable_softmax_param()->set_scaling_temperature(temperature);
-	      }
-	    // we don't break in case multiple softmax heads.
-	  }
-	caffe::WriteProtoToTextFile(deploy_net_param,deploy_file);
+        double temperature = ad.get("scaling_temperature").get<double>();
+        std::string deploy_file = this->_mlmodel._repo + "/deploy.prototxt";
+        caffe::NetParameter deploy_net_param;
+        caffe::ReadProtoFromTextFile(deploy_file, &deploy_net_param);
+        int k = deploy_net_param.layer_size();
+        for (int l = k - 1; l > 0; l--)
+          {
+            caffe::LayerParameter *lparam = deploy_net_param.mutable_layer(l);
+            if (lparam->type() == "Softmax")
+              {
+                lparam->mutable_softmax_param()->set_scaling_temperature(
+                    temperature);
+              }
+            // we don't break in case multiple softmax heads.
+          }
+        caffe::WriteProtoToTextFile(deploy_net_param, deploy_file);
       }
-    else return;
+    else
+      return;
   }
-  
-  // XXX: we are no more pre-setting the batch_size to the data set values (e.g. number of samples)
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::update_protofile_net(const std::string &net_file,
-												 const std::string &deploy_file,
-												 const TInputConnectorStrategy &inputc,
-												 const bool &has_class_weights,
-												 const int &ignore_label,
-                                                 const int &timesteps,
-                                                 const APIData& ad_mllib)
+
+  // XXX: we are no more pre-setting the batch_size to the data set values
+  // (e.g. number of samples)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void CaffeLib<TInputConnectorStrategy, TOutputConnectorStrategy, TMLModel>::
+      update_protofile_net(const std::string &net_file,
+                           const std::string &deploy_file,
+                           const TInputConnectorStrategy &inputc,
+                           const bool &has_class_weights,
+                           const int &ignore_label, const int &timesteps,
+                           const APIData &ad_mllib)
   {
     caffe::NetParameter net_param;
-    caffe::ReadProtoFromTextFile(net_file,&net_param); //TODO: catch parsing error (returns bool true on success)
+    caffe::ReadProtoFromTextFile(net_file,
+                                 &net_param); // TODO: catch parsing error
+                                              // (returns bool true on success)
     int width = inputc.width();
     int height = inputc.height();
     bool has_embed = false;
     if (_crop_size > 0)
       width = height = _crop_size;
 
-    if (!inputc._db && !inputc._bbox && !inputc._ctc && typeid(this->_inputc) == typeid(ImgCaffeInputFileConn))
+    if (!inputc._db && !inputc._bbox && !inputc._ctc
+        && typeid(this->_inputc) == typeid(ImgCaffeInputFileConn))
       {
-            caffe::LayerParameter *lparam = net_param.mutable_layer(0);
-            caffe::ImageDataParameter* image_data_parameter = lparam->mutable_image_data_param();
-            image_data_parameter->set_source(inputc._uris.at(0));
-	    image_data_parameter->set_root_folder(inputc._root_folder);
-            image_data_parameter->set_batch_size(inputc.batch_size());
-            image_data_parameter->set_new_height(inputc.height());
-            image_data_parameter->set_new_width(inputc.width());
+        caffe::LayerParameter *lparam = net_param.mutable_layer(0);
+        caffe::ImageDataParameter *image_data_parameter
+            = lparam->mutable_image_data_param();
+        image_data_parameter->set_source(inputc._uris.at(0));
+        image_data_parameter->set_root_folder(inputc._root_folder);
+        image_data_parameter->set_batch_size(inputc.batch_size());
+        image_data_parameter->set_new_height(inputc.height());
+        image_data_parameter->set_new_width(inputc.width());
       }
 
     if (this->_inputc._ctc) // crnn
       {
-	int k = net_param.layer_size();
-	for (int l=0;l<k;l++)
-	  {
-	    caffe::LayerParameter *lparam = net_param.mutable_layer(l);
-	    if (lparam->type() == "Reshape")
-	      {
-		lparam->mutable_reshape_param()->mutable_shape()->set_dim(2,timesteps);
-	      }
-	    else if (lparam->type() == "ContinuationIndicator")
-	      {
-		lparam->mutable_continuation_indicator_param()->set_time_step(timesteps);
-	      }
-	    else if (lparam->type() == "CtcLoss")
-	      {
-		lparam->mutable_ctc_loss_param()->set_time_step(timesteps);
-		lparam->mutable_ctc_loss_param()->set_alphabet_size(inputc._alphabet_size);
-	      }
-	    else if (lparam->type() == "InnerProduct") // last layer before ctcloss
-	      {
-		lparam->mutable_inner_product_param()->set_num_output(inputc._alphabet_size);
-	      }
-	  }
+        int k = net_param.layer_size();
+        for (int l = 0; l < k; l++)
+          {
+            caffe::LayerParameter *lparam = net_param.mutable_layer(l);
+            if (lparam->type() == "Reshape")
+              {
+                lparam->mutable_reshape_param()->mutable_shape()->set_dim(
+                    2, timesteps);
+              }
+            else if (lparam->type() == "ContinuationIndicator")
+              {
+                lparam->mutable_continuation_indicator_param()->set_time_step(
+                    timesteps);
+              }
+            else if (lparam->type() == "CtcLoss")
+              {
+                lparam->mutable_ctc_loss_param()->set_time_step(timesteps);
+                lparam->mutable_ctc_loss_param()->set_alphabet_size(
+                    inputc._alphabet_size);
+              }
+            else if (lparam->type()
+                     == "InnerProduct") // last layer before ctcloss
+              {
+                lparam->mutable_inner_product_param()->set_num_output(
+                    inputc._alphabet_size);
+              }
+          }
       }
 
     if (net_param.mutable_layer(0)->has_memory_data_param()
-	|| net_param.mutable_layer(1)->has_memory_data_param())
+        || net_param.mutable_layer(1)->has_memory_data_param())
       {
         if (_ntargets == 0 || _ntargets == 1 || this->_inputc._timeserie)
-	  {
-	    if (net_param.mutable_layer(0)->has_memory_data_param())
-	      {
-		net_param.mutable_layer(0)->mutable_memory_data_param()->set_channels(inputc.channels());
-		net_param.mutable_layer(0)->mutable_memory_data_param()->set_width(width);
-		net_param.mutable_layer(0)->mutable_memory_data_param()->set_height(height);
-	      }
-	    if (net_param.mutable_layer(1)->has_memory_data_param())
-	      {
-		net_param.mutable_layer(1)->mutable_memory_data_param()->set_channels(inputc.channels()); // test layer
-		net_param.mutable_layer(1)->mutable_memory_data_param()->set_width(width);
-		net_param.mutable_layer(1)->mutable_memory_data_param()->set_height(height);
-	      }
-	  }
-	else if (typeid(this->_inputc) != typeid(ImgCaffeInputFileConn))
-	  {
-	    if (net_param.mutable_layer(0)->has_memory_data_param())
-	      net_param.mutable_layer(0)->mutable_memory_data_param()->set_channels(inputc.channels()+_ntargets);
-	    if (net_param.mutable_layer(1)->has_memory_data_param())
-	      net_param.mutable_layer(1)->mutable_memory_data_param()->set_channels(inputc.channels()+_ntargets);
-	    if (net_param.mutable_layer(2)->has_slice_param())
-	      net_param.mutable_layer(2)->mutable_slice_param()->set_slice_point(0,inputc.channels());
-	  }
+          {
+            if (net_param.mutable_layer(0)->has_memory_data_param())
+              {
+                net_param.mutable_layer(0)
+                    ->mutable_memory_data_param()
+                    ->set_channels(inputc.channels());
+                net_param.mutable_layer(0)
+                    ->mutable_memory_data_param()
+                    ->set_width(width);
+                net_param.mutable_layer(0)
+                    ->mutable_memory_data_param()
+                    ->set_height(height);
+              }
+            if (net_param.mutable_layer(1)->has_memory_data_param())
+              {
+                net_param.mutable_layer(1)
+                    ->mutable_memory_data_param()
+                    ->set_channels(inputc.channels()); // test layer
+                net_param.mutable_layer(1)
+                    ->mutable_memory_data_param()
+                    ->set_width(width);
+                net_param.mutable_layer(1)
+                    ->mutable_memory_data_param()
+                    ->set_height(height);
+              }
+          }
+        else if (typeid(this->_inputc) != typeid(ImgCaffeInputFileConn))
+          {
+            if (net_param.mutable_layer(0)->has_memory_data_param())
+              net_param.mutable_layer(0)
+                  ->mutable_memory_data_param()
+                  ->set_channels(inputc.channels() + _ntargets);
+            if (net_param.mutable_layer(1)->has_memory_data_param())
+              net_param.mutable_layer(1)
+                  ->mutable_memory_data_param()
+                  ->set_channels(inputc.channels() + _ntargets);
+            if (net_param.mutable_layer(2)->has_slice_param())
+              net_param.mutable_layer(2)
+                  ->mutable_slice_param()
+                  ->set_slice_point(0, inputc.channels());
+          }
       }
-    
-    if (net_param.mutable_layer(3)->type() == "Embed") // embed is preceded by a flatten layer
+
+    if (net_param.mutable_layer(3)->type()
+        == "Embed") // embed is preceded by a flatten layer
       {
-	has_embed = true;
-	net_param.mutable_layer(3)->mutable_embed_param()->set_input_dim(inputc._max_embed_id);
+        has_embed = true;
+        net_param.mutable_layer(3)->mutable_embed_param()->set_input_dim(
+            inputc._max_embed_id);
       }
 
     if (net_param.mutable_layer(4)->type() == "Reshape" && has_embed)
       {
-	net_param.mutable_layer(4)->mutable_reshape_param()->mutable_shape()->set_dim(2,inputc._sequence_txt);
+        net_param.mutable_layer(4)
+            ->mutable_reshape_param()
+            ->mutable_shape()
+            ->set_dim(2, inputc._sequence_txt);
       }
-    
-    // if autoencoder, set the last inner product layer output number to input size (i.e. inputc.channels())
+
+    // if autoencoder, set the last inner product layer output number to input
+    // size (i.e. inputc.channels())
     if (_autoencoder && this->_inputc._timeserie)
       {
-	int k = net_param.layer_size();
-	std::string bottom;
-	for (int l=k-1;l>0;l--)
-	  {
-	    caffe::LayerParameter *lparam = net_param.mutable_layer(l);
-	    if (lparam->type() == "SigmoidCrossEntropyLoss")
-	      {
-		bottom = lparam->bottom(0);
-	      }
-	    if (!bottom.empty() && lparam->type() == "InnerProduct")
-	      {
-		lparam->mutable_inner_product_param()->set_num_output(inputc.channels());
-		break;
-	      }
-	  }
+        int k = net_param.layer_size();
+        std::string bottom;
+        for (int l = k - 1; l > 0; l--)
+          {
+            caffe::LayerParameter *lparam = net_param.mutable_layer(l);
+            if (lparam->type() == "SigmoidCrossEntropyLoss")
+              {
+                bottom = lparam->bottom(0);
+              }
+            if (!bottom.empty() && lparam->type() == "InnerProduct")
+              {
+                lparam->mutable_inner_product_param()->set_num_output(
+                    inputc.channels());
+                break;
+              }
+          }
       }
 
     if (has_class_weights)
       {
-	int k = net_param.layer_size();
-	for (int l=k-1;l>0;l--)
-	  {
-	    caffe::LayerParameter *lparam = net_param.mutable_layer(l);
-	    if (lparam->type() == "SoftmaxWithLoss")
-	      {
-		lparam->set_type("SoftmaxWithInfogainLoss");
-		lparam->mutable_infogain_loss_param()->set_source(this->_mlmodel._repo + "/class_weights.binaryproto");
-		break;
-	      }
-           else if (lparam->type().compare("DiceCoefLoss") == 0)
-             {
-               lparam->mutable_dice_coef_loss_param()->set_weights(this->_mlmodel._repo + "/class_weights.binaryproto");
-               break;
-             }
-	  }
+        int k = net_param.layer_size();
+        for (int l = k - 1; l > 0; l--)
+          {
+            caffe::LayerParameter *lparam = net_param.mutable_layer(l);
+            if (lparam->type() == "SoftmaxWithLoss")
+              {
+                lparam->set_type("SoftmaxWithInfogainLoss");
+                lparam->mutable_infogain_loss_param()->set_source(
+                    this->_mlmodel._repo + "/class_weights.binaryproto");
+                break;
+              }
+            else if (lparam->type().compare("DiceCoefLoss") == 0)
+              {
+                lparam->mutable_dice_coef_loss_param()->set_weights(
+                    this->_mlmodel._repo + "/class_weights.binaryproto");
+                break;
+              }
+          }
       }
 
     if (ignore_label >= 0)
       {
-	int k = net_param.layer_size();
-	for (int l=k-1;l>0;l--)
-	  {
-	    caffe::LayerParameter *lparam = net_param.mutable_layer(l);
-	    if (lparam->type() == "SoftmaxWithLoss" || lparam->type() == "SoftmaxWithInfogainLoss")
-	      {
-		lparam->mutable_loss_param()->set_ignore_label(ignore_label);
-	      }
-	  }
+        int k = net_param.layer_size();
+        for (int l = k - 1; l > 0; l--)
+          {
+            caffe::LayerParameter *lparam = net_param.mutable_layer(l);
+            if (lparam->type() == "SoftmaxWithLoss"
+                || lparam->type() == "SoftmaxWithInfogainLoss")
+              {
+                lparam->mutable_loss_param()->set_ignore_label(ignore_label);
+              }
+          }
       }
 
     caffe::NetParameter deploy_net_param;
-    caffe::ReadProtoFromTextFile(deploy_file,&deploy_net_param);
+    caffe::ReadProtoFromTextFile(deploy_file, &deploy_net_param);
 #ifdef USE_CUDNN
     update_protofile_engine(deploy_net_param, ad_mllib);
 #endif
 
     if (this->_inputc._ctc) // crnn
       {
-	int k = deploy_net_param.layer_size();
-	for (int l=0;l<k;l++)
-	  {
-	    caffe::LayerParameter *lparam = deploy_net_param.mutable_layer(l);
-	    if (lparam->type() == "Reshape")
-	      {
-		lparam->mutable_reshape_param()->mutable_shape()->set_dim(2,timesteps);
-	      }
-	    else if (lparam->type() == "ContinuationIndicator")
-	      {
-		lparam->mutable_continuation_indicator_param()->set_time_step(timesteps);
-	      }
-	    else if (lparam->type() == "InnerProduct") // last layer before ctcloss
-	      {
-		lparam->mutable_inner_product_param()->set_num_output(inputc._alphabet_size);
-	      }
-	  }
+        int k = deploy_net_param.layer_size();
+        for (int l = 0; l < k; l++)
+          {
+            caffe::LayerParameter *lparam = deploy_net_param.mutable_layer(l);
+            if (lparam->type() == "Reshape")
+              {
+                lparam->mutable_reshape_param()->mutable_shape()->set_dim(
+                    2, timesteps);
+              }
+            else if (lparam->type() == "ContinuationIndicator")
+              {
+                lparam->mutable_continuation_indicator_param()->set_time_step(
+                    timesteps);
+              }
+            else if (lparam->type()
+                     == "InnerProduct") // last layer before ctcloss
+              {
+                lparam->mutable_inner_product_param()->set_num_output(
+                    inputc._alphabet_size);
+              }
+          }
       }
-    
+
     if (deploy_net_param.mutable_layer(2)->type() == "Embed")
       {
-	deploy_net_param.mutable_layer(2)->mutable_embed_param()->set_input_dim(inputc._max_embed_id);
+        deploy_net_param.mutable_layer(2)
+            ->mutable_embed_param()
+            ->set_input_dim(inputc._max_embed_id);
       }
     if (deploy_net_param.mutable_layer(3)->type() == "Reshape" && has_embed)
       {
-	deploy_net_param.mutable_layer(3)->mutable_reshape_param()->mutable_shape()->set_dim(2,inputc._sequence_txt);
+        deploy_net_param.mutable_layer(3)
+            ->mutable_reshape_param()
+            ->mutable_shape()
+            ->set_dim(2, inputc._sequence_txt);
       }
-    
+
     if (_autoencoder && typeid(this->_inputc) == typeid(CSVCaffeInputFileConn))
       {
-	int k = deploy_net_param.layer_size();
-	std::string bottom = "";
-	for (int l=k-1;l>0;l--)
-	  {
-	    caffe::LayerParameter *lparam = deploy_net_param.mutable_layer(l);
-	    if (lparam->type() == "InnerProduct")
-	      {
-		lparam->mutable_inner_product_param()->set_num_output(inputc.channels());
-		break;
-	      }
-	  }
+        int k = deploy_net_param.layer_size();
+        std::string bottom = "";
+        for (int l = k - 1; l > 0; l--)
+          {
+            caffe::LayerParameter *lparam = deploy_net_param.mutable_layer(l);
+            if (lparam->type() == "InnerProduct")
+              {
+                lparam->mutable_inner_product_param()->set_num_output(
+                    inputc.channels());
+                break;
+              }
+          }
       }
 
     if (deploy_net_param.mutable_layer(0)->has_memory_data_param())
       {
-	// no batch size set on deploy model since it is adjusted for every prediction batch
-        if (_ntargets == 0 || _ntargets == 1  || this->_inputc._timeserie)
-	  {
-	    deploy_net_param.mutable_layer(0)->mutable_memory_data_param()->set_channels(inputc.channels());
-	    deploy_net_param.mutable_layer(0)->mutable_memory_data_param()->set_width(width);
-	    deploy_net_param.mutable_layer(0)->mutable_memory_data_param()->set_height(height);
-	  }
-	else if (typeid(this->_inputc) != typeid(ImgCaffeInputFileConn))
-	  {
-	    deploy_net_param.mutable_layer(0)->mutable_memory_data_param()->set_channels(inputc.channels()+_ntargets);
-	    if (deploy_net_param.mutable_layer(1)->has_slice_param())
-	      deploy_net_param.mutable_layer(1)->mutable_slice_param()->set_slice_point(0,inputc.channels());
-	  }
-	if (!_autoencoder)
-	  for (size_t d=0;d<inputc._mean_values.size();d++)
-	    deploy_net_param.mutable_layer(0)->mutable_transform_param()->add_mean_value(inputc._mean_values.at(d));
-	if (_scale != 1.0)
-	  deploy_net_param.mutable_layer(0)->mutable_transform_param()->set_scale(_scale);
-	if (_crop_size > 0)
-	  deploy_net_param.mutable_layer(0)->mutable_transform_param()->set_crop_size(_crop_size);
+        // no batch size set on deploy model since it is adjusted for every
+        // prediction batch
+        if (_ntargets == 0 || _ntargets == 1 || this->_inputc._timeserie)
+          {
+            deploy_net_param.mutable_layer(0)
+                ->mutable_memory_data_param()
+                ->set_channels(inputc.channels());
+            deploy_net_param.mutable_layer(0)
+                ->mutable_memory_data_param()
+                ->set_width(width);
+            deploy_net_param.mutable_layer(0)
+                ->mutable_memory_data_param()
+                ->set_height(height);
+          }
+        else if (typeid(this->_inputc) != typeid(ImgCaffeInputFileConn))
+          {
+            deploy_net_param.mutable_layer(0)
+                ->mutable_memory_data_param()
+                ->set_channels(inputc.channels() + _ntargets);
+            if (deploy_net_param.mutable_layer(1)->has_slice_param())
+              deploy_net_param.mutable_layer(1)
+                  ->mutable_slice_param()
+                  ->set_slice_point(0, inputc.channels());
+          }
+        if (!_autoencoder)
+          for (size_t d = 0; d < inputc._mean_values.size(); d++)
+            deploy_net_param.mutable_layer(0)
+                ->mutable_transform_param()
+                ->add_mean_value(inputc._mean_values.at(d));
+        if (_scale != 1.0)
+          deploy_net_param.mutable_layer(0)
+              ->mutable_transform_param()
+              ->set_scale(_scale);
+        if (_crop_size > 0)
+          deploy_net_param.mutable_layer(0)
+              ->mutable_transform_param()
+              ->set_crop_size(_crop_size);
       }
 
-    caffe::WriteProtoToTextFile(net_param,net_file);
-    caffe::WriteProtoToTextFile(deploy_net_param,deploy_file);
+    caffe::WriteProtoToTextFile(net_param, net_file);
+    caffe::WriteProtoToTextFile(deploy_net_param, deploy_file);
   }
 
 #ifdef USE_CUDNN
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::update_protofile_engine(const APIData& ad)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void CaffeLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+                TMLModel>::update_protofile_engine(const APIData &ad)
   {
 
-	std::string deploy_file = this->_mlmodel._repo + "/deploy.prototxt";
-	caffe::NetParameter deploy_net_param;
-	caffe::ReadProtoFromTextFile(deploy_file,&deploy_net_param);
-	update_protofile_engine(deploy_net_param, ad);
-	caffe::WriteProtoToTextFile(deploy_net_param,deploy_file);
+    std::string deploy_file = this->_mlmodel._repo + "/deploy.prototxt";
+    caffe::NetParameter deploy_net_param;
+    caffe::ReadProtoFromTextFile(deploy_file, &deploy_net_param);
+    update_protofile_engine(deploy_net_param, ad);
+    caffe::WriteProtoToTextFile(deploy_net_param, deploy_file);
 
     if (this->_mlmodel._model_template.empty())
       return;
 
-    std::string train_file = this->_mlmodel._repo + "/" + this->_mlmodel._model_template + ".prototxt";
-	caffe::NetParameter net_param;
-	caffe::ReadProtoFromTextFile(train_file,&net_param);
+    std::string train_file = this->_mlmodel._repo + "/"
+                             + this->_mlmodel._model_template + ".prototxt";
+    caffe::NetParameter net_param;
+    caffe::ReadProtoFromTextFile(train_file, &net_param);
     update_protofile_engine(net_param, ad);
-	caffe::WriteProtoToTextFile(net_param,train_file);
+    caffe::WriteProtoToTextFile(net_param, train_file);
   }
 
-
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  bool CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::is_refinedet(caffe::NetParameter &net_param)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  bool CaffeLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+                TMLModel>::is_refinedet(caffe::NetParameter &net_param)
   {
-    for (int l=net_param.layer_size()-1;l>0;l--)
+    for (int l = net_param.layer_size() - 1; l > 0; l--)
       {
-		caffe::LayerParameter *lparam = net_param.mutable_layer(l);
-		if (lparam->type() == "DetectionOutput" && lparam->bottom().size() > 3)
-		  return true;
-	  }
-	return false;
+        caffe::LayerParameter *lparam = net_param.mutable_layer(l);
+        if (lparam->type() == "DetectionOutput" && lparam->bottom().size() > 3)
+          return true;
+      }
+    return false;
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::update_protofile_engine(caffe::NetParameter &net_param, const APIData& ad)
-{
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void
+  CaffeLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+           TMLModel>::update_protofile_engine(caffe::NetParameter &net_param,
+                                              const APIData &ad)
+  {
 
-  bool refinedet = is_refinedet(net_param);
-  
-  if (!ad.has("engine") && !refinedet)
-    return;
+    bool refinedet = is_refinedet(net_param);
 
-  for (int l=0; l< net_param.layer_size();l++)
-    {
-      caffe::LayerParameter *lparam = net_param.mutable_layer(l);
-      if (lparam->type() == "Convolution" || lparam->type() == "Deconvolution")
-        {
-          bool use_dilation = false;
-          for (int i = 0; i< lparam->convolution_param().dilation_size(); ++i)
-            if (lparam->convolution_param().dilation(i) > 1)
-              {
-                lparam->mutable_convolution_param()->set_engine(::caffe::ConvolutionParameter::DEFAULT);
-                lparam->mutable_convolution_param()->clear_cudnn_flavor();
-                use_dilation = true;
-                break;
-              }
-          if (use_dilation)
+    if (!ad.has("engine") && !refinedet)
+      return;
+
+    for (int l = 0; l < net_param.layer_size(); l++)
+      {
+        caffe::LayerParameter *lparam = net_param.mutable_layer(l);
+        if (lparam->type() == "Convolution"
+            || lparam->type() == "Deconvolution")
+          {
+            bool use_dilation = false;
+            for (int i = 0; i < lparam->convolution_param().dilation_size();
+                 ++i)
+              if (lparam->convolution_param().dilation(i) > 1)
+                {
+                  lparam->mutable_convolution_param()->set_engine(
+                      ::caffe::ConvolutionParameter::DEFAULT);
+                  lparam->mutable_convolution_param()->clear_cudnn_flavor();
+                  use_dilation = true;
+                  break;
+                }
+            if (use_dilation)
               continue;
 
-          if (!refinedet && ad.has("engine") && ad.get("engine").get<std::string>() == "DEFAULT")
-            {
-              lparam->mutable_convolution_param()->set_engine(::caffe::ConvolutionParameter::DEFAULT);
-              lparam->mutable_convolution_param()->clear_cudnn_flavor();
-            }
-          else if (!refinedet && ad.has("engine") && ad.get("engine").get<std::string>() == "CAFFE")
-            {
-              lparam->mutable_convolution_param()->set_engine(::caffe::ConvolutionParameter::CAFFE);
-              lparam->mutable_convolution_param()->clear_cudnn_flavor();
-            }
-          else if (!refinedet && ad.has("engine") && ad.get("engine").get<std::string>() == "CUDNN")
-            {
-              lparam->mutable_convolution_param()->set_engine(::caffe::ConvolutionParameter::CUDNN);
-              lparam->mutable_convolution_param()->set_cudnn_flavor(::caffe::ConvolutionParameter::MULTIPLE_HANDLES);
-            }
-          else if (!refinedet && ad.has("engine") &&  ad.get("engine").get<std::string>() == "CUDNN_SINGLE_HANDLE")
-            {
-              lparam->mutable_convolution_param()->set_engine(::caffe::ConvolutionParameter::CUDNN);
-              lparam->mutable_convolution_param()->set_cudnn_flavor(::caffe::ConvolutionParameter::SINGLE_HANDLE);
-            }
-          else if (refinedet || (ad.has("engine") && ad.get("engine").get<std::string>() == "CUDNN_MIN_MEMORY") )
-            {
-              lparam->mutable_convolution_param()->set_engine(::caffe::ConvolutionParameter::CUDNN);
-              lparam->mutable_convolution_param()->set_cudnn_flavor(::caffe::ConvolutionParameter::MIN_MEMORY);
-            }
-        }
-    }
-}
+            if (!refinedet && ad.has("engine")
+                && ad.get("engine").get<std::string>() == "DEFAULT")
+              {
+                lparam->mutable_convolution_param()->set_engine(
+                    ::caffe::ConvolutionParameter::DEFAULT);
+                lparam->mutable_convolution_param()->clear_cudnn_flavor();
+              }
+            else if (!refinedet && ad.has("engine")
+                     && ad.get("engine").get<std::string>() == "CAFFE")
+              {
+                lparam->mutable_convolution_param()->set_engine(
+                    ::caffe::ConvolutionParameter::CAFFE);
+                lparam->mutable_convolution_param()->clear_cudnn_flavor();
+              }
+            else if (!refinedet && ad.has("engine")
+                     && ad.get("engine").get<std::string>() == "CUDNN")
+              {
+                lparam->mutable_convolution_param()->set_engine(
+                    ::caffe::ConvolutionParameter::CUDNN);
+                lparam->mutable_convolution_param()->set_cudnn_flavor(
+                    ::caffe::ConvolutionParameter::MULTIPLE_HANDLES);
+              }
+            else if (!refinedet && ad.has("engine")
+                     && ad.get("engine").get<std::string>()
+                            == "CUDNN_SINGLE_HANDLE")
+              {
+                lparam->mutable_convolution_param()->set_engine(
+                    ::caffe::ConvolutionParameter::CUDNN);
+                lparam->mutable_convolution_param()->set_cudnn_flavor(
+                    ::caffe::ConvolutionParameter::SINGLE_HANDLE);
+              }
+            else if (refinedet
+                     || (ad.has("engine")
+                         && ad.get("engine").get<std::string>()
+                                == "CUDNN_MIN_MEMORY"))
+              {
+                lparam->mutable_convolution_param()->set_engine(
+                    ::caffe::ConvolutionParameter::CUDNN);
+                lparam->mutable_convolution_param()->set_cudnn_flavor(
+                    ::caffe::ConvolutionParameter::MIN_MEMORY);
+              }
+          }
+      }
+  }
 #endif
 
-
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::update_protofile_classes(caffe::NetParameter &net_param)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void
+  CaffeLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+           TMLModel>::update_protofile_classes(caffe::NetParameter &net_param)
   {
     // fix class numbers
-    // this procedure looks for the first bottom layer with a 'num_output' field and
-    // set it to the number of classes defined by the supervised service.
+    // this procedure looks for the first bottom layer with a 'num_output'
+    // field and set it to the number of classes defined by the supervised
+    // service.
     if (this->_inputc._bbox)
       return;
     bool last_layer = true;
-    for (int l=net_param.layer_size()-1;l>0;l--)
+    for (int l = net_param.layer_size() - 1; l > 0; l--)
       {
-	caffe::LayerParameter *lparam = net_param.mutable_layer(l);
-	if (lparam->type() == "Convolution" || lparam->type() == "Deconvolution")
-	  {
-	    if (lparam->has_convolution_param())
-	      {
-            int num_output = lparam->mutable_convolution_param()->num_output();
-            if (last_layer || num_output == 0)
-              lparam->mutable_convolution_param()->set_num_output(_nclasses);
-            if (last_layer && num_output != 0)
-              break;
-            else last_layer = false;
-	      }
-	  }
-	else if (lparam->type() == "InnerProduct" || lparam->type() == "SparseInnerProduct")
-	  {
-	    if (lparam->has_inner_product_param())
-	      {
-            if (!_regression || _ntargets == 0)
-                lparam->mutable_inner_product_param()->set_num_output(_nclasses);
-            else lparam->mutable_inner_product_param()->set_num_output(_ntargets);
-            break;
-	      }
-	  }
-	/*else if (lparam->type() == "DetectionOutput")
-	  {
-	    if (lparam->has_detection_output_param())
-	      {
-		lparam->mutable_detection_output_param()->set_num_classes(_nclasses);
-		break;
-		}
-	      }*/
+        caffe::LayerParameter *lparam = net_param.mutable_layer(l);
+        if (lparam->type() == "Convolution"
+            || lparam->type() == "Deconvolution")
+          {
+            if (lparam->has_convolution_param())
+              {
+                int num_output
+                    = lparam->mutable_convolution_param()->num_output();
+                if (last_layer || num_output == 0)
+                  lparam->mutable_convolution_param()->set_num_output(
+                      _nclasses);
+                if (last_layer && num_output != 0)
+                  break;
+                else
+                  last_layer = false;
+              }
+          }
+        else if (lparam->type() == "InnerProduct"
+                 || lparam->type() == "SparseInnerProduct")
+          {
+            if (lparam->has_inner_product_param())
+              {
+                if (!_regression || _ntargets == 0)
+                  lparam->mutable_inner_product_param()->set_num_output(
+                      _nclasses);
+                else
+                  lparam->mutable_inner_product_param()->set_num_output(
+                      _ntargets);
+                break;
+              }
+          }
+        /*else if (lparam->type() == "DetectionOutput")
+          {
+            if (lparam->has_detection_output_param())
+              {
+                lparam->mutable_detection_output_param()->set_num_classes(_nclasses);
+                break;
+                }
+              }*/
       }
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::update_protofile_finetune(caffe::NetParameter &net_param)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void
+  CaffeLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+           TMLModel>::update_protofile_finetune(caffe::NetParameter &net_param)
   {
     std::string ft_lname, ft_oldname;
 
     if (net_param.name() == "deeplab_vgg16")
       // special case with 4 ends to change
       {
-        for (int l=net_param.layer_size()-1;l>0;l--)
+        for (int l = net_param.layer_size() - 1; l > 0; l--)
           {
             caffe::LayerParameter *lparam = net_param.mutable_layer(l);
-            if (lparam->type() == "Convolution" &&
-                (lparam->name() == "fc8_vgg16_1" ||
-                 lparam->name() == "fc8_vgg16_2" ||
-                 lparam->name() == "fc8_vgg16_3" ||
-                 lparam->name() == "fc8_vgg16_4" ))
+            if (lparam->type() == "Convolution"
+                && (lparam->name() == "fc8_vgg16_1"
+                    || lparam->name() == "fc8_vgg16_2"
+                    || lparam->name() == "fc8_vgg16_3"
+                    || lparam->name() == "fc8_vgg16_4"))
               {
                 ft_oldname = lparam->top(0);
                 ft_lname = lparam->name() + "_ftune";
                 lparam->set_name(ft_lname);
-                lparam->set_top(0,ft_lname);
+                lparam->set_top(0, ft_lname);
                 continue;
               }
             if (lparam->name() == "fc8_vgg16")
               {
                 ft_lname = lparam->name() + "_ftune";
                 lparam->set_name(ft_lname);
-                lparam->set_top(0,ft_lname);
-                for (int i=0; i<4; ++i) {
-                  std::string ft_lname_b = lparam->bottom(i) + "_ftune";
-                  lparam->set_bottom(i,ft_lname_b);
-                }
+                lparam->set_top(0, ft_lname);
+                for (int i = 0; i < 4; ++i)
+                  {
+                    std::string ft_lname_b = lparam->bottom(i) + "_ftune";
+                    lparam->set_bottom(i, ft_lname_b);
+                  }
                 continue;
               }
-            if (lparam->name() == "normalization" && lparam->bottom(0) == "fc8_vgg16")
+            if (lparam->name() == "normalization"
+                && lparam->bottom(0) == "fc8_vgg16")
               {
                 lparam->set_bottom(0, lparam->bottom(0) + "_ftune");
                 continue;
@@ -3674,124 +4371,142 @@ namespace dd
         return;
       }
     // fix class numbers
-    // this procedure looks for the first bottom layer with a 'num_output' field and
-    // rename the layer so that its weights can be reinitialized and the net finetuned
+    // this procedure looks for the first bottom layer with a 'num_output'
+    // field and rename the layer so that its weights can be reinitialized and
+    // the net finetuned
     int k = net_param.layer_size();
-    for (int l=net_param.layer_size()-1;l>0;l--)
+    for (int l = net_param.layer_size() - 1; l > 0; l--)
       {
-	caffe::LayerParameter *lparam = net_param.mutable_layer(l);
-	if (lparam->type() == "Convolution")
-	  {
-	    ft_oldname = lparam->top(0);
-	    ft_lname = lparam->name() + "_ftune";
-	    lparam->set_name(ft_lname);
-	    lparam->set_top(0,ft_lname);
-	    k = l;
-	    break;
-	  }
-	else if (lparam->type() == "InnerProduct")
-	  {
-	    ft_oldname = lparam->top(0);
-	    ft_lname = lparam->name() + "_ftune";
-	    lparam->set_name(ft_lname);
-	    lparam->set_top(0,ft_lname);
-	    k = l;
-	    break;
-	  }
+        caffe::LayerParameter *lparam = net_param.mutable_layer(l);
+        if (lparam->type() == "Convolution")
+          {
+            ft_oldname = lparam->top(0);
+            ft_lname = lparam->name() + "_ftune";
+            lparam->set_name(ft_lname);
+            lparam->set_top(0, ft_lname);
+            k = l;
+            break;
+          }
+        else if (lparam->type() == "InnerProduct")
+          {
+            ft_oldname = lparam->top(0);
+            ft_lname = lparam->name() + "_ftune";
+            lparam->set_name(ft_lname);
+            lparam->set_top(0, ft_lname);
+            k = l;
+            break;
+          }
       }
     // update relations from other layers
-    for (int l=net_param.layer_size()-1;l>k;l--)
+    for (int l = net_param.layer_size() - 1; l > k; l--)
       {
-	caffe::LayerParameter *lparam = net_param.mutable_layer(l);
-	if (lparam->top(0) == ft_oldname)
-	  lparam->set_top(0,ft_lname);
-	if (lparam->bottom(0) == ft_oldname)
-	  lparam->set_bottom(0,ft_lname);
+        caffe::LayerParameter *lparam = net_param.mutable_layer(l);
+        if (lparam->top(0) == ft_oldname)
+          lparam->set_top(0, ft_lname);
+        if (lparam->bottom(0) == ft_oldname)
+          lparam->set_bottom(0, ft_lname);
       }
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::fix_batch_size(const APIData &ad,
-											   const TInputConnectorStrategy &inputc,
-											   int &user_batch_size,
-											   int &batch_size,
-											   int &test_batch_size,
-											   int &test_iter)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void
+  CaffeLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+           TMLModel>::fix_batch_size(const APIData &ad,
+                                     const TInputConnectorStrategy &inputc,
+                                     int &user_batch_size, int &batch_size,
+                                     int &test_batch_size, int &test_iter)
   {
     // acquire custom batch size if any
     APIData ad_net = ad.getobj("parameters").getobj("mllib").getobj("net");
     if (ad_net.has("batch_size"))
       {
-	// adjust batch size so that it is a multiple of the number of training samples (Caffe requirement)
-	user_batch_size = batch_size = test_batch_size = ad_net.get("batch_size").get<int>();
-	if (ad_net.has("test_batch_size"))
-	  test_batch_size = ad_net.get("test_batch_size").get<int>();
-	if (batch_size == 0)
-	  throw MLLibBadParamException("batch size set to zero");
-	this->_logger->info("user batch_size={} / inputc batch_size=",batch_size,inputc.batch_size());
-	
-	// code below is required when Caffe (weirdly) requires the batch size 
-	// to be a multiple of the training dataset size.
-	if (!inputc._ctc && !inputc._segmentation && !(!inputc._db && typeid(inputc) == typeid(ImgCaffeInputFileConn)))
-	  {
-	    if (batch_size < inputc.batch_size())
-	      {
-		int min_batch_size = 0;
-		for (int i=batch_size;i>=1;i--)
-		  if (inputc.batch_size() % i == 0)
-		    {
-		      min_batch_size = i;
-		      break;
-		    }
-		int max_batch_size = 0;
-		for (int i=batch_size;i<inputc.batch_size();i++)
-		  {
-		    if (inputc.batch_size() % i == 0)
-		      {
-			max_batch_size = i;
-			break;
-		      }
-		  }
-		if (std::abs(batch_size-min_batch_size) < std::abs(max_batch_size-batch_size))
-		  batch_size = min_batch_size;
-		else batch_size = max_batch_size;
-		for (int i=test_batch_size;i>1;i--)
-		  if (inputc.test_batch_size() % i == 0)
-		    {
-		      test_batch_size = i;
-		      break;
-		    }
-		test_iter = inputc.test_batch_size() / test_batch_size;
-	      }
-	    else batch_size = inputc.batch_size();
-	    test_iter = inputc.test_batch_size() / test_batch_size;
-	  }
-	else
-	  {
-	    batch_size = user_batch_size;
-	    test_iter = std::max(inputc.test_batch_size() / test_batch_size,1);
-	  }
-	    
-	//debug
-	this->_logger->info("batch_size={} / test_batch_size={} / test_iter={}", batch_size, test_batch_size, test_iter);
-	//debug
+        // adjust batch size so that it is a multiple of the number of training
+        // samples (Caffe requirement)
+        user_batch_size = batch_size = test_batch_size
+            = ad_net.get("batch_size").get<int>();
+        if (ad_net.has("test_batch_size"))
+          test_batch_size = ad_net.get("test_batch_size").get<int>();
+        if (batch_size == 0)
+          throw MLLibBadParamException("batch size set to zero");
+        this->_logger->info("user batch_size={} / inputc batch_size=",
+                            batch_size, inputc.batch_size());
 
-	if (batch_size == 0)
-	  throw MLLibBadParamException("auto batch size set to zero: MemoryData input requires batch size to be a multiple of training set");
+        // code below is required when Caffe (weirdly) requires the batch size
+        // to be a multiple of the training dataset size.
+        if (!inputc._ctc && !inputc._segmentation
+            && !(!inputc._db
+                 && typeid(inputc) == typeid(ImgCaffeInputFileConn)))
+          {
+            if (batch_size < inputc.batch_size())
+              {
+                int min_batch_size = 0;
+                for (int i = batch_size; i >= 1; i--)
+                  if (inputc.batch_size() % i == 0)
+                    {
+                      min_batch_size = i;
+                      break;
+                    }
+                int max_batch_size = 0;
+                for (int i = batch_size; i < inputc.batch_size(); i++)
+                  {
+                    if (inputc.batch_size() % i == 0)
+                      {
+                        max_batch_size = i;
+                        break;
+                      }
+                  }
+                if (std::abs(batch_size - min_batch_size)
+                    < std::abs(max_batch_size - batch_size))
+                  batch_size = min_batch_size;
+                else
+                  batch_size = max_batch_size;
+                for (int i = test_batch_size; i > 1; i--)
+                  if (inputc.test_batch_size() % i == 0)
+                    {
+                      test_batch_size = i;
+                      break;
+                    }
+                test_iter = inputc.test_batch_size() / test_batch_size;
+              }
+            else
+              batch_size = inputc.batch_size();
+            test_iter = inputc.test_batch_size() / test_batch_size;
+          }
+        else
+          {
+            batch_size = user_batch_size;
+            test_iter
+                = std::max(inputc.test_batch_size() / test_batch_size, 1);
+          }
+
+        // debug
+        this->_logger->info(
+            "batch_size={} / test_batch_size={} / test_iter={}", batch_size,
+            test_batch_size, test_iter);
+        // debug
+
+        if (batch_size == 0)
+          throw MLLibBadParamException(
+              "auto batch size set to zero: MemoryData input requires batch "
+              "size to be a multiple of training set");
       }
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::model_complexity(long int &flops,
-                                                                                             long int &params)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void CaffeLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+                TMLModel>::model_complexity(long int &flops, long int &params)
   {
-    for (size_t l=0;l<_net->layers().size();l++)
+    for (size_t l = 0; l < _net->layers().size(); l++)
       {
-        const boost::shared_ptr<caffe::Layer<float>> &layer = _net->layers().at(l);
+        const boost::shared_ptr<caffe::Layer<float>> &layer
+            = _net->layers().at(l);
         std::string lname = layer->layer_param().name();
         std::string ltype = layer->layer_param().type();
         std::vector<boost::shared_ptr<Blob<float>>> blblobs = layer->blobs();
-        const std::vector<caffe::Blob<float>*> &tlblobs = _net->top_vecs().at(l);
+        const std::vector<caffe::Blob<float> *> &tlblobs
+            = _net->top_vecs().at(l);
         if (blblobs.empty())
           continue;
         long int lcount = blblobs.at(0)->count();
@@ -3809,108 +4524,126 @@ namespace dd
         flops += lflops;
         params += lcount;
       }
-    this->_logger->info("Net total flops={} / total params={}",flops,params);
+    this->_logger->info("Net total flops={} / total params={}", flops, params);
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::model_type(caffe::Net<float> *net,
-										       std::string &mltype)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void CaffeLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+                TMLModel>::model_type(caffe::Net<float> *net,
+                                      std::string &mltype)
   {
     // XXX: using deploy.prototxt to detect network's task type.
     if (_autoencoder)
       {
-	mltype = "autoencoder";
-	return;
+        mltype = "autoencoder";
+        return;
       }
     bool has_deconv = false;
-    for (size_t l=0;l<net->layers().size();l++)
+    for (size_t l = 0; l < net->layers().size(); l++)
       {
-	const boost::shared_ptr<caffe::Layer<float>> &layer = net->layers().at(l);
-	std::string lname = layer->layer_param().name();
-	std::string ltype = layer->layer_param().type();
+        const boost::shared_ptr<caffe::Layer<float>> &layer
+            = net->layers().at(l);
+        std::string lname = layer->layer_param().name();
+        std::string ltype = layer->layer_param().type();
 
-	if (ltype == "DetectionOutput" || ltype == "MultiBoxLoss" || ltype == "PriorBox")
-	  {
-	    mltype = "detection";
-	    const boost::shared_ptr<caffe::Layer<float>> &final_layer = net->layers().at(net->layers().size()-1);
-	    if (final_layer->layer_param().type() == "Slice")
-	      mltype = "rois";
-	    break;
-	  }
-	if (ltype == "ContinuationIndicator") // XXX: CTC layer does not appear in deploy file, this is a hack used by our LSTMs
-	  {
-	    mltype = "ctc";
-	    break;
-	  }
-	if (ltype == "Interp" || ltype == "Deconvolution") // XXX: using interpolation and deconvolution as proxy to segmentation
-	  {
-	    mltype = "segmentation";
-	    has_deconv = true;
-	    // we don't break since some detection tasks may use deconvolutions
-	  }
-	if (!has_deconv && ltype == "Sigmoid" && l == net->layers().size()-1)
-	  {
-	    mltype = "regression";
-	    break;
-	  }
-	
+        if (ltype == "DetectionOutput" || ltype == "MultiBoxLoss"
+            || ltype == "PriorBox")
+          {
+            mltype = "detection";
+            const boost::shared_ptr<caffe::Layer<float>> &final_layer
+                = net->layers().at(net->layers().size() - 1);
+            if (final_layer->layer_param().type() == "Slice")
+              mltype = "rois";
+            break;
+          }
+        if (ltype == "ContinuationIndicator") // XXX: CTC layer does not appear
+                                              // in deploy file, this is a hack
+                                              // used by our LSTMs
+          {
+            mltype = "ctc";
+            break;
+          }
+        if (ltype == "Interp"
+            || ltype == "Deconvolution") // XXX: using interpolation and
+                                         // deconvolution as proxy to
+                                         // segmentation
+          {
+            mltype = "segmentation";
+            has_deconv = true;
+            // we don't break since some detection tasks may use deconvolutions
+          }
+        if (!has_deconv && ltype == "Sigmoid" && l == net->layers().size() - 1)
+          {
+            mltype = "regression";
+            break;
+          }
       }
     if (mltype.empty())
       mltype = "classification";
-    this->_logger->info("detected network type is {}",mltype);
+    this->_logger->info("detected network type is {}", mltype);
   }
-  
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::update_protofiles_dice_deeplab_vgg16(caffe::NetParameter &net_param,caffe::NetParameter &deploy_net_param, const APIData& ad)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void CaffeLib<TInputConnectorStrategy, TOutputConnectorStrategy, TMLModel>::
+      update_protofiles_dice_deeplab_vgg16(
+          caffe::NetParameter &net_param,
+          caffe::NetParameter &deploy_net_param, const APIData &ad)
   {
-    caffe::LayerParameter *shrink_param = find_layer_by_name(net_param,"label_shrink");
+    caffe::LayerParameter *shrink_param
+        = find_layer_by_name(net_param, "label_shrink");
     shrink_param->add_include();
     caffe::NetStateRule *nsr = shrink_param->mutable_include(0);
     nsr->set_phase(caffe::TRAIN);
     caffe::InterpParameter *ip = shrink_param->mutable_interp_param();
     ip->set_mode(caffe::InterpParameter::NEAREST);
 
-
-    int softml_pos = find_index_layer_by_type(net_param,"SoftmaxWithLoss");
+    int softml_pos = find_index_layer_by_type(net_param, "SoftmaxWithLoss");
     std::string logits = net_param.layer(softml_pos).bottom(0);
     std::string loss_input = logits + "_prob";
 
     std::string logits_norm = logits + "_norm";
     std::string agg_output = logits_norm + "_agg";
 
-    caffe::LayerParameter* mvn_param = insert_layer_before(net_param, softml_pos++);
+    caffe::LayerParameter *mvn_param
+        = insert_layer_before(net_param, softml_pos++);
     *mvn_param->mutable_name() = "normalization";
     *mvn_param->mutable_type() = "MVN";
     mvn_param->mutable_mvn_param()->set_across_channels(true);
     mvn_param->add_bottom(logits);
     mvn_param->add_top(logits_norm);
 
-	caffe::LayerParameter* sigmoid_loss_param = insert_layer_before(net_param, softml_pos++);
-	sigmoid_loss_param->set_name("probabilizer");
-	sigmoid_loss_param->set_type("Softmax");
-	sigmoid_loss_param->add_bottom(logits_norm);
-	sigmoid_loss_param->add_top(loss_input);
-	sigmoid_loss_param->add_include();
-	nsr = sigmoid_loss_param->mutable_include(0);
-	nsr->set_phase(caffe::TRAIN);
+    caffe::LayerParameter *sigmoid_loss_param
+        = insert_layer_before(net_param, softml_pos++);
+    sigmoid_loss_param->set_name("probabilizer");
+    sigmoid_loss_param->set_type("Softmax");
+    sigmoid_loss_param->add_bottom(logits_norm);
+    sigmoid_loss_param->add_top(loss_input);
+    sigmoid_loss_param->add_include();
+    nsr = sigmoid_loss_param->mutable_include(0);
+    nsr->set_phase(caffe::TRAIN);
 
-    caffe::LayerParameter* final_interp_param = find_layer_by_name(net_param,"final_interp");
-	*final_interp_param->mutable_bottom(0) = logits_norm;
-	caffe::LayerParameter* probt_param = find_layer_by_name(net_param, "probt");
-	*probt_param->mutable_type() = "Softmax";
+    caffe::LayerParameter *final_interp_param
+        = find_layer_by_name(net_param, "final_interp");
+    *final_interp_param->mutable_bottom(0) = logits_norm;
+    caffe::LayerParameter *probt_param
+        = find_layer_by_name(net_param, "probt");
+    *probt_param->mutable_type() = "Softmax";
 
     caffe::LayerParameter *lossparam = net_param.mutable_layer(softml_pos);
     *lossparam->mutable_type() = "DiceCoefLoss";
     *lossparam->mutable_bottom(0) = loss_input;
-    caffe::DiceCoefLossParameter* dclp = lossparam->mutable_dice_coef_loss_param();
+    caffe::DiceCoefLossParameter *dclp
+        = lossparam->mutable_dice_coef_loss_param();
 
     update_protofiles_dice_params(dclp, ad);
 
     // now work on deploy.txt
-    int final_interp_pos = find_index_layer_by_type(deploy_net_param, "Interp");
+    int final_interp_pos
+        = find_index_layer_by_type(deploy_net_param, "Interp");
     final_interp_param = deploy_net_param.mutable_layer(final_interp_pos);
-	*final_interp_param->mutable_bottom(0) = logits_norm;
+    *final_interp_param->mutable_bottom(0) = logits_norm;
 
     mvn_param = insert_layer_before(deploy_net_param, final_interp_pos++);
     *mvn_param->mutable_name() = "normalization";
@@ -3919,29 +4652,36 @@ namespace dd
     mvn_param->add_bottom(logits);
     mvn_param->add_top(logits_norm);
 
-	probt_param = find_layer_by_name(deploy_net_param, "probt");
-	*probt_param->mutable_type() = "Softmax";
+    probt_param = find_layer_by_name(deploy_net_param, "probt");
+    *probt_param->mutable_type() = "Softmax";
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::update_protofiles_one_hot(caffe::NetParameter &net_param)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void
+  CaffeLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+           TMLModel>::update_protofiles_one_hot(caffe::NetParameter &net_param)
   {
-    caffe::LayerParameter* denseImageDataLayer = find_layer_by_type(net_param,"DenseImageData");
-    caffe::DenseImageDataParameter *dp = denseImageDataLayer->mutable_dense_image_data_param();
+    caffe::LayerParameter *denseImageDataLayer
+        = find_layer_by_type(net_param, "DenseImageData");
+    caffe::DenseImageDataParameter *dp
+        = denseImageDataLayer->mutable_dense_image_data_param();
     dp->set_one_hot_nclasses(_nclasses);
   }
 
-
-    template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::update_protofiles_dice_params(caffe::DiceCoefLossParameter*dclp,  const APIData &ad)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void CaffeLib<TInputConnectorStrategy, TOutputConnectorStrategy, TMLModel>::
+      update_protofiles_dice_params(caffe::DiceCoefLossParameter *dclp,
+                                    const APIData &ad)
   {
 
-    caffe::DiceCoefLossParameter::GeneralizationMode genMode =
-      caffe::DiceCoefLossParameter::MULTICLASS;
-    caffe::DiceCoefLossParameter::WeightMode weightMode =
-      caffe::DiceCoefLossParameter::INVERSE_VOLUME;
-    caffe::DiceCoefLossParameter::ContourShape contours =
-      caffe::DiceCoefLossParameter::NO;
+    caffe::DiceCoefLossParameter::GeneralizationMode genMode
+        = caffe::DiceCoefLossParameter::MULTICLASS;
+    caffe::DiceCoefLossParameter::WeightMode weightMode
+        = caffe::DiceCoefLossParameter::INVERSE_VOLUME;
+    caffe::DiceCoefLossParameter::ContourShape contours
+        = caffe::DiceCoefLossParameter::NO;
     int contour_size = 7;
     float contour_amplitude = 5.0;
     if (ad.has("dice_param"))
@@ -3956,13 +4696,18 @@ namespace dd
                 if (wm == "image")
                   genMode = caffe::DiceCoefLossParameter::MULTICLASS_WEIGHTED;
                 else if (wm == "batch")
-                  genMode = caffe::DiceCoefLossParameter::MULTICLASS_WEIGHTED_BATCH;
+                  genMode = caffe::DiceCoefLossParameter::
+                      MULTICLASS_WEIGHTED_BATCH;
                 else if (wm == "all")
-                  genMode = caffe::DiceCoefLossParameter::MULTICLASS_WEIGHTED_ALL;
+                  genMode
+                      = caffe::DiceCoefLossParameter::MULTICLASS_WEIGHTED_ALL;
                 else
                   {
-                    this->_logger->warn("dice class weighting on {} unrecognized , setting to all",wm);
-                    genMode = caffe::DiceCoefLossParameter::MULTICLASS_WEIGHTED_ALL;
+                    this->_logger->warn("dice class weighting on {} "
+                                        "unrecognized , setting to all",
+                                        wm);
+                    genMode = caffe::DiceCoefLossParameter::
+                        MULTICLASS_WEIGHTED_ALL;
                   }
               }
             if (cwd.has("weight"))
@@ -3971,20 +4716,22 @@ namespace dd
                 if (wm == "equalize_classes")
                   weightMode = caffe::DiceCoefLossParameter::EQUALIZE_CLASSES;
                 else if (wm == "extra_small_volumes")
-                  weightMode = caffe::DiceCoefLossParameter::EXTRA_SMALL_VOLUMES;
+                  weightMode
+                      = caffe::DiceCoefLossParameter::EXTRA_SMALL_VOLUMES;
                 else if (wm == "inverse_volume")
                   weightMode = caffe::DiceCoefLossParameter::INVERSE_VOLUME;
                 else
                   {
-                    this->_logger->warn("dice weight mode {} unrecognized , setting to inverse volume",wm);
+                    this->_logger->warn("dice weight mode {} unrecognized , "
+                                        "setting to inverse volume",
+                                        wm);
                     weightMode = caffe::DiceCoefLossParameter::INVERSE_VOLUME;
                   }
               }
           }
 
-
         if (diceParams.has("contour"))
-		  {
+          {
 
             APIData contourdata = diceParams.getobj("contour");
 
@@ -3997,7 +4744,9 @@ namespace dd
                   contours = caffe::DiceCoefLossParameter::SHARP;
                 else
                   {
-                    this->_logger->warn("dice contour shape {} unrecognized , setting to sharp",cs);
+                    this->_logger->warn("dice contour shape {} unrecognized , "
+                                        "setting to sharp",
+                                        cs);
                     contours = caffe::DiceCoefLossParameter::SHARP;
                   }
               }
@@ -4009,31 +4758,32 @@ namespace dd
                   }
                 catch (std::exception &e)
                   {
-                    this->_logger->warn("dice contour size unrecognized, (odd) int expected");
+                    this->_logger->warn(
+                        "dice contour size unrecognized, (odd) int expected");
                   }
-
               }
             if (contourdata.has("amplitude"))
               {
                 try
                   {
-                    contour_amplitude = contourdata.get("amplitude").get<double>();
+                    contour_amplitude
+                        = contourdata.get("amplitude").get<double>();
                   }
                 catch (std::exception &e)
                   {
-                    this->_logger->warn("dice contour amplitude unrecognized, float expected");
+                    this->_logger->warn(
+                        "dice contour amplitude unrecognized, float expected");
                   }
               }
-			this->_logger->warn("dice contour is not working (2020 - 05 - 19) disabling it");
-			contours = caffe::DiceCoefLossParameter::NO;
-
+            this->_logger->warn(
+                "dice contour is not working (2020 - 05 - 19) disabling it");
+            contours = caffe::DiceCoefLossParameter::NO;
           }
       }
 
-
-	dclp->set_generalization(genMode);
-	if (genMode != caffe::DiceCoefLossParameter::MULTICLASS)
-		dclp->set_weight_mode(weightMode);
+    dclp->set_generalization(genMode);
+    if (genMode != caffe::DiceCoefLossParameter::MULTICLASS)
+      dclp->set_weight_mode(weightMode);
 
     dclp->set_contour_shape(contours);
     if (contours != caffe::DiceCoefLossParameter::NO)
@@ -4043,41 +4793,48 @@ namespace dd
       }
   }
 
-
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::update_protofiles_dice_unet(caffe::NetParameter &net_param,caffe::NetParameter &deploy_net_param,  const APIData&ad)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void CaffeLib<TInputConnectorStrategy, TOutputConnectorStrategy, TMLModel>::
+      update_protofiles_dice_unet(caffe::NetParameter &net_param,
+                                  caffe::NetParameter &deploy_net_param,
+                                  const APIData &ad)
   {
-    int softml_pos = find_index_layer_by_type(net_param,"SoftmaxWithLoss");
+    int softml_pos = find_index_layer_by_type(net_param, "SoftmaxWithLoss");
 
     std::string logits = net_param.layer(softml_pos).bottom(0);
-    std::string loss_input = logits +  "_prob";
-    std::string logits_norm  = logits + "_norm";
+    std::string loss_input = logits + "_prob";
+    std::string logits_norm = logits + "_norm";
     std::string agg_output = logits + "_agg";
 
-    caffe::LayerParameter* mvn_param = insert_layer_before(net_param, softml_pos++);
+    caffe::LayerParameter *mvn_param
+        = insert_layer_before(net_param, softml_pos++);
     *mvn_param->mutable_name() = "normalization";
     *mvn_param->mutable_type() = "MVN";
     mvn_param->mutable_mvn_param()->set_across_channels(true);
     mvn_param->add_bottom(logits);
     mvn_param->add_top(logits_norm);
 
-	caffe::LayerParameter* softmax_param = insert_layer_before(net_param, softml_pos++);
-	softmax_param->set_name("probabilizer_multi");
-	softmax_param->set_type("Softmax");
-	softmax_param->add_bottom(logits_norm);
-	softmax_param->add_top(loss_input);
-	softmax_param->add_include();
-	caffe::NetStateRule *nsr = softmax_param->mutable_include(0);
-	nsr->set_phase(caffe::TRAIN);
+    caffe::LayerParameter *softmax_param
+        = insert_layer_before(net_param, softml_pos++);
+    softmax_param->set_name("probabilizer_multi");
+    softmax_param->set_type("Softmax");
+    softmax_param->add_bottom(logits_norm);
+    softmax_param->add_top(loss_input);
+    softmax_param->add_include();
+    caffe::NetStateRule *nsr = softmax_param->mutable_include(0);
+    nsr->set_phase(caffe::TRAIN);
 
-	caffe::LayerParameter* probt_param = find_layer_by_name(net_param, "probt");
-	*probt_param->mutable_bottom(0) = logits_norm;
+    caffe::LayerParameter *probt_param
+        = find_layer_by_name(net_param, "probt");
+    *probt_param->mutable_bottom(0) = logits_norm;
 
     caffe::LayerParameter *lossparam = net_param.mutable_layer(softml_pos);
     lossparam->clear_softmax_param();
     *lossparam->mutable_type() = "DiceCoefLoss";
     *lossparam->mutable_bottom(0) = loss_input;
-    caffe::DiceCoefLossParameter* dclp = lossparam->mutable_dice_coef_loss_param();
+    caffe::DiceCoefLossParameter *dclp
+        = lossparam->mutable_dice_coef_loss_param();
 
     update_protofiles_dice_params(dclp, ad);
 
@@ -4091,24 +4848,27 @@ namespace dd
     mvn_param->add_bottom(logits);
     mvn_param->add_top(logits_norm);
 
-	probt_param = find_layer_by_name(deploy_net_param, "pred");
-	*probt_param->mutable_bottom(0) = logits_norm;
-
+    probt_param = find_layer_by_name(deploy_net_param, "pred");
+    *probt_param->mutable_bottom(0) = logits_norm;
   }
 
-
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::update_protofile_imageDataLayer(caffe::NetParameter &net_param)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void CaffeLib<TInputConnectorStrategy, TOutputConnectorStrategy, TMLModel>::
+      update_protofile_imageDataLayer(caffe::NetParameter &net_param)
   {
     caffe::LayerParameter *lparam = net_param.mutable_layer(0);
-    caffe::ImageDataParameter* image_data_parameter = lparam->mutable_image_data_param();
+    caffe::ImageDataParameter *image_data_parameter
+        = lparam->mutable_image_data_param();
     lparam->set_type("ImageData");
-    image_data_parameter->set_source(this->_inputc._root_folder); // placeholder
+    image_data_parameter->set_source(
+        this->_inputc._root_folder); // placeholder
     image_data_parameter->set_batch_size(this->_inputc.batch_size());
     image_data_parameter->set_shuffle(this->_inputc._shuffle);
     image_data_parameter->set_new_height(this->_inputc.height());
     image_data_parameter->set_new_width(this->_inputc.width());
-    ImgCaffeInputFileConn *timg = reinterpret_cast<ImgCaffeInputFileConn*>(&this->_inputc);
+    ImgCaffeInputFileConn *timg
+        = reinterpret_cast<ImgCaffeInputFileConn *>(&this->_inputc);
     image_data_parameter->set_is_color(!timg->_bw);
     if (this->_inputc._multi_label)
       image_data_parameter->set_label_size(_nclasses);
@@ -4122,20 +4882,29 @@ namespace dd
     lparam->clear_transform_param();
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  bool CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::is_better(double v1, double v2, std::string metric_name)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  bool CaffeLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+                TMLModel>::is_better(double v1, double v2,
+                                     std::string metric_name)
   {
-    if (metric_name == "eucll" || metric_name == "delta_score_0.1" || metric_name == "L1_mean_error")
+    if (metric_name == "eucll" || metric_name == "delta_score_0.1"
+        || metric_name == "L1_mean_error")
       return (v2 > v1);
     return (v1 > v2);
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::save_if_best(APIData &meas_out, boost::shared_ptr<caffe::Solver<float>>solver, bool already_snapshoted)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void CaffeLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+                TMLModel>::save_if_best(APIData &meas_out,
+                                        boost::shared_ptr<caffe::Solver<float>>
+                                            solver,
+                                        bool already_snapshoted)
   {
     double cur_meas = std::numeric_limits<double>::infinity();
     std::string meas;
-    for (auto m: _best_metrics)
+    for (auto m : _best_metrics)
       {
         if (meas_out.has(m))
           {
@@ -4147,11 +4916,12 @@ namespace dd
     if (cur_meas == std::numeric_limits<double>::infinity())
       {
         // could not find value for measuring best
-        this->_logger->info("could not find any value for measuring best model");
+        this->_logger->info(
+            "could not find any value for measuring best model");
         return;
       }
-    if (_best_metric_value == std::numeric_limits<double>::infinity() ||
-        is_better(cur_meas, _best_metric_value, meas))
+    if (_best_metric_value == std::numeric_limits<double>::infinity()
+        || is_better(cur_meas, _best_metric_value, meas))
       {
         _best_metric_value = cur_meas;
         if (!already_snapshoted)
@@ -4159,28 +4929,29 @@ namespace dd
         try
           {
             std::ofstream bestfile;
-            std::string bestfilename = this->_mlmodel._repo + this->_mlmodel._best_model_filename;
-            bestfile.open(bestfilename,std::ios::out);
-            bestfile << "iteration:" <<  solver->iter_ << std::endl;
-            bestfile <<  meas << ":" << cur_meas << std::endl;
+            std::string bestfilename
+                = this->_mlmodel._repo + this->_mlmodel._best_model_filename;
+            bestfile.open(bestfilename, std::ios::out);
+            bestfile << "iteration:" << solver->iter_ << std::endl;
+            bestfile << meas << ":" << cur_meas << std::endl;
             bestfile.close();
           }
-        catch(std::exception &e)
+        catch (std::exception &e)
           {
             this->_logger->error("could not write best model file");
           }
       }
-
   }
 
-
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  int CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::findOutputSlotNumberByBlobName(const caffe::Net<float> *net,
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  int CaffeLib<TInputConnectorStrategy, TOutputConnectorStrategy, TMLModel>::
+      findOutputSlotNumberByBlobName(const caffe::Net<float> *net,
                                      const std::string blob_name)
   {
     const std::vector<std::string> blob_names = net->blob_names();
     const std::vector<int> output_blob_indices = net->output_blob_indices();
-    for (int i =0; i<net->num_outputs(); ++i)
+    for (int i = 0; i < net->num_outputs(); ++i)
       {
         if (blob_names[output_blob_indices[i]] == blob_name)
           return i;
@@ -4188,11 +4959,14 @@ namespace dd
     return -1;
   }
 
-
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  boost::shared_ptr<Blob<float>> CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::findBlobByName(const caffe::Net<float> *net, const std::string blob_name)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  boost::shared_ptr<Blob<float>>
+  CaffeLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+           TMLModel>::findBlobByName(const caffe::Net<float> *net,
+                                     const std::string blob_name)
   {
-    for (unsigned int i =0; i<net->blob_names().size(); ++i)
+    for (unsigned int i = 0; i < net->blob_names().size(); ++i)
       {
         if (net->blob_names()[i] == blob_name)
           return net->blobs()[i];
@@ -4200,28 +4974,43 @@ namespace dd
     return nullptr;
   }
 
-
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  std::vector<double> CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::img_resize(const std::vector<double>& vals, const int height_net, const int width_net, const int height_dest, const int width_dest, bool resize_nn)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  std::vector<double>
+  CaffeLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+           TMLModel>::img_resize(const std::vector<double> &vals,
+                                 const int height_net, const int width_net,
+                                 const int height_dest, const int width_dest,
+                                 bool resize_nn)
   {
-    cv::Mat segimg = cv::Mat(height_net,width_net, CV_64FC1);
-    std::memcpy(segimg.data,vals.data(),vals.size()*sizeof(double));
+    cv::Mat segimg = cv::Mat(height_net, width_net, CV_64FC1);
+    std::memcpy(segimg.data, vals.data(), vals.size() * sizeof(double));
     cv::Mat segimg_res;
     if (resize_nn)
-      cv::resize(segimg,segimg_res,cv::Size(width_dest,height_dest),0,0,cv::INTER_NEAREST);
+      cv::resize(segimg, segimg_res, cv::Size(width_dest, height_dest), 0, 0,
+                 cv::INTER_NEAREST);
     else
-      cv::resize(segimg,segimg_res,cv::Size(width_dest,height_dest),0,0,cv::INTER_LINEAR);
-    return std::vector<double>((double*)segimg_res.data,(double*)segimg_res.data+segimg_res.rows*segimg_res.cols);
+      cv::resize(segimg, segimg_res, cv::Size(width_dest, height_dest), 0, 0,
+                 cv::INTER_LINEAR);
+    return std::vector<double>((double *)segimg_res.data,
+                               (double *)segimg_res.data
+                                   + segimg_res.rows * segimg_res.cols);
   }
 
-  template class CaffeLib<ImgCaffeInputFileConn,SupervisedOutput,CaffeModel>;
-  template class CaffeLib<CSVCaffeInputFileConn,SupervisedOutput,CaffeModel>;
-  template class CaffeLib<CSVTSCaffeInputFileConn,SupervisedOutput,CaffeModel>;
-  template class CaffeLib<TxtCaffeInputFileConn,SupervisedOutput,CaffeModel>;
-  template class CaffeLib<SVMCaffeInputFileConn,SupervisedOutput,CaffeModel>;
-  template class CaffeLib<ImgCaffeInputFileConn,UnsupervisedOutput,CaffeModel>;
-  template class CaffeLib<CSVCaffeInputFileConn,UnsupervisedOutput,CaffeModel>;
-  template class CaffeLib<CSVTSCaffeInputFileConn,UnsupervisedOutput,CaffeModel>;
-  template class CaffeLib<TxtCaffeInputFileConn,UnsupervisedOutput,CaffeModel>;
-  template class CaffeLib<SVMCaffeInputFileConn,UnsupervisedOutput,CaffeModel>;
+  template class CaffeLib<ImgCaffeInputFileConn, SupervisedOutput, CaffeModel>;
+  template class CaffeLib<CSVCaffeInputFileConn, SupervisedOutput, CaffeModel>;
+  template class CaffeLib<CSVTSCaffeInputFileConn, SupervisedOutput,
+                          CaffeModel>;
+  template class CaffeLib<TxtCaffeInputFileConn, SupervisedOutput, CaffeModel>;
+  template class CaffeLib<SVMCaffeInputFileConn, SupervisedOutput, CaffeModel>;
+  template class CaffeLib<ImgCaffeInputFileConn, UnsupervisedOutput,
+                          CaffeModel>;
+  template class CaffeLib<CSVCaffeInputFileConn, UnsupervisedOutput,
+                          CaffeModel>;
+  template class CaffeLib<CSVTSCaffeInputFileConn, UnsupervisedOutput,
+                          CaffeModel>;
+  template class CaffeLib<TxtCaffeInputFileConn, UnsupervisedOutput,
+                          CaffeModel>;
+  template class CaffeLib<SVMCaffeInputFileConn, UnsupervisedOutput,
+                          CaffeModel>;
 }

--- a/src/backends/caffe/caffelib.h
+++ b/src/backends/caffe/caffelib.h
@@ -35,22 +35,25 @@ namespace dd
   /**
    * \brief Caffe library wrapper for deepdetect
    */
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel=CaffeModel>
-    class CaffeLib : public MLLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>
-    {
-      friend class caffe::MemoryDataLayer<float>;
-    public:
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel = CaffeModel>
+  class CaffeLib : public MLLib<TInputConnectorStrategy,
+                                TOutputConnectorStrategy, TMLModel>
+  {
+    friend class caffe::MemoryDataLayer<float>;
+
+  public:
     /**
      * \brief constructor from model
      * @param model Caffe model
      */
     CaffeLib(const CaffeModel &cmodel);
-    
+
     /**
      * \brief copy-constructor
      */
     CaffeLib(CaffeLib &&cl) noexcept;
-    
+
     /**
      * \brief destructor
      */
@@ -71,49 +74,49 @@ namespace dd
      * @param net_param the training net object
      * @param deploy_net_param the deploy net object
      */
-      void configure_mlp_template(const APIData &ad,
-				  const TInputConnectorStrategy &inputc,
-				  caffe::NetParameter &net_param,
-				  caffe::NetParameter &dnet_param);
+    void configure_mlp_template(const APIData &ad,
+                                const TInputConnectorStrategy &inputc,
+                                caffe::NetParameter &net_param,
+                                caffe::NetParameter &dnet_param);
 
+    void configure_convnet_template(const APIData &ad,
+                                    const TInputConnectorStrategy &inputc,
+                                    caffe::NetParameter &net_param,
+                                    caffe::NetParameter &dnet_param);
 
-      void configure_convnet_template(const APIData &ad,
-				      const TInputConnectorStrategy &inputc,
-				      caffe::NetParameter &net_param,
-				      caffe::NetParameter &dnet_param);
-      
-      void configure_resnet_template(const APIData &ad,
-				     const TInputConnectorStrategy &inputc,
-				     caffe::NetParameter &net_param,
-				     caffe::NetParameter &dnet_param);
+    void configure_resnet_template(const APIData &ad,
+                                   const TInputConnectorStrategy &inputc,
+                                   caffe::NetParameter &net_param,
+                                   caffe::NetParameter &dnet_param);
 
-      void configure_ssd_template(const std::string &dest_net,
-				  const std::string &deploy_dest_net,
-				  const APIData &ad,
-				  TInputConnectorStrategy &inputc,
-				  const bool &refinedet);
+    void configure_ssd_template(const std::string &dest_net,
+                                const std::string &deploy_dest_net,
+                                const APIData &ad,
+                                TInputConnectorStrategy &inputc,
+                                const bool &refinedet);
 
-      void configure_recurrent_template(const APIData &ad,
-                                        const TInputConnectorStrategy &inputc,
-                                        caffe::NetParameter &net_param,
-                                        caffe::NetParameter &dnet_param);
+    void configure_recurrent_template(const APIData &ad,
+                                      const TInputConnectorStrategy &inputc,
+                                      caffe::NetParameter &net_param,
+                                      caffe::NetParameter &dnet_param);
 
-      void configure_geometry_augmentation(const APIData &ad, caffe::TransformationParameter * trp);
+    void configure_geometry_augmentation(const APIData &ad,
+                                         caffe::TransformationParameter *trp);
 
     /**
      * \brief configure noise data augmentation in training template
      * @param ad the template data object
      * @param net_param the trainng net object
      */
-      void configure_image_augmentation(const APIData &ad,
-				       caffe::NetParameter &net_param);
+    void configure_image_augmentation(const APIData &ad,
+                                      caffe::NetParameter &net_param);
 
     /**
      * \brief creates neural net instance based on model
      * @return 0 if OK, 2, if missing 'deploy' file, 1 otherwise
      */
-    int create_model(const bool &test=false);
-    
+    int create_model(const bool &test = false);
+
     /*- from mllib -*/
     /**
      * \brief init this instance (e.g. sets GPU/CPU) and creates model
@@ -134,7 +137,7 @@ namespace dd
      * @return 0 if OK, 1 otherwise
      */
     int train(const APIData &ad, APIData &out);
-    
+
     /**
      * \brief predicts from model
      * @param ad root data object
@@ -142,172 +145,188 @@ namespace dd
      * @return 0 if OK, 1 otherwise
      */
     int predict(const APIData &ad, APIData &out);
-    
-    //TODO: status ?
+
+    // TODO: status ?
 
     /*- local functions -*/
-      /**
-      * \brief test net
-      * @param ad root data object
-      * @param inputc input connector
-      * @param test_batch_size current size of the test batches
-      * @param has_mean_file whereas testing set uses a mean file (for images)
-      * @param test_iter the number of test iterations (used for ctc)
-      * @param out output data object
-      */
-      void test(caffe::Net<float> *net,
-	      const APIData &ad,
-	      TInputConnectorStrategy &inputc,
-	      const int &test_batch_size,
-	      const bool &has_mean_file,
-		const int &test_iter,
-		APIData &out);
+    /**
+     * \brief test net
+     * @param ad root data object
+     * @param inputc input connector
+     * @param test_batch_size current size of the test batches
+     * @param has_mean_file whereas testing set uses a mean file (for images)
+     * @param test_iter the number of test iterations (used for ctc)
+     * @param out output data object
+     */
+    void test(caffe::Net<float> *net, const APIData &ad,
+              TInputConnectorStrategy &inputc, const int &test_batch_size,
+              const bool &has_mean_file, const int &test_iter, APIData &out);
 
     /**
-     * \brief updates: - solver's paths to data according to current Caffe model
+     * \brief updates: - solver's paths to data according to current Caffe
+     * model
      *                 - net's batch size and data sources (e.g. lmdb sources)
-     *        XXX: As for now, everything in the solver is volatile, and not written back to model file
+     *        XXX: As for now, everything in the solver is volatile, and not
+     * written back to model file
      * @param sp Caffe's solver's parameters
      * @param ad the root data object
      * @param inputc the current input constructor that holds the training data
      * @param user_batch_size the user specified batch size
-     * @param batch_size the automatically computed batch size, since some input Caffe layers do require it to divide cleanly the size of the training set
-     * @param test_batch_size automatically computed value for the test batch size
-     * @param test_iter automatically computed number of iterations of batches to cover the full test set
-     * @param has_mean_file whether the current net uses a mean file (i.e. for images)
+     * @param batch_size the automatically computed batch size, since some
+     * input Caffe layers do require it to divide cleanly the size of the
+     * training set
+     * @param test_batch_size automatically computed value for the test batch
+     * size
+     * @param test_iter automatically computed number of iterations of batches
+     * to cover the full test set
+     * @param has_mean_file whether the current net uses a mean file (i.e. for
+     * images)
      */
-      void update_in_memory_net_and_solver(caffe::SolverParameter &sp,
-					   const APIData &ad,
-					   const TInputConnectorStrategy &inputc,
-					   bool &has_mean_file,
-					   int &user_batch_size,
-					   int &batch_size,
-					   int &test_batch_size,
-					   int &test_iter);
+    void update_in_memory_net_and_solver(caffe::SolverParameter &sp,
+                                         const APIData &ad,
+                                         const TInputConnectorStrategy &inputc,
+                                         bool &has_mean_file,
+                                         int &user_batch_size, int &batch_size,
+                                         int &test_batch_size, int &test_iter);
 
-      /**
-       * \brief updates the protocol buffer text file of the net directly at training time
-       *        i.e. changes are permanent. This is against the rules of training calls that 
-       *        should not make hard changes to service configuration but this is the only way
-       *        to transparently use the data in input in order to shape a net's template.
-       *
-       * @param net_file the file containing the net template, as copied from the template itself
-       *                 at service creation
-       * @param deploy_file the deploy file, same remark as net_file
-       * @param inputc the current input constructor that holds the training data
-       * @param has_class_weights whether training uses class weights
-       * @param ignore_label label to be ignored, -1 otherwise
-       * @param timesteps number of timesteps for recurrent models
-       * @param ad_mllib in order to change engine CUDNN vs CAFFE for cudnn memory consumption problems
-       */
-      void update_protofile_net(const std::string &net_file,
-				const std::string &deploy_file,
-				const TInputConnectorStrategy &inputc,
-				const bool &has_class_weights,
-				const int &ignore_label,
-                const int &timesteps,
-                const APIData& ad_mllib);
+    /**
+     * \brief updates the protocol buffer text file of the net directly at
+     * training time i.e. changes are permanent. This is against the rules of
+     * training calls that should not make hard changes to service
+     * configuration but this is the only way to transparently use the data in
+     * input in order to shape a net's template.
+     *
+     * @param net_file the file containing the net template, as copied from the
+     * template itself at service creation
+     * @param deploy_file the deploy file, same remark as net_file
+     * @param inputc the current input constructor that holds the training data
+     * @param has_class_weights whether training uses class weights
+     * @param ignore_label label to be ignored, -1 otherwise
+     * @param timesteps number of timesteps for recurrent models
+     * @param ad_mllib in order to change engine CUDNN vs CAFFE for cudnn
+     * memory consumption problems
+     */
+    void update_protofile_net(const std::string &net_file,
+                              const std::string &deploy_file,
+                              const TInputConnectorStrategy &inputc,
+                              const bool &has_class_weights,
+                              const int &ignore_label, const int &timesteps,
+                              const APIData &ad_mllib);
 
-      /**
-       * \brief updates the softmax temperature
-       * @param mllib apidata object
-       */
+    /**
+     * \brief updates the softmax temperature
+     * @param mllib apidata object
+     */
 
-      void update_deploy_protofile_softmax(const APIData &ad);
-      /**
-       * \brief updates the channel / timeteps number for timeseries
-       * @param mllib apidata object
-       */
-      bool update_timesteps(int timesteps);
-      
-    private:
-      void update_protofile_classes(caffe::NetParameter &net_param);
+    void update_deploy_protofile_softmax(const APIData &ad);
+    /**
+     * \brief updates the channel / timeteps number for timeseries
+     * @param mllib apidata object
+     */
+    bool update_timesteps(int timesteps);
+
+  private:
+    void update_protofile_classes(caffe::NetParameter &net_param);
 
 #ifdef USE_CUDNN
-      void update_protofile_engine(const APIData&ad);
-      void update_protofile_engine(caffe::NetParameter &net_param, const APIData&ad);
+    void update_protofile_engine(const APIData &ad);
+    void update_protofile_engine(caffe::NetParameter &net_param,
+                                 const APIData &ad);
 #endif
 
-      void update_protofiles_one_hot(caffe::NetParameter &net_param);
+    void update_protofiles_one_hot(caffe::NetParameter &net_param);
 
-      void update_protofiles_dice_deeplab_vgg16(caffe::NetParameter &net_param, caffe::NetParameter &deploy_net_param, const APIData &ad);
-      void update_protofiles_dice_unet(caffe::NetParameter &net_param, caffe::NetParameter &deploy_net_param, const APIData &ad);
+    void
+    update_protofiles_dice_deeplab_vgg16(caffe::NetParameter &net_param,
+                                         caffe::NetParameter &deploy_net_param,
+                                         const APIData &ad);
+    void update_protofiles_dice_unet(caffe::NetParameter &net_param,
+                                     caffe::NetParameter &deploy_net_param,
+                                     const APIData &ad);
 
-      void update_protofile_imageDataLayer(caffe::NetParameter &net_param);
+    void update_protofile_imageDataLayer(caffe::NetParameter &net_param);
 
-      void update_protofiles_dice_params(caffe::DiceCoefLossParameter*dclp,  const APIData &ad);
+    void update_protofiles_dice_params(caffe::DiceCoefLossParameter *dclp,
+                                       const APIData &ad);
 
-      void update_protofile_finetune(caffe::NetParameter &net_param);
+    void update_protofile_finetune(caffe::NetParameter &net_param);
 
-      caffe::LayerParameter* insert_layer_before
-      (caffe::NetParameter &net_param, int layer_number);
-      caffe::LayerParameter*  find_layer_by_name(caffe::NetParameter &net_param, std::string name);
+    caffe::LayerParameter *insert_layer_before(caffe::NetParameter &net_param,
+                                               int layer_number);
+    caffe::LayerParameter *find_layer_by_name(caffe::NetParameter &net_param,
+                                              std::string name);
 
-      int find_index_layer_by_type(caffe::NetParameter &net_param, std::string type);
-      int find_index_layer_by_name(caffe::NetParameter &net_param, std::string name);
-      caffe::LayerParameter* find_layer_by_type(caffe::NetParameter &net_param, std::string type);
+    int find_index_layer_by_type(caffe::NetParameter &net_param,
+                                 std::string type);
+    int find_index_layer_by_name(caffe::NetParameter &net_param,
+                                 std::string name);
+    caffe::LayerParameter *find_layer_by_type(caffe::NetParameter &net_param,
+                                              std::string type);
 
+    void fix_batch_size(const APIData &ad,
+                        const TInputConnectorStrategy &inputc,
+                        int &user_batch_size, int &batch_size,
+                        int &test_batch_size, int &test_iter);
 
-      void fix_batch_size(const APIData &ad,
-			  const TInputConnectorStrategy &inputc,
-			  int &user_batch_size,
-			  int &batch_size,
-			  int &test_batch_size,
-			  int &test_iter);
+    void set_gpuid(const APIData &ad);
 
-      void set_gpuid(const APIData &ad);
+    void model_complexity(long int &flops, long int &params);
 
-      void model_complexity(long int &flops,
-                            long int &params);
+    void model_type(caffe::Net<float> *net, std::string &mltype);
 
-      void model_type(caffe::Net<float> *net,
-		      std::string &mltype);
+    /**
+     * \brief checks wether v1 is better than v2
+     */
+    bool is_better(double v1, double v2, std::string metric_name);
 
+    /**
+     * \brief generates a file containing best iteration so far
+     */
+    void save_if_best(APIData &meas_out,
+                      boost::shared_ptr<caffe::Solver<float>> solver,
+                      bool already_snapshoted);
 
-      /**
-       * \brief checks wether v1 is better than v2
-       */
-      bool is_better(double v1, double v2, std::string metric_name);
+    int findOutputSlotNumberByBlobName(const caffe::Net<float> *net,
+                                       const std::string blob_name);
 
-      /**
-       * \brief generates a file containing best iteration so far
-       */
-      void save_if_best(APIData &meas_out, boost::shared_ptr<caffe::Solver<float>>solver,
-                        bool already_snapshoted);
+    boost::shared_ptr<Blob<float>> findBlobByName(const caffe::Net<float> *net,
+                                                  const std::string blob_name);
 
-      int findOutputSlotNumberByBlobName(const caffe::Net<float> *net,
-                                     const std::string blob_name);
+    std::vector<double> img_resize(const std::vector<double> &vals,
+                                   const int height_net, const int width_net,
+                                   const int height_dest, const int width_dest,
+                                   bool resize_nn);
 
+    bool is_refinedet(caffe::NetParameter &net_param);
 
-      boost::shared_ptr<Blob<float>> findBlobByName(const caffe::Net<float> *net,
-                                                    const std::string blob_name);
+  public:
+    caffe::Net<float> *_net = nullptr; /**< neural net. */
+    bool _gpu = false;                 /**< whether to use GPU. */
+    std::vector<int> _gpuid = { 0 };   /**< GPU id. */
+    int _nclasses
+        = 0; /**< required, as difficult to acquire from Caffe's internals. */
+    bool _regression = false; /**< whether the net acts as a regressor. */
+    std::string _loss
+        = ""; /**< loss to use : 0 softmax+multinomail logistic or1: dice*/
+    int _ntargets = 0; /**< number of classification or regression targets. */
+    //      std::vector<int> _targets; /**< id number of classification or
+    //      regression targets. */
+    bool _autoencoder = false; /**< whether an autoencoder. */
+    std::mutex
+        _net_mutex; /**< mutex around net, e.g. no concurrent predict calls as
+                       net is not re-instantiated. Use batches instead. */
+    int _crop_size = -1; /**< cropping is part of Caffe transforms in input
+                            layers, storing here. */
+    float _scale = 1.0; /**< scale is part of Caffe transforms in input layers,
+                           storing here. */
 
-      std::vector<double> img_resize(const std::vector<double>& vals,
-                                     const int height_net,  const int width_net,
-                                     const int height_dest, const int width_dest, bool resize_nn);
+    std::vector<std::string>
+        _best_metrics;         /**< metric to use for saving best model */
+    double _best_metric_value; /**< best metric value  */
 
-	  bool is_refinedet(caffe::NetParameter &net_param);
-
-    public:
-      caffe::Net<float> *_net = nullptr; /**< neural net. */
-      bool _gpu = false; /**< whether to use GPU. */
-      std::vector<int> _gpuid = {0}; /**< GPU id. */
-      int _nclasses = 0; /**< required, as difficult to acquire from Caffe's internals. */
-      bool _regression = false; /**< whether the net acts as a regressor. */
-      std::string _loss = ""; /**< loss to use : 0 softmax+multinomail logistic or1: dice*/
-      int _ntargets = 0; /**< number of classification or regression targets. */
-      //      std::vector<int> _targets; /**< id number of classification or regression targets. */
-      bool _autoencoder = false; /**< whether an autoencoder. */
-      std::mutex _net_mutex; /**< mutex around net, e.g. no concurrent predict calls as net is not re-instantiated. Use batches instead. */
-      int _crop_size = -1; /**< cropping is part of Caffe transforms in input layers, storing here. */
-      float _scale = 1.0; /**< scale is part of Caffe transforms in input layers, storing here. */
-
-      std::vector<std::string> _best_metrics; /**< metric to use for saving best model */
-      double _best_metric_value; /**< best metric value  */
-
-      caffe::P2PSync<float> *_sync = nullptr;
-      std::vector<boost::shared_ptr<caffe::P2PSync<float>>> _syncs;
-    };
+    caffe::P2PSync<float> *_sync = nullptr;
+    std::vector<boost::shared_ptr<caffe::P2PSync<float>>> _syncs;
+  };
 
 }
 

--- a/src/backends/caffe/caffemodel.cc
+++ b/src/backends/caffe/caffemodel.cc
@@ -30,12 +30,13 @@
 namespace dd
 {
   CaffeModel::CaffeModel(const APIData &ad, APIData &adg,
-			 const std::shared_ptr<spdlog::logger> &logger)
-    :MLModel(ad,adg,logger)
+                         const std::shared_ptr<spdlog::logger> &logger)
+      : MLModel(ad, adg, logger)
   {
     if (ad.has("templates"))
       this->_mlmodel_template_repo = ad.get("templates").get<std::string>();
-    else this->_mlmodel_template_repo += "caffe/"; // default
+    else
+      this->_mlmodel_template_repo += "caffe/"; // default
 
     if (ad.has("def"))
       _def = ad.get("def").get<std::string>();
@@ -49,18 +50,20 @@ namespace dd
       _solver = ad.get("solver").get<std::string>();
     if (ad.has("repository"))
       {
-       	if (read_from_repository(ad.get("repository").get<std::string>(),spdlog::get("api")))
-	  throw MLLibBadParamException("error reading or listing Caffe models in repository " + _repo);
+        if (read_from_repository(ad.get("repository").get<std::string>(),
+                                 spdlog::get("api")))
+          throw MLLibBadParamException(
+              "error reading or listing Caffe models in repository " + _repo);
       }
     read_corresp_file();
   }
 
-  CaffeModel::CaffeModel(const APIData &ad)
-      :MLModel(ad)
+  CaffeModel::CaffeModel(const APIData &ad) : MLModel(ad)
   {
     if (ad.has("templates"))
       this->_mlmodel_template_repo = ad.get("templates").get<std::string>();
-    else this->_mlmodel_template_repo += "caffe/"; // default
+    else
+      this->_mlmodel_template_repo += "caffe/"; // default
 
     if (ad.has("def"))
       _def = ad.get("def").get<std::string>();
@@ -74,15 +77,17 @@ namespace dd
       _solver = ad.get("solver").get<std::string>();
     if (ad.has("repository"))
       {
-       	if (read_from_repository(ad.get("repository").get<std::string>(),spdlog::get("api")))
-	  throw MLLibBadParamException("error reading or listing Caffe models in repository " + _repo);
+        if (read_from_repository(ad.get("repository").get<std::string>(),
+                                 spdlog::get("api")))
+          throw MLLibBadParamException(
+              "error reading or listing Caffe models in repository " + _repo);
       }
     read_corresp_file();
   }
-  
-  int CaffeModel::read_from_repository(const std::string &repo,
-				       const std::shared_ptr<spdlog::logger> &logger,
-				       const bool &new_first)
+
+  int CaffeModel::read_from_repository(
+      const std::string &repo, const std::shared_ptr<spdlog::logger> &logger,
+      const bool &new_first)
   {
     static std::string deploy = "deploy.prototxt";
     static std::string train = ".prototxt";
@@ -93,56 +98,57 @@ namespace dd
     static std::string meanf = "mean.binaryproto";
     this->_repo = repo;
     std::unordered_set<std::string> lfiles;
-    int e = fileops::list_directory(repo,true,false,false,lfiles);
+    int e = fileops::list_directory(repo, true, false, false, lfiles);
     if (e != 0)
       {
-	logger->error("error reading or listing caffe models in repository {}",repo);
-	return 1;
+        logger->error("error reading or listing caffe models in repository {}",
+                      repo);
+        return 1;
       }
-    std::string deployf,trainf,weightsf,correspf,solverf,sstatef;
-    long int state_t=-1, weight_t=-1;
+    std::string deployf, trainf, weightsf, correspf, solverf, sstatef;
+    long int state_t = -1, weight_t = -1;
     auto hit = lfiles.begin();
-    while(hit!=lfiles.end())
+    while (hit != lfiles.end())
       {
-	if ((*hit).find(meanf)!=std::string::npos)
-	  {
-	    _has_mean_file = true;
-	  }
-	else if ((*hit).find(sstate)!=std::string::npos)
-	  {
-	    // stat file to pick the latest one
-	    long int st = fileops::file_last_modif((*hit));
-	    if (st > state_t)
-	      {
-		sstatef = (*hit);
-		state_t = st;
-	      }
-	  }
-	else if ((*hit).find(weights)!=std::string::npos)
-	  {
-	    // stat file to pick the latest one
-	    long int wt = fileops::file_last_modif((*hit));
-	    if (wt > weight_t)
-	      {
-		weightsf = (*hit);
-		weight_t = wt;
-	      }
-	  }
-	else if ((*hit).find(corresp)!=std::string::npos)
-	  correspf = (*hit);
-	else if ((*hit).find("~")!=std::string::npos 
-	    || (*hit).find(".prototxt")==std::string::npos)
-	  {
-	    ++hit;
-	    continue;
-	  }
-	else if ((*hit).find(deploy)!=std::string::npos)
-	  deployf = (*hit);
-	else if ((*hit).find(solver)!=std::string::npos)
-	  solverf = (*hit);
-	else if ((*hit).find(train)!=std::string::npos)
-	  trainf = (*hit);
-	++hit;
+        if ((*hit).find(meanf) != std::string::npos)
+          {
+            _has_mean_file = true;
+          }
+        else if ((*hit).find(sstate) != std::string::npos)
+          {
+            // stat file to pick the latest one
+            long int st = fileops::file_last_modif((*hit));
+            if (st > state_t)
+              {
+                sstatef = (*hit);
+                state_t = st;
+              }
+          }
+        else if ((*hit).find(weights) != std::string::npos)
+          {
+            // stat file to pick the latest one
+            long int wt = fileops::file_last_modif((*hit));
+            if (wt > weight_t)
+              {
+                weightsf = (*hit);
+                weight_t = wt;
+              }
+          }
+        else if ((*hit).find(corresp) != std::string::npos)
+          correspf = (*hit);
+        else if ((*hit).find("~") != std::string::npos
+                 || (*hit).find(".prototxt") == std::string::npos)
+          {
+            ++hit;
+            continue;
+          }
+        else if ((*hit).find(deploy) != std::string::npos)
+          deployf = (*hit);
+        else if ((*hit).find(solver) != std::string::npos)
+          solverf = (*hit);
+        else if ((*hit).find(train) != std::string::npos)
+          trainf = (*hit);
+        ++hit;
       }
     if (_def.empty())
       _def = deployf;
@@ -155,60 +161,67 @@ namespace dd
     if (_solver.empty())
       _solver = solverf;
     if (new_first || _sstate.empty())
-      _sstate = sstatef;    
+      _sstate = sstatef;
     return 0;
   }
 
   int CaffeModel::copy_to_target(const std::string &source_repo,
-				 const std::string &target_repo,
-				 const std::shared_ptr<spdlog::logger> &logger)
+                                 const std::string &target_repo,
+                                 const std::shared_ptr<spdlog::logger> &logger)
   {
     if (target_repo.empty())
       {
-	logger->warn("empty target repository, bypassing");
-	return 0;
+        logger->warn("empty target repository, bypassing");
+        return 0;
       }
-    if (!fileops::create_dir(target_repo,0755)) // create target repo as needed
-      logger->info("created target repository {}",target_repo);
+    if (!fileops::create_dir(target_repo,
+                             0755)) // create target repo as needed
+      logger->info("created target repository {}", target_repo);
     std::string bfile = source_repo + this->_best_model_filename;
     if (fileops::file_exists(bfile))
       {
-	std::ifstream inp(bfile);
-	if (!inp.is_open())
-	  return 1;
-	std::string line;
-	std::getline(inp,line);
-	std::vector<std::string> elts = dd_utils::split(line,':');
-	std::string best_caffemodel = "/model_iter_" + elts.at(1) + ".caffemodel";
-	if (fileops::copy_file(source_repo + best_caffemodel,target_repo + best_caffemodel))
-	  {
-	    logger->error("failed copying best model {} to {}",source_repo + best_caffemodel,
-			  target_repo + best_caffemodel);
-	    return 1;
-	  }
-	else logger->info("sucessfully copied best model file {}",best_caffemodel);
-	std::unordered_set<std::string> lfiles;
-	fileops::list_directory(source_repo,true,false,false,lfiles);
-	auto hit = lfiles.begin();
-	while(hit!=lfiles.end())
-	  {
-	    if ((*hit).find("prototxt")!=std::string::npos
-		|| (*hit).find(".json")!=std::string::npos
-              || (*hit).find(".txt")!=std::string::npos
-              || (*hit).find("bounds.dat")!=std::string::npos
-		|| (*hit).find("vocab.dat")!=std::string::npos)
-	      {
-		std::vector<std::string> selts = dd_utils::split((*hit),'/');
-		fileops::copy_file((*hit),target_repo + '/' + selts.back());
-	      }
-	    ++hit;
-	  }
-	logger->info("successfully copied best model files from {} to {}",
-		     source_repo,target_repo);
-	return 0;
+        std::ifstream inp(bfile);
+        if (!inp.is_open())
+          return 1;
+        std::string line;
+        std::getline(inp, line);
+        std::vector<std::string> elts = dd_utils::split(line, ':');
+        std::string best_caffemodel
+            = "/model_iter_" + elts.at(1) + ".caffemodel";
+        if (fileops::copy_file(source_repo + best_caffemodel,
+                               target_repo + best_caffemodel))
+          {
+            logger->error("failed copying best model {} to {}",
+                          source_repo + best_caffemodel,
+                          target_repo + best_caffemodel);
+            return 1;
+          }
+        else
+          logger->info("sucessfully copied best model file {}",
+                       best_caffemodel);
+        std::unordered_set<std::string> lfiles;
+        fileops::list_directory(source_repo, true, false, false, lfiles);
+        auto hit = lfiles.begin();
+        while (hit != lfiles.end())
+          {
+            if ((*hit).find("prototxt") != std::string::npos
+                || (*hit).find(".json") != std::string::npos
+                || (*hit).find(".txt") != std::string::npos
+                || (*hit).find("bounds.dat") != std::string::npos
+                || (*hit).find("vocab.dat") != std::string::npos)
+              {
+                std::vector<std::string> selts = dd_utils::split((*hit), '/');
+                fileops::copy_file((*hit), target_repo + '/' + selts.back());
+              }
+            ++hit;
+          }
+        logger->info("successfully copied best model files from {} to {}",
+                     source_repo, target_repo);
+        return 0;
       }
-    logger->error("failed finding best model to copy from {} to target repository {}",
-		  source_repo,target_repo);
+    logger->error(
+        "failed finding best model to copy from {} to target repository {}",
+        source_repo, target_repo);
     return 1;
   }
 

--- a/src/backends/caffe/caffemodel.h
+++ b/src/backends/caffe/caffemodel.h
@@ -32,31 +32,38 @@ namespace dd
   class CaffeModel : public MLModel
   {
   public:
-  CaffeModel(): MLModel() {}
+    CaffeModel() : MLModel()
+    {
+    }
     CaffeModel(const APIData &ad);
     CaffeModel(const APIData &ad, APIData &adg,
-	       const std::shared_ptr<spdlog::logger> &logger);
-  CaffeModel(const APIData &ad, const std::string &repo)
-    :MLModel(ad, repo) {}
-    ~CaffeModel() {};
+               const std::shared_ptr<spdlog::logger> &logger);
+    CaffeModel(const APIData &ad, const std::string &repo) : MLModel(ad, repo)
+    {
+    }
+    ~CaffeModel(){};
 
     int read_from_repository(const std::string &repo,
-			     const std::shared_ptr<spdlog::logger> &logger,
-			     const bool &new_first=false);
+                             const std::shared_ptr<spdlog::logger> &logger,
+                             const bool &new_first = false);
 
     int copy_to_target(const std::string &source_repo,
-		       const std::string &target_repo,
-		       const std::shared_ptr<spdlog::logger> &logger);
-    
-    std::string _def; /**< file name of the model definition in the form of a protocol buffer message description. */
-    std::string _trainf; /**< file name of the training model definition. */
+                       const std::string &target_repo,
+                       const std::shared_ptr<spdlog::logger> &logger);
+
+    std::string _def; /**< file name of the model definition in the form of a
+                         protocol buffer message description. */
+    std::string _trainf;  /**< file name of the training model definition. */
     std::string _weights; /**< file name of the network's weights. */
-    std::string _solver; /**< solver description file, included here as part of the model, very specific to Caffe. */
-    std::string _sstate; /**< current solver state, useful for resuming training. */
+    std::string _solver; /**< solver description file, included here as part of
+                            the model, very specific to Caffe. */
+    std::string
+        _sstate; /**< current solver state, useful for resuming training. */
     std::string _model_template; /**< model template name, if any. */
-    bool _has_mean_file = false; /**< whether a mean.binaryproto file is available, for image models only. */
-};
-  
+    bool _has_mean_file = false; /**< whether a mean.binaryproto file is
+                                    available, for image models only. */
+  };
+
 }
 
 #endif

--- a/src/backends/caffe2/caffe2inputconns.h
+++ b/src/backends/caffe2/caffe2inputconns.h
@@ -28,15 +28,22 @@
 #include "svminputfileconn.h"
 #include "backends/caffe2/nettools.h"
 
-namespace dd {
+namespace dd
+{
 
   /**
-   * \brief high-level data structure shared among Caffe2-compatible connectors of DeepDetect
+   * \brief high-level data structure shared among Caffe2-compatible connectors
+   * of DeepDetect
    */
-  class Caffe2InputInterface {
+  class Caffe2InputInterface
+  {
   public:
-    Caffe2InputInterface() {}
-    ~Caffe2InputInterface() {}
+    Caffe2InputInterface()
+    {
+    }
+    ~Caffe2InputInterface()
+    {
+    }
 
     /* Functions that should be kept by childrens */
 
@@ -44,7 +51,7 @@ namespace dd {
      * \brief reinserts dumped database informations into the workspace
      */
     void load_dbreader(Caffe2NetTools::ModelContext &context,
-		       const std::string &file, bool train = false) const;
+                       const std::string &file, bool train = false) const;
 
     /**
      * \brief inserts database informations into an initialization net
@@ -52,11 +59,12 @@ namespace dd {
     void create_dbreader(caffe2::NetDef &init_net, bool train = false) const;
 
     /**
-     * \brief asserts that the context can be used with the current input configuration
+     * \brief asserts that the context can be used with the current input
+     * configuration
      */
     void assert_context_validity(Caffe2NetTools::ModelContext &context,
-				 const std::vector<std::string> &ids,
-				 bool train = false) const;
+                                 const std::vector<std::string> &ids,
+                                 bool train = false) const;
 
     /* Functions that should be re-implemented by childrens */
 
@@ -67,14 +75,20 @@ namespace dd {
      * @param context the context of the net
      * @param init_net the net to update
      */
-    void add_constant_layers(const Caffe2NetTools::ModelContext &, caffe2::NetDef &) const {}
+    void add_constant_layers(const Caffe2NetTools::ModelContext &,
+                             caffe2::NetDef &) const
+    {
+    }
 
     /**
      * \brief adds operators to format the input
      * @param context the context of the net
      * @param net the net to update
      */
-    void add_transformation_layers(const Caffe2NetTools::ModelContext &, caffe2::NetDef &) const {}
+    void add_transformation_layers(const Caffe2NetTools::ModelContext &,
+                                   caffe2::NetDef &) const
+    {
+    }
 
     // Database read
 
@@ -82,15 +96,17 @@ namespace dd {
      * \brief links the dbreader with the given net
      */
     void link_train_dbreader(const Caffe2NetTools::ModelContext &context,
-			     caffe2::NetDef &net) const;
+                             caffe2::NetDef &net) const;
 
     /**
      * \brief uses the dbreader to insert data into the workspace
      * @param context context of the nets
      * @param already_loaded how many tensors must be ignored
-     * @return size of this batch (0 if there was not enough data to fill the tensors)
+     * @return size of this batch (0 if there was not enough data to fill the
+     * tensors)
      */
-    int use_test_dbreader(Caffe2NetTools::ModelContext &context, int already_loaded) const;
+    int use_test_dbreader(Caffe2NetTools::ModelContext &context,
+                          int already_loaded) const;
 
     // Manual data transformations (from raw data)
 
@@ -98,30 +114,34 @@ namespace dd {
      * \brief loads a batch
      * @param context context of the nets
      * @param already_loaded how many tensor where already loaded
-     * @return size of this batch (0 if there was not enough data to fill the tensors)
+     * @return size of this batch (0 if there was not enough data to fill the
+     * tensors)
      */
-    int load_batch(Caffe2NetTools::ModelContext &, int) { return 0; }
+    int load_batch(Caffe2NetTools::ModelContext &, int)
+    {
+      return 0;
+    }
 
     // Global configuration of the network
 
     bool _measuring = false;
 
   private:
-
     /* Internal functions */
 
     void set_batch_sizes(const APIData &ad, bool train,
-			 const std::vector<std::string> &ids);
+                         const std::vector<std::string> &ids);
 
   protected:
-
     /* Functions that should be called by the childrens */
 
     void init(InputConnectorStrategy *child);
 
     // Should be called AFTER the children has initialized protected members
-    void finalize_transform_predict(const APIData &ad, const std::vector<std::string> &ids);
-    void finalize_transform_train(const APIData &ad, const std::vector<std::string> &ids);
+    void finalize_transform_predict(const APIData &ad,
+                                    const std::vector<std::string> &ids);
+    void finalize_transform_train(const APIData &ad,
+                                  const std::vector<std::string> &ids);
 
     /**
      * \brief used to alert Caffe2Lib that the nets should be reconstructed
@@ -135,29 +155,35 @@ namespace dd {
      */
     void compute_db_sizes();
 
-    // Function that configure a tensor loader with given dbreader and batch size
-    using DBInputSetter = std::function<void(caffe2::OperatorDef&, const std::string &, int)>;
+    // Function that configure a tensor loader with given dbreader and batch
+    // size
+    using DBInputSetter
+        = std::function<void(caffe2::OperatorDef &, const std::string &, int)>;
 
-    void link_dbreader(const Caffe2NetTools::ModelContext &context, caffe2::NetDef &net,
-		       const DBInputSetter &config_dbinput, bool train) const;
+    void link_dbreader(const Caffe2NetTools::ModelContext &context,
+                       caffe2::NetDef &net,
+                       const DBInputSetter &config_dbinput, bool train) const;
 
-    // Function that convert a TensorProtos into a vector of tensor (already allocated)
-    using ProtosConverter =
-      std::function<void(const caffe2::TensorProtos&, std::vector<caffe2::Tensor>&)>;
+    // Function that convert a TensorProtos into a vector of tensor (already
+    // allocated)
+    using ProtosConverter = std::function<void(const caffe2::TensorProtos &,
+                                               std::vector<caffe2::Tensor> &)>;
 
     /**
      * \brief uses the dbreader to insert data into the workspace
      * @param context context of the nets
      * @param already_loaded how many tensors must be ignored
-     * @param convert_protos, callback to convert a TensorProtos into the corresponding tensors
+     * @param convert_protos, callback to convert a TensorProtos into the
+     * corresponding tensors
      * @param train which db must be read
-     * @return size of this batch (0 if there was not enough data to fill the tensors)
+     * @return size of this batch (0 if there was not enough data to fill the
+     * tensors)
      */
     int use_dbreader(Caffe2NetTools::ModelContext &context, int already_loaded,
-		     const ProtosConverter &convert_protos, bool train) const;
+                     const ProtosConverter &convert_protos, bool train) const;
 
     // Function that populate a vector with input tensors (already allocated)
-    using InputGetter = std::function<void(std::vector<caffe2::Tensor>&)>;
+    using InputGetter = std::function<void(std::vector<caffe2::Tensor> &)>;
 
     /**
      * \brief fill the workspace with batches of tensors
@@ -168,8 +194,9 @@ namespace dd {
      * @param train whether to use the train batch size or not
      * @return how many tensors were insered
      */
-    int insert_inputs(Caffe2NetTools::ModelContext &context, const std::vector<std::string> &blobs,
-		      int nb_data, const InputGetter &get_tensors, bool train) const;
+    int insert_inputs(Caffe2NetTools::ModelContext &context,
+                      const std::vector<std::string> &blobs, int nb_data,
+                      const InputGetter &get_tensors, bool train) const;
 
     /* Members managed by the mother class */
 
@@ -183,7 +210,7 @@ namespace dd {
     int _train_batch_size = 0;
     int _default_batch_size = 32;
 
-    //XXX Implement a way to change thoses ?
+    // XXX Implement a way to change thoses ?
     std::string _db_type = "lmdb";
     std::string _blob_dbreader = "dbreader";
     std::string _blob_dbreader_train = "dbreader_train";
@@ -192,16 +219,22 @@ namespace dd {
 
     /* Members that should be managed by the childrens */
 
-    std::string _db; // path to the database
-    std::string _train_db; // path to the training database
-    bool _is_testable = false; // whether test data is available
-    bool _is_load_manual = true; // whether data is manually loaded (as opposed to database-loaded)
-    bool _is_batchable = true; // whether inputs can be pre-computed into the same format
+    std::string _db;             // path to the database
+    std::string _train_db;       // path to the training database
+    bool _is_testable = false;   // whether test data is available
+    bool _is_load_manual = true; // whether data is manually loaded (as opposed
+                                 // to database-loaded)
+    bool _is_batchable
+        = true; // whether inputs can be pre-computed into the same format
     std::vector<std::vector<float>> _scales; // input scale coefficients
 
     /* Public getters */
   public:
-#define _GETTER(name) inline const decltype(_##name) &name() const { return _##name; }
+#define _GETTER(name)                                                         \
+  inline const decltype(_##name) &name() const                                \
+  {                                                                           \
+    return _##name;                                                           \
+  }
     _GETTER(is_testable);
     _GETTER(is_load_manual);
     //    _GETTER(ids);
@@ -212,31 +245,44 @@ namespace dd {
   /**
    * \brief Caffe2 image connector
    */
-  class ImgCaffe2InputFileConn : public ImgInputFileConn, public Caffe2InputInterface {
+  class ImgCaffe2InputFileConn : public ImgInputFileConn,
+                                 public Caffe2InputInterface
+  {
   public:
-    ImgCaffe2InputFileConn(): ImgInputFileConn(), Caffe2InputInterface() {}
-    ~ImgCaffe2InputFileConn() {}
+    ImgCaffe2InputFileConn() : ImgInputFileConn(), Caffe2InputInterface()
+    {
+    }
+    ~ImgCaffe2InputFileConn()
+    {
+    }
 
     /* Overloads */
 
-    inline int height() const { return _height; }
-    inline int width() const { return _width; }
+    inline int height() const
+    {
+      return _height;
+    }
+    inline int width() const
+    {
+      return _width;
+    }
 
     void init(const APIData &ad);
     void transform(const APIData &ad);
     void link_train_dbreader(const Caffe2NetTools::ModelContext &context,
-			     caffe2::NetDef &net) const;
-    int use_test_dbreader(Caffe2NetTools::ModelContext &context, int already_loaded) const;
+                             caffe2::NetDef &net) const;
+    int use_test_dbreader(Caffe2NetTools::ModelContext &context,
+                          int already_loaded) const;
     int load_batch(Caffe2NetTools::ModelContext &context, int already_loaded);
     bool needs_reconfiguration(const ImgCaffe2InputFileConn &inputc) const;
     void add_constant_layers(const Caffe2NetTools::ModelContext &context,
-			     caffe2::NetDef &init_net) const;
+                             caffe2::NetDef &init_net) const;
     void add_transformation_layers(const Caffe2NetTools::ModelContext &context,
-				   caffe2::NetDef &net) const;
+                                   caffe2::NetDef &net) const;
 
   private:
-
-    inline int channels() const {
+    inline int channels() const
+    {
       return _bw ? 1 : 3;
     }
 
@@ -254,17 +300,19 @@ namespace dd {
     void load_mean_file();
 
     /**
-     * \brief transforms a tensor proto containing an image into a vector of channels
-     *        See pytorch/caffe2/image/image_input_op.h GetImageAndLabelAndInfoFromDBValue
+     * \brief transforms a tensor proto containing an image into a vector of
+     * channels See pytorch/caffe2/image/image_input_op.h
+     * GetImageAndLabelAndInfoFromDBValue
      */
     void image_proto_to_mats(const caffe2::TensorProto &proto,
-			     std::vector<cv::Mat> &mats,
-			     bool resize=false) const;
+                             std::vector<cv::Mat> &mats,
+                             bool resize = false) const;
 
     /**
      * \brief transforms vector of channels into a CHW float tensor
      */
-    void mats_to_tensor(const std::vector<cv::Mat> &mats, caffe2::Tensor &tensor) const;
+    void mats_to_tensor(const std::vector<cv::Mat> &mats,
+                        caffe2::Tensor &tensor) const;
 
     /**
      * \brief stores the image dimensions into a tensor
@@ -278,14 +326,17 @@ namespace dd {
 
     /**
      * \brief converts images into db entries.
-     *        If '_uris' contains one root folder, it will be used for both training and testing.
-     *        Else, the first is used for training and the second for testing.
+     *        If '_uris' contains one root folder, it will be used for both
+     * training and testing. Else, the first is used for training and the
+     * second for testing.
      */
     void images_to_db();
 
     /**
-     * \brief checks which database(s) can/should be used depending on the 'uris' content
-     * @return true if images were used to create (a) new database(s), false otherwise
+     * \brief checks which database(s) can/should be used depending on the
+     * 'uris' content
+     * @return true if images were used to create (a) new database(s), false
+     * otherwise
      */
     bool uris_to_db();
 
@@ -296,25 +347,28 @@ namespace dd {
      * @param corresp_r reverse correspondence
      * @param files list of labeled files
      * @param is_reversed 'true' means using corresp_r to fetch the ids,
-     *                    'false' means filling corresp_r with ids for a future use
+     *                    'false' means filling corresp_r with ids for a future
+     * use
      */
     void list_images(const std::string &root,
-		     std::unordered_map<int, std::string> &corresp,
-		     std::unordered_map<std::string,int> &corresp_r,
-		     std::vector<std::pair<std::string, int>> &files,
-		     bool is_reversed);
+                     std::unordered_map<int, std::string> &corresp,
+                     std::unordered_map<std::string, int> &corresp_r,
+                     std::vector<std::pair<std::string, int>> &files,
+                     bool is_reversed);
 
     /**
      * \brief writes pairs of file/label inside a database
      */
-    void write_images_to_db(const std::string &dbname,
-			    const std::vector<std::pair<std::string,int>> &lfiles);
+    void
+    write_images_to_db(const std::string &dbname,
+                       const std::vector<std::pair<std::string, int>> &lfiles);
 
     std::string _mean_file;
     std::string _corresp_file;
     float _std = 1.0f;
 
-    // ImageInput augmentations (See https://caffe2.ai/docs/operators-catalogue.html#imageinput)
+    // ImageInput augmentations (See
+    // https://caffe2.ai/docs/operators-catalogue.html#imageinput)
     bool _color_jitter = false;
     float _img_saturation = 0.4f;
     float _img_brightness = 0.4f;
@@ -324,11 +378,11 @@ namespace dd {
     int _scale_jitter_type = 0;
     bool _mirror = false;
 
-    //XXX Implement a way to change it ?
+    // XXX Implement a way to change it ?
     std::string _blob_mean_values = "mean_values";
   };
 
-  //XXX Do other connectors XXXCaffe2InputFileConn (CSV, Txt, SVM, etc.)
+  // XXX Do other connectors XXXCaffe2InputFileConn (CSV, Txt, SVM, etc.)
 }
 
 #endif

--- a/src/backends/caffe2/caffe2inputimg.cc
+++ b/src/backends/caffe2/caffe2inputimg.cc
@@ -19,7 +19,7 @@
  * along with deepdetect.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-//XXX Remove that to print the warnings
+// XXX Remove that to print the warnings
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsign-compare"
 #pragma GCC diagnostic ignored "-Wunused-parameter"
@@ -29,47 +29,65 @@
 #include "utils/utils.hpp"
 #include "backends/caffe2/caffe2inputconns.h"
 
-namespace dd {
+namespace dd
+{
 
-  inline void get_if_present(const APIData &ad, const std::string &name, int &v) {
-    if (ad.has(name)) v = ad.get(name).get<int>(); }
+  inline void get_if_present(const APIData &ad, const std::string &name,
+                             int &v)
+  {
+    if (ad.has(name))
+      v = ad.get(name).get<int>();
+  }
 
-  inline void get_if_present(const APIData &ad, const std::string &name, bool &v) {
-    if (ad.has(name)) v = ad.get(name).get<bool>(); }
+  inline void get_if_present(const APIData &ad, const std::string &name,
+                             bool &v)
+  {
+    if (ad.has(name))
+      v = ad.get(name).get<bool>();
+  }
 
-  inline void get_if_present(const APIData &ad, const std::string &name, float &v) {
-    if (ad.has(name)) apitools::get_float(ad, name, v); }
+  inline void get_if_present(const APIData &ad, const std::string &name,
+                             float &v)
+  {
+    if (ad.has(name))
+      apitools::get_float(ad, name, v);
+  }
 
-  void ImgCaffe2InputFileConn::update(const APIData &ad) {
+  void ImgCaffe2InputFileConn::update(const APIData &ad)
+  {
 
     // std
     get_if_present(ad, "std", _std);
 
     // mean
-    if (!_has_mean_scalar) {
-      load_mean_file();
-    }
+    if (!_has_mean_scalar)
+      {
+        load_mean_file();
+      }
 
     // Data augmentation
-    if (ad.has("img_aug")) {
-      const APIData &aug = ad.getobj("img_aug");
-      get_if_present(aug, "color_jitter", _color_jitter);
-      get_if_present(aug, "img_saturation", _img_saturation);
-      get_if_present(aug, "img_brightness", _img_brightness);
-      get_if_present(aug, "img_contrast", _img_contrast);
-      get_if_present(aug, "color_lighting", _color_lighting);
-      get_if_present(aug, "color_lighting_std", _color_lighting_std);
-      get_if_present(aug, "scale_jitter_type", _scale_jitter_type);
-      get_if_present(aug, "mirror", _mirror);
-    }
+    if (ad.has("img_aug"))
+      {
+        const APIData &aug = ad.getobj("img_aug");
+        get_if_present(aug, "color_jitter", _color_jitter);
+        get_if_present(aug, "img_saturation", _img_saturation);
+        get_if_present(aug, "img_brightness", _img_brightness);
+        get_if_present(aug, "img_contrast", _img_contrast);
+        get_if_present(aug, "color_lighting", _color_lighting);
+        get_if_present(aug, "color_lighting_std", _color_lighting_std);
+        get_if_present(aug, "scale_jitter_type", _scale_jitter_type);
+        get_if_present(aug, "mirror", _mirror);
+      }
 
-    // If the images are scaled but not stretched or cropped, then their sizes will differ
+    // If the images are scaled but not stretched or cropped, then their sizes
+    // will differ
     _is_batchable &= !_scaled;
 
-    //XXX Implement support for other tags (multi_label, segmentation, ...)
+    // XXX Implement support for other tags (multi_label, segmentation, ...)
   }
 
-  void ImgCaffe2InputFileConn::init(const APIData &ad) {
+  void ImgCaffe2InputFileConn::init(const APIData &ad)
+  {
 
     ImgInputFileConn::init(ad);
     Caffe2InputInterface::init(this);
@@ -78,37 +96,45 @@ namespace dd {
     update(ad);
   }
 
-  void ImgCaffe2InputFileConn::transform(const APIData &ad) {
+  void ImgCaffe2InputFileConn::transform(const APIData &ad)
+  {
 
     // Update internal values
-    if (ad.has("parameters")) {
-      APIData ad_param = ad.getobj("parameters");
-      if (ad_param.has("input")) {
-	APIData ad_input = ad_param.getobj("input");
-	fillup_parameters(ad_input);
-	update(ad_input);
+    if (ad.has("parameters"))
+      {
+        APIData ad_param = ad.getobj("parameters");
+        if (ad_param.has("input"))
+          {
+            APIData ad_input = ad_param.getobj("input");
+            fillup_parameters(ad_input);
+            update(ad_input);
+          }
       }
-    }
 
     // Prepare the images
-    if (_train) {
-      transform_train(ad);
-      finalize_transform_train(ad,this->_ids);
-    } else {
-      transform_predict(ad);
-      finalize_transform_predict(ad,this->_ids);
-    }
+    if (_train)
+      {
+        transform_train(ad);
+        finalize_transform_train(ad, this->_ids);
+      }
+    else
+      {
+        transform_predict(ad);
+        finalize_transform_predict(ad, this->_ids);
+      }
   }
 
-  void ImgCaffe2InputFileConn::load_mean_file() {
+  void ImgCaffe2InputFileConn::load_mean_file()
+  {
 
     // Default values
-    if (!fileops::file_exists(_mean_file)) {
-      _logger->info("No mean file in the repository");
-      _mean.clear();
-      _mean.resize(channels());
-      return;
-    }
+    if (!fileops::file_exists(_mean_file))
+      {
+        _logger->info("No mean file in the repository");
+        _mean.clear();
+        _mean.resize(channels());
+        return;
+      }
 
     // Load
     caffe2::TensorProto mean;
@@ -126,248 +152,298 @@ namespace dd {
     _mean.assign(data.begin(), data.end());
   }
 
-  inline std::vector<float> compute_scale(const cv::Mat &image, const std::pair<int, int> &size) {
-    return {
-      static_cast<float>(image.rows) / size.first,
-      static_cast<float>(image.cols) / size.second
-    };
+  inline std::vector<float> compute_scale(const cv::Mat &image,
+                                          const std::pair<int, int> &size)
+  {
+    return { static_cast<float>(image.rows) / size.first,
+             static_cast<float>(image.cols) / size.second };
   }
 
-  void ImgCaffe2InputFileConn::transform_predict(const APIData &ad) {
+  void ImgCaffe2InputFileConn::transform_predict(const APIData &ad)
+  {
 
-    if (ad.has("data")) { // If we know what kind of data we'll have to work with
+    if (ad.has("data"))
+      { // If we know what kind of data we'll have to work with
 
-      get_data(ad);
-      _is_load_manual = !fileops::is_db(_uris[0]);
-      if (_is_load_manual) {
-	ImgInputFileConn::transform(ad); // Apply classic image pre-computations
+        get_data(ad);
+        _is_load_manual = !fileops::is_db(_uris[0]);
+        if (_is_load_manual)
+          {
+            ImgInputFileConn::transform(
+                ad); // Apply classic image pre-computations
+          }
       }
-
-    } else {
-      _is_load_manual = true; // Can't add automatic inputs without data
-    }
+    else
+      {
+        _is_load_manual = true; // Can't add automatic inputs without data
+      }
 
     _train_db = "";
-    if (_is_load_manual) {
+    if (_is_load_manual)
+      {
 
-      _db = "";
-      compute_db_sizes();
-      _is_testable = false; //XXX Can't infer labels from raw data
-      _is_load_manual = true;
-      this->_ids = _uris;
-      _scales.resize(this->_ids.size());
-      std::transform(_images.begin(), _images.end(), _images_size.begin(), _scales.begin(),
-		     compute_scale);
-
-    } else {
-
-      _db = _uris[0];
-      compute_db_sizes();
-      _is_testable = true;
-      _is_load_manual = false;
-      this->_ids.resize(_db_size);
-      _scales.resize(_db_size);
-
-      // Set indices as ids
-      for (int id = 0; id < _db_size; ++id) {
-	this->_ids[id] = std::to_string(id);
+        _db = "";
+        compute_db_sizes();
+        _is_testable = false; // XXX Can't infer labels from raw data
+        _is_load_manual = true;
+        this->_ids = _uris;
+        _scales.resize(this->_ids.size());
+        std::transform(_images.begin(), _images.end(), _images_size.begin(),
+                       _scales.begin(), compute_scale);
       }
-      // No pre-computation
-      std::fill(_scales.begin(), _scales.end(), std::vector<float>({1, 1}));
-    }
+    else
+      {
+
+        _db = _uris[0];
+        compute_db_sizes();
+        _is_testable = true;
+        _is_load_manual = false;
+        this->_ids.resize(_db_size);
+        _scales.resize(_db_size);
+
+        // Set indices as ids
+        for (int id = 0; id < _db_size; ++id)
+          {
+            this->_ids[id] = std::to_string(id);
+          }
+        // No pre-computation
+        std::fill(_scales.begin(), _scales.end(),
+                  std::vector<float>({ 1, 1 }));
+      }
   }
 
-  void ImgCaffe2InputFileConn::transform_train(const APIData &ad) {
+  void ImgCaffe2InputFileConn::transform_train(const APIData &ad)
+  {
 
     _shuffle = true;
     _is_load_manual = false;
     bool new_data = false;
 
     // Get databases paths
-    if (ad.has("data")) {
+    if (ad.has("data"))
+      {
 
-      get_data(ad);
-      new_data = uris_to_db();
-
-    } else {
-
-      _train_db = _default_train_db;
-      if (!fileops::file_exists(_train_db)) { // No database in the model repository
-	_logger->error("Missing training inputs");
-	throw;
+        get_data(ad);
+        new_data = uris_to_db();
       }
+    else
+      {
 
-      _db = _default_db;
-      _is_testable = fileops::file_exists(_db);
-    }
+        _train_db = _default_train_db;
+        if (!fileops::file_exists(_train_db))
+          { // No database in the model repository
+            _logger->error("Missing training inputs");
+            throw;
+          }
+
+        _db = _default_db;
+        _is_testable = fileops::file_exists(_db);
+      }
 
     compute_db_sizes();
 
-    if (_has_mean_scalar) {
-      // Save the mean values used in this training
-      caffe2::TensorProto mean;
-      std::vector<size_t> dims({ _mean.size(), 1, 1 });
-      *mean.mutable_dims() = {dims.begin(), dims.end()};
-      *mean.mutable_float_data() = {_mean.begin(), _mean.end()};
-      std::ofstream ofs(_mean_file);
-      mean.SerializeToOstream(&ofs);
-      ofs.close();
-
-    } else if (new_data || !fileops::file_exists(_mean_file)) {
-      // Compute the mean values of the database and save it into a file
-      compute_images_mean();
-      load_mean_file();
-    }
+    if (_has_mean_scalar)
+      {
+        // Save the mean values used in this training
+        caffe2::TensorProto mean;
+        std::vector<size_t> dims({ _mean.size(), 1, 1 });
+        *mean.mutable_dims() = { dims.begin(), dims.end() };
+        *mean.mutable_float_data() = { _mean.begin(), _mean.end() };
+        std::ofstream ofs(_mean_file);
+        mean.SerializeToOstream(&ofs);
+        ofs.close();
+      }
+    else if (new_data || !fileops::file_exists(_mean_file))
+      {
+        // Compute the mean values of the database and save it into a file
+        compute_images_mean();
+        load_mean_file();
+      }
   }
 
-  bool ImgCaffe2InputFileConn::uris_to_db() {
+  bool ImgCaffe2InputFileConn::uris_to_db()
+  {
 
     // Check if the uris are coherent
     bool uris_are_db = fileops::is_db(_uris[0]);
-    if (uris_are_db && _uris.size() > 1 && !fileops::is_db(_uris[1])) {
-      throw InputConnectorBadParamException("Can't use both files and databases as inputs");
-    }
+    if (uris_are_db && _uris.size() > 1 && !fileops::is_db(_uris[1]))
+      {
+        throw InputConnectorBadParamException(
+            "Can't use both files and databases as inputs");
+      }
 
     // Check if there is data to test on
     _is_testable = (_uris.size() > 1); // Two sets of data
-    _is_testable |= (!uris_are_db && _test_split > 0); // A folder with a split size
+    _is_testable
+        |= (!uris_are_db && _test_split > 0); // A folder with a split size
 
     // Set databases paths
-    if (uris_are_db) {
-      _train_db = _uris[0];
-      _db = _is_testable ? _uris[1] : "";
-      return false;
-    }
+    if (uris_are_db)
+      {
+        _train_db = _uris[0];
+        _db = _is_testable ? _uris[1] : "";
+        return false;
+      }
     _train_db = _default_train_db;
     _db = _is_testable ? _default_db : "";
 
     // Check if local databases could be used
-    bool is_train = fileops::file_exists(_train_db), is_test = fileops::file_exists(_db);
-    if (is_train && (!_is_testable || is_test)) {
-      _logger->warn("Found local database(s), bypassing creation");
-      return false;
-    }
+    bool is_train = fileops::file_exists(_train_db),
+         is_test = fileops::file_exists(_db);
+    if (is_train && (!_is_testable || is_test))
+      {
+        _logger->warn("Found local database(s), bypassing creation");
+        return false;
+      }
 
     // Check if creation would overwrite existing data
-    if (is_train != (_is_testable && is_test)) {
-      _logger->error("Creating a pair of local train/test databases would overwrite files");
-      throw InputConnectorBadParamException("failed to create databases");
-    }
+    if (is_train != (_is_testable && is_test))
+      {
+        _logger->error("Creating a pair of local train/test databases would "
+                       "overwrite files");
+        throw InputConnectorBadParamException("failed to create databases");
+      }
 
     // Create database(s)
-    if (!is_train) {
-      _logger->info("Transforming images to database(s)");
-      images_to_db();
-    }
+    if (!is_train)
+      {
+        _logger->info("Transforming images to database(s)");
+        images_to_db();
+      }
     return is_train;
   }
 
-  void ImgCaffe2InputFileConn::list_images(const std::string &root,
-					   std::unordered_map<int, std::string> &corresp,
-					   std::unordered_map<std::string,int> &corresp_r,
-					   std::vector<std::pair<std::string, int>> &files,
-					   bool is_reversed) {
+  void ImgCaffe2InputFileConn::list_images(
+      const std::string &root, std::unordered_map<int, std::string> &corresp,
+      std::unordered_map<std::string, int> &corresp_r,
+      std::vector<std::pair<std::string, int>> &files, bool is_reversed)
+  {
 
     std::unordered_set<std::string> subdirs;
-    if (fileops::list_directory(root, false, true, false, subdirs)) {
-      std::string msg("Failed reading image data directory " + root);
-      _logger->error(msg);
-      throw InputConnectorBadParamException(msg);
-    }
+    if (fileops::list_directory(root, false, true, false, subdirs))
+      {
+        std::string msg("Failed reading image data directory " + root);
+        _logger->error(msg);
+        throw InputConnectorBadParamException(msg);
+      }
 
     // list files and classes
     int cl = 0;
-    for (const std::string &dir : subdirs) {
+    for (const std::string &dir : subdirs)
+      {
 
-      std::unordered_set<std::string> subdir_files;
-      if (fileops::list_directory(dir, true, false, true, subdir_files)) {
-	std::string msg("Failed reading image data sub-directory " + dir);
-	_logger->error(msg);
-	throw InputConnectorBadParamException(msg);
-      }
-      std::string cls = dd_utils::split(dir, '/').back();
+        std::unordered_set<std::string> subdir_files;
+        if (fileops::list_directory(dir, true, false, true, subdir_files))
+          {
+            std::string msg("Failed reading image data sub-directory " + dir);
+            _logger->error(msg);
+            throw InputConnectorBadParamException(msg);
+          }
+        std::string cls = dd_utils::split(dir, '/').back();
 
-      if (is_reversed) { // retrieve the class id
-	auto it = corresp_r.find(cls);
-	if (it == corresp_r.end()) {
-	  _logger->warn("Class {} was not indexed, skipping", cls);
-	  continue;
-	}
-	cl = it->second;
-      } else { // save the class id
-	corresp.insert(std::pair<int,std::string>(cl, cls));
-	corresp_r.insert(std::pair<std::string,int>(cls, cl));
+        if (is_reversed)
+          { // retrieve the class id
+            auto it = corresp_r.find(cls);
+            if (it == corresp_r.end())
+              {
+                _logger->warn("Class {} was not indexed, skipping", cls);
+                continue;
+              }
+            cl = it->second;
+          }
+        else
+          { // save the class id
+            corresp.insert(std::pair<int, std::string>(cl, cls));
+            corresp_r.insert(std::pair<std::string, int>(cls, cl));
+          }
+
+        for (const std::string &file : subdir_files)
+          {
+            files.push_back(std::pair<std::string, int>(file, cl));
+          }
+        ++cl;
       }
 
-      for (const std::string &file : subdir_files) {
-	files.push_back(std::pair<std::string,int>(file, cl));
+    if (_shuffle)
+      {
+        std::mt19937 g;
+        if (_seed >= 0)
+          {
+            g = std::mt19937(_seed);
+          }
+        else
+          {
+            std::random_device rd;
+            g = std::mt19937(rd());
+          }
+        std::shuffle(files.begin(), files.end(), g);
       }
-      ++cl;
-    }
-
-    if (_shuffle) {
-      std::mt19937 g;
-      if (_seed >= 0) {
-	g = std::mt19937(_seed);
-      } else {
-	std::random_device rd;
-	g = std::mt19937(rd());
-      }
-      std::shuffle(files.begin(), files.end(), g);
-    }
   }
 
-  void ImgCaffe2InputFileConn::image_proto_to_mats(const caffe2::TensorProto &proto,
-						   std::vector<cv::Mat> &mats,
-						   bool resize) const {
+  void
+  ImgCaffe2InputFileConn::image_proto_to_mats(const caffe2::TensorProto &proto,
+                                              std::vector<cv::Mat> &mats,
+                                              bool resize) const
+  {
 
     cv::Mat src;
     int chans = channels();
     int type = proto.data_type();
 
     // Encoded
-    if (type == proto.STRING) {
-      auto &data = proto.string_data();
-      CAFFE_ENFORCE(data.size() == 1);
+    if (type == proto.STRING)
+      {
+        auto &data = proto.string_data();
+        CAFFE_ENFORCE(data.size() == 1);
 
-      // Convert
-      const std::string &img = data[0];
-      int size = img.size();
-      src = cv::imdecode(cv::Mat(1, &size, CV_8UC1, const_cast<char *>(img.data())),
-			 _bw ? CV_LOAD_IMAGE_GRAYSCALE : CV_LOAD_IMAGE_COLOR);
-      CAFFE_ENFORCE(src.rows && src.cols);
+        // Convert
+        const std::string &img = data[0];
+        int size = img.size();
+        src = cv::imdecode(
+            cv::Mat(1, &size, CV_8UC1, const_cast<char *>(img.data())),
+            _bw ? CV_LOAD_IMAGE_GRAYSCALE : CV_LOAD_IMAGE_COLOR);
+        CAFFE_ENFORCE(src.rows && src.cols);
 
-      // Raw
-    } else if (type == proto.BYTE) {
-      auto &data = proto.byte_data();
-      int src_c = (proto.dims_size() == 3) ? proto.dims(2) : 1;
-      CAFFE_ENFORCE(src_c == 3 || src_c == 1);
-
-      // Convert
-      src.create(proto.dims(0), proto.dims(1), (src_c == 1) ? CV_8UC1 : CV_8UC3);
-      std::memcpy(src.ptr<uchar>(0), data.data(), data.size());
-      if (chans != src_c) {
-	cv::cvtColor(src, src, _bw ? cv::COLOR_RGB2GRAY : cv::COLOR_GRAY2RGB);
+        // Raw
       }
-    } else {
-      throw InputConnectorBadParamException("Unknown image data type.");
-    }
+    else if (type == proto.BYTE)
+      {
+        auto &data = proto.byte_data();
+        int src_c = (proto.dims_size() == 3) ? proto.dims(2) : 1;
+        CAFFE_ENFORCE(src_c == 3 || src_c == 1);
 
-    if (resize) {
-      cv::resize(src, src, cv::Size(_width, _height), 0, 0, CV_INTER_CUBIC);
-    }
+        // Convert
+        src.create(proto.dims(0), proto.dims(1),
+                   (src_c == 1) ? CV_8UC1 : CV_8UC3);
+        std::memcpy(src.ptr<uchar>(0), data.data(), data.size());
+        if (chans != src_c)
+          {
+            cv::cvtColor(src, src,
+                         _bw ? cv::COLOR_RGB2GRAY : cv::COLOR_GRAY2RGB);
+          }
+      }
+    else
+      {
+        throw InputConnectorBadParamException("Unknown image data type.");
+      }
+
+    if (resize)
+      {
+        cv::resize(src, src, cv::Size(_width, _height), 0, 0, CV_INTER_CUBIC);
+      }
     mats.resize(chans);
     cv::split(src, mats);
   }
 
   void ImgCaffe2InputFileConn::mats_to_tensor(const std::vector<cv::Mat> &mats,
-					      caffe2::Tensor &tensor) const {
+                                              caffe2::Tensor &tensor) const
+  {
     // Fill with the current configuration
     CAFFE_ENFORCE(mats.size() == static_cast<size_t>(channels()));
     int h = _scaled ? mats[0].rows : _height;
     int w = _scaled ? mats[0].cols : _width;
     size_t channel_size = h * w * sizeof(float);
-    std::vector<long int> dims({channels(), h, w});
+    std::vector<long int> dims({ channels(), h, w });
 
     // Resize the tensor
     tensor.Resize(dims);
@@ -375,27 +451,31 @@ namespace dd {
 
     // Convert to float
     cv::Mat ch;
-    for (const cv::Mat &mat : mats) {
-      CAFFE_ENFORCE(mat.cols == w && mat.rows == h);
-      mat.convertTo(ch, CV_32F);
-      std::memcpy(data, ch.data, channel_size);
-      data += channel_size;
-    }
+    for (const cv::Mat &mat : mats)
+      {
+        CAFFE_ENFORCE(mat.cols == w && mat.rows == h);
+        mat.convertTo(ch, CV_32F);
+        std::memcpy(data, ch.data, channel_size);
+        data += channel_size;
+      }
   }
 
   void ImgCaffe2InputFileConn::im_info_to_tensor(const cv::Mat &img,
-						 caffe2::Tensor &tensor) const {
-    tensor.Resize(std::vector<long int>({3}));
+                                                 caffe2::Tensor &tensor) const
+  {
+    tensor.Resize(std::vector<long int>({ 3 }));
     float *data = tensor.mutable_data<float>();
     data[0] = img.rows;
     data[1] = img.cols;
     data[2] = 1;
   }
 
-  void ImgCaffe2InputFileConn::compute_images_mean() {
+  void ImgCaffe2InputFileConn::compute_images_mean()
+  {
 
     _logger->info("Creating mean file {}", _mean_file);
-    std::unique_ptr<caffe2::db::DB> db(caffe2::db::CreateDB(_db_type, _db, caffe2::db::READ));
+    std::unique_ptr<caffe2::db::DB> db(
+        caffe2::db::CreateDB(_db_type, _db, caffe2::db::READ));
     std::unique_ptr<caffe2::db::Cursor> cursor(db->NewCursor());
 
     // Preset mean tensor
@@ -410,21 +490,25 @@ namespace dd {
     caffe2::TensorProtos protos;
     std::vector<cv::Mat> mats;
     int count = 0;
-    for (; cursor->Valid(); cursor->Next()) {
-      protos.ParseFromString(cursor->value());
-      image_proto_to_mats(protos.protos(0), mats);
+    for (; cursor->Valid(); cursor->Next())
+      {
+        protos.ParseFromString(cursor->value());
+        image_proto_to_mats(protos.protos(0), mats);
 
-      // Sum the channel and add
-      for (int i = 0; i < chans; ++i) {
-	data[i] += cv::mean(mats[i])[0];
+        // Sum the channel and add
+        for (int i = 0; i < chans; ++i)
+          {
+            data[i] += cv::mean(mats[i])[0];
+          }
+
+        if (!(++count % 1000))
+          {
+            _logger->info("Processed {} entries", count);
+          }
       }
 
-      if (!(++count % 1000)) {
-	_logger->info("Processed {} entries", count);
-      }
-    }
-
-    std::for_each(data.begin(), data.end(), [&count](float &f) { f /= count; });
+    std::for_each(data.begin(), data.end(),
+                  [&count](float &f) { f /= count; });
 
     // Write to disk
     std::ofstream ofs(_mean_file);
@@ -432,44 +516,52 @@ namespace dd {
     ofs.close();
   }
 
-  void ImgCaffe2InputFileConn::images_to_db() {
+  void ImgCaffe2InputFileConn::images_to_db()
+  {
 
-    std::unordered_map<int,std::string> corresp;
-    std::unordered_map<std::string,int> corresp_r;
-    std::vector<std::pair<std::string,int>> train_files, test_files;
+    std::unordered_map<int, std::string> corresp;
+    std::unordered_map<std::string, int> corresp_r;
+    std::vector<std::pair<std::string, int>> train_files, test_files;
     list_images(_uris[0], corresp, corresp_r, train_files, false);
 
     // Create a test db
-    if (_is_testable) {
+    if (_is_testable)
+      {
 
-      if (_uris.size() > 1) {
-	list_images(_uris[1], corresp, corresp_r, test_files, true);
-
-      } else { // Split that data
-	auto it = train_files.begin() + std::floor(train_files.size() * (1.0 - _test_split));
-	test_files.assign(it, train_files.end());
-	train_files.erase(it, train_files.end());
+        if (_uris.size() > 1)
+          {
+            list_images(_uris[1], corresp, corresp_r, test_files, true);
+          }
+        else
+          { // Split that data
+            auto it = train_files.begin()
+                      + std::floor(train_files.size() * (1.0 - _test_split));
+            test_files.assign(it, train_files.end());
+            train_files.erase(it, train_files.end());
+          }
+        write_images_to_db(_db, test_files);
       }
-      write_images_to_db(_db, test_files);
-    }
     write_images_to_db(_train_db, train_files);
 
     // write corresp file
     std::ofstream correspf(_corresp_file, std::ios::binary);
-    for (auto &kp : corresp) {
-      correspf << kp.first << " " << kp.second << std::endl;
-    }
+    for (auto &kp : corresp)
+      {
+        correspf << kp.first << " " << kp.second << std::endl;
+      }
     correspf.close();
   }
 
-  void ImgCaffe2InputFileConn::write_images_to_db(const std::string &dbname,
-						  const std::vector<std::pair<std::string, int>>
-						  &lfiles) {
+  void ImgCaffe2InputFileConn::write_images_to_db(
+      const std::string &dbname,
+      const std::vector<std::pair<std::string, int>> &lfiles)
+  {
 
-    std::unique_ptr<caffe2::db::DB> db(caffe2::db::CreateDB(_db_type, dbname, caffe2::db::NEW));
+    std::unique_ptr<caffe2::db::DB> db(
+        caffe2::db::CreateDB(_db_type, dbname, caffe2::db::NEW));
     std::unique_ptr<caffe2::db::Transaction> txn(db->NewTransaction());
 
-    //XXX Manage Dectron-like databases (im_info blob, bbox, classes, ...)
+    // XXX Manage Dectron-like databases (im_info blob, bbox, classes, ...)
 
     // Prefill db entries
     caffe2::TensorProtos protos;
@@ -487,45 +579,55 @@ namespace dd {
     const int kMaxKeyLength = 256, batch_size = 1000;
     char key_cstr[kMaxKeyLength];
 
-    for (const std::pair<std::string, int> &file : lfiles) {
+    for (const std::pair<std::string, int> &file : lfiles)
+      {
 
-      // Fill db entry
-      std::string out;
-      try {
-	std::stringstream s;
-	s << std::ifstream(file.first).rdbuf();
-	data = s.str();
-	label = file.second;
-	CAFFE_ENFORCE(protos.SerializeToString(&out));
-      } catch (...) {
-	_logger->warn("Could not load {}", file.first);
-	continue;
-      }
+        // Fill db entry
+        std::string out;
+        try
+          {
+            std::stringstream s;
+            s << std::ifstream(file.first).rdbuf();
+            data = s.str();
+            label = file.second;
+            CAFFE_ENFORCE(protos.SerializeToString(&out));
+          }
+        catch (...)
+          {
+            _logger->warn("Could not load {}", file.first);
+            continue;
+          }
 
-      // Put in db
-      int length = snprintf(key_cstr, kMaxKeyLength, "%08d_%s", count, file.first.c_str());
-      txn->Put(std::string(key_cstr, length), out);
-      if (!(++count % batch_size)) {
-	_logger->info("Processed {} entries", count);
-	txn->Commit();
+        // Put in db
+        int length = snprintf(key_cstr, kMaxKeyLength, "%08d_%s", count,
+                              file.first.c_str());
+        txn->Put(std::string(key_cstr, length), out);
+        if (!(++count % batch_size))
+          {
+            _logger->info("Processed {} entries", count);
+            txn->Commit();
+          }
       }
-    }
-    if (!count) {
-      std::string msg("Could not fill " + dbname + " with the requested dataset");
-      _logger->error(msg);
-      throw InputConnectorBadParamException(msg);
-    }
+    if (!count)
+      {
+        std::string msg("Could not fill " + dbname
+                        + " with the requested dataset");
+        _logger->error(msg);
+        throw InputConnectorBadParamException(msg);
+      }
 
     // Write the last batch
-    if (count % batch_size) {
-      _logger->info("Processed {} entries", count);
-      txn->Commit();
-    }
+    if (count % batch_size)
+      {
+        _logger->info("Processed {} entries", count);
+        txn->Commit();
+      }
     _logger->info("{} successfully created ({} entries)", dbname, count);
   }
 
-  void ImgCaffe2InputFileConn::link_train_dbreader(const Caffe2NetTools::ModelContext &context,
-						   caffe2::NetDef &net) const {
+  void ImgCaffe2InputFileConn::link_train_dbreader(
+      const Caffe2NetTools::ModelContext &context, caffe2::NetDef &net) const
+  {
     // Notes
     //
     // -- 1 --
@@ -537,8 +639,8 @@ namespace dd {
     // See pytorch/caffe2/image/transform_gpu.cu
     //
     // -- 3 --
-    // NHWC2NCHW can't be inplace, so its input must have a different name from its output
-    // See pytorch/caffe2/operators/order_switch_ops.cc
+    // NHWC2NCHW can't be inplace, so its input must have a different name from
+    // its output See pytorch/caffe2/operators/order_switch_ops.cc
 
     // Square
     CAFFE_ENFORCE(_width == _height);
@@ -546,23 +648,27 @@ namespace dd {
     // Check if gpu optimizations can be used
     bool use_gpu_transform =
 #ifdef CPU_ONLY
-      false
+        false
 #else
-      (context._devices[0].device_type() == caffe2::DeviceTypeProto::PROTO_CUDA)
+        (context._devices[0].device_type()
+         == caffe2::DeviceTypeProto::PROTO_CUDA)
 #endif
-      ;
+        ;
 
     std::string input = context._input_blob;
-    if (!use_gpu_transform) {
-      input += "_NHWC";
-    }
+    if (!use_gpu_transform)
+      {
+        input += "_NHWC";
+      }
 
     // Add an ImageInput
-    //XXX manage Detectron databases
-    DBInputSetter config_dbinput =
-      [&](caffe2::OperatorDef &op, const std::string &reader, int batch_size) {
-      Caffe2NetTools::ImageInput(op, reader, input, context._blob_label, batch_size,
-				 channels(), _width, use_gpu_transform);
+    // XXX manage Detectron databases
+    DBInputSetter config_dbinput = [&](caffe2::OperatorDef &op,
+                                       const std::string &reader,
+                                       int batch_size) {
+      Caffe2NetTools::ImageInput(op, reader, input, context._blob_label,
+                                 batch_size, channels(), _width,
+                                 use_gpu_transform);
       Caffe2NetTools::add_arg(op, "color_jitter", _color_jitter);
       Caffe2NetTools::add_arg(op, "img_saturation", _img_saturation);
       Caffe2NetTools::add_arg(op, "img_brightness", _img_brightness);
@@ -575,35 +681,39 @@ namespace dd {
     link_dbreader(context, net, config_dbinput, true);
 
     // Swap manually
-    if (!use_gpu_transform) {
-      Caffe2NetTools::ScopedNet ns(context.scope_net(net));
-      Caffe2NetTools::NHWC2NCHW(ns, input, context._input_blob);
-    }
+    if (!use_gpu_transform)
+      {
+        Caffe2NetTools::ScopedNet ns(context.scope_net(net));
+        Caffe2NetTools::NHWC2NCHW(ns, input, context._input_blob);
+      }
   }
 
-  int ImgCaffe2InputFileConn::use_test_dbreader(Caffe2NetTools::ModelContext &context,
-						int already_loaded) const {
+  int ImgCaffe2InputFileConn::use_test_dbreader(
+      Caffe2NetTools::ModelContext &context, int already_loaded) const
+  {
     caffe2::TensorDeserializer deserializer;
-    ProtosConverter convert_protos =
-      [&](const caffe2::TensorProtos &protos, std::vector<caffe2::Tensor> &tensors) {
+    ProtosConverter convert_protos
+        = [&](const caffe2::TensorProtos &protos,
+              std::vector<caffe2::Tensor> &tensors) {
+            // Convert the image
+            std::vector<cv::Mat> mats;
+            image_proto_to_mats(protos.protos(0), mats, true);
+            mats_to_tensor(mats, tensors[0]);
 
-      // Convert the image
-      std::vector<cv::Mat> mats;
-      image_proto_to_mats(protos.protos(0), mats, true);
-      mats_to_tensor(mats, tensors[0]);
-
-      // Deserialize the label
-      deserializer.Deserialize(protos.protos(1), &tensors[1]);
-    };
+            // Deserialize the label
+            deserializer.Deserialize(protos.protos(1), &tensors[1]);
+          };
     return use_dbreader(context, already_loaded, convert_protos, false);
   }
 
   int ImgCaffe2InputFileConn::load_batch(Caffe2NetTools::ModelContext &context,
-					 int already_loaded) {
+                                         int already_loaded)
+  {
     // Call the generic batch loader
-    if (!_is_load_manual) {
-      return use_test_dbreader(context, already_loaded);
-    }
+    if (!_is_load_manual)
+      {
+        return use_test_dbreader(context, already_loaded);
+      }
 
     auto image = _images.begin() + already_loaded;
     InputGetter get_tensors = [&](std::vector<caffe2::Tensor> &tensors) {
@@ -612,31 +722,38 @@ namespace dd {
       mats_to_tensor(chan, tensors[0]);
       im_info_to_tensor(*image++, tensors[1]);
     };
-    return insert_inputs(context, {context._input_blob, context._blob_im_info},
-			 _images.size() - already_loaded, get_tensors, false);
+    return insert_inputs(context,
+                         { context._input_blob, context._blob_im_info },
+                         _images.size() - already_loaded, get_tensors, false);
   }
 
-  bool ImgCaffe2InputFileConn::needs_reconfiguration(const ImgCaffe2InputFileConn &inputc) const {
+  bool ImgCaffe2InputFileConn::needs_reconfiguration(
+      const ImgCaffe2InputFileConn &inputc) const
+  {
     return Caffe2InputInterface::needs_reconfiguration(inputc)
-      ||	_std	!= inputc._std
-      ||	_mean	!= inputc._mean
-      ;
+           || _std != inputc._std || _mean != inputc._mean;
   }
 
-  void ImgCaffe2InputFileConn::add_constant_layers(const Caffe2NetTools::ModelContext &context,
-						   caffe2::NetDef &init_net) const {
+  void ImgCaffe2InputFileConn::add_constant_layers(
+      const Caffe2NetTools::ModelContext &context,
+      caffe2::NetDef &init_net) const
+  {
     caffe2::OperatorDef op;
-    Caffe2NetTools::GivenTensorFill(op, _blob_mean_values, { channels() }, _mean);
+    Caffe2NetTools::GivenTensorFill(op, _blob_mean_values, { channels() },
+                                    _mean);
     Caffe2NetTools::copy_and_broadcast_operator(context, init_net, op);
   }
 
-  void ImgCaffe2InputFileConn::
-  add_transformation_layers(const Caffe2NetTools::ModelContext &context,
-			    caffe2::NetDef &net_def) const {
+  void ImgCaffe2InputFileConn::add_transformation_layers(
+      const Caffe2NetTools::ModelContext &context,
+      caffe2::NetDef &net_def) const
+  {
     Caffe2NetTools::ScopedNet net = context.scope_net(net_def);
     Caffe2NetTools::add_external_input(net, _blob_mean_values);
     Caffe2NetTools::Sub(net, context._input_blob, _blob_mean_values,
-			context._input_blob, 1, 1); // broadcast axis=1 means channel N[C]HW
-    Caffe2NetTools::Scale(net, context._input_blob, context._input_blob, 1.f / _std);
+                        context._input_blob, 1,
+                        1); // broadcast axis=1 means channel N[C]HW
+    Caffe2NetTools::Scale(net, context._input_blob, context._input_blob,
+                          1.f / _std);
   }
 }

--- a/src/backends/caffe2/caffe2lib.cc
+++ b/src/backends/caffe2/caffe2lib.cc
@@ -19,7 +19,7 @@
  * along with deepdetect.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-//XXX Remove that to print the warnings
+// XXX Remove that to print the warnings
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsign-compare"
 #pragma GCC diagnostic ignored "-Wunused-parameter"
@@ -35,25 +35,32 @@
 #include "backends/caffe2/caffe2lib.h"
 #include "backends/caffe2/nettools.h"
 
-//XXX Remove that to print the warnings
+// XXX Remove that to print the warnings
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #include "outputconnectorstrategy.h"
 #pragma GCC diagnostic pop
 
-namespace dd {
+namespace dd
+{
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  Caffe2Lib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::
-  Caffe2Lib(const Caffe2Model &c2model)
-    :MLLib<TInputConnectorStrategy,TOutputConnectorStrategy,Caffe2Model>(c2model) {
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  Caffe2Lib<TInputConnectorStrategy, TOutputConnectorStrategy,
+            TMLModel>::Caffe2Lib(const Caffe2Model &c2model)
+      : MLLib<TInputConnectorStrategy, TOutputConnectorStrategy, Caffe2Model>(
+          c2model)
+  {
     this->_libname = "caffe2";
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  Caffe2Lib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::
-  Caffe2Lib(Caffe2Lib &&c2l) noexcept
-    :MLLib<TInputConnectorStrategy,TOutputConnectorStrategy,Caffe2Model>(std::move(c2l)) {
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  Caffe2Lib<TInputConnectorStrategy, TOutputConnectorStrategy,
+            TMLModel>::Caffe2Lib(Caffe2Lib &&c2l) noexcept
+      : MLLib<TInputConnectorStrategy, TOutputConnectorStrategy, Caffe2Model>(
+          std::move(c2l))
+  {
     this->_libname = "caffe2";
 
     _context = std::move(c2l._context);
@@ -62,69 +69,89 @@ namespace dd {
     _last_inputc = c2l._last_inputc;
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  Caffe2Lib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::~Caffe2Lib() {}
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  Caffe2Lib<TInputConnectorStrategy, TOutputConnectorStrategy,
+            TMLModel>::~Caffe2Lib()
+  {
+  }
 
 #ifdef CPU_ONLY
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void Caffe2Lib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::
-  set_gpu_state(const APIData &ad, bool) {
-    if (ad.has("gpuid") || ad.has("gpu")) {
-      this->_logger->warn("Parametters 'gpuid' and 'gpu' are not used in CPU_ONLY mode");
-    }
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void Caffe2Lib<TInputConnectorStrategy, TOutputConnectorStrategy,
+                 TMLModel>::set_gpu_state(const APIData &ad, bool)
+  {
+    if (ad.has("gpuid") || ad.has("gpu"))
+      {
+        this->_logger->warn(
+            "Parametters 'gpuid' and 'gpu' are not used in CPU_ONLY mode");
+      }
   }
 #else
 
   template <typename T>
-  using StateSetter = void(Caffe2LibState::*)(const T&);
+  using StateSetter = void (Caffe2LibState::*)(const T &);
 
   inline void _set_gpu_state(const APIData &ad, Caffe2LibState &state,
-			     StateSetter<std::vector<int>> gpu_ids, StateSetter<bool> is_gpu) {
-    if (ad.has("gpuid")) {
-      std::vector<int> ids;
+                             StateSetter<std::vector<int>> gpu_ids,
+                             StateSetter<bool> is_gpu)
+  {
+    if (ad.has("gpuid"))
+      {
+        std::vector<int> ids;
 
-      // Fetch ids from the ApiData
-      apitools::get_vector(ad, "gpuid", ids);
+        // Fetch ids from the ApiData
+        apitools::get_vector(ad, "gpuid", ids);
 
-      // By default, use every GPUs
-      if (ids.size() == 1 && ids[0] == -1) {
-	ids.clear();
-	int count_gpus = 0;
-	cudaGetDeviceCount(&count_gpus);
-	ids.resize(count_gpus);
-	std::iota(ids.begin(), ids.end(), 0);
+        // By default, use every GPUs
+        if (ids.size() == 1 && ids[0] == -1)
+          {
+            ids.clear();
+            int count_gpus = 0;
+            cudaGetDeviceCount(&count_gpus);
+            ids.resize(count_gpus);
+            std::iota(ids.begin(), ids.end(), 0);
+          }
+        CAFFE_ENFORCE(!ids.empty());
+        (state.*gpu_ids)(ids);
+        (state.*is_gpu)(true);
       }
-      CAFFE_ENFORCE(!ids.empty());
-      (state.*gpu_ids)(ids);
-      (state.*is_gpu)(true);
-    }
 
-    if (ad.has("gpu")) {
-      (state.*is_gpu)(ad.get("gpu").get<bool>());
-    }
+    if (ad.has("gpu"))
+      {
+        (state.*is_gpu)(ad.get("gpu").get<bool>());
+      }
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void Caffe2Lib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::
-  set_gpu_state(const APIData &ad, bool dft) {
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void Caffe2Lib<TInputConnectorStrategy, TOutputConnectorStrategy,
+                 TMLModel>::set_gpu_state(const APIData &ad, bool dft)
+  {
     StateSetter<std::vector<int>> gpu_ids;
     StateSetter<bool> is_gpu;
-    if (dft) {
-      gpu_ids = &Caffe2LibState::set_default_gpu_ids;
-      is_gpu = &Caffe2LibState::set_default_is_gpu;
-    } else {
-      gpu_ids = &Caffe2LibState::set_gpu_ids;
-      is_gpu = &Caffe2LibState::set_is_gpu;
-    }
+    if (dft)
+      {
+        gpu_ids = &Caffe2LibState::set_default_gpu_ids;
+        is_gpu = &Caffe2LibState::set_default_is_gpu;
+      }
+    else
+      {
+        gpu_ids = &Caffe2LibState::set_gpu_ids;
+        is_gpu = &Caffe2LibState::set_is_gpu;
+      }
     _set_gpu_state(ad, _state, gpu_ids, is_gpu);
   }
 #endif
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void Caffe2Lib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::
-  instantiate_template(const APIData &ad) {
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void Caffe2Lib<TInputConnectorStrategy, TOutputConnectorStrategy,
+                 TMLModel>::instantiate_template(const APIData &ad)
+  {
 
-    //XXX Implement build-in template creation (mlp, convnet, resnet, etc.)
+    // XXX Implement build-in template creation (mlp, convnet, resnet, etc.)
 
     std::string model_tmpl = ad.get("template").get<std::string>();
     this->_logger->info("Instantiating model template {}", model_tmpl);
@@ -133,34 +160,41 @@ namespace dd {
     std::map<std::string, std::string> files;
     bool finetuning = ad.has("finetuning") && ad.get("finetuning").get<bool>();
     this->_mlmodel.list_template_files(model_tmpl, files, finetuning);
-    for (const std::pair<std::string, std::string> &file : files) {
+    for (const std::pair<std::string, std::string> &file : files)
+      {
 
-      // Assert the remote file exists
-      if (!fileops::file_exists(file.first)) {
-	throw MLLibBadParamException("file '" + file.first + "' doen't exists");
+        // Assert the remote file exists
+        if (!fileops::file_exists(file.first))
+          {
+            throw MLLibBadParamException("file '" + file.first
+                                         + "' doen't exists");
+          }
+
+        // Assert the local file won't be erased
+        if (fileops::file_exists(file.second))
+          {
+            throw MLLibBadParamException(
+                "using template while model files already exists, "
+                "remove 'template' from 'mllib', "
+                "or remove existing '.pb' files ?");
+          }
+
+        // Convert the prototxt file
+        caffe2::NetDef buffer;
+        Caffe2NetTools::import_net(buffer, file.first);
+        Caffe2NetTools::export_net(buffer, file.second);
       }
-
-      // Assert the local file won't be erased
-      if (fileops::file_exists(file.second)) {
-	throw MLLibBadParamException("using template while model files already exists, "
-				     "remove 'template' from 'mllib', "
-				     "or remove existing '.pb' files ?");
-      }
-
-      // Convert the prototxt file
-      caffe2::NetDef buffer;
-      Caffe2NetTools::import_net(buffer, file.first);
-      Caffe2NetTools::export_net(buffer, file.second);
-    }
 
     // Update the mlmodel
     this->_mlmodel._model_template = model_tmpl;
     this->_mlmodel.update_from_repository(this->_logger);
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void Caffe2Lib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::
-  set_train_mode(const APIData &ad, bool train) {
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void Caffe2Lib<TInputConnectorStrategy, TOutputConnectorStrategy,
+                 TMLModel>::set_train_mode(const APIData &ad, bool train)
+  {
 
     // Update the input connector
     TInputConnectorStrategy inputc(this->_inputc);
@@ -168,15 +202,20 @@ namespace dd {
 
     // If the net is neither training nor testing, the input connector can
     // load all the data into a single batch
-    inputc._measuring = ad.getobj("parameters").getobj("output").has("measure");
+    inputc._measuring
+        = ad.getobj("parameters").getobj("output").has("measure");
 
     // Configure the input data
-    try {
-      inputc.transform(ad);
-    } catch (std::exception &e) {
-      this->_logger->error("Could not configure the InputConnector {}", e.what());
-      throw;
-    }
+    try
+      {
+        inputc.transform(ad);
+      }
+    catch (std::exception &e)
+      {
+        this->_logger->error("Could not configure the InputConnector {}",
+                             e.what());
+        throw;
+      }
 
     // Read the repository again in case the input connector added something
     this->_mlmodel.update_from_repository(this->_logger);
@@ -188,40 +227,50 @@ namespace dd {
     // Reset the state
     _state.reset();
     _state.set_is_training(train);
-    if (force_init) {
-      _state.force_init();
-    }
+    if (force_init)
+      {
+        _state.force_init();
+      }
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void Caffe2Lib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::
-  create_model_train() {
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void Caffe2Lib<TInputConnectorStrategy, TOutputConnectorStrategy,
+                 TMLModel>::create_model_train()
+  {
 
-    //XXX Manage multi-net training
-    CAFFE_ENFORCE(_nets.size() == 1, "Extended nets doesn't support training yet.");
+    // XXX Manage multi-net training
+    CAFFE_ENFORCE(_nets.size() == 1,
+                  "Extended nets doesn't support training yet.");
     Caffe2NetTools::NetGroup &main_nets(find_net_group("main"));
 
     // Computation is done on new nets
     Caffe2NetTools::NetGroup nets;
 
-    //XXX Find a way to prevent code duplication when applying changes to the test net
+    // XXX Find a way to prevent code duplication when applying changes to the
+    // test net
 
     // Load or create a dbreader per net
-    if (_state.resume()) {
+    if (_state.resume())
+      {
 
-      _last_inputc.load_dbreader(_context, this->_mlmodel._dbreader_train_state, true);
-      if (_state.is_testing()) {
-	_last_inputc.load_dbreader(_context, this->_mlmodel._dbreader_state);
+        _last_inputc.load_dbreader(_context,
+                                   this->_mlmodel._dbreader_train_state, true);
+        if (_state.is_testing())
+          {
+            _last_inputc.load_dbreader(_context,
+                                       this->_mlmodel._dbreader_state);
+          }
       }
+    else
+      {
 
-    } else {
-
-      _last_inputc.create_dbreader(nets._init, true);
-      if (_state.is_testing()) {
-	_last_inputc.create_dbreader(nets._init);
+        _last_inputc.create_dbreader(nets._init, true);
+        if (_state.is_testing())
+          {
+            _last_inputc.create_dbreader(nets._init);
+          }
       }
-
-    }
 
     // Load batches from the database
     _last_inputc.link_train_dbreader(_context, nets._train);
@@ -229,47 +278,61 @@ namespace dd {
     // Apply input tranformations
     _last_inputc.add_constant_layers(_context, nets._init);
     _last_inputc.add_transformation_layers(_context, nets._train);
-    if (_state.is_testing()) {
-      _last_inputc.add_transformation_layers(_context, nets._predict);
-    }
+    if (_state.is_testing())
+      {
+        _last_inputc.add_transformation_layers(_context, nets._predict);
+      }
 
     // Add the requested net, with its loss and gradients
-    _context.append_trainable_net(nets._train, main_nets._predict, main_nets._output_blobs);
-    if (_state.is_testing()) {
-      _context.append_net(nets._predict, main_nets._predict);
-    }
+    _context.append_trainable_net(nets._train, main_nets._predict,
+                                  main_nets._output_blobs);
+    if (_state.is_testing())
+      {
+        _context.append_net(nets._predict, main_nets._predict);
+      }
 
     // The test net is complete
 
     // Set the learning-related operators and blobs to the desired iteration
-    if (_state.resume()) {
-      _context.load_lr(this->_mlmodel._lr_state); // Prefill the workspace
-      _context.load_iter(this->_mlmodel._iter_state); // Just load the integer
-    } else {
-      _context.reset_iter();
-    }
+    if (_state.resume())
+      {
+        _context.load_lr(this->_mlmodel._lr_state); // Prefill the workspace
+        _context.load_iter(
+            this->_mlmodel._iter_state); // Just load the integer
+      }
+    else
+      {
+        _context.reset_iter();
+      }
 
     // Duplicate the init net outputs on all the devices
-    Caffe2NetTools::copy_and_broadcast_operators(_context, nets._init, main_nets._init);
+    Caffe2NetTools::copy_and_broadcast_operators(_context, nets._init,
+                                                 main_nets._init);
 
     // Forward the APIData configuration in an operator
-    Caffe2NetTools::LROpModifier lr_config =
-      [&](caffe2::OperatorDef &lr, const std::string &iter, const std::string &rate) {
-      Caffe2NetTools::LearningRate(lr, iter, rate, _state.lr_policy(), _state.base_lr(),
-				   _state.stepsize(), _state.max_iter(),
-				   _state.gamma(), _state.power());
-    };
-    Caffe2NetTools::insert_learning_operators(_context, nets._train, nets._init, lr_config);
-    Caffe2NetTools::get_optimizer(_state.solver_type())
-      (_context, nets._train, nets._init, _state.momentum(), _state.rms_decay());
+    Caffe2NetTools::LROpModifier lr_config
+        = [&](caffe2::OperatorDef &lr, const std::string &iter,
+              const std::string &rate) {
+            Caffe2NetTools::LearningRate(lr, iter, rate, _state.lr_policy(),
+                                         _state.base_lr(), _state.stepsize(),
+                                         _state.max_iter(), _state.gamma(),
+                                         _state.power());
+          };
+    Caffe2NetTools::insert_learning_operators(_context, nets._train,
+                                              nets._init, lr_config);
+    Caffe2NetTools::get_optimizer(_state.solver_type())(
+        _context, nets._train, nets._init, _state.momentum(),
+        _state.rms_decay());
 
     // Apply changes
     main_nets.swap(nets);
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void Caffe2Lib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::
-  create_model_predict() {
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void Caffe2Lib<TInputConnectorStrategy, TOutputConnectorStrategy,
+                 TMLModel>::create_model_predict()
+  {
     _context._parallelized = false;
 
     // Computation is done on a new net
@@ -277,9 +340,10 @@ namespace dd {
     caffe2::NetDef tmp_net;
 
     // Add database informations
-    if (!_last_inputc.is_load_manual()) {
-      _last_inputc.create_dbreader(main_nets._init);
-    }
+    if (!_last_inputc.is_load_manual())
+      {
+        _last_inputc.create_dbreader(main_nets._init);
+      }
 
     // Add transformations
     _last_inputc.add_constant_layers(_context, main_nets._init);
@@ -289,96 +353,118 @@ namespace dd {
     _context.append_net(tmp_net, main_nets._predict);
 
     std::string extract = _state.extract_layer();
-    if (!extract.empty()) { // unsupervised
-      // Operators placed after the extracted layer are removed (they would do useless computation)
-      Caffe2NetTools::truncate_net(tmp_net, extract);
-    }
+    if (!extract.empty())
+      { // unsupervised
+        // Operators placed after the extracted layer are removed (they would
+        // do useless computation)
+        Caffe2NetTools::truncate_net(tmp_net, extract);
+      }
 
     // Force the device for every operators
     Caffe2NetTools::set_net_device(main_nets._init, _context._devices[0]);
-    for (auto nets_it = _nets.begin() + 1; nets_it < _nets.end(); ++nets_it) {
-      Caffe2NetTools::set_net_device(nets_it->_init, _context._devices[0]);
-      Caffe2NetTools::set_net_device(nets_it->_predict, _context._devices[0]);
-    }
+    for (auto nets_it = _nets.begin() + 1; nets_it < _nets.end(); ++nets_it)
+      {
+        Caffe2NetTools::set_net_device(nets_it->_init, _context._devices[0]);
+        Caffe2NetTools::set_net_device(nets_it->_predict,
+                                       _context._devices[0]);
+      }
 
     // Apply changes
     main_nets._predict.Swap(&tmp_net);
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void Caffe2Lib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::
-  create_model() {
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void Caffe2Lib<TInputConnectorStrategy, TOutputConnectorStrategy,
+                 TMLModel>::create_model()
+  {
     this->_logger->info("Re-creating the nets");
 
-    // _input_blob and _output_blobs should have been initialized during init_mllib
-    // (by "inputlayer" and "outputlayer" respectively)
-    // If the are not, we'll do a guess based on the following conventions:
+    // _input_blob and _output_blobs should have been initialized during
+    // init_mllib (by "inputlayer" and "outputlayer" respectively) If the are
+    // not, we'll do a guess based on the following conventions:
     //    - the input blob name is (or contains) "data"
     //    - the external inputs are sorted
     //    - all the outputs are created by the last operator
 
-    for (Caffe2NetTools::NetGroup &nets : _nets) {
-      Caffe2NetTools::ensure_is_batchable(nets._predict);
-      if (!nets._output_blobs.size()) {
-	const auto &ops = nets._predict.op();
-	const auto &outputs = ops[ops.size() - 1].output();
-	nets._output_blobs.assign(outputs.begin(), outputs.end());
+    for (Caffe2NetTools::NetGroup &nets : _nets)
+      {
+        Caffe2NetTools::ensure_is_batchable(nets._predict);
+        if (!nets._output_blobs.size())
+          {
+            const auto &ops = nets._predict.op();
+            const auto &outputs = ops[ops.size() - 1].output();
+            nets._output_blobs.assign(outputs.begin(), outputs.end());
+          }
       }
-    }
 
-    if (_context._input_blob.empty()) {
-      const auto &inputs = find_net_group("main")._predict.external_input();
-      _context._input_blob = inputs[0];
-      if (_context._input_blob.find("data") == std::string::npos) {
-	_context._input_blob = inputs[inputs.size() - 1];
-	if (_context._input_blob.find("data") == std::string::npos) {
-	  _context._input_blob = "data";
-	}
+    if (_context._input_blob.empty())
+      {
+        const auto &inputs = find_net_group("main")._predict.external_input();
+        _context._input_blob = inputs[0];
+        if (_context._input_blob.find("data") == std::string::npos)
+          {
+            _context._input_blob = inputs[inputs.size() - 1];
+            if (_context._input_blob.find("data") == std::string::npos)
+              {
+                _context._input_blob = "data";
+              }
+          }
       }
-    }
 
     // Reset the context
     _context.reset_workspace();
 #ifndef CPU_ONLY
-    if (_state.is_gpu()) {
-      _context.reset_devices(_state.gpu_ids());
-    } else
+    if (_state.is_gpu())
+      {
+        _context.reset_devices(_state.gpu_ids());
+      }
+    else
 #endif
       _context.reset_devices();
 
     // Transform the nets
-    if (_state.is_training()) {
-      create_model_train();
-    } else {
-      create_model_predict();
-    }
+    if (_state.is_training())
+      {
+        create_model_train();
+      }
+    else
+      {
+        create_model_predict();
+      }
 
     // Add the inputs and register the nets
     _context.create_input();
-    for (size_t i = 0; i < _nets.size(); ++i) {
+    for (size_t i = 0; i < _nets.size(); ++i)
+      {
 
-      Caffe2NetTools::NetGroup &nets(_nets[i]);
-      bool predict(!_state.is_training() || _state.is_testing());
-      bool train(_state.is_training());
+        Caffe2NetTools::NetGroup &nets(_nets[i]);
+        bool predict(!_state.is_training() || _state.is_testing());
+        bool train(_state.is_training());
 
-      this->_logger->info("Preparing {} nets", nets._type);
-      nets.rename("net" + std::to_string(i));
-      _context.run_net_once(nets._init);
-      if (predict) _context.create_net(nets._predict);
-      if (train) _context.create_net(nets._train);
-    }
+        this->_logger->info("Preparing {} nets", nets._type);
+        nets.rename("net" + std::to_string(i));
+        _context.run_net_once(nets._init);
+        if (predict)
+          _context.create_net(nets._predict);
+        if (train)
+          _context.create_net(nets._train);
+      }
 
     model_type(this->_mltype);
-    
+
     this->_logger->info("Nets updated");
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void Caffe2Lib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::
-  load_nets() {
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void Caffe2Lib<TInputConnectorStrategy, TOutputConnectorStrategy,
+                 TMLModel>::load_nets()
+  {
 
-    std::string init_net_path = _state.is_training() && _state.resume() ?
-      this->_mlmodel._init_state : this->_mlmodel._init;
+    std::string init_net_path = _state.is_training() && _state.resume()
+                                    ? this->_mlmodel._init_state
+                                    : this->_mlmodel._init;
 
     _nets.clear();
     _nets.reserve(this->_mlmodel._extensions.size() + 1);
@@ -388,120 +474,152 @@ namespace dd {
     Caffe2NetTools::NetGroup &main_nets(_nets.back());
 
     // Load the extensions
-    for (const Caffe2Model::Extension &ext : this->_mlmodel._extensions) {
-      _nets.emplace_back(ext._type, ext._init, ext._predict);
-      Caffe2NetTools::NetGroup &new_nets(_nets.back());
+    for (const Caffe2Model::Extension &ext : this->_mlmodel._extensions)
+      {
+        _nets.emplace_back(ext._type, ext._init, ext._predict);
+        Caffe2NetTools::NetGroup &new_nets(_nets.back());
 
-      // Merge them if possible
-      if (new_nets._type == "append") {
-	Caffe2NetTools::append_model(main_nets._predict, main_nets._init,
-				     new_nets._predict, new_nets._init);
-	_nets.pop_back();
+        // Merge them if possible
+        if (new_nets._type == "append")
+          {
+            Caffe2NetTools::append_model(main_nets._predict, main_nets._init,
+                                         new_nets._predict, new_nets._init);
+            _nets.pop_back();
+          }
       }
-    }
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void Caffe2Lib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::
-  update_model() {
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void Caffe2Lib<TInputConnectorStrategy, TOutputConnectorStrategy,
+                 TMLModel>::update_model()
+  {
 
-    if (!_state.changed()) {
-      if (_state.is_training()) {
-	this->_logger->info("Reseting the workspace");
-	for (Caffe2NetTools::NetGroup &nets : _nets) {
-	  _context.run_net_once(nets._init);
-	}
+    if (!_state.changed())
+      {
+        if (_state.is_training())
+          {
+            this->_logger->info("Reseting the workspace");
+            for (Caffe2NetTools::NetGroup &nets : _nets)
+              {
+                _context.run_net_once(nets._init);
+              }
+          }
+        return;
       }
-      return;
-    }
 
-    try {
+    try
+      {
 
-      // Reconfigure the model
-      load_nets();
-      create_model();
-
-    } catch (std::exception &e) {
-      this->_logger->error("Couldn't create model {}", e.what());
-      // Must stay in a 'changed_state' until a call to create_model finally succeed.
-      _state.force_init();
-      throw;
-    }
+        // Reconfigure the model
+        load_nets();
+        create_model();
+      }
+    catch (std::exception &e)
+      {
+        this->_logger->error("Couldn't create model {}", e.what());
+        // Must stay in a 'changed_state' until a call to create_model finally
+        // succeed.
+        _state.force_init();
+        throw;
+      }
     // Save the current net configuration.
     _state.backup();
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void Caffe2Lib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::
-  dump_model_state() {
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void Caffe2Lib<TInputConnectorStrategy, TOutputConnectorStrategy,
+                 TMLModel>::dump_model_state()
+  {
     caffe2::NetDef init;
     std::map<std::string, std::string> blobs;
-    // Blobs and nets are formatted here, so mlmodel just have to manage the files
+    // Blobs and nets are formatted here, so mlmodel just have to manage the
+    // files
     _context.extract_state(blobs);
-    //XXX Manage multi-net models
+    // XXX Manage multi-net models
     _context.create_init_net(find_net_group("main")._train, init);
     this->_mlmodel.write_state(init, blobs);
     this->_logger->info("Dumped model state");
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void Caffe2Lib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::
-  init_mllib(const APIData &ad) {
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void Caffe2Lib<TInputConnectorStrategy, TOutputConnectorStrategy,
+                 TMLModel>::init_mllib(const APIData &ad)
+  {
 
     // Store the net's default (but variable) configuration
     set_gpu_state(ad, true);
 
-    bool has_template = ad.has("template") && ad.get("template").get<std::string>() != "";
-    if (has_template) {
-      instantiate_template(ad);
-    }
+    bool has_template
+        = ad.has("template") && ad.get("template").get<std::string>() != "";
+    if (has_template)
+      {
+        instantiate_template(ad);
+      }
 
     // Check if the mandatory files are present
-    if (this->_mlmodel._predict.empty() || this->_mlmodel._init.empty()) {
-      throw MLLibInternalException
-	(this->_mlmodel._repo + " does not contain the required files to initialize a net");
-    }
+    if (this->_mlmodel._predict.empty() || this->_mlmodel._init.empty())
+      {
+        throw MLLibInternalException(
+            this->_mlmodel._repo
+            + " does not contain the required files to initialize a net");
+      }
 
     // Load the model
     load_nets();
     Caffe2NetTools::NetGroup &main_nets(find_net_group("main"));
 
     // Store the net's general configuration
-    if (ad.has("inputlayer")) {
-      _context._input_blob = ad.get("inputlayer").get<std::string>();
-    }
-    if (ad.has("outputlayer")) {
-      //XXX Manage multi-net context
-      apitools::get_vector(ad, "outputlayer", main_nets._output_blobs);
-    }
-    if (ad.has("nclasses")) {
-      _context._nclasses = ad.get("nclasses").get<int>();
-    }
+    if (ad.has("inputlayer"))
+      {
+        _context._input_blob = ad.get("inputlayer").get<std::string>();
+      }
+    if (ad.has("outputlayer"))
+      {
+        // XXX Manage multi-net context
+        apitools::get_vector(ad, "outputlayer", main_nets._output_blobs);
+      }
+    if (ad.has("nclasses"))
+      {
+        _context._nclasses = ad.get("nclasses").get<int>();
+      }
 
-    //XXX Get more informations (targets for multi-label, autoencoder, regression, ...)
+    // XXX Get more informations (targets for multi-label, autoencoder,
+    // regression, ...)
 
-    //XXX See how get_nclasses and set_nclasses can be used with multi-net models
+    // XXX See how get_nclasses and set_nclasses can be used with multi-net
+    // models
 
     // Check the number of classes
-    int current_nclasses = Caffe2NetTools::get_nclasses(main_nets._predict, main_nets._init);
+    int current_nclasses
+        = Caffe2NetTools::get_nclasses(main_nets._predict, main_nets._init);
 
     // Keep the current shape
-    if (!_context._nclasses) {
-      _context._nclasses = current_nclasses;
+    if (!_context._nclasses)
+      {
+        _context._nclasses = current_nclasses;
 
-      // Change the shape
-    } else if (has_template) {
+        // Change the shape
+      }
+    else if (has_template)
+      {
 
-      // Reset parameters to ConstantFills, XaviersFills, etc.
-      Caffe2NetTools::set_nclasses(main_nets._predict, main_nets._init, _context._nclasses);
-      Caffe2NetTools::export_net(main_nets._init, this->_mlmodel._init);
+        // Reset parameters to ConstantFills, XaviersFills, etc.
+        Caffe2NetTools::set_nclasses(main_nets._predict, main_nets._init,
+                                     _context._nclasses);
+        Caffe2NetTools::export_net(main_nets._init, this->_mlmodel._init);
 
-      // Assert the shape is correct
-    } else {
-      CAFFE_ENFORCE(_context._nclasses == current_nclasses);
-    }
+        // Assert the shape is correct
+      }
+    else
+      {
+        CAFFE_ENFORCE(_context._nclasses == current_nclasses);
+      }
 
-    // Now that every '_default' configuration values are defined, initialize the '_current' ones
+    // Now that every '_default' configuration values are defined, initialize
+    // the '_current' ones
     _state.reset();
     _last_inputc = this->_inputc;
 
@@ -510,71 +628,83 @@ namespace dd {
     _state.backup();
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void Caffe2Lib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::
-  clear_mllib(const APIData &) {
-    std::vector<std::string> extensions({".json"});
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void Caffe2Lib<TInputConnectorStrategy, TOutputConnectorStrategy,
+                 TMLModel>::clear_mllib(const APIData &)
+  {
+    std::vector<std::string> extensions({ ".json" });
     fileops::remove_directory_files(this->_mlmodel._repo, extensions);
     this->_mlmodel.update_from_repository(this->_logger);
-    std::vector<std::string> files({
-	this->_mlmodel._init_state,
-	this->_mlmodel._dbreader_state,
-	this->_mlmodel._dbreader_train_state,
-	this->_mlmodel._iter_state,
-	this->_mlmodel._lr_state
-    });
-    for (const std::string &file : files) {
-      if (!file.empty()) {
-	remove(file.c_str());
+    std::vector<std::string> files(
+        { this->_mlmodel._init_state, this->_mlmodel._dbreader_state,
+          this->_mlmodel._dbreader_train_state, this->_mlmodel._iter_state,
+          this->_mlmodel._lr_state });
+    for (const std::string &file : files)
+      {
+        if (!file.empty())
+          {
+            remove(file.c_str());
+          }
       }
-    }
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  Caffe2NetTools::NetGroup &Caffe2Lib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::
-  find_net_group(const std::string &type) {
-    for (Caffe2NetTools::NetGroup &nets : _nets) {
-      if (nets._type == type) {
-	return nets;
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  Caffe2NetTools::NetGroup &
+  Caffe2Lib<TInputConnectorStrategy, TOutputConnectorStrategy,
+            TMLModel>::find_net_group(const std::string &type)
+  {
+    for (Caffe2NetTools::NetGroup &nets : _nets)
+      {
+        if (nets._type == type)
+          {
+            return nets;
+          }
       }
-    }
     CAFFE_THROW("The '", type, "' net could not be found");
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  float Caffe2Lib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::
-  run_net(const std::string &net) {
-    try {
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  float Caffe2Lib<TInputConnectorStrategy, TOutputConnectorStrategy,
+                  TMLModel>::run_net(const std::string &net)
+  {
+    try
+      {
 
-      using namespace std::chrono;
-      time_point<system_clock> start = system_clock::now();
-      _context.run_net(net);
-      return duration_cast<milliseconds>(system_clock::now() - start).count();
-
-    } catch(std::exception &e) {
-      this->_logger->error("Error while running the network: {}", e.what());
-      throw;
-    }
+        using namespace std::chrono;
+        time_point<system_clock> start = system_clock::now();
+        _context.run_net(net);
+        return duration_cast<milliseconds>(system_clock::now() - start)
+            .count();
+      }
+    catch (std::exception &e)
+      {
+        this->_logger->error("Error while running the network: {}", e.what());
+        throw;
+      }
   }
 
   inline void extract_sizes(const Caffe2NetTools::ModelContext &context,
-			    std::vector<size_t> &sizes,
-			    int batch_size,
-			    const std::string &name) {
+                            std::vector<size_t> &sizes, int batch_size,
+                            const std::string &name)
+  {
     // Fetch the items size
     std::vector<std::vector<float>> float_sizes(batch_size);
     context.extract(float_sizes, name, std::vector<size_t>(batch_size, 1));
     sizes.resize(batch_size);
     std::transform(float_sizes.begin(), float_sizes.end(), sizes.begin(),
-		   [&](const std::vector<float> &size){ return size[0]; });
+                   [&](const std::vector<float> &size) { return size[0]; });
   }
 
-  inline void extract_layers(const Caffe2NetTools::ModelContext &context,
-			     std::vector<std::vector<std::vector<float>>> &results,
-			     std::vector<size_t> &sizes,
-			     int batch_size,
-			     const std::vector<std::string> &names,
-			     const std::vector<size_t> &scales = {}) {
+  inline void
+  extract_layers(const Caffe2NetTools::ModelContext &context,
+                 std::vector<std::vector<std::vector<float>>> &results,
+                 std::vector<size_t> &sizes, int batch_size,
+                 const std::vector<std::string> &names,
+                 const std::vector<size_t> &scales = {})
+  {
 
     size_t layers = names.size();
     bool no_sizes = sizes.empty();
@@ -582,26 +712,31 @@ namespace dd {
 
     // Fetch the layers
     results.resize(layers);
-    for (size_t i = 0; i < layers; ++i) {
-      std::vector<std::vector<float>> &result(results[i]);
-      const std::string &name(names[i]);
+    for (size_t i = 0; i < layers; ++i)
+      {
+        std::vector<std::vector<float>> &result(results[i]);
+        const std::string &name(names[i]);
 
-      // Fetch the items
-      result.resize(batch_size);
-      if (no_sizes) {
-	context.extract(result, name);
-      } else {
-	context.extract(result, name, sizes, scales[i]);
+        // Fetch the items
+        result.resize(batch_size);
+        if (no_sizes)
+          {
+            context.extract(result, name);
+          }
+        else
+          {
+            context.extract(result, name, sizes, scales[i]);
+          }
       }
-    }
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void Caffe2Lib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::
-  extract_results(std::vector<std::vector<std::vector<float>>> &results,
-		  std::vector<size_t> &sizes,
-		  int batch_size,
-		  const std::vector<std::string> &outputs) {
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void Caffe2Lib<TInputConnectorStrategy, TOutputConnectorStrategy, TMLModel>::
+      extract_results(std::vector<std::vector<std::vector<float>>> &results,
+                      std::vector<size_t> &sizes, int batch_size,
+                      const std::vector<std::string> &outputs)
+  {
 
     size_t nb_output = outputs.size();
     std::string extract_layer = _state.extract_layer();
@@ -611,55 +746,70 @@ namespace dd {
     };
 
     auto extract_class = [&]() {
-      CAFFE_ENFORCE(nb_output == 1, "classification outputs should fit in a single blob");
+      CAFFE_ENFORCE(nb_output == 1,
+                    "classification outputs should fit in a single blob");
       extract_layers(_context, results, sizes, batch_size, outputs);
     };
 
     // scores, bboxes, classes, batch_splits
     auto extract_bbox = [&]() {
-      CAFFE_ENFORCE(nb_output == 4,
-		    "bboxes should be shaped like (scores, bboxes, classes, batch_splits)");
+      CAFFE_ENFORCE(nb_output == 4, "bboxes should be shaped like (scores, "
+                                    "bboxes, classes, batch_splits)");
       extract_sizes(_context, sizes, batch_size, outputs.back());
       std::vector<std::string> bbox_layers(outputs.begin(), outputs.end() - 1);
-      extract_layers(_context, results, sizes, batch_size, bbox_layers, {1, 4, 1});
+      extract_layers(_context, results, sizes, batch_size, bbox_layers,
+                     { 1, 4, 1 });
     };
 
     // masks, im_info
     auto extract_mask = [&]() {
-      if (nb_output == 4) return extract_bbox();
+      if (nb_output == 4)
+        return extract_bbox();
       CAFFE_ENFORCE(nb_output == 2,
-		    "bboxes should be shaped like (scores, bboxes, classes, batch_splits) "
-		    "and masks should be shaped like (masks, im_info)");
-      extract_layers(_context, results, sizes, batch_size, { outputs[0] }, {0});
+                    "bboxes should be shaped like (scores, bboxes, classes, "
+                    "batch_splits) "
+                    "and masks should be shaped like (masks, im_info)");
+      extract_layers(_context, results, sizes, batch_size, { outputs[0] },
+                     { 0 });
       results.emplace_back(batch_size);
       _context.extract(results.back(), outputs[1]);
     };
 
-    if (!extract_layer.empty()) {
-      extract_raw_layer();
-    } else if (_state.mask()) {
-      extract_mask();
-    } else if (_state.bbox()) {
-      extract_bbox();
-    } else { // Default
-      extract_class();
-    }
+    if (!extract_layer.empty())
+      {
+        extract_raw_layer();
+      }
+    else if (_state.mask())
+      {
+        extract_mask();
+      }
+    else if (_state.bbox())
+      {
+        extract_bbox();
+      }
+    else
+      { // Default
+        extract_class();
+      }
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void Caffe2Lib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::
-  typed_prediction(std::vector<std::vector<std::vector<float>>> &results,
-		   std::vector<size_t> &sizes,
-		   int batch_size,
-		   const std::string &type) {
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void Caffe2Lib<TInputConnectorStrategy, TOutputConnectorStrategy, TMLModel>::
+      typed_prediction(std::vector<std::vector<std::vector<float>>> &results,
+                       std::vector<size_t> &sizes, int batch_size,
+                       const std::string &type)
+  {
     Caffe2NetTools::NetGroup &nets(find_net_group(type));
     run_net(nets._predict.name());
     extract_results(results, sizes, batch_size, nets._output_blobs);
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  int Caffe2Lib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::
-  train(const APIData &ad, APIData &out) {
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  int Caffe2Lib<TInputConnectorStrategy, TOutputConnectorStrategy,
+                TMLModel>::train(const APIData &ad, APIData &out)
+  {
     set_train_mode(ad, true);
 
     APIData ad_mllib = ad.getobj("parameters").getobj("mllib");
@@ -673,59 +823,72 @@ namespace dd {
 
     // Update the solver's tags
     APIData ad_solver = ad_mllib.getobj("solver");
-    if (ad_solver.size()) {
+    if (ad_solver.size())
+      {
 
-      // Learning rate, optimizer, etc.
-      _state.set_lr_policy(ad_solver);
-      _state.set_base_lr(ad_solver);
-      _state.set_stepsize(ad_solver);
-      _state.set_gamma(ad_solver);
-      _state.set_power(ad_solver);
-      _state.set_max_iter(ad_solver);
-      _state.set_solver_type(ad_solver);
-      _state.set_momentum(ad_solver);
-      _state.set_rms_decay(ad_solver);
+        // Learning rate, optimizer, etc.
+        _state.set_lr_policy(ad_solver);
+        _state.set_base_lr(ad_solver);
+        _state.set_stepsize(ad_solver);
+        _state.set_gamma(ad_solver);
+        _state.set_power(ad_solver);
+        _state.set_max_iter(ad_solver);
+        _state.set_solver_type(ad_solver);
+        _state.set_momentum(ad_solver);
+        _state.set_rms_decay(ad_solver);
 
-      // To be compatible with caffe's syntax, the 'solver_type' is allowed to be sent in uppercase
-      std::string solver_type = _state.solver_type();
-      std::transform(solver_type.begin(), solver_type.end(), solver_type.begin(), ::tolower);
-      _state.set_solver_type(solver_type);
+        // To be compatible with caffe's syntax, the 'solver_type' is allowed
+        // to be sent in uppercase
+        std::string solver_type = _state.solver_type();
+        std::transform(solver_type.begin(), solver_type.end(),
+                       solver_type.begin(), ::tolower);
+        _state.set_solver_type(solver_type);
 
-      //XXX Allow more parameters: decay, epsilon, ...
+        // XXX Allow more parameters: decay, epsilon, ...
 
-      // Iterations count
-      if (ad_solver.has("iterations")) {
-	iterations = ad_solver.get("iterations").get<int>();
+        // Iterations count
+        if (ad_solver.has("iterations"))
+          {
+            iterations = ad_solver.get("iterations").get<int>();
+          }
+        if (ad_solver.has("test_interval"))
+          {
+            test_interval = ad_solver.get("test_interval").get<int>();
+          }
+        if (ad_solver.has("snapshot"))
+          {
+            snapshot_interval = ad_solver.get("snapshot").get<int>();
+          }
       }
-      if (ad_solver.has("test_interval")) {
-	test_interval = ad_solver.get("test_interval").get<int>();
-      }
-      if (ad_solver.has("snapshot")) {
-	snapshot_interval = ad_solver.get("snapshot").get<int>();
-      }
-    }
 
-    if (!iterations) {
-      //XXX Use a default number of epoch ? (e.g. 50 * _last_inputc.db_size())
-      throw MLLibBadParamException("'iterations' must be set to a positive integer");
-    }
+    if (!iterations)
+      {
+        // XXX Use a default number of epoch ? (e.g. 50 *
+        // _last_inputc.db_size())
+        throw MLLibBadParamException(
+            "'iterations' must be set to a positive integer");
+      }
 
     // Update the training's tags
     _state.set_is_testing(test_interval > 0 && _last_inputc.is_testable());
     _state.set_resume(ad_mllib);
-    if (_state.resume()) {
-      _state.force_init(); // When resuming, blobs like DBreaders and Iters must be updated
-    }
+    if (_state.resume())
+      {
+        _state.force_init(); // When resuming, blobs like DBreaders and Iters
+                             // must be updated
+      }
 
-    update_model(); // Recreate the net from protobuf files if the configuration has changed
+    update_model(); // Recreate the net from protobuf files if the
+                    // configuration has changed
 
     // Check if everything is well configured
     _last_inputc.assert_context_validity(_context, _last_inputc._ids, true);
-    if (_state.is_testing()) {
-      _last_inputc.assert_context_validity(_context, _last_inputc._ids);
-    }
+    if (_state.is_testing())
+      {
+        _last_inputc.assert_context_validity(_context, _last_inputc._ids);
+      }
 
-    //XXX Manage multi-net training
+    // XXX Manage multi-net training
     Caffe2NetTools::NetGroup &main_nets(find_net_group("main"));
 
     // Start the training
@@ -733,368 +896,437 @@ namespace dd {
     if (!_state.resume())
       this->clear_all_meas_per_iter();
     this->_tjob_running = true;
-    if (start_iter) {
-      this->_logger->info("Training is restarting at iteration {}", start_iter);
-    } else {
-      this->_logger->info("Training is starting");
-    }
-    for (int iter = start_iter; iter < iterations && this->_tjob_running.load(); ++iter) {
-
-      // Add measures
-      float iter_time = run_net(main_nets._train.name());
-      this->add_meas("iter_time", iter_time);
-      this->add_meas("remain_time", iter_time * (iterations - iter) / 1000.0);
-      this->add_meas("train_loss", _context.extract_loss());
-      this->add_meas("iteration", iter);
-
-      // Save snapshot
-      if (snapshot_interval && iter > start_iter && !(iter % snapshot_interval)) {
-	dump_model_state();
+    if (start_iter)
+      {
+        this->_logger->info("Training is restarting at iteration {}",
+                            start_iter);
       }
-
-      // Test the net
-      if (_state.is_testing() && iter > start_iter && !(iter % test_interval)) {
-	this->_logger->info("Testing model");
-
-	APIData meas_out;
-	test(ad, meas_out);
-	APIData meas_obj = meas_out.getobj("measure");
-
-	// Loop over the test measures
-	for (auto meas : meas_obj.list_keys()) {
-	  apitools::test_variants<double, std::vector<double>>
-	    (meas_obj, meas,
-
-	    // Single value
-	    [&](const double &value) {
-	      this->add_meas(meas, value);
-	      this->add_meas_per_iter(meas, value);
-	      this->_logger->info("{} = {}", meas, value);
-	    },
-
-	    // Multiple values
-	    [&](const std::vector<double> &values) {
-	      size_t nb_values = values.size();
-	      std::vector<std::string> cls(nb_values);
-	      this->_mlmodel.get_hcorresp(cls);
-	      this->add_meas(meas, values, cls);
-	      std::stringstream s;
-	      for (size_t value = 0; value < nb_values; ++value) {
-		s << (value ? ", " : "") << cls[value] << ": " << values[value];
-	      }
-	      this->_logger->info("{} = [ {} ]", meas, s.str());
-	    });
-	}
-	this->_logger->info("Model tested");
+    else
+      {
+        this->_logger->info("Training is starting");
       }
-    }
+    for (int iter = start_iter;
+         iter < iterations && this->_tjob_running.load(); ++iter)
+      {
+
+        // Add measures
+        float iter_time = run_net(main_nets._train.name());
+        this->add_meas("iter_time", iter_time);
+        this->add_meas("remain_time",
+                       iter_time * (iterations - iter) / 1000.0);
+        this->add_meas("train_loss", _context.extract_loss());
+        this->add_meas("iteration", iter);
+
+        // Save snapshot
+        if (snapshot_interval && iter > start_iter
+            && !(iter % snapshot_interval))
+          {
+            dump_model_state();
+          }
+
+        // Test the net
+        if (_state.is_testing() && iter > start_iter
+            && !(iter % test_interval))
+          {
+            this->_logger->info("Testing model");
+
+            APIData meas_out;
+            test(ad, meas_out);
+            APIData meas_obj = meas_out.getobj("measure");
+
+            // Loop over the test measures
+            for (auto meas : meas_obj.list_keys())
+              {
+                apitools::test_variants<double, std::vector<double>>(
+                    meas_obj, meas,
+
+                    // Single value
+                    [&](const double &value) {
+                      this->add_meas(meas, value);
+                      this->add_meas_per_iter(meas, value);
+                      this->_logger->info("{} = {}", meas, value);
+                    },
+
+                    // Multiple values
+                    [&](const std::vector<double> &values) {
+                      size_t nb_values = values.size();
+                      std::vector<std::string> cls(nb_values);
+                      this->_mlmodel.get_hcorresp(cls);
+                      this->add_meas(meas, values, cls);
+                      std::stringstream s;
+                      for (size_t value = 0; value < nb_values; ++value)
+                        {
+                          s << (value ? ", " : "") << cls[value] << ": "
+                            << values[value];
+                        }
+                      this->_logger->info("{} = [ {} ]", meas, s.str());
+                    });
+              }
+            this->_logger->info("Model tested");
+          }
+      }
 
     dump_model_state(); // Save the final snapshot
-    if (this->_tjob_running.load()) { // Training stopped cleanly
+    if (this->_tjob_running.load())
+      { // Training stopped cleanly
 
-      if (_state.is_testing()) {
-	this->_logger->info("Adding final measures");
-	test(ad, out);
+        if (_state.is_testing())
+          {
+            this->_logger->info("Adding final measures");
+            test(ad, out);
+          }
+
+        this->_logger->info("Updating net parameters");
+        caffe2::NetDef init;
+        // XXX Manage multi-net models
+        _context.create_init_net(main_nets._train, init);
+        caffe2::WriteProtoToTextFile(init, this->_mlmodel._init);
+
+        // Forward informations the input connector wants to send
+        _last_inputc.response_params(out);
       }
-
-      this->_logger->info("Updating net parameters");
-      caffe2::NetDef init;
-      //XXX Manage multi-net models
-      _context.create_init_net(main_nets._train, init);
-      caffe2::WriteProtoToTextFile(init, this->_mlmodel._init);
-
-      // Forward informations the input connector wants to send
-      _last_inputc.response_params(out);
-    }
     return 0;
   }
 
-  //XXX Some code in common with 'predict', it should be possible to group it into another function
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void Caffe2Lib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::
-  test(const APIData &ad, APIData &out) {
+  // XXX Some code in common with 'predict', it should be possible to group it
+  // into another function
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void
+  Caffe2Lib<TInputConnectorStrategy, TOutputConnectorStrategy, TMLModel>::test(
+      const APIData &ad, APIData &out)
+  {
 
-    //XXX Right now it means supervised single-label classification
+    // XXX Right now it means supervised single-label classification
     CAFFE_ENFORCE(!_state.bbox() && !_state.mask() && _nets.size() == 1
-		  && _nets[0]._output_blobs.size() == 1);
+                  && _nets[0]._output_blobs.size() == 1);
 
     // Add already computed measures
     APIData ad_res;
-    if (_state.is_training()) {
-      ad_res.add("iteration", this->get_meas("iteration"));
-      ad_res.add("train_loss", this->get_meas("train_loss"));
-    }
+    if (_state.is_training())
+      {
+        ad_res.add("iteration", this->get_meas("iteration"));
+        ad_res.add("train_loss", this->get_meas("train_loss"));
+      }
 
-    //XXX This 'nout' value is supposed to be set accordingly to the type of prediction
-    //(classification, regression, autoencoder, etc.)
+    // XXX This 'nout' value is supposed to be set accordingly to the type of
+    // prediction (classification, regression, autoencoder, etc.)
     int nout = _context._nclasses;
 
     std::vector<std::string> clnames(nout);
     this->_mlmodel.get_hcorresp(clnames);
     ad_res.add("clnames", clnames);
     ad_res.add("nclasses", nout);
-    //XXX True/False flags can be forwarded to ad_res (segmentation, multi_label, etc.)
+    // XXX True/False flags can be forwarded to ad_res (segmentation,
+    // multi_label, etc.)
 
     // Loop while there is data to test
     int batch_size, total_size = 0;
-    while ((batch_size = _last_inputc.load_batch(_context, total_size))) {
+    while ((batch_size = _last_inputc.load_batch(_context, total_size)))
+      {
 
-      // Extract results
-      std::vector<std::vector<std::vector<float>>> results;
-      std::vector<size_t> sizes;
-      typed_prediction(results, sizes, batch_size);
+        // Extract results
+        std::vector<std::vector<std::vector<float>>> results;
+        std::vector<size_t> sizes;
+        typed_prediction(results, sizes, batch_size);
 
-      //XXX Find how labels could be fetched when loading manually
-      std::vector<float> labels(batch_size);
-      _context.extract_labels(labels);
+        // XXX Find how labels could be fetched when loading manually
+        std::vector<float> labels(batch_size);
+        _context.extract_labels(labels);
 
-      // Loop on each item of the batch
-      for (int item = 0; item < batch_size; ++item, ++total_size) {
-	APIData bad;
+        // Loop on each item of the batch
+        for (int item = 0; item < batch_size; ++item, ++total_size)
+          {
+            APIData bad;
 
-	//XXX 'target' and 'pred' format will change depending on the prediction mode
-	//(e.g. bbox or multi-label)
-	//XXX Support test of multi-net models
-	const std::vector<float> &result = results[0][item];
-	std::vector<double> predictions;
-	predictions.assign(result.begin(), result.end());
-	bad.add("target", static_cast<double>(labels[item]));
-	bad.add("pred", predictions);
+            // XXX 'target' and 'pred' format will change depending on the
+            // prediction mode (e.g. bbox or multi-label)
+            // XXX Support test of multi-net models
+            const std::vector<float> &result = results[0][item];
+            std::vector<double> predictions;
+            predictions.assign(result.begin(), result.end());
+            bad.add("target", static_cast<double>(labels[item]));
+            bad.add("pred", predictions);
 
-	ad_res.add(std::to_string(total_size), bad);
+            ad_res.add(std::to_string(total_size), bad);
+          }
       }
-    }
 
     // Compute the measures
     ad_res.add("batch_size", total_size);
-    SupervisedOutput::measure(ad_res, ad.getobj("parameters").getobj("output"), out);
+    SupervisedOutput::measure(ad_res, ad.getobj("parameters").getobj("output"),
+                              out);
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  int Caffe2Lib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::
-  predict(const APIData &ad, APIData &out) {
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  int Caffe2Lib<TInputConnectorStrategy, TOutputConnectorStrategy,
+                TMLModel>::predict(const APIData &ad, APIData &out)
+  {
     set_train_mode(ad, false);
 
     TOutputConnectorStrategy tout(this->_outputc);
     APIData ad_mllib = ad.getobj("parameters").getobj("mllib");
     APIData ad_output = ad.getobj("parameters").getobj("output");
 
-    // Get the lower limit of confidence requested for an prediction to be acceptable
+    // Get the lower limit of confidence requested for an prediction to be
+    // acceptable
     float confidence_threshold = 0.0;
-    if (ad_output.has("confidence_threshold")) {
-      apitools::get_float(ad_output, "confidence_threshold", confidence_threshold);
-    }
-    std::function<bool(float)> pass_threshold([&](float value) {
-      return value >= confidence_threshold;
-    });
+    if (ad_output.has("confidence_threshold"))
+      {
+        apitools::get_float(ad_output, "confidence_threshold",
+                            confidence_threshold);
+      }
+    std::function<bool(float)> pass_threshold(
+        [&](float value) { return value >= confidence_threshold; });
 
     _state.set_bbox(ad_output);
     _state.set_mask(ad_output);
 
-    //XXX More informations could be fetched in the future (bbox, rois, etc.)
+    // XXX More informations could be fetched in the future (bbox, rois, etc.)
 
-    _state.set_extract_layer(ad_mllib); // The net will be truncated if this flag is present
+    _state.set_extract_layer(
+        ad_mllib); // The net will be truncated if this flag is present
 
     // Update GPUs tags
     set_gpu_state(ad_mllib);
 
-    if (ad_output.has("measure")) {
-      CAFFE_ENFORCE(_state.extract_layer().empty()); // A truncated net can't be mesured
-      CAFFE_ENFORCE(_last_inputc.is_testable());
-      _state.set_is_testing(true);
-    }
+    if (ad_output.has("measure"))
+      {
+        CAFFE_ENFORCE(_state.extract_layer()
+                          .empty()); // A truncated net can't be mesured
+        CAFFE_ENFORCE(_last_inputc.is_testable());
+        _state.set_is_testing(true);
+      }
 
-    update_model(); // Recreate the net from protobuf files if the configuration has changed
-    _last_inputc.assert_context_validity(_context, _last_inputc._ids); // Check if everything is well configured
-
+    update_model(); // Recreate the net from protobuf files if the
+                    // configuration has changed
+    _last_inputc.assert_context_validity(
+        _context, _last_inputc._ids); // Check if everything is well configured
 
     // Special case where the net is runned by test()
-    if (_state.is_testing()) {
-      test(ad, out);
-      return 0;
-    }
+    if (_state.is_testing())
+      {
+        test(ad, out);
+        return 0;
+      }
 
     // Extract results
     std::vector<APIData> vrad;
 
     int batch_size, total_size = 0;
-    while ((batch_size = _last_inputc.load_batch(_context, total_size))) {
+    while ((batch_size = _last_inputc.load_batch(_context, total_size)))
+      {
 
-      // Extract results
-      std::vector<std::vector<std::vector<float>>> results;
-      std::vector<size_t> sizes;
-      typed_prediction(results, sizes, batch_size);
+        // Extract results
+        std::vector<std::vector<std::vector<float>>> results;
+        std::vector<size_t> sizes;
+        typed_prediction(results, sizes, batch_size);
 
-      //XXX Print the blobs shape after the first run
-      // _context._workspace->PrintBlobSizes()
-      // https://github.com/pytorch/pytorch/blob/master/caffe2/core/workspace.cc#L21
+        // XXX Print the blobs shape after the first run
+        // _context._workspace->PrintBlobSizes()
+        // https://github.com/pytorch/pytorch/blob/master/caffe2/core/workspace.cc#L21
 
-      // Loop on each item of the input batch
-      for (int item = 0; item < batch_size; ++item, ++total_size) {
+        // Loop on each item of the input batch
+        for (int item = 0; item < batch_size; ++item, ++total_size)
+          {
 
-	vrad.emplace_back();
-	APIData &rad = vrad.back();
-	rad.add("uri", _last_inputc._ids.at(total_size)); // Store its name
-	rad.add("loss", 0.0); //XXX Needed but not relevant
+            vrad.emplace_back();
+            APIData &rad = vrad.back();
+            rad.add("uri", _last_inputc._ids.at(total_size)); // Store its name
+            rad.add("loss", 0.0); // XXX Needed but not relevant
 
-	if (!_state.extract_layer().empty()) {
+            if (!_state.extract_layer().empty())
+              {
 
-	  const std::vector<float> &result = results[0][item];
-	  std::vector<double> vals(result.begin(), result.end()); // raw extracted layer
-	  rad.add("vals", vals);
+                const std::vector<float> &result = results[0][item];
+                std::vector<double> vals(result.begin(),
+                                         result.end()); // raw extracted layer
+                rad.add("vals", vals);
+              }
+            else if (_state.bbox() || _state.mask())
+              {
 
-	} else if (_state.bbox() || _state.mask()) {
+                // Fetch data
+                const std::vector<float> &scale
+                    = _last_inputc.scales().at(total_size);
+                const std::vector<float> &scores = results[0][item];
+                const std::vector<float> &coords = results[1][item];
+                const std::vector<float> &classes = results[2][item];
+                std::vector<double> probs;
+                std::vector<std::string> cats;
+                std::vector<APIData> bboxes;
+                std::vector<APIData> masks;
+                CAFFE_ENFORCE(scores.size() == classes.size());
+                CAFFE_ENFORCE(scores.size() * 4 == coords.size());
+                auto coords_it = coords.begin();
 
-	  // Fetch data
-	  const std::vector<float> &scale = _last_inputc.scales().at(total_size);
-	  const std::vector<float> &scores = results[0][item];
-	  const std::vector<float> &coords = results[1][item];
-	  const std::vector<float> &classes = results[2][item];
-	  std::vector<double> probs;
-	  std::vector<std::string> cats;
-	  std::vector<APIData> bboxes;
-	  std::vector<APIData> masks;
-	  CAFFE_ENFORCE(scores.size() == classes.size());
-	  CAFFE_ENFORCE(scores.size() * 4 == coords.size());
-	  auto coords_it = coords.begin();
+                std::vector<uchar> raw_masks;
+                size_t mask_h(0), mask_w(0), img_h(0), img_w(0), mask_size(0);
+                if (_state.mask()
+                    && std::count_if(scores.begin(), scores.end(),
+                                     pass_threshold))
+                  {
+                    std::vector<std::vector<std::vector<float>>> mask_results;
+                    // XXX Filter bboxes before comptuing masks
+                    typed_prediction(mask_results, sizes, batch_size, "mask");
+                    raw_masks.assign(mask_results[0][item].begin(),
+                                     mask_results[0][item].end());
+                    std::vector<float> im_info = mask_results[1][item];
+                    CAFFE_ENFORCE(im_info.size() == 3);
+                    mask_h = im_info[0];
+                    mask_w = im_info[1];
+                    img_h = mask_h / scale[0];
+                    img_w = mask_w / scale[1];
+                    mask_size = mask_h * mask_w;
+                  }
+                cv::Size img_size(img_w, img_h);
+                uchar *masks_data = raw_masks.data();
 
-	  std::vector<uchar> raw_masks;
-	  size_t mask_h(0), mask_w(0), img_h(0), img_w(0), mask_size(0);
-	  if ( _state.mask() && std::count_if(scores.begin(), scores.end(), pass_threshold)) {
-	    std::vector<std::vector<std::vector<float>>> mask_results;
-	    //XXX Filter bboxes before comptuing masks
-	    typed_prediction(mask_results, sizes, batch_size, "mask");
-	    raw_masks.assign(mask_results[0][item].begin(), mask_results[0][item].end());
-	    std::vector<float> im_info = mask_results[1][item];
-	    CAFFE_ENFORCE(im_info.size() == 3);
-	    mask_h = im_info[0];
-	    mask_w = im_info[1];
-	    img_h = mask_h / scale[0];
-	    img_w = mask_w / scale[1];
-	    mask_size = mask_h * mask_w;
-	  }
-	  cv::Size img_size(img_w, img_h);
-	  uchar *masks_data = raw_masks.data();
+                for (size_t box = 0; box < scores.size();
+                     ++box, coords_it += 4, masks_data += mask_size)
+                  {
 
-	  for (size_t box = 0; box < scores.size(); ++box,
-		 coords_it += 4, masks_data += mask_size) {
+                    // Ignore low score
+                    float prob = scores[box];
+                    if (prob < confidence_threshold)
+                      {
+                        continue;
+                      }
 
-	    // Ignore low score
-	    float prob = scores[box];
-	    if (prob < confidence_threshold) {
-	      continue;
-	    }
+                    // Append the data
+                    probs.push_back(prob);
+                    cats.push_back(this->_mlmodel.get_hcorresp(classes[box]));
 
-	    // Append the data
-	    probs.push_back(prob);
-	    cats.push_back(this->_mlmodel.get_hcorresp(classes[box]));
+                    // Set the bounding box
+                    bboxes.emplace_back();
+                    APIData &ad_bbox = bboxes.back();
+                    const std::vector<std::string> coord(
+                        { "xmin", "ymin", "xmax", "ymax" });
+                    const std::vector<float> coord_scale(
+                        { scale[1], scale[0], scale[1], scale[0] });
+                    int scaled_coords[4];
+                    for (int coord_idx = 0; coord_idx < 4; ++coord_idx)
+                      {
+                        double scaled = *(coords_it + coord_idx)
+                                        / coord_scale[coord_idx];
+                        scaled_coords[coord_idx] = scaled;
+                        ad_bbox.add(coord[coord_idx], scaled);
+                      }
 
-	    // Set the bounding box
-	    bboxes.emplace_back();
-	    APIData &ad_bbox = bboxes.back();
-	    const std::vector<std::string> coord({"xmin", "ymin", "xmax", "ymax"});
-	    const std::vector<float> coord_scale({scale[1], scale[0], scale[1], scale[0]});
-	    int scaled_coords[4];
-	    for (int coord_idx = 0; coord_idx < 4; ++coord_idx) {
-	      double scaled = *(coords_it + coord_idx) / coord_scale[coord_idx];
-	      scaled_coords[coord_idx] = scaled;
-	      ad_bbox.add(coord[coord_idx], scaled);
-	    }
+                    // Set the mask
+                    if (_state.mask())
+                      {
+                        masks.emplace_back();
+                        APIData &ad_mask = masks.back();
+                        cv::Mat img(mask_h, mask_w, CV_8U);
+                        img.data = masks_data;
+                        cv::resize(img, img, img_size, 0, 0,
+                                   cv::INTER_NEAREST);
+                        int width = scaled_coords[2] - scaled_coords[0] + 1;
+                        int height = scaled_coords[3] - scaled_coords[1] + 1;
+                        cv::Mat mask;
+                        img(cv::Rect(scaled_coords[0], scaled_coords[1], width,
+                                     height))
+                            .copyTo(mask);
+                        ad_mask.add("format", std::string("HW"));
+                        ad_mask.add("width", width);
+                        ad_mask.add("height", height);
+                        ad_mask.add("data",
+                                    std::vector<int>(
+                                        mask.data, mask.data + mask.total()));
+                      }
+                  }
 
-	    // Set the mask
-	    if ( _state.mask()) {
-	      masks.emplace_back();
-	      APIData &ad_mask = masks.back();
-	      cv::Mat img(mask_h, mask_w, CV_8U);
-	      img.data = masks_data;
-	      cv::resize(img, img, img_size, 0, 0, cv::INTER_NEAREST);
-	      int width = scaled_coords[2] - scaled_coords[0] + 1;
-	      int height = scaled_coords[3] - scaled_coords[1] + 1;
-	      cv::Mat mask;
-	      img(cv::Rect(scaled_coords[0], scaled_coords[1], width, height)).copyTo(mask);
-	      ad_mask.add("format", std::string("HW"));
-	      ad_mask.add("width", width);
-	      ad_mask.add("height", height);
-	      ad_mask.add("data", std::vector<int>(mask.data, mask.data + mask.total()));
-	    }
-	  }
+                rad.add("probs", probs);
+                rad.add("cats", cats);
+                rad.add("bboxes", bboxes);
+                if (_state.mask())
+                  {
+                    rad.add("masks", masks);
+                  }
+              }
+            else
+              { // XXX for now this means supervised classification
 
-	  rad.add("probs", probs);
-	  rad.add("cats", cats);
-	  rad.add("bboxes", bboxes);
-	  if ( _state.mask()) {
-	    rad.add("masks", masks);
-	  }
+                const std::vector<float> &result = results[0][item];
+                std::vector<double> probs;
+                std::vector<std::string> cats;
+                for (size_t cls = 0; cls < result.size(); ++cls)
+                  {
+                    float prob = result[cls];
+                    if (prob < confidence_threshold)
+                      continue;
+                    probs.push_back(prob);
+                    cats.push_back(this->_mlmodel.get_hcorresp(cls));
+                  }
+                rad.add("probs", probs);
+                rad.add("cats", cats);
+              }
 
-	} else { //XXX for now this means supervised classification
-
-	  const std::vector<float> &result = results[0][item];
-	  std::vector<double> probs;
-	  std::vector<std::string> cats;
-	  for (size_t cls = 0; cls < result.size(); ++cls) {
-	    float prob = result[cls];
-	    if (prob < confidence_threshold)
-	      continue;
-	    probs.push_back(prob);
-	    cats.push_back(this->_mlmodel.get_hcorresp(cls));
-	  }
-	  rad.add("probs", probs);
-	  rad.add("cats", cats);
-
-	}
-
-	//XXX This if/else could contain more extraction types (segmentation, etc.)
+            // XXX This if/else could contain more extraction types
+            // (segmentation, etc.)
+          }
       }
-    }
 
     tout.add_results(vrad);
 
     // ad_api_variants work with 'bool', not 'const bool &'
     out.add("bbox", bool(_state.bbox()));
-    out.add("mask", bool( _state.mask()));
+    out.add("mask", bool(_state.mask()));
 
-    //XXX More tags can be forwarded (regression, autoencoder, etc.)
+    // XXX More tags can be forwarded (regression, autoencoder, etc.)
 
     tout.finalize(ad.getobj("parameters").getobj("output"), out,
-		  static_cast<MLModel*>(&this->_mlmodel));
+                  static_cast<MLModel *>(&this->_mlmodel));
     out.add("status", 0);
     return 0;
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void Caffe2Lib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::model_type(std::string &mltype)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void Caffe2Lib<TInputConnectorStrategy, TOutputConnectorStrategy,
+                 TMLModel>::model_type(std::string &mltype)
   {
     // Search each net
-    for (auto ext: this->_mlmodel._extensions)
+    for (auto ext : this->_mlmodel._extensions)
       {
-	if (ext._type == "mask")
-	  {
-	    mltype = "instance_segmentation";
-	    return;
-	  }
+        if (ext._type == "mask")
+          {
+            mltype = "instance_segmentation";
+            return;
+          }
       }
 
     // Search the layers of the main net
     const caffe2::NetDef *main_net;
-    if (_state.is_training()) {
-      main_net = &_nets[0]._train;
-    } else {
-      main_net = &_nets[0]._predict;
-    }
-
-    for (const caffe2::OperatorDef &op : main_net->op()) {
-      if (op.type() == "BoxWithNMSLimit") {
-	mltype = "bbox";
-	return;
+    if (_state.is_training())
+      {
+        main_net = &_nets[0]._train;
       }
-    }
+    else
+      {
+        main_net = &_nets[0]._predict;
+      }
 
-    mltype = "classification"; // at this stage, if not mask or bbox, it's a classification model
+    for (const caffe2::OperatorDef &op : main_net->op())
+      {
+        if (op.type() == "BoxWithNMSLimit")
+          {
+            mltype = "bbox";
+            return;
+          }
+      }
+
+    mltype = "classification"; // at this stage, if not mask or bbox, it's a
+                               // classification model
     return;
   }
-  
+
   // Template instantiation
-  template class Caffe2Lib<ImgCaffe2InputFileConn,SupervisedOutput,Caffe2Model>;
-  template class Caffe2Lib<ImgCaffe2InputFileConn,UnsupervisedOutput,Caffe2Model>;
-  //XXX Make more input connectors
+  template class Caffe2Lib<ImgCaffe2InputFileConn, SupervisedOutput,
+                           Caffe2Model>;
+  template class Caffe2Lib<ImgCaffe2InputFileConn, UnsupervisedOutput,
+                           Caffe2Model>;
+  // XXX Make more input connectors
 }

--- a/src/backends/caffe2/caffe2lib.h
+++ b/src/backends/caffe2/caffe2lib.h
@@ -22,13 +22,13 @@
 #ifndef CAFFE2LIB_H
 #define CAFFE2LIB_H
 
-//XXX Remove that to print the warnings
+// XXX Remove that to print the warnings
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #include <caffe2/core/workspace.h>
 #pragma GCC diagnostic pop
 
-//XXX Remove that to print the warnings
+// XXX Remove that to print the warnings
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsign-compare"
 #include "mllibstrategy.h"
@@ -37,157 +37,158 @@
 #include "backends/caffe2/caffe2libstate.h"
 #include "backends/caffe2/caffe2model.h"
 
-namespace dd {
+namespace dd
+{
 
   /**
    * \brief Caffe2 library wrapper for deepdetect
    */
-  template <
-    class TInputConnectorStrategy,
-    class TOutputConnectorStrategy,
-    class TMLModel=Caffe2Model>
-    class Caffe2Lib : public MLLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel> {
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel = Caffe2Model>
+  class Caffe2Lib : public MLLib<TInputConnectorStrategy,
+                                 TOutputConnectorStrategy, TMLModel>
+  {
 
   public: // from mllib
+    /**
+     * \brief constructor from model
+     * @param model Caffe2 model
+     */
+    Caffe2Lib(const Caffe2Model &c2model);
 
-  /**
-   * \brief constructor from model
-   * @param model Caffe2 model
-   */
-  Caffe2Lib(const Caffe2Model &c2model);
+    /**
+     * \brief copy-constructor
+     */
+    Caffe2Lib(Caffe2Lib &&cl) noexcept;
 
-  /**
-   * \brief copy-constructor
-   */
-  Caffe2Lib(Caffe2Lib &&cl) noexcept;
+    /**
+     * \brief destructor
+     */
+    ~Caffe2Lib();
 
-  /**
-   * \brief destructor
-   */
-  ~Caffe2Lib();
+    void init_mllib(const APIData &ad);
+    void clear_mllib(const APIData &ad);
 
-  void init_mllib(const APIData &ad);
-  void clear_mllib(const APIData &ad);
+    /**
+     * \brief trains a model
+     * @param ad root data object
+     * @param out output data object (e.g. loss, ...)
+     * @return 0 if OK, 1 otherwise
+     */
+    int train(const APIData &ad, APIData &out);
 
-  /**
-   * \brief trains a model
-   * @param ad root data object
-   * @param out output data object (e.g. loss, ...)
-   * @return 0 if OK, 1 otherwise
-   */
-  int train(const APIData &ad, APIData &out);
-
-  /**
-   * \brief predicts from model
-   * @param ad root data object
-   * @param out output data object (e.g. predictions, ...)
-   * @return 0 if OK, 1 otherwise
-   */
-  int predict(const APIData &ad, APIData &out);
+    /**
+     * \brief predicts from model
+     * @param ad root data object
+     * @param out output data object (e.g. predictions, ...)
+     * @return 0 if OK, 1 otherwise
+     */
+    int predict(const APIData &ad, APIData &out);
 
   private:
+    /**
+     * \brief create nets and update the repository
+     * @param ad mllib data object
+     */
+    void instantiate_template(const APIData &ad);
 
-  /**
-   * \brief create nets and update the repository
-   * @param ad mllib data object
-   */
-  void instantiate_template(const APIData &ad);
+    /**
+     * \brief sets (/resets) internal values to fit the matching mode
+     * @param ad APIData of the current request
+     * @param train true means train and false mean predict
+     */
+    void set_train_mode(const APIData &ad, bool train);
 
-  /**
-   * \brief sets (/resets) internal values to fit the matching mode
-   * @param ad APIData of the current request
-   * @param train true means train and false mean predict
-   */
-  void set_train_mode(const APIData &ad, bool train);
+    /**
+     * \brief update the gpu configuration from the APIData
+     * @param ad mllib APIData
+     * @param dft true to set thoses values as the default ones
+     */
+    void set_gpu_state(const APIData &ad, bool dft = false);
 
-  /**
-   * \brief update the gpu configuration from the APIData
-   * @param ad mllib APIData
-   * @param dft true to set thoses values as the default ones
-   */
-  void set_gpu_state(const APIData &ad, bool dft=false);
+    /**
+     * \brief creates neural net instance based on model
+     */
+    void create_model();
 
-  /**
-   * \brief creates neural net instance based on model
-   */
-  void create_model();
+    /**
+     * \brief tests a model and compute measures
+     * @param ad root data object
+     * @param out output data object
+     */
+    void test(const APIData &ad, APIData &out);
 
-  /**
-   * \brief tests a model and compute measures
-   * @param ad root data object
-   * @param out output data object
-   */
-  void test(const APIData &ad, APIData &out);
+    /**
+     * \brief setups the nets, inputs, outputs, gradients, etc.
+     */
+    void create_model_train();
+    void create_model_predict();
 
-  /**
-   * \brief setups the nets, inputs, outputs, gradients, etc.
-   */
-  void create_model_train();
-  void create_model_predict();
+    /**
+     * \brief (re)loads nets from the disk
+     */
+    void load_nets();
 
-  /**
-   * \brief (re)loads nets from the disk
-   */
-  void load_nets();
+    /**
+     * \brief recreates nets if the configuration changed and resets the
+     * workspace
+     */
+    void update_model();
 
-  /**
-   * \brief recreates nets if the configuration changed and resets the workspace
-   */
-  void update_model();
+    /**
+     * \brief dumps on the filesystem usefull information to resume training
+     */
+    void dump_model_state();
 
-  /**
-   * \brief dumps on the filesystem usefull information to resume training
-   */
-  void dump_model_state();
+    /**
+     * \brief finds the first the group of nets of the specified type
+     * @param type type to find
+     * @return the net group
+     */
+    Caffe2NetTools::NetGroup &find_net_group(const std::string &type);
 
-  /**
-   * \brief finds the first the group of nets of the specified type
-   * @param type type to find
-   * @return the net group
-   */
-  Caffe2NetTools::NetGroup &find_net_group(const std::string &type);
+    /**
+     * \brief runs a net once (both forward and backward if the gradients are
+     * set)
+     * @param net net to run
+     * @return the elapsed time
+     */
+    float run_net(const std::string &net);
 
-  /**
-   * \brief runs a net once (both forward and backward if the gradients are set)
-   * @param net net to run
-   * @return the elapsed time
-   */
-  float run_net(const std::string &net);
+    /**
+     * \bried extracts the results of the last run
+     * @param results vector of results ( [layer][batch_item][data] )
+     * @param sizes vector to read / write the size of each batch item
+     * @param batch_size number of item in this batch
+     * @param outputs blobs created by the last run
+     */
+    void extract_results(std::vector<std::vector<std::vector<float>>> &results,
+                         std::vector<size_t> &sizes, int batch_size,
+                         const std::vector<std::string> &outputs);
 
-  /**
-   * \bried extracts the results of the last run
-   * @param results vector of results ( [layer][batch_item][data] )
-   * @param sizes vector to read / write the size of each batch item
-   * @param batch_size number of item in this batch
-   * @param outputs blobs created by the last run
-   */
-  void extract_results(std::vector<std::vector<std::vector<float>>> &results,
-		       std::vector<size_t> &sizes,
-		       int batch_size,
-		       const std::vector<std::string> &outputs);
+    /**
+     * \brief finds a net of the given type, execute it and fetch the output
+     * @param results vector of results ( [layer][batch_item][data] )
+     * @param sizes vector to read / write the size of each batch item data
+     * @param batch_size number of item in this batch
+     * @param type type of net to execute ("main" by default)
+     */
+    void
+    typed_prediction(std::vector<std::vector<std::vector<float>>> &results,
+                     std::vector<size_t> &sizes, int batch_size,
+                     const std::string &type = "main");
 
-  /**
-   * \brief finds a net of the given type, execute it and fetch the output
-   * @param results vector of results ( [layer][batch_item][data] )
-   * @param sizes vector to read / write the size of each batch item data
-   * @param batch_size number of item in this batch
-   * @param type type of net to execute ("main" by default)
-   */
-  void typed_prediction(std::vector<std::vector<std::vector<float>>> &results,
-			std::vector<size_t> &sizes,
-			int batch_size,
-			const std::string &type="main");
+    /**
+     * \brief detects and reports model type
+     * @param mltype output string variable
+     */
+    void model_type(std::string &mltype);
 
-  /**
-   * \brief detects and reports model type
-   * @param mltype output string variable
-   */
-  void model_type(std::string &mltype);
-  
-  Caffe2NetTools::ModelContext _context;
-  std::vector<Caffe2NetTools::NetGroup> _nets;
-  Caffe2LibState _state;
-  TInputConnectorStrategy _last_inputc; // Last transformed version of the default _inputc
+    Caffe2NetTools::ModelContext _context;
+    std::vector<Caffe2NetTools::NetGroup> _nets;
+    Caffe2LibState _state;
+    TInputConnectorStrategy
+        _last_inputc; // Last transformed version of the default _inputc
   };
 }
 

--- a/src/backends/caffe2/caffe2libstate.h
+++ b/src/backends/caffe2/caffe2libstate.h
@@ -25,69 +25,83 @@
 #include "utils/apitools.h"
 
 // Create getters, setters and check callbacks
-#define _REGISTER_CONFIG(type, name, def)				\
-									\
-private:								\
-									\
- type _##name##_default = def;						\
- type _##name##_current = def;						\
- type _##name##_last;							\
- bool name##_changed() const {						\
-   return _##name##_last != _##name##_current;				\
- }									\
- void name##_backup() {							\
-   _##name##_last = _##name##_current;					\
- }									\
- void name##_reset() {							\
-   _##name##_current = _##name##_default;				\
- }									\
- void init_##name() {							\
-   _changed.push_back(&Caffe2LibState::name##_changed);			\
-   _backup.push_back(&Caffe2LibState::name##_backup);			\
-   _reset.push_back(&Caffe2LibState::name##_reset);			\
- }									\
-									\
-public:						                        \
-									\
- inline const type &name() const {					\
-   return _##name##_current;						\
- }									\
- void set_##name(const type &value) {					\
-   _##name##_current = value;						\
- }									\
- void set_default_##name(const type &value) {				\
-   _##name##_default = value;						\
- }
+#define _REGISTER_CONFIG(type, name, def)                                     \
+                                                                              \
+private:                                                                      \
+  type _##name##_default = def;                                               \
+  type _##name##_current = def;                                               \
+  type _##name##_last;                                                        \
+  bool name##_changed() const                                                 \
+  {                                                                           \
+    return _##name##_last != _##name##_current;                               \
+  }                                                                           \
+  void name##_backup()                                                        \
+  {                                                                           \
+    _##name##_last = _##name##_current;                                       \
+  }                                                                           \
+  void name##_reset()                                                         \
+  {                                                                           \
+    _##name##_current = _##name##_default;                                    \
+  }                                                                           \
+  void init_##name()                                                          \
+  {                                                                           \
+    _changed.push_back(&Caffe2LibState::name##_changed);                      \
+    _backup.push_back(&Caffe2LibState::name##_backup);                        \
+    _reset.push_back(&Caffe2LibState::name##_reset);                          \
+  }                                                                           \
+                                                                              \
+public:                                                                       \
+  inline const type &name() const                                             \
+  {                                                                           \
+    return _##name##_current;                                                 \
+  }                                                                           \
+  void set_##name(const type &value)                                          \
+  {                                                                           \
+    _##name##_current = value;                                                \
+  }                                                                           \
+  void set_default_##name(const type &value)                                  \
+  {                                                                           \
+    _##name##_default = value;                                                \
+  }
 
 // Special setters using an APIData
-#define REGISTER_CONFIG(type, name, def)				\
- _REGISTER_CONFIG(type, name, def)					\
- void set_##name(const APIData &ad, bool force_get=false) {		\
-   if (force_get || ad.has(#name)) {					\
-     set_##name(ad.get(#name).get<type>());				\
-   }									\
- }									\
- void set_default_##name(const APIData &ad, bool force_get=false) {	\
-   if (force_get || ad.has(#name)) {					\
-     set_default_##name(ad.get(#name).get<type>());			\
-   }									\
- }
+#define REGISTER_CONFIG(type, name, def)                                      \
+  _REGISTER_CONFIG(type, name, def)                                           \
+  void set_##name(const APIData &ad, bool force_get = false)                  \
+  {                                                                           \
+    if (force_get || ad.has(#name))                                           \
+      {                                                                       \
+        set_##name(ad.get(#name).get<type>());                                \
+      }                                                                       \
+  }                                                                           \
+  void set_default_##name(const APIData &ad, bool force_get = false)          \
+  {                                                                           \
+    if (force_get || ad.has(#name))                                           \
+      {                                                                       \
+        set_default_##name(ad.get(#name).get<type>());                        \
+      }                                                                       \
+  }
 
 // Even more special setters using an APIData
-#define REGISTER_CONFIG_FLOAT(name, def)				\
- _REGISTER_CONFIG(float, name, def)					\
- void set_##name(const APIData &ad, bool force_get=false) {		\
-   if (force_get || ad.has(#name)) {					\
-     apitools::get_float(ad, #name, _##name##_current);			\
-   }									\
- }									\
- void set_default_##name(const APIData &ad, bool force_get=false) {	\
-   if (force_get || ad.has(#name)) {					\
-     apitools::get_float(ad, #name, _##name##_default);			\
-   }									\
- }
+#define REGISTER_CONFIG_FLOAT(name, def)                                      \
+  _REGISTER_CONFIG(float, name, def)                                          \
+  void set_##name(const APIData &ad, bool force_get = false)                  \
+  {                                                                           \
+    if (force_get || ad.has(#name))                                           \
+      {                                                                       \
+        apitools::get_float(ad, #name, _##name##_current);                    \
+      }                                                                       \
+  }                                                                           \
+  void set_default_##name(const APIData &ad, bool force_get = false)          \
+  {                                                                           \
+    if (force_get || ad.has(#name))                                           \
+      {                                                                       \
+        apitools::get_float(ad, #name, _##name##_default);                    \
+      }                                                                       \
+  }
 
-namespace dd {
+namespace dd
+{
 
   /**
    * \brief Contains informations about the current configuration of the nets :
@@ -95,20 +109,20 @@ namespace dd {
    *           - cpu or gpu
    *           - gpu ids
    *           - ...
-   *        Each one has a getter and two setter (current value, and default value).
-   *        (Note that setters can use an APIData to retrieve the value themselves)
-   *        The goals of this class are to allow a simple flag management,
+   *        Each one has a getter and two setter (current value, and default
+   * value). (Note that setters can use an APIData to retrieve the value
+   * themselves) The goals of this class are to allow a simple flag management,
    *        and to provide a quick way to know if the nets need
    *        to be reconfigured between two api call.
    */
-  class Caffe2LibState {
+  class Caffe2LibState
+  {
 
   private:
-
     bool _force_init = true;
-    std::vector<bool(Caffe2LibState::*)()const> _changed;
-    std::vector<void(Caffe2LibState::*)()> _backup;
-    std::vector<void(Caffe2LibState::*)()> _reset;
+    std::vector<bool (Caffe2LibState::*)() const> _changed;
+    std::vector<void (Caffe2LibState::*)()> _backup;
+    std::vector<void (Caffe2LibState::*)()> _reset;
 
     // Declare here every parameter needed to configure a net
     // (type, name, default value)
@@ -117,7 +131,7 @@ namespace dd {
     REGISTER_CONFIG(bool, is_training, false);
     REGISTER_CONFIG(bool, is_testing, false);
     REGISTER_CONFIG(bool, resume, false);
-    REGISTER_CONFIG(std::vector<int>, gpu_ids, {0});
+    REGISTER_CONFIG(std::vector<int>, gpu_ids, { 0 });
 
     REGISTER_CONFIG(std::string, extract_layer, "");
     REGISTER_CONFIG(bool, bbox, false);
@@ -135,9 +149,9 @@ namespace dd {
     REGISTER_CONFIG_FLOAT(rms_decay, -1.f);
 
   public:
-
     // For every declared parameter call the corresponding init function
-    Caffe2LibState() {
+    Caffe2LibState()
+    {
 
       init_is_gpu();
       init_is_training();
@@ -162,14 +176,17 @@ namespace dd {
     }
 
     /**
-     * \brief Is the current configuration different from the last backuped one ?
+     * \brief Is the current configuration different from the last backuped one
+     * ?
      * @return True they differ and False otherwise
      */
-    bool changed() const {
+    bool changed() const
+    {
       bool b = _force_init;
-      for (auto f : _changed) {
-	b |= (this->*f)();
-      }
+      for (auto f : _changed)
+        {
+          b |= (this->*f)();
+        }
       return b;
     }
 
@@ -180,29 +197,34 @@ namespace dd {
      *        (e.g. an unexpected error occured during the initialization)
      *        and they need to be reconfigured before being used.
      */
-    void force_init() {
+    void force_init()
+    {
       _force_init = true;
     }
 
     /**
-     * \brief Tag the current configuration as being the last configuration used.
+     * \brief Tag the current configuration as being the last configuration
+     * used.
      */
-    void backup() {
+    void backup()
+    {
       _force_init = false;
-      for (auto f : _backup) {
-	(this->*f)();
-      }
+      for (auto f : _backup)
+        {
+          (this->*f)();
+        }
     }
 
     /**
      * \brief Set current configuration to the default one.
      */
-    void reset() {
-      for (auto f : _reset) {
-	(this->*f)();
-      }
+    void reset()
+    {
+      for (auto f : _reset)
+        {
+          (this->*f)();
+        }
     }
-
   };
 }
 

--- a/src/backends/caffe2/caffe2model.cc
+++ b/src/backends/caffe2/caffe2model.cc
@@ -23,147 +23,179 @@
 #include "mllibstrategy.h"
 #include "utils/fileops.hpp"
 
-namespace dd {
+namespace dd
+{
 
   Caffe2Model::Caffe2Model(const APIData &ad, APIData &adg,
-			   const std::shared_ptr<spdlog::logger> &logger)
-    :MLModel(ad, adg, logger)
+                           const std::shared_ptr<spdlog::logger> &logger)
+      : MLModel(ad, adg, logger)
   {
-    std::map<std::string, std::string *> names =
-      {
-	{ "predictf", &_predict },
-	{ "initf", &_init },
-	{ "corresp", &_corresp },
-	{ "weights", &_weights }
-      };
+    std::map<std::string, std::string *> names = { { "predictf", &_predict },
+                                                   { "initf", &_init },
+                                                   { "corresp", &_corresp },
+                                                   { "weights", &_weights } };
 
     // Update from API
-    for (auto &it : names) {
-      if (ad.has(it.first)) {
-	*it.second = ad.get(it.first).get<std::string>();
+    for (auto &it : names)
+      {
+        if (ad.has(it.first))
+          {
+            *it.second = ad.get(it.first).get<std::string>();
+          }
       }
-    }
-    
+
     // Register repositories
     this->_repo = ad.get("repository").get<std::string>();
-    this->_mlmodel_template_repo = ad.has("templates") ?
-      ad.get("templates").get<std::string>() : "caffe2"; // Default
+    this->_mlmodel_template_repo = ad.has("templates")
+                                       ? ad.get("templates").get<std::string>()
+                                       : "caffe2"; // Default
 
     // List the extensions' nets
-    if (ad.has("extensions")) {
-      std::vector<APIData> extensions = ad.getv("extensions");
-      for (const APIData &extension : extensions) {
+    if (ad.has("extensions"))
+      {
+        std::vector<APIData> extensions = ad.getv("extensions");
+        for (const APIData &extension : extensions)
+          {
 
-	const std::string &ext_type(extension.get("type").get<std::string>());
-	std::string ext_repo;
-	if (extension.has("repository")) {
-	  ext_repo = extension.get("repository").get<std::string>();
-	} else {
-	  ext_repo = this->_repo + "/" + ext_type;
-	}
+            const std::string &ext_type(
+                extension.get("type").get<std::string>());
+            std::string ext_repo;
+            if (extension.has("repository"))
+              {
+                ext_repo = extension.get("repository").get<std::string>();
+              }
+            else
+              {
+                ext_repo = this->_repo + "/" + ext_type;
+              }
 
-	// Check if the extension is a repository
-	bool is_dir;
-	if (!fileops::file_exists(ext_repo, is_dir) || !is_dir) {
-	  std::string msg("'" + ext_repo + "' is not a directory");
-	  logger->error(msg);
-	  throw MLLibBadParamException(msg);
-	}
+            // Check if the extension is a repository
+            bool is_dir;
+            if (!fileops::file_exists(ext_repo, is_dir) || !is_dir)
+              {
+                std::string msg("'" + ext_repo + "' is not a directory");
+                logger->error(msg);
+                throw MLLibBadParamException(msg);
+              }
 
-	_extensions.emplace_back();
-	Extension &ext(_extensions.back());
-	ext._init = ext_repo + "/init_net.pb";
-	ext._predict = ext_repo + "/predict_net.pb";
-	ext._type = ext_type;
+            _extensions.emplace_back();
+            Extension &ext(_extensions.back());
+            ext._init = ext_repo + "/init_net.pb";
+            ext._predict = ext_repo + "/predict_net.pb";
+            ext._type = ext_type;
 
-	// Check if the nets exist
-	if (!fileops::file_exists(ext._predict)) {
-	  std::string msg("'" + ext._predict + "' does not exists");
-	  logger->error(msg);
-	  throw MLLibBadParamException(msg);
-	}
-	if (!fileops::file_exists(ext._init)) {
-	  logger->warn("No initialization net found in '" + ext_repo + "'");
-	  ext._init = "";
-	}
+            // Check if the nets exist
+            if (!fileops::file_exists(ext._predict))
+              {
+                std::string msg("'" + ext._predict + "' does not exists");
+                logger->error(msg);
+                throw MLLibBadParamException(msg);
+              }
+            if (!fileops::file_exists(ext._init))
+              {
+                logger->warn("No initialization net found in '" + ext_repo
+                             + "'");
+                ext._init = "";
+              }
+          }
       }
-    }
 
     update_from_repository(logger);
   }
 
-  void Caffe2Model::update_from_repository(const std::shared_ptr<spdlog::logger> &logger) {
-    std::map<std::string, std::string *> names =
-      {
-	{ "predict_net.pb", &_predict },
-	{ "init_net.pb", &_init },
-	{ "corresp.txt", &_corresp },
-	{ "mean.pb", &_meanfile },
-	{ "init_state.pb", &_init_state },
-	{ "dbreader_state.pb", &_dbreader_state },
-	{ "dbreader_train_state.pb", &_dbreader_train_state },
-	{ "iter_state.pb", &_iter_state },
-	{ "lr_state.pb", &_lr_state },
-      };
+  void Caffe2Model::update_from_repository(
+      const std::shared_ptr<spdlog::logger> &logger)
+  {
+    std::map<std::string, std::string *> names = {
+      { "predict_net.pb", &_predict },
+      { "init_net.pb", &_init },
+      { "corresp.txt", &_corresp },
+      { "mean.pb", &_meanfile },
+      { "init_state.pb", &_init_state },
+      { "dbreader_state.pb", &_dbreader_state },
+      { "dbreader_train_state.pb", &_dbreader_train_state },
+      { "iter_state.pb", &_iter_state },
+      { "lr_state.pb", &_lr_state },
+    };
 
     // List available files
     std::unordered_set<std::string> lfiles;
-    if (fileops::list_directory(_repo, true, false, false, lfiles)) {
-      std::string msg("error reading or listing Caffe2 models in repository " + _repo);
-      logger->error(msg);
-      throw MLLibBadParamException(msg);
-    }
-
-    for (const std::string &file : lfiles) {
-      for (auto &it : names) {
-	// if the file name contains a string from the map
-	if (file.find(it.first) != std::string::npos) {
-	  // And if the corresponding variable is still uninitialized
-	  if (it.second->empty()) {
-	    *it.second = file;
-	  }
-	  break;
-	}
+    if (fileops::list_directory(_repo, true, false, false, lfiles))
+      {
+        std::string msg("error reading or listing Caffe2 models in repository "
+                        + _repo);
+        logger->error(msg);
+        throw MLLibBadParamException(msg);
       }
-    }
+
+    for (const std::string &file : lfiles)
+      {
+        for (auto &it : names)
+          {
+            // if the file name contains a string from the map
+            if (file.find(it.first) != std::string::npos)
+              {
+                // And if the corresponding variable is still uninitialized
+                if (it.second->empty())
+                  {
+                    *it.second = file;
+                  }
+                break;
+              }
+          }
+      }
 
     read_corresp_file();
   }
 
-  void Caffe2Model::get_hcorresp(std::vector<std::string> &clnames) {
+  void Caffe2Model::get_hcorresp(std::vector<std::string> &clnames)
+  {
     int i = 0;
-    for (std::string &name : clnames) {
-      name = get_hcorresp(i++);
-    }
+    for (std::string &name : clnames)
+      {
+        name = get_hcorresp(i++);
+      }
   }
 
-  void Caffe2Model::write_state(const google::protobuf::Message &init,
-				const std::map<std::string, std::string> &blobs) {
-    for (auto it : blobs) {
-      std::ofstream(_repo + "/" + it.first + "_state.pb") << it.second;
-    }
+  void
+  Caffe2Model::write_state(const google::protobuf::Message &init,
+                           const std::map<std::string, std::string> &blobs)
+  {
+    for (auto it : blobs)
+      {
+        std::ofstream(_repo + "/" + it.first + "_state.pb") << it.second;
+      }
     std::ofstream f(_repo + "/init_state.pb");
     init.SerializeToOstream(&f);
   }
 
-  void Caffe2Model::list_template_files(const std::string &name,
-					std::map<std::string, std::string> &files,
-					bool external_weights) {
+  void
+  Caffe2Model::list_template_files(const std::string &name,
+                                   std::map<std::string, std::string> &files,
+                                   bool external_weights)
+  {
 
     // Path manipulation
     std::string source = this->_mlmodel_template_repo + '/' + name;
-    auto set_path = [&](const std::string &net, const std::string &remote="") {
-      files[remote.empty() ? source + '/' + net + ".pbtxt" : remote] = _repo + '/' + net + ".pb";
-    };
+    auto set_path
+        = [&](const std::string &net, const std::string &remote = "") {
+            files[remote.empty() ? source + '/' + net + ".pbtxt" : remote]
+                = _repo + '/' + net + ".pb";
+          };
 
     // Choose the files
     set_path("predict_net");
-    if (!external_weights) {
-      set_path("init_net");
-    } else if (_weights.empty()) {
-      throw MLLibBadParamException("No external weights specified");
-    } else {
-      set_path("init_net", _weights);
-    }
+    if (!external_weights)
+      {
+        set_path("init_net");
+      }
+    else if (_weights.empty())
+      {
+        throw MLLibBadParamException("No external weights specified");
+      }
+    else
+      {
+        set_path("init_net", _weights);
+      }
   }
 }

--- a/src/backends/caffe2/caffe2model.h
+++ b/src/backends/caffe2/caffe2model.h
@@ -28,16 +28,21 @@
 #include <string>
 #include <google/protobuf/message.h>
 
-namespace dd {
+namespace dd
+{
 
-  class Caffe2Model : public MLModel {
+  class Caffe2Model : public MLModel
+  {
   public:
-    Caffe2Model():MLModel() {}
+    Caffe2Model() : MLModel()
+    {
+    }
     Caffe2Model(const APIData &ad, APIData &adg,
-		const std::shared_ptr<spdlog::logger> &logger);
-    Caffe2Model(const std::string &repo)
-      :MLModel(repo) {}
-    ~Caffe2Model() {};
+                const std::shared_ptr<spdlog::logger> &logger);
+    Caffe2Model(const std::string &repo) : MLModel(repo)
+    {
+    }
+    ~Caffe2Model(){};
 
     /**
      * \brief checks if the repository contains new files
@@ -48,20 +53,22 @@ namespace dd {
      * \brief dumps informations in the repository
      */
     void write_state(const google::protobuf::Message &init_net,
-		     const std::map<std::string, std::string> &blobs);
+                     const std::map<std::string, std::string> &blobs);
 
     /**
      * \brief list the template's files
      * @param name name of the template
      * @param files correspondance between remote and local files
-     * @param external_weights whether to use the template weights or thoses set in the api data
+     * @param external_weights whether to use the template weights or thoses
+     * set in the api data
      */
     void list_template_files(const std::string &name,
-			     std::map<std::string, std::string> &files,
-			     bool external_weights);
+                             std::map<std::string, std::string> &files,
+                             bool external_weights);
 
     /**
-     * \brief assigns a class name to each element of the vector (the vector is not resized)
+     * \brief assigns a class name to each element of the vector (the vector is
+     * not resized)
      */
     void get_hcorresp(std::vector<std::string> &clnames);
     using MLModel::get_hcorresp;
@@ -73,7 +80,8 @@ namespace dd {
     std::string _iter_state;
     std::string _lr_state;
 
-    class Extension {
+    class Extension
+    {
     public:
       std::string _init;
       std::string _predict;
@@ -81,8 +89,8 @@ namespace dd {
     }; //! Extension
 
     std::vector<Extension> _extensions; // nets to append, if any
-    std::string _model_template; // model template name, if any
-    std::string _weights; // external weights, if any
+    std::string _model_template;        // model template name, if any
+    std::string _weights;               // external weights, if any
 
     // Files path (empty if non-existant)
     std::string _init;

--- a/src/backends/caffe2/nettools.h
+++ b/src/backends/caffe2/nettools.h
@@ -22,7 +22,7 @@
 #ifndef CAFFE2NETTOOLS_H
 #define CAFFE2NETTOOLS_H
 
-//XXX Remove that to print the warnings
+// XXX Remove that to print the warnings
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wsign-compare"
@@ -31,21 +31,24 @@
 
 #include <caffe2/utils/proto_utils.h>
 
-namespace dd {
-  namespace Caffe2NetTools {
+namespace dd
+{
+  namespace Caffe2NetTools
+  {
 
     /*
      *  Debug
      */
 
-    //XXX Doesn't work on too heavy graphs
+    // XXX Doesn't work on too heavy graphs
     void net_to_svg(const caffe2::NetDef &net, const std::string &path);
 
     // Exports in three formats : <path>.pb, <path>.pbtxt and <path>.svg
     void dump_net(const caffe2::NetDef &net, const std::string &path);
 
-    // Reads 'predict_net.pb' and 'init_net.pb' in the input folder, resets the weights,
-    // and dumps the result as 'predict_net.pbtxt' and 'init_net.pbtxt' in the output folder
+    // Reads 'predict_net.pb' and 'init_net.pb' in the input folder, resets the
+    // weights, and dumps the result as 'predict_net.pbtxt' and
+    // 'init_net.pbtxt' in the output folder
     void untrain_model(const std::string &input, const std::string &output);
 
     /*
@@ -53,15 +56,17 @@ namespace dd {
      */
 
     // Aliases to make things more readable
-    using OpModifier = std::function<void(caffe2::OperatorDef&)>;
-    using LROpModifier = std::function<void(caffe2::OperatorDef&, // LearningRate
-					    const std::string&, // Iter blob
-					    const std::string&)>; // LR blob
+    using OpModifier = std::function<void(caffe2::OperatorDef &)>;
+    using LROpModifier
+        = std::function<void(caffe2::OperatorDef &, // LearningRate
+                             const std::string &,   // Iter blob
+                             const std::string &)>; // LR blob
 
     /**
      * \brief device-tagged net
      *
-     *        When adding blobs or operators, each device will have its own version (e.g. below)
+     *        When adding blobs or operators, each device will have its own
+     * version (e.g. below)
      *
      *        op {
      *          input: "gpu_1/data",	<- input renamed
@@ -74,10 +79,10 @@ namespace dd {
      *        }
      *
      */
-    class ScopedNet {
+    class ScopedNet
+    {
 
     public:
-
       std::reference_wrapper<caffe2::NetDef> _net;
       std::vector<caffe2::DeviceOption> _devices;
 
@@ -87,19 +92,27 @@ namespace dd {
       // If set to a gpu id, devices vector will be ignored
       int _force_device = -1;
 
-      ScopedNet(caffe2::NetDef &n): _net(n) {}
-
+      ScopedNet(caffe2::NetDef &n) : _net(n)
+      {
+      }
     };
 
     /**
      * \breif backups ScopedNet tags and restore them upon destruction
      */
-    class ScopeKeeper {
+    class ScopeKeeper
+    {
       ScopedNet &_ref;
       ScopedNet _backup;
+
     public:
-      ScopeKeeper(ScopedNet &net): _ref(net), _backup(net) {}
-      ~ScopeKeeper() { _ref = _backup; }
+      ScopeKeeper(ScopedNet &net) : _ref(net), _backup(net)
+      {
+      }
+      ~ScopeKeeper()
+      {
+        _ref = _backup;
+      }
     };
 
 #ifndef CPU_ONLY
@@ -130,7 +143,8 @@ namespace dd {
     /**
      * \brief sets set device_option of every operators
      */
-    void set_net_device(caffe2::NetDef &net, const caffe2::DeviceOption &device);
+    void set_net_device(caffe2::NetDef &net,
+                        const caffe2::DeviceOption &device);
 
     /*
      *	Protobuffer manipulation
@@ -143,14 +157,17 @@ namespace dd {
      * \brief finds where the given blob was previously updataded
      * @param net net to search
      * @param name name of the blob
-     * @param idx first operator index to check (the search is done by decreasing this index)
+     * @param idx first operator index to check (the search is done by
+     * decreasing this index)
      * @return the index of the found operator
      */
-    int find_previous_update(const caffe2::NetDef &net, const std::string &name, int idx);
+    int find_previous_update(const caffe2::NetDef &net,
+                             const std::string &name, int idx);
 
     // Adds an 'Argument' in an 'OperatorDef'
-#define PROTOTYPE(type)							\
-    caffe2::Argument &add_arg(caffe2::OperatorDef &op, const std::string &name, type const &value);
+#define PROTOTYPE(type)                                                       \
+  caffe2::Argument &add_arg(caffe2::OperatorDef &op, const std::string &name, \
+                            type const &value);
     PROTOTYPE(int);
     PROTOTYPE(bool);
     PROTOTYPE(float);
@@ -163,7 +180,8 @@ namespace dd {
     /**
      * \brief adds an operator into a net
      */
-    caffe2::OperatorDef &add_op(caffe2::NetDef &net, const caffe2::OperatorDef &op);
+    caffe2::OperatorDef &add_op(caffe2::NetDef &net,
+                                const caffe2::OperatorDef &op);
 
     /**
      * \brief for each device, adds a copy of an operator into a NetDef
@@ -171,97 +189,116 @@ namespace dd {
     void add_op(ScopedNet &net, const caffe2::OperatorDef &op);
 
     /**
-     * \brief appends a net into another (adds operators and external inputs only)
+     * \brief appends a net into another (adds operators and external inputs
+     * only)
      * @param dst destination net
      * @param dst source net
-     * @param ignore external inputs to ignore (usefull if defined by the destination net)
+     * @param ignore external inputs to ignore (usefull if defined by the
+     * destination net)
      */
     void add_ops_and_inputs(caffe2::NetDef &dst, const caffe2::NetDef &src,
-			    const std::vector<std::string> &ignore = {});
+                            const std::vector<std::string> &ignore = {});
     // Same as above, except a copy is added for each devices
     void add_ops_and_inputs(ScopedNet &dst, const caffe2::NetDef &src,
-			    const std::vector<std::string> &ignore = {});
+                            const std::vector<std::string> &ignore = {});
 
     // Declare variants of the same function:
     //		- NetDef	adds a single operator into a net
     //		- ScopedNet	adds an operator for each device
     //		- OperatorDef	simply configures the operator
-#define PROTOTYPE(name, args...)					\
-    caffe2::OperatorDef &name(caffe2::NetDef&, args);			\
-    void name(ScopedNet&, args);					\
-    void name(caffe2::OperatorDef&, args);
+#define PROTOTYPE(name, args...)                                              \
+  caffe2::OperatorDef &name(caffe2::NetDef &, args);                          \
+  void name(ScopedNet &, args);                                               \
+  void name(caffe2::OperatorDef &, args);
 
     // Database
     PROTOTYPE(CreateDB, const std::string &reader, const std::string &db);
-    PROTOTYPE(TensorProtosDBInput,
-	      const std::string &reader, const std::string &data, const std::string &label,
-	      int batch_size);
-    PROTOTYPE(ImageInput,
-	      const std::string &reader, const std::string &data, const std::string &label,
-	      int batch_size, int color, int size, bool use_gpu_transform);
+    PROTOTYPE(TensorProtosDBInput, const std::string &reader,
+              const std::string &data, const std::string &label,
+              int batch_size);
+    PROTOTYPE(ImageInput, const std::string &reader, const std::string &data,
+              const std::string &label, int batch_size, int color, int size,
+              bool use_gpu_transform);
     PROTOTYPE(NHWC2NCHW, const std::string &input, const std::string &output);
 
     // Basic
-    PROTOTYPE(Sum, const std::vector<std::string> &inputs, const std::string &output);
-    PROTOTYPE(Sub, const std::string &input1, const std::string &input2, const std::string &output,
-	      int broadcast, int axis);
+    PROTOTYPE(Sum, const std::vector<std::string> &inputs,
+              const std::string &output);
+    PROTOTYPE(Sub, const std::string &input1, const std::string &input2,
+              const std::string &output, int broadcast, int axis);
     PROTOTYPE(Copy, const std::string &input, const std::string &output);
     PROTOTYPE(Alias, const std::string &input, const std::string &output);
-    PROTOTYPE(Scale, const std::string &input, const std::string &output, float scale);
+    PROTOTYPE(Scale, const std::string &input, const std::string &output,
+              float scale);
 
     // Sum and Optimize
-    PROTOTYPE(WeightedSum, const std::vector<std::string> &inputs, const std::string &output);
-    PROTOTYPE(MomentumSGDUpdate, const std::string &param, const std::string &momentum_blob,
-	      const std::string &gradient, const std::string &rate, float momentum);
+    PROTOTYPE(WeightedSum, const std::vector<std::string> &inputs,
+              const std::string &output);
+    PROTOTYPE(MomentumSGDUpdate, const std::string &param,
+              const std::string &momentum_blob, const std::string &gradient,
+              const std::string &rate, float momentum);
     PROTOTYPE(Adagrad, const std::string &param, const std::string &momentum,
-	      const std::string &gradient, const std::string &rate, float decay);
-    PROTOTYPE(Adam, const std::string &param,
-	      const std::string &momentum1, const std::string &momentum2,
-	      const std::string &gradient, const std::string &rate, const std::string &iter);
-    PROTOTYPE(RmsProp, const std::string &gradient, const std::string &mean_square,
-	      const std::string &momentum_blob, const std::string &rate,
-	      float momentum, float decay);
+              const std::string &gradient, const std::string &rate,
+              float decay);
+    PROTOTYPE(Adam, const std::string &param, const std::string &momentum1,
+              const std::string &momentum2, const std::string &gradient,
+              const std::string &rate, const std::string &iter);
+    PROTOTYPE(RmsProp, const std::string &gradient,
+              const std::string &mean_square, const std::string &momentum_blob,
+              const std::string &rate, float momentum, float decay);
 
     // Fill
-    PROTOTYPE(ConstantFill, const std::string &input, const std::string &output, float value);
-    PROTOTYPE(ConstantFill, const std::string &output, const std::vector<int> &shape, float value);
-    PROTOTYPE(ConstantFill, const std::string &output, const std::vector<int> &shape, int value);
+    PROTOTYPE(ConstantFill, const std::string &input,
+              const std::string &output, float value);
+    PROTOTYPE(ConstantFill, const std::string &output,
+              const std::vector<int> &shape, float value);
+    PROTOTYPE(ConstantFill, const std::string &output,
+              const std::vector<int> &shape, int value);
     PROTOTYPE(GivenTensorFill, const std::string &output,
-	      const std::vector<int> &shape, const std::vector<float> &values);
+              const std::vector<int> &shape, const std::vector<float> &values);
     PROTOTYPE(XavierFill, const std::string &input, const std::string &output);
-    PROTOTYPE(XavierFill, const std::string &output, const std::vector<int> &shape);
-    PROTOTYPE(GaussianFill, const std::string &input, const std::string &output);
-    PROTOTYPE(GaussianFill, const std::string &output, const std::vector<int> &shape);
+    PROTOTYPE(XavierFill, const std::string &output,
+              const std::vector<int> &shape);
+    PROTOTYPE(GaussianFill, const std::string &input,
+              const std::string &output);
+    PROTOTYPE(GaussianFill, const std::string &output,
+              const std::vector<int> &shape);
     PROTOTYPE(MSRAFill, const std::string &input, const std::string &output);
-    PROTOTYPE(MSRAFill, const std::string &output, const std::vector<int> &shape);
+    PROTOTYPE(MSRAFill, const std::string &output,
+              const std::vector<int> &shape);
     PROTOTYPE(RangeFill, const std::string &input, const std::string &output);
-    PROTOTYPE(RangeFill, const std::string &output, const std::vector<int> &shape);
-    PROTOTYPE(LengthsRangeFill, const std::string &input, const std::string &output);
+    PROTOTYPE(RangeFill, const std::string &output,
+              const std::vector<int> &shape);
+    PROTOTYPE(LengthsRangeFill, const std::string &input,
+              const std::string &output);
 
     // Train
     PROTOTYPE(Iter, const std::string &iter);
     PROTOTYPE(StopGradient, const std::string &blob);
-    PROTOTYPE(LearningRate,
-	      const std::string &iter, const std::string &rate, const std::string &policy,
-	      float base_lr, int stepsize, int max_iter, float gamma, float power);
+    PROTOTYPE(LearningRate, const std::string &iter, const std::string &rate,
+              const std::string &policy, float base_lr, int stepsize,
+              int max_iter, float gamma, float power);
 
     // Test
-    PROTOTYPE(LabelCrossEntropy, const std::string &prediction, const std::string &label,
-	      const std::string &output);
+    PROTOTYPE(LabelCrossEntropy, const std::string &prediction,
+              const std::string &label, const std::string &output);
     PROTOTYPE(AveragedLoss, const std::string &xent, const std::string &loss);
-    PROTOTYPE(Accuracy, const std::string &prediction, const std::string &label,
-	      const std::string &output);
+    PROTOTYPE(Accuracy, const std::string &prediction,
+              const std::string &label, const std::string &output);
     PROTOTYPE(Softmax, const std::string &input, const std::string &output);
 
     // Misc
-    PROTOTYPE(CopyFromCPUInput, const std::string &input, const std::string &output);
-    PROTOTYPE(EnsureCPUOutput, const std::string &input, const std::string &output);
-    PROTOTYPE(FC, const std::string &input, const std::string &weight, const std::string &bias,
-	      const std::string &output);
-    PROTOTYPE(Conv, const std::string &input, const std::string &weight, const std::string &bias,
-	      const std::string &output, int stride, int pad, int kernel);
+    PROTOTYPE(CopyFromCPUInput, const std::string &input,
+              const std::string &output);
+    PROTOTYPE(EnsureCPUOutput, const std::string &input,
+              const std::string &output);
+    PROTOTYPE(FC, const std::string &input, const std::string &weight,
+              const std::string &bias, const std::string &output);
+    PROTOTYPE(Conv, const std::string &input, const std::string &weight,
+              const std::string &bias, const std::string &output, int stride,
+              int pad, int kernel);
     PROTOTYPE(MaxPool, const std::string &input, const std::string &output,
-	      int stride, int pad, int kernel);
+              int stride, int pad, int kernel);
 
 #undef PROTOTYPE
 
@@ -283,50 +320,63 @@ namespace dd {
     /**
      * \brief A workspace with its configuration
      */
-    class ModelContext {
+    class ModelContext
+    {
     public:
-
       // Workspaces cannot be std::move()'d or assigned
       // (see DISABLE_COPY_AND_ASSIGN in caffe2/core/workspace.h)
       // Hence the usage of a pointer.
-      std::unique_ptr<caffe2::Workspace> _workspace =
-	std::unique_ptr<caffe2::Workspace>(new caffe2::Workspace);
+      std::unique_ptr<caffe2::Workspace> _workspace
+          = std::unique_ptr<caffe2::Workspace>(new caffe2::Workspace);
       std::vector<caffe2::DeviceOption> _devices;
       std::string _input_blob;
       int _nclasses = 0;
 
-      //XXX Should be optionals / configurables in the future
+      // XXX Should be optionals / configurables in the future
       std::string _blob_label = "label";
       std::string _blob_im_info = "im_info";
       std::string _net_type = "dag";
       int _thread_per_device = 4;
 
       bool _parallelized; // Whether multiple devices are used
-      int _loaded_iter; // Last iteration number that was loaded from the file system
+      int _loaded_iter; // Last iteration number that was loaded from the file
+                        // system
 
-      inline void reset_workspace() { _workspace.reset(new caffe2::Workspace); }
-      inline size_t device_count() const { return _parallelized ? _devices.size() : 1; }
-      inline std::string get_prefix(int device_idx) const {
-	return _parallelized ? get_device_prefix(_devices[device_idx]) : "";
+      inline void reset_workspace()
+      {
+        _workspace.reset(new caffe2::Workspace);
       }
-      inline void create_input() {
-	for (size_t i = 0; i < device_count(); ++i) {
-	  _workspace->CreateBlob(get_prefix(i) + _input_blob);
-	}
+      inline size_t device_count() const
+      {
+        return _parallelized ? _devices.size() : 1;
       }
-      inline void create_net(caffe2::NetDef &net) const {
-	net.set_type(_net_type);
-	net.set_num_workers(_thread_per_device * device_count());
-	final_optimizations(net);
-	CAFFE_ENFORCE(_workspace->CreateNet(net));
+      inline std::string get_prefix(int device_idx) const
+      {
+        return _parallelized ? get_device_prefix(_devices[device_idx]) : "";
+      }
+      inline void create_input()
+      {
+        for (size_t i = 0; i < device_count(); ++i)
+          {
+            _workspace->CreateBlob(get_prefix(i) + _input_blob);
+          }
+      }
+      inline void create_net(caffe2::NetDef &net) const
+      {
+        net.set_type(_net_type);
+        net.set_num_workers(_thread_per_device * device_count());
+        final_optimizations(net);
+        CAFFE_ENFORCE(_workspace->CreateNet(net));
       }
 
       // Enforce
-      inline void run_net(const std::string &net) {
-	CAFFE_ENFORCE(_workspace->RunNet(net));
+      inline void run_net(const std::string &net)
+      {
+        CAFFE_ENFORCE(_workspace->RunNet(net));
       }
-      inline void run_net_once(const caffe2::NetDef &net) {
-	CAFFE_ENFORCE(_workspace->RunNetOnce(net));
+      inline void run_net_once(const caffe2::NetDef &net)
+      {
+        CAFFE_ENFORCE(_workspace->RunNetOnce(net));
       }
 
       /*
@@ -354,9 +404,13 @@ namespace dd {
        * \brief tries to find the blob of the given name on the given device,
        *        and to use the tensor to fill it
        */
-      void insert_tensor(int device_idx, const std::string &name, const caffe2::Tensor &tensor);
+      void insert_tensor(int device_idx, const std::string &name,
+                         const caffe2::Tensor &tensor);
 
-      inline void reset_iter() { _loaded_iter = 0; }
+      inline void reset_iter()
+      {
+        _loaded_iter = 0;
+      }
 
       /**
        * \brief loads an iteration counter from a serialized blob
@@ -381,7 +435,8 @@ namespace dd {
       /**
        * \brief adds a copy of the tensor on each device
        */
-      void broadcast_tensor(const std::string &name, const caffe2::Tensor &tensor);
+      void broadcast_tensor(const std::string &name,
+                            const caffe2::Tensor &tensor);
 
       /*
        *  Information extraction
@@ -391,7 +446,8 @@ namespace dd {
        * \brief tries to find the blob of the given name on the given device,
        *        and to use it to fill the tensor (true if successfull)
        */
-      bool extract_tensor(int device_idx, const std::string &name, caffe2::Tensor &tensor) const;
+      bool extract_tensor(int device_idx, const std::string &name,
+                          caffe2::Tensor &tensor) const;
 
       /**
        * \brief fetches the scaled losses of every devices and sums them
@@ -404,37 +460,46 @@ namespace dd {
       int extract_iter() const;
 
       /**
-       * \brief fetches the labels and store them as float values (the vector size must be pre-set)
+       * \brief fetches the labels and store them as float values (the vector
+       * size must be pre-set)
        */
       void extract_labels(std::vector<float> &labels) const;
 
       /**
-       * \brief serializes every blobs related to the training state (except parameters)
-       *        and store them in a map
+       * \brief serializes every blobs related to the training state (except
+       * parameters) and store them in a map
        */
       void extract_state(std::map<std::string, std::string> &blobs) const;
 
       /**
-       * \brief fetches the given layer and merge the results of each devices into a single batch.
-       *        Note that the function does not append elements, but assign a value to them
+       * \brief fetches the given layer and merge the results of each devices
+       * into a single batch. Note that the function does not append elements,
+       * but assign a value to them
        * @param results where to store the data
        * @param name name of the layer
-       * @param sizes size of each element of the batch (split equally if empty)
-       * @param scale scale factor for the elements of the 'sizes' vector (inferred if 0)
+       * @param sizes size of each element of the batch (split equally if
+       * empty)
+       * @param scale scale factor for the elements of the 'sizes' vector
+       * (inferred if 0)
        */
-      void extract(std::vector<std::vector<float>> &results, const std::string &name,
-		   const std::vector<size_t> &sizes={}, size_t scale=1) const;
+      void extract(std::vector<std::vector<float>> &results,
+                   const std::string &name,
+                   const std::vector<size_t> &sizes = {},
+                   size_t scale = 1) const;
 
       /*
        *  Network manipulation
        */
 
-      //XXX Recreate the 'OptimizeGradientMemory' function to reuse blobs in the net
+      // XXX Recreate the 'OptimizeGradientMemory' function to reuse blobs in
+      // the net
 
       /**
-       * \brief creates an init net capable of setting the net parameters to their current value
+       * \brief creates an init net capable of setting the net parameters to
+       * their current value
        */
-      void create_init_net(const caffe2::NetDef &net, caffe2::NetDef &init) const;
+      void create_init_net(const caffe2::NetDef &net,
+                           caffe2::NetDef &init) const;
 
       /**
        * \bried appends a net's operators and inputs to another
@@ -442,14 +507,14 @@ namespace dd {
       void append_net(caffe2::NetDef &dst, const caffe2::NetDef &src) const;
 
       /**
-       * \bried appends a net's operators and inputs to another (its 'main' input is ignored)
-       *        then adds gradients for the new operators
+       * \bried appends a net's operators and inputs to another (its 'main'
+       * input is ignored) then adds gradients for the new operators
        */
-      void append_trainable_net(caffe2::NetDef &dst, const caffe2::NetDef &src,
-				const std::vector<std::string> &output_blobs) const;
+      void
+      append_trainable_net(caffe2::NetDef &dst, const caffe2::NetDef &src,
+                           const std::vector<std::string> &output_blobs) const;
 
     private:
-
       // Tools to generalize the 'extract_*' functions
 
       template <typename Result, typename Data>
@@ -457,39 +522,37 @@ namespace dd {
 
       // Extract from each device and return the total size
       size_t extract_tensors(const std::string &name,
-			     std::vector<caffe2::Tensor> &tensors) const;
+                             std::vector<caffe2::Tensor> &tensors) const;
 
       // Merge the tensors and re-split into a single batch of items
       template <typename Result, typename Data>
       void split_tensors(std::vector<Result> &results,
-			 const std::vector<caffe2::Tensor> &tensors,
-			 const std::vector<size_t> &sizes,
-			 const Stockage<Result, Data> &store) const;
+                         const std::vector<caffe2::Tensor> &tensors,
+                         const std::vector<size_t> &sizes,
+                         const Stockage<Result, Data> &store) const;
       template <typename T>
       void split_tensors(std::vector<T> &results,
-			 const std::vector<caffe2::Tensor> &tensors,
-			 const std::vector<size_t> &sizes) const;
+                         const std::vector<caffe2::Tensor> &tensors,
+                         const std::vector<size_t> &sizes) const;
       template <typename T>
       void split_tensors(std::vector<std::vector<T>> &results,
-			 const std::vector<caffe2::Tensor> &tensors,
-			 const std::vector<size_t> &sizes) const;
+                         const std::vector<caffe2::Tensor> &tensors,
+                         const std::vector<size_t> &sizes) const;
 
       // Fecth the data then split it
       template <typename T>
-      void extract_results(std::vector<T> &results,
-			   const std::string &name,
-			   size_t size=0) const;
+      void extract_results(std::vector<T> &results, const std::string &name,
+                           size_t size = 0) const;
       template <typename T>
-      void extract_results(std::vector<T> &results,
-			   const std::string &name,
-			   const std::vector<size_t> &sizes,
-			   size_t scale=0) const;
+      void extract_results(std::vector<T> &results, const std::string &name,
+                           const std::vector<size_t> &sizes,
+                           size_t scale = 0) const;
 
       // Fetch, split and cast the data
       template <typename Result, typename Data, typename Size>
       void extract_and_cast_results(std::vector<Result> &results,
-				    const std::string &name,
-				    const Size &size) const;
+                                    const std::string &name,
+                                    const Size &size) const;
 
     }; //! ModelContext
 
@@ -498,51 +561,60 @@ namespace dd {
      */
 
     /**
-     * \brief adds a tensor loader on each device, all sharing the same DBReader
+     * \brief adds a tensor loader on each device, all sharing the same
+     * DBReader
      */
-    void insert_db_input_operator(const ModelContext &context, caffe2::NetDef &net_def,
-				  const caffe2::OperatorDef &dbinput);
+    void insert_db_input_operator(const ModelContext &context,
+                                  caffe2::NetDef &net_def,
+                                  const caffe2::OperatorDef &dbinput);
 
     /**
-     * \brief adds operators related to the training on each device (iter, learning_rate, etc.)
+     * \brief adds operators related to the training on each device (iter,
+     * learning_rate, etc.)
      */
     void insert_learning_operators(const ModelContext &context,
-				   caffe2::NetDef &net_def,
-				   caffe2::NetDef &init_def,
-				   const LROpModifier &lr_config);
+                                   caffe2::NetDef &net_def,
+                                   caffe2::NetDef &init_def,
+                                   const LROpModifier &lr_config);
 
     /**
-     * \brief copies an operator on the main device and broadcasts the outputs on the others
+     * \brief copies an operator on the main device and broadcasts the outputs
+     * on the others
      */
-    void copy_and_broadcast_operator(const ModelContext &context, caffe2::NetDef &net,
-				     const caffe2::OperatorDef &op);
+    void copy_and_broadcast_operator(const ModelContext &context,
+                                     caffe2::NetDef &net,
+                                     const caffe2::OperatorDef &op);
     // Same as above but with every operator of the source
-    void copy_and_broadcast_operators(const ModelContext &context, caffe2::NetDef &dest,
-				      const caffe2::NetDef &src);
+    void copy_and_broadcast_operators(const ModelContext &context,
+                                      caffe2::NetDef &dest,
+                                      const caffe2::NetDef &src);
 
     /*
      *	Gradient management
      */
 
-    void add_gradient_ops(caffe2::NetDef &net, const std::set<std::string> &main_gradients);
+    void add_gradient_ops(caffe2::NetDef &net,
+                          const std::set<std::string> &main_gradients);
 
     /*
      *  Gradient & Device
      */
 
     /**
-     * \brief browses the net and lists external inputs that are used by trainable operators
+     * \brief browses the net and lists external inputs that are used by
+     * trainable operators
      * @param net net to browse
      * @param params used to store input blobs that are used by the gradients
      * @param computed_params used to store the other input blobs
      * @param prefix filter out blob names that don't start with this prefix
-     * @param remove_prefix whether the given prefix must be removed from the blob name
+     * @param remove_prefix whether the given prefix must be removed from the
+     * blob name
      */
     void collect_params(const caffe2::NetDef &net,
-			std::set<std::string> &params,
-			std::set<std::string> &computed_params,
-			const std::string &prefix = "",
-			bool remove_prefix = true);
+                        std::set<std::string> &params,
+                        std::set<std::string> &computed_params,
+                        const std::string &prefix = "",
+                        bool remove_prefix = true);
 #ifndef CPU_ONLY
 
     /**
@@ -564,7 +636,8 @@ namespace dd {
     /**
      * \brief creates a filler for each parameter defining the shape
      */
-    void set_nclasses(const caffe2::NetDef &net, caffe2::NetDef &init, int nclasses);
+    void set_nclasses(const caffe2::NetDef &net, caffe2::NetDef &init,
+                      int nclasses);
 
     /**
      * \brief infers the number of classes based on the output's shape
@@ -577,18 +650,16 @@ namespace dd {
 
     // Optimizers are stored as functions that take a net
     // and use the gradients to update the parameters
-    using Optimizer = std::function<
-      void
-      (const ModelContext&,	// context
-       caffe2::NetDef&,		// net
-       caffe2::NetDef&,		// init_net
-       float,			// momentum
-       float			// rms_decay
-       )>;
+    using Optimizer = std::function<void(const ModelContext &, // context
+                                         caffe2::NetDef &,     // net
+                                         caffe2::NetDef &,     // init_net
+                                         float,                // momentum
+                                         float                 // rms_decay
+                                         )>;
 
     // List of registered optimizers : sgd, adagrad, adam, rmsprop
     // See caffe2/python/optimizer.py
-    //XXX Add other optimizers: SparseAdagrad, RowWiseSparseAdagrad, etc.
+    // XXX Add other optimizers: SparseAdagrad, RowWiseSparseAdagrad, etc.
     const Optimizer &get_optimizer(const std::string &name);
 
     /*
@@ -596,10 +667,11 @@ namespace dd {
      */
 
     /**
-     * \brief truncates a net to keep only the operators and inputs needed to compute 'blob'
-     *        This 'blob' is tagged as the external output of the net
+     * \brief truncates a net to keep only the operators and inputs needed to
+     * compute 'blob' This 'blob' is tagged as the external output of the net
      */
-    void truncate_net(const caffe2::NetDef &net, caffe2::NetDef &out, const std::string &blob);
+    void truncate_net(const caffe2::NetDef &net, caffe2::NetDef &out,
+                      const std::string &blob);
 
     // Same as above, except that the net is replaced by its truncated version
     void truncate_net(caffe2::NetDef &net, const std::string &blob);
@@ -607,36 +679,37 @@ namespace dd {
     /**
      * \brief reads a .pb or .pbtxt file
      */
-    void import_net(caffe2::NetDef &net, const std::string &file, bool unscoped = true);
+    void import_net(caffe2::NetDef &net, const std::string &file,
+                    bool unscoped = true);
 
     /**
      * \brief writes a .pb or .pbtxt file
      */
-    void export_net(const caffe2::NetDef &net, const std::string &file, bool human_readable=false);
+    void export_net(const caffe2::NetDef &net, const std::string &file,
+                    bool human_readable = false);
 
     /**
      * \brief extends a model with another
      */
     void append_model(caffe2::NetDef &dst_net, caffe2::NetDef &dst_init,
-		      const caffe2::NetDef &src_net, const caffe2::NetDef &src_init);
+                      const caffe2::NetDef &src_net,
+                      const caffe2::NetDef &src_init);
 
     /**
      * \brief A pack of three nets (initialization, training, prediction)
      */
-    class NetGroup {
+    class NetGroup
+    {
     public:
-
       const std::string _type;
       caffe2::NetDef _init;
       caffe2::NetDef _train;
       caffe2::NetDef _predict;
       std::vector<std::string> _output_blobs;
 
-      NetGroup(): _type("") {};
-      NetGroup(const std::string &type,
-	       const std::string &init,
-	       const std::string &predict,
-	       const std::string &train="");
+      NetGroup() : _type(""){};
+      NetGroup(const std::string &type, const std::string &init,
+               const std::string &predict, const std::string &train = "");
 
       /**
        * \brief swap nets with another group
@@ -651,9 +724,8 @@ namespace dd {
       /**
        * \brief import protobuf files
        */
-      void import(const std::string &init,
-		  const std::string &predict,
-		  const std::string &train="");
+      void import(const std::string &init, const std::string &predict,
+                  const std::string &train = "");
 
     }; //! NetGroup
 

--- a/src/backends/caffe2/nettools/debug.cc
+++ b/src/backends/caffe2/nettools/debug.cc
@@ -22,48 +22,59 @@
 #include <fstream>
 #include "backends/caffe2/nettools/internal.h"
 
-namespace dd {
-  namespace Caffe2NetTools {
+namespace dd
+{
+  namespace Caffe2NetTools
+  {
 
     /*
      *  Debug
      */
 
-    void net_to_svg(const caffe2::NetDef &net, const std::string &path) {
+    void net_to_svg(const caffe2::NetDef &net, const std::string &path)
+    {
       int size = net.op().size();
       CAFFE_ENFORCE(size < 600, "Net size is too big: ", size);
       auto graph = path + ".tmpgraph";
       std::ofstream file(graph);
       file << "digraph {" << std::endl;
       file << '\t' << "node [shape=box];";
-      for (int i = 0; i < size; ++i) {
-	file << ' ' << net.op(i).type() + '_' + std::to_string(i);
-      }
+      for (int i = 0; i < size; ++i)
+        {
+          file << ' ' << net.op(i).type() + '_' + std::to_string(i);
+        }
       file << "; node [shape=oval];" << std::endl;
-      for (int i = 0; i < size; ++i) {
-	const caffe2::OperatorDef &op = net.op(i);
-	std::string name = op.type() + '_' + std::to_string(i);
-	for (const std::string &blob : op.input()) {
-	  file << "\t\"" << blob << "\" -> \"" << name << "\";" << std::endl;
-	}
-	for (const std::string &blob : op.output()) {
-	  file << "\t\"" << name << "\" -> \"" << blob << "\";" << std::endl;
-	}
-      }
+      for (int i = 0; i < size; ++i)
+        {
+          const caffe2::OperatorDef &op = net.op(i);
+          std::string name = op.type() + '_' + std::to_string(i);
+          for (const std::string &blob : op.input())
+            {
+              file << "\t\"" << blob << "\" -> \"" << name << "\";"
+                   << std::endl;
+            }
+          for (const std::string &blob : op.output())
+            {
+              file << "\t\"" << name << "\" -> \"" << blob << "\";"
+                   << std::endl;
+            }
+        }
       file << "}" << std::endl;
       file.close();
       CAFFE_ENFORCE(!system(("dot -Tsvg -o" + path + " " + graph).c_str()));
       remove(graph.c_str());
     }
 
-    void dump_net(const caffe2::NetDef &net, const std::string &path) {
-      export_net(net, path + ".pb"); // Raw protobuf file
+    void dump_net(const caffe2::NetDef &net, const std::string &path)
+    {
+      export_net(net, path + ".pb");          // Raw protobuf file
       export_net(net, path + ".pbtxt", true); // Human-readable protobuf file
-      net_to_svg(net, path + ".svg"); // SVG file
+      net_to_svg(net, path + ".svg");         // SVG file
     }
 
     void _reset_init_net(const caffe2::NetDef &net, caffe2::NetDef &init);
-    void untrain_model(const std::string &input, const std::string &output) {
+    void untrain_model(const std::string &input, const std::string &output)
+    {
       caffe2::NetDef net, init;
       import_net(net, input + "/predict_net.pb");
       import_net(init, input + "/init_net.pb");

--- a/src/backends/caffe2/nettools/devices_and_operators.cc
+++ b/src/backends/caffe2/nettools/devices_and_operators.cc
@@ -19,7 +19,7 @@
  * along with deepdetect.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-//XXX Remove that to print the warnings
+// XXX Remove that to print the warnings
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsign-compare"
 #pragma GCC diagnostic ignored "-Wunused-parameter"
@@ -28,31 +28,41 @@
 
 #include "backends/caffe2/nettools/internal.h"
 
-namespace dd {
-  namespace Caffe2NetTools {
+namespace dd
+{
+  namespace Caffe2NetTools
+  {
 
     /*
      *  Simple tools
      */
 
-    template<typename T, typename U>
-    inline bool has_value(const T &container, const U &value) {
-      return std::find(container.begin(), container.end(), value) != container.end();
+    template <typename T, typename U>
+    inline bool has_value(const T &container, const U &value)
+    {
+      return std::find(container.begin(), container.end(), value)
+             != container.end();
     }
 
-    bool has_input(const caffe2::OperatorDef &op, const std::string &name) {
+    bool has_input(const caffe2::OperatorDef &op, const std::string &name)
+    {
       return has_value(op.input(), name);
     }
-    bool has_output(const caffe2::OperatorDef &op, const std::string &name) {
+    bool has_output(const caffe2::OperatorDef &op, const std::string &name)
+    {
       return has_value(op.output(), name);
     }
 
-    int find_previous_update(const caffe2::NetDef &net, const std::string &name, int idx) {
-      for (; idx >= 0; --idx) {
-	if (has_output(net.op(idx), name)) {
-	  return idx;
-	}
-      }
+    int find_previous_update(const caffe2::NetDef &net,
+                             const std::string &name, int idx)
+    {
+      for (; idx >= 0; --idx)
+        {
+          if (has_output(net.op(idx), name))
+            {
+              return idx;
+            }
+        }
       CAFFE_THROW("Can't find '", name, "' first update");
     }
 
@@ -63,101 +73,127 @@ namespace dd {
     /* ------------------------- Create prefix ------------------------- */
 
 #ifdef CPU_ONLY
-    std::string get_device_prefix(const caffe2::DeviceOption &) { return ""; }
+    std::string get_device_prefix(const caffe2::DeviceOption &)
+    {
+      return "";
+    }
 #else
-    std::string device_id_to_prefix(int id) {
+    std::string device_id_to_prefix(int id)
+    {
       return "gpu_" + std::to_string(id) + "/";
     }
-    std::string get_device_prefix(const caffe2::DeviceOption &option) {
-      return option.device_type() == caffe2::DeviceTypeProto::PROTO_CUDA ?
-	device_id_to_prefix(option.cuda_gpu_id()) : "";
+    std::string get_device_prefix(const caffe2::DeviceOption &option)
+    {
+      return option.device_type() == caffe2::DeviceTypeProto::PROTO_CUDA
+                 ? device_id_to_prefix(option.cuda_gpu_id())
+                 : "";
     }
 #endif
 
-    /* ------------------------- Add input / output in loop ------------------------- */
+    /* ------------------------- Add input / output in loop
+     * ------------------------- */
 
     using ExtSetter = void (caffe2::NetDef::*)(const std::string &);
 
     inline void add_external(ScopedNet &net, const std::string &name,
-			     const ExtSetter &setter, bool rename) {
-      for (const caffe2::DeviceOption &option : net._devices) {
-	std::string prefix = rename ? get_device_prefix(option) : "";
-	(net._net.get().*setter)(prefix + name);
-      }
+                             const ExtSetter &setter, bool rename)
+    {
+      for (const caffe2::DeviceOption &option : net._devices)
+        {
+          std::string prefix = rename ? get_device_prefix(option) : "";
+          (net._net.get().*setter)(prefix + name);
+        }
     }
 
-#define ADD_EXTERNAL(type)						\
-    void add_external_##type(ScopedNet &net, const std::string &name) {	\
-      add_external(net, name, &caffe2::NetDef::add_external_##type, net._rename_##type##s); \
-    }									\
-    void add_external_##type(caffe2::NetDef &net, const std::string &name) { \
-      net.add_external_##type(name);					\
-    }
+#define ADD_EXTERNAL(type)                                                    \
+  void add_external_##type(ScopedNet &net, const std::string &name)           \
+  {                                                                           \
+    add_external(net, name, &caffe2::NetDef::add_external_##type,             \
+                 net._rename_##type##s);                                      \
+  }                                                                           \
+  void add_external_##type(caffe2::NetDef &net, const std::string &name)      \
+  {                                                                           \
+    net.add_external_##type(name);                                            \
+  }
     ADD_EXTERNAL(input)
     ADD_EXTERNAL(output)
 #undef ADD_EXTERNAL
 
     /* ------------------------- Add op ------------------------- */
 
-    inline bool is_cpu_only(const std::string &op) {
+    inline bool is_cpu_only(const std::string &op)
+    {
 #ifdef CPU_ONLY
       return true;
 #else
-      return !has_value(caffe2::gDeviceTypeRegistry()->at(caffe2::CUDA)->Keys(), op);
+      return !has_value(
+          caffe2::gDeviceTypeRegistry()->at(caffe2::CUDA)->Keys(), op);
 #endif
     }
 
     // Returns true if successfull, false if CPU was forced
-    static bool set_op_device(caffe2::OperatorDef &op, const caffe2::DeviceOption &device) {
+    static bool set_op_device(caffe2::OperatorDef &op,
+                              const caffe2::DeviceOption &device)
+    {
       caffe2::DeviceOption &op_device = *op.mutable_device_option();
-      if (is_cpu_only(op.type())) {
-	op_device.set_device_type(caffe2::DeviceTypeProto::PROTO_CPU);
-	return device.device_type() == caffe2::DeviceTypeProto::PROTO_CPU;
-      }
+      if (is_cpu_only(op.type()))
+        {
+          op_device.set_device_type(caffe2::DeviceTypeProto::PROTO_CPU);
+          return device.device_type() == caffe2::DeviceTypeProto::PROTO_CPU;
+        }
       op_device.CopyFrom(device);
       return true;
     }
 
-    static void add_op(caffe2::NetDef &net,
-		       const caffe2::OperatorDef &op,
-		       const caffe2::DeviceOption &device) {
+    static void add_op(caffe2::NetDef &net, const caffe2::OperatorDef &op,
+                       const caffe2::DeviceOption &device)
+    {
       caffe2::OperatorDef new_op(op);
-      if (set_op_device(new_op, device)) {
-	net.add_op()->CopyFrom(new_op);
-	return;
-      }
+      if (set_op_device(new_op, device))
+        {
+          net.add_op()->CopyFrom(new_op);
+          return;
+        }
 
       // Device unavailable
 
       // Convert & Rename inputs
-      for (std::string &input : *new_op.mutable_input()) {
-	caffe2::OperatorDef &to_cpu(EnsureCPUOutput(net, input, input + force_device_suffix));
-	CAFFE_ENFORCE(set_op_device(to_cpu, device));
-	input += force_device_suffix;
-      }
+      for (std::string &input : *new_op.mutable_input())
+        {
+          caffe2::OperatorDef &to_cpu(
+              EnsureCPUOutput(net, input, input + force_device_suffix));
+          CAFFE_ENFORCE(set_op_device(to_cpu, device));
+          input += force_device_suffix;
+        }
 
       // Rename outputs
-      for (std::string &output : *new_op.mutable_output()) {
-	output += force_device_suffix;
-      }
+      for (std::string &output : *new_op.mutable_output())
+        {
+          output += force_device_suffix;
+        }
 
       net.add_op()->CopyFrom(new_op);
 
       // Convert outputs
-      for (const std::string &output : op.output()) {
-	caffe2::OperatorDef &from_cpu(CopyFromCPUInput(net, output + force_device_suffix, output));
-	CAFFE_ENFORCE(set_op_device(from_cpu, device));
-      }
+      for (const std::string &output : op.output())
+        {
+          caffe2::OperatorDef &from_cpu(
+              CopyFromCPUInput(net, output + force_device_suffix, output));
+          CAFFE_ENFORCE(set_op_device(from_cpu, device));
+        }
     }
 
     /* ------------------------- Add ops in loop ------------------------- */
 
-    void set_net_device(caffe2::NetDef &net, const caffe2::DeviceOption &device) {
+    void set_net_device(caffe2::NetDef &net,
+                        const caffe2::DeviceOption &device)
+    {
 
       caffe2::NetDef tmp;
-      for (const caffe2::OperatorDef &op : net.op()) {
-	add_op(tmp, op, device);
-      }
+      for (const caffe2::OperatorDef &op : net.op())
+        {
+          add_op(tmp, op, device);
+        }
       net.mutable_op()->Swap(tmp.mutable_op());
     }
 
@@ -167,383 +203,339 @@ namespace dd {
 
     /* ------------------------- Add arg ------------------------- */
 
-    template<typename T>
-    using ArgSetter = void (caffe2::Argument::*)(T);
+    template <typename T> using ArgSetter = void (caffe2::Argument::*)(T);
 
     // Single value
-    template<typename T1, typename T2>
-    inline void set_arg_value(caffe2::Argument &arg,
-			      const T1 &value,
-			      const ArgSetter<T2> &setter) {
+    template <typename T1, typename T2>
+    inline void set_arg_value(caffe2::Argument &arg, const T1 &value,
+                              const ArgSetter<T2> &setter)
+    {
       (arg.*setter)(value);
     }
 
     // Multiple values
-    template<typename T1, typename T2>
+    template <typename T1, typename T2>
     inline void set_arg_value(caffe2::Argument &arg,
-			      const std::vector<T1> &values,
-			      const ArgSetter<T2> &setter) {
-      for (const T1 &value : values) {
-	set_arg_value(arg, value, setter);
-      }
+                              const std::vector<T1> &values,
+                              const ArgSetter<T2> &setter)
+    {
+      for (const T1 &value : values)
+        {
+          set_arg_value(arg, value, setter);
+        }
     }
 
     // Create set and return
-    template<typename T1, typename T2>
+    template <typename T1, typename T2>
     inline caffe2::Argument &add_arg(caffe2::OperatorDef &op,
-				     const std::string& name,
-				     const T1 &value,
-				     const ArgSetter<T2> &setter) {
+                                     const std::string &name, const T1 &value,
+                                     const ArgSetter<T2> &setter)
+    {
       caffe2::Argument &arg = *op.add_arg();
       arg.set_name(name);
       set_arg_value(arg, value, setter);
       return arg;
     }
 
-#define ADD_ARG(t1, t2, function)						\
-    caffe2::Argument &add_arg(caffe2::OperatorDef &op,				\
-			      const std::string& name,				\
-			      t1 const &value) {				\
-      return add_arg<t1, t2>(op, name, value, &caffe2::Argument::function);	\
-    }
-    //		Our type		Protobuf type		Name of the setter
-    ADD_ARG(	int,			long int,		set_i)
-    ADD_ARG(	bool,			long int,		set_i)
-    ADD_ARG(	float,			float,			set_f)
-    ADD_ARG(	char const*,		std::string const&,	set_s)
-    ADD_ARG(	std::string,		std::string const&,	set_s)
-    ADD_ARG(	std::vector<int>,	long int,		add_ints)
-    ADD_ARG(	std::vector<float>,	float,			add_floats)
+#define ADD_ARG(t1, t2, function)                                             \
+  caffe2::Argument &add_arg(caffe2::OperatorDef &op, const std::string &name, \
+                            t1 const &value)                                  \
+  {                                                                           \
+    return add_arg<t1, t2>(op, name, value, &caffe2::Argument::function);     \
+  }
+    //		Our type		Protobuf type		Name of the
+    // setter
+    ADD_ARG(int, long int, set_i)
+    ADD_ARG(bool, long int, set_i)
+    ADD_ARG(float, float, set_f)
+    ADD_ARG(char const *, std::string const &, set_s)
+    ADD_ARG(std::string, std::string const &, set_s)
+    ADD_ARG(std::vector<int>, long int, add_ints)
+    ADD_ARG(std::vector<float>, float, add_floats)
 #undef ADD_ARG
 
     /* ------------------------- Add operator ------------------------- */
 
     // Configure an operator type, inputs and outputs
-    static void set_op(caffe2::OperatorDef &op,
-		       const std::string &type,
-		       const std::vector<std::string> &inputs,
-		       const std::vector<std::string> &outputs) {
+    static void set_op(caffe2::OperatorDef &op, const std::string &type,
+                       const std::vector<std::string> &inputs,
+                       const std::vector<std::string> &outputs)
+    {
       op.set_type(type);
-      for (const std::string &input : inputs) op.add_input(input);
-      for (const std::string &output : outputs) op.add_output(output);
+      for (const std::string &input : inputs)
+        op.add_input(input);
+      for (const std::string &output : outputs)
+        op.add_output(output);
     }
 
-    caffe2::OperatorDef &add_op(caffe2::NetDef &net, const caffe2::OperatorDef &op) {
+    caffe2::OperatorDef &add_op(caffe2::NetDef &net,
+                                const caffe2::OperatorDef &op)
+    {
       caffe2::OperatorDef &copy = *net.add_op();
       copy.CopyFrom(op);
       return copy;
     }
 
-    // For each device, an operator is created, initialized and configured for the current device
-    static void add_op_for_each_device(ScopedNet &net, const OpModifier &init) {
+    // For each device, an operator is created, initialized and configured for
+    // the current device
+    static void add_op_for_each_device(ScopedNet &net, const OpModifier &init)
+    {
 
       const std::vector<caffe2::DeviceOption> *devices = &net._devices;
 
 #ifndef CPU_ONLY
       // Handle the _force_device tag
       std::vector<caffe2::DeviceOption> buffer(1);
-      if (net._force_device >= 0) {
-	buffer[0].set_device_type(caffe2::DeviceTypeProto::PROTO_CUDA);
-	buffer[0].set_cuda_gpu_id(net._force_device);
-	devices = &buffer;
-      }
+      if (net._force_device >= 0)
+        {
+          buffer[0].set_device_type(caffe2::DeviceTypeProto::PROTO_CUDA);
+          buffer[0].set_cuda_gpu_id(net._force_device);
+          devices = &buffer;
+        }
 #endif
 
-      for (const caffe2::DeviceOption &option : *devices) {
-	caffe2::OperatorDef op;
-	init(op);
+      for (const caffe2::DeviceOption &option : *devices)
+        {
+          caffe2::OperatorDef op;
+          init(op);
 #ifndef CPU_ONLY
-	if (option.device_type() == caffe2::DeviceTypeProto::PROTO_CUDA) {
-	  std::string prefix = device_id_to_prefix(option.cuda_gpu_id());
-	  // Handle _rename_* tags
-	  if (net._rename_inputs) {
-	    for (std::string &name : *op.mutable_input()) {
-	      name = prefix + name;
-	    }
-	  }
-	  if (net._rename_outputs) {
-	    for (std::string &name : *op.mutable_output()) {
-	      name = prefix + name;
-	    }
-	  }
-	}
+          if (option.device_type() == caffe2::DeviceTypeProto::PROTO_CUDA)
+            {
+              std::string prefix = device_id_to_prefix(option.cuda_gpu_id());
+              // Handle _rename_* tags
+              if (net._rename_inputs)
+                {
+                  for (std::string &name : *op.mutable_input())
+                    {
+                      name = prefix + name;
+                    }
+                }
+              if (net._rename_outputs)
+                {
+                  for (std::string &name : *op.mutable_output())
+                    {
+                      name = prefix + name;
+                    }
+                }
+            }
 #endif
-	add_op(net._net, op, option);
-      }
+          add_op(net._net, op, option);
+        }
     }
 
-    void add_op(ScopedNet &net, const caffe2::OperatorDef &op) {
-      add_op_for_each_device(net, [&](caffe2::OperatorDef &copy) {
-	  copy.CopyFrom(op);
-	});
+    void add_op(ScopedNet &net, const caffe2::OperatorDef &op)
+    {
+      add_op_for_each_device(
+          net, [&](caffe2::OperatorDef &copy) { copy.CopyFrom(op); });
     }
 
-    template<class Net>
+    template <class Net>
     inline void add_ops_and_inputs(Net &dst, const caffe2::NetDef &src,
-				   const std::vector<std::string> &ignore) {
-      for (const caffe2::OperatorDef &op : src.op()) {
-	add_op(dst, op);
-      }
-      for (const std::string &input : src.external_input()) {
-	if (!has_value(ignore, input)) {
-	  add_external_input(dst, input);
-	}
-      }
+                                   const std::vector<std::string> &ignore)
+    {
+      for (const caffe2::OperatorDef &op : src.op())
+        {
+          add_op(dst, op);
+        }
+      for (const std::string &input : src.external_input())
+        {
+          if (!has_value(ignore, input))
+            {
+              add_external_input(dst, input);
+            }
+        }
     }
 
-    // Explicit declaration of the functions (easier to call, overload, and set default parameters)
-#define ADD_OPS_AND_INPUTS(net)						\
-    void add_ops_and_inputs(net &dst, const caffe2::NetDef &src,	\
-			    const std::vector<std::string> &ignore) {	\
-      add_ops_and_inputs<net>(dst, src, ignore);			\
-    }
+    // Explicit declaration of the functions (easier to call, overload, and set
+    // default parameters)
+#define ADD_OPS_AND_INPUTS(net)                                               \
+  void add_ops_and_inputs(net &dst, const caffe2::NetDef &src,                \
+                          const std::vector<std::string> &ignore)             \
+  {                                                                           \
+    add_ops_and_inputs<net>(dst, src, ignore);                                \
+  }
     ADD_OPS_AND_INPUTS(ScopedNet)
     ADD_OPS_AND_INPUTS(caffe2::NetDef)
 #undef ADD_OPS_AND_INPUTS
 
     /* ------------------------- Declare operator ------------------------- */
 
-    inline caffe2::OperatorDef &create_operator(caffe2::NetDef &net, const OpModifier &config) {
+    inline caffe2::OperatorDef &create_operator(caffe2::NetDef &net,
+                                                const OpModifier &config)
+    {
       caffe2::OperatorDef &op = *net.add_op();
       config(op);
       return op;
     }
 
-    inline void create_operator(ScopedNet &net, const OpModifier &config) {
+    inline void create_operator(ScopedNet &net, const OpModifier &config)
+    {
       add_op_for_each_device(net, config);
     }
 
-    inline void create_operator(caffe2::OperatorDef &op, const OpModifier &config) {
+    inline void create_operator(caffe2::OperatorDef &op,
+                                const OpModifier &config)
+    {
       config(op);
     }
 
     // Define for NetDef, ScopedNet and OperatorDef
-#define REGISTER_OP_FUNCTIONS(name, lambda, proto...)			\
-    caffe2::OperatorDef &name(caffe2::NetDef &net, proto) {		\
-      return create_operator(net, lambda);				\
-    }									\
-    void name(ScopedNet &net, proto) {					\
-      return create_operator(net, lambda);				\
-    }									\
-    void name(caffe2::OperatorDef &op, proto) {				\
-      return create_operator(op, lambda);				\
-    }
+#define REGISTER_OP_FUNCTIONS(name, lambda, proto...)                         \
+  caffe2::OperatorDef &name(caffe2::NetDef &net, proto)                       \
+  {                                                                           \
+    return create_operator(net, lambda);                                      \
+  }                                                                           \
+  void name(ScopedNet &net, proto)                                            \
+  {                                                                           \
+    return create_operator(net, lambda);                                      \
+  }                                                                           \
+  void name(caffe2::OperatorDef &op, proto)                                   \
+  {                                                                           \
+    return create_operator(op, lambda);                                       \
+  }
 
     // OperatorDef arguments
-#define ADD_ARG_VALUE(arg, value)	add_arg(op, #arg, value)
-#define ADD_ARG(arg)			add_arg(op, #arg, arg)
+#define ADD_ARG_VALUE(arg, value) add_arg(op, #arg, value)
+#define ADD_ARG(arg) add_arg(op, #arg, arg)
 #define NO_ARG
 
     // Blobs
-#define BLOBS(...)			std::vector<std::string>({__VA_ARGS__})
-#define INPUT				BLOBS
-#define OUTPUT				BLOBS
-#define NO_INPUT			BLOBS()
-#define NO_OUTPUT			BLOBS()
+#define BLOBS(...) std::vector<std::string>({ __VA_ARGS__ })
+#define INPUT BLOBS
+#define OUTPUT BLOBS
+#define NO_INPUT BLOBS()
+#define NO_OUTPUT BLOBS()
 
     // Create a lambda with the requested configuration
-#define REGISTER_OP(name, input, output, args, proto...)		\
-    REGISTER_OP_FUNCTIONS(name, [&](caffe2::OperatorDef &op) {		\
-	set_op(op, #name, input, output); args;				\
-      }, proto)
+#define REGISTER_OP(name, input, output, args, proto...)                      \
+  REGISTER_OP_FUNCTIONS(                                                      \
+      name,                                                                   \
+      [&](caffe2::OperatorDef &op) {                                          \
+        set_op(op, #name, input, output);                                     \
+        args;                                                                 \
+      },                                                                      \
+      proto)
 
     // input blob == output blob
-#define REGISTER_SIMPLE_OP(name)					\
-    REGISTER_OP(name,							\
-		INPUT(blob),						\
-		OUTPUT(blob),						\
-		NO_ARG,							\
-		const std::string &blob)
+#define REGISTER_SIMPLE_OP(name)                                              \
+  REGISTER_OP(name, INPUT(blob), OUTPUT(blob), NO_ARG, const std::string &blob)
 
     // N input and one output
-#define REGISTER_SIMPLE_OP_1I1O(name)					\
-    REGISTER_OP(name,							\
-		INPUT(input),						\
-		OUTPUT(output),						\
-		NO_ARG,							\
-		const std::string &input,				\
-		const std::string &output)
-#define REGISTER_SIMPLE_OP_2I1O(name)					\
-    REGISTER_OP(name,							\
-		INPUT(input1, input2),					\
-		OUTPUT(output),						\
-		NO_ARG,							\
-		const std::string &input1,				\
-		const std::string &input2,				\
-		const std::string &output)
-#define REGISTER_SIMPLE_OP_3I1O(name)					\
-    REGISTER_OP(name,							\
-		INPUT(input1, input2, input3),				\
-		OUTPUT(output),						\
-		NO_ARG,							\
-		const std::string &input1,				\
-		const std::string &input2,				\
-		const std::string &input3,				\
-		const std::string &output)
+#define REGISTER_SIMPLE_OP_1I1O(name)                                         \
+  REGISTER_OP(name, INPUT(input), OUTPUT(output), NO_ARG,                     \
+              const std::string &input, const std::string &output)
+#define REGISTER_SIMPLE_OP_2I1O(name)                                         \
+  REGISTER_OP(name, INPUT(input1, input2), OUTPUT(output), NO_ARG,            \
+              const std::string &input1, const std::string &input2,           \
+              const std::string &output)
+#define REGISTER_SIMPLE_OP_3I1O(name)                                         \
+  REGISTER_OP(name, INPUT(input1, input2, input3), OUTPUT(output), NO_ARG,    \
+              const std::string &input1, const std::string &input2,           \
+              const std::string &input3, const std::string &output)
 
     // one input, one output and one argument
-#define REGISTER_SIMPLE_OP_1I1O1A(name, type, arg)			\
-    REGISTER_OP(name,							\
-		INPUT(input),						\
-		OUTPUT(output),						\
-		ADD_ARG(arg),						\
-		const std::string &input,				\
-		const std::string &output,				\
-		type arg)
+#define REGISTER_SIMPLE_OP_1I1O1A(name, type, arg)                            \
+  REGISTER_OP(name, INPUT(input), OUTPUT(output), ADD_ARG(arg),               \
+              const std::string &input, const std::string &output, type arg)
 
     //    one output and a shape
     // or one output and an input (used as a shape)
-#define REGISTER_SIMPLE_OP_FILLER(name)				\
-    REGISTER_SIMPLE_OP_1I1O(name)				\
-    REGISTER_OP(name,						\
-		NO_INPUT,					\
-		OUTPUT(output),					\
-		ADD_ARG(shape),					\
-		const std::string &output,			\
-		const std::vector<int> &shape)
+#define REGISTER_SIMPLE_OP_FILLER(name)                                       \
+  REGISTER_SIMPLE_OP_1I1O(name)                                               \
+  REGISTER_OP(name, NO_INPUT, OUTPUT(output), ADD_ARG(shape),                 \
+              const std::string &output, const std::vector<int> &shape)
 
-    /*
-     *  Operators declaration
-     */
+/*
+ *  Operators declaration
+ */
 
-    // Database
-    #define DB_TYPE "lmdb"
-    REGISTER_OP(CreateDB,
-		NO_INPUT,
-		OUTPUT(reader),
-		ADD_ARG(db);
-		ADD_ARG_VALUE(db_type, DB_TYPE),
-		const std::string &reader,
-		const std::string &db)
-    REGISTER_OP(TensorProtosDBInput,
-		INPUT(reader),
-		OUTPUT(data, label),
-		ADD_ARG(batch_size),
-		const std::string &reader,
-		const std::string &data,
-		const std::string &label,
-		int batch_size)
-    REGISTER_OP(ImageInput,
-	        INPUT(reader),
-		OUTPUT(data, label),
-		ADD_ARG(batch_size);
-		ADD_ARG(color);
-		ADD_ARG_VALUE(minsize, size);
-		ADD_ARG_VALUE(crop, size);
-		ADD_ARG_VALUE(is_test, true);
-		ADD_ARG(use_gpu_transform),
-		const std::string &reader,
-		const std::string &data,
-		const std::string &label,
-		int batch_size,
-		int color,
-		int size,
-		bool use_gpu_transform)
+// Database
+#define DB_TYPE "lmdb"
+    REGISTER_OP(CreateDB, NO_INPUT, OUTPUT(reader), ADD_ARG(db);
+                ADD_ARG_VALUE(db_type, DB_TYPE), const std::string &reader,
+                const std::string &db)
+    REGISTER_OP(TensorProtosDBInput, INPUT(reader), OUTPUT(data, label),
+                ADD_ARG(batch_size), const std::string &reader,
+                const std::string &data, const std::string &label,
+                int batch_size)
+    REGISTER_OP(ImageInput, INPUT(reader), OUTPUT(data, label),
+                ADD_ARG(batch_size);
+                ADD_ARG(color); ADD_ARG_VALUE(minsize, size);
+                ADD_ARG_VALUE(crop, size); ADD_ARG_VALUE(is_test, true);
+                ADD_ARG(use_gpu_transform), const std::string &reader,
+                const std::string &data, const std::string &label,
+                int batch_size, int color, int size, bool use_gpu_transform)
     REGISTER_SIMPLE_OP_1I1O(NHWC2NCHW)
 
     // Basic
-    REGISTER_OP(Sum,
-		inputs,
-		OUTPUT(output),
-		NO_ARG,
-		const std::vector<std::string> &inputs,
-		const std::string &output)
-    REGISTER_OP(Sub,
-		INPUT(input1, input2),
-		OUTPUT(output),
-		ADD_ARG(broadcast); ADD_ARG(axis),
-		const std::string &input1,
-		const std::string &input2,
-		const std::string &output,
-		int broadcast, int axis)
+    REGISTER_OP(Sum, inputs, OUTPUT(output), NO_ARG,
+                const std::vector<std::string> &inputs,
+                const std::string &output)
+    REGISTER_OP(Sub, INPUT(input1, input2), OUTPUT(output), ADD_ARG(broadcast);
+                ADD_ARG(axis), const std::string &input1,
+                const std::string &input2, const std::string &output,
+                int broadcast, int axis)
     REGISTER_SIMPLE_OP_1I1O(Copy)
     REGISTER_SIMPLE_OP_1I1O(Alias)
     REGISTER_SIMPLE_OP_1I1O1A(Scale, float, scale)
 
     // Sum and Optimize
-    REGISTER_OP(WeightedSum,
-		inputs,
-		OUTPUT(output),
-		NO_ARG,
-		const std::vector<std::string> &inputs,
-		const std::string &output)
-    REGISTER_OP(MomentumSGDUpdate,
-		INPUT(gradient, momentum_blob, rate, param),
-		OUTPUT(gradient, momentum_blob, param),
-		//https://caffe2.ai/docs/operators-catalogue.html#momentumsgdupdate
-		ADD_ARG_VALUE(nesterov, 1);
-		ADD_ARG(momentum),
-		const std::string &param,
-		const std::string &momentum_blob,
-		const std::string &gradient,
-		const std::string &rate,
-		float momentum)
-    REGISTER_OP(Adagrad,
-		INPUT(param, momentum, gradient, rate),
-		OUTPUT(param, momentum),
-		ADD_ARG_VALUE(epsilon, 1e-4f);
-		ADD_ARG(decay),
-		const std::string &param,
-		const std::string &momentum,
-		const std::string &gradient,
-		const std::string &rate,
-		float decay)
-    REGISTER_OP(Adam,
-		INPUT(param, momentum1, momentum2, gradient, rate, iter),
-		OUTPUT(param, momentum1, momentum2),
-		ADD_ARG_VALUE(epsilon, 1e-8f);
-		ADD_ARG_VALUE(beta1, 0.9f);
-		ADD_ARG_VALUE(beta2, 0.999f),
-		const std::string &param,
-		const std::string &momentum1,
-		const std::string &momentum2,
-		const std::string &gradient,
-		const std::string &rate,
-		const std::string &iter)
-    REGISTER_OP(RmsProp,
-		INPUT(gradient, mean_square, momentum_blob, rate),
-		OUTPUT(gradient, mean_square, momentum_blob),
-		ADD_ARG_VALUE(epsilon, 1e-5f);
-		ADD_ARG(momentum); ADD_ARG(decay),
-		const std::string &gradient,
-		const std::string &mean_square,
-		const std::string &momentum_blob,
-		const std::string &rate,
-		float momentum, float decay);
+    REGISTER_OP(WeightedSum, inputs, OUTPUT(output), NO_ARG,
+                const std::vector<std::string> &inputs,
+                const std::string &output)
+    REGISTER_OP(
+        MomentumSGDUpdate, INPUT(gradient, momentum_blob, rate, param),
+        OUTPUT(gradient, momentum_blob, param),
+        // https://caffe2.ai/docs/operators-catalogue.html#momentumsgdupdate
+        ADD_ARG_VALUE(nesterov, 1);
+        ADD_ARG(momentum), const std::string &param,
+        const std::string &momentum_blob, const std::string &gradient,
+        const std::string &rate, float momentum)
+    REGISTER_OP(Adagrad, INPUT(param, momentum, gradient, rate),
+                OUTPUT(param, momentum), ADD_ARG_VALUE(epsilon, 1e-4f);
+                ADD_ARG(decay), const std::string &param,
+                const std::string &momentum, const std::string &gradient,
+                const std::string &rate, float decay)
+    REGISTER_OP(Adam, INPUT(param, momentum1, momentum2, gradient, rate, iter),
+                OUTPUT(param, momentum1, momentum2),
+                ADD_ARG_VALUE(epsilon, 1e-8f);
+                ADD_ARG_VALUE(beta1, 0.9f);
+                ADD_ARG_VALUE(beta2, 0.999f), const std::string &param,
+                const std::string &momentum1, const std::string &momentum2,
+                const std::string &gradient, const std::string &rate,
+                const std::string &iter)
+    REGISTER_OP(RmsProp, INPUT(gradient, mean_square, momentum_blob, rate),
+                OUTPUT(gradient, mean_square, momentum_blob),
+                ADD_ARG_VALUE(epsilon, 1e-5f);
+                ADD_ARG(momentum);
+                ADD_ARG(decay), const std::string &gradient,
+                const std::string &mean_square,
+                const std::string &momentum_blob, const std::string &rate,
+                float momentum, float decay);
 
     // Fill
-    //ConstantFill
+    // ConstantFill
     REGISTER_SIMPLE_OP_1I1O1A(ConstantFill, float, value)
-    REGISTER_OP(ConstantFill,
-		NO_INPUT,
-		OUTPUT(output),
-		ADD_ARG(shape); ADD_ARG(value),
-		const std::string &output,
-		const std::vector<int> &shape,
-		float value)
-    REGISTER_OP(ConstantFill,
-		NO_INPUT,
-		OUTPUT(output),
-		ADD_ARG(shape); ADD_ARG(value);
-		ADD_ARG_VALUE(dtype, caffe2::TensorProto_DataType_INT64),
-		const std::string &output,
-		const std::vector<int> &shape,
-		int value)
-    //GivenTensorFill
-    REGISTER_OP(GivenTensorFill,
-		NO_INPUT,
-		OUTPUT(output),
-		ADD_ARG(shape); ADD_ARG(values),
-		const std::string &output,
-		const std::vector<int> &shape,
-		const std::vector<float> &values)
-    //Classic fill
+    REGISTER_OP(ConstantFill, NO_INPUT, OUTPUT(output), ADD_ARG(shape);
+                ADD_ARG(value), const std::string &output,
+                const std::vector<int> &shape, float value)
+    REGISTER_OP(ConstantFill, NO_INPUT, OUTPUT(output), ADD_ARG(shape);
+                ADD_ARG(value);
+                ADD_ARG_VALUE(dtype, caffe2::TensorProto_DataType_INT64),
+                const std::string &output, const std::vector<int> &shape,
+                int value)
+    // GivenTensorFill
+    REGISTER_OP(GivenTensorFill, NO_INPUT, OUTPUT(output), ADD_ARG(shape);
+                ADD_ARG(values), const std::string &output,
+                const std::vector<int> &shape,
+                const std::vector<float> &values)
+    // Classic fill
     REGISTER_SIMPLE_OP_FILLER(XavierFill)
     REGISTER_SIMPLE_OP_FILLER(GaussianFill)
     REGISTER_SIMPLE_OP_FILLER(MSRAFill)
     REGISTER_SIMPLE_OP_FILLER(RangeFill)
     REGISTER_SIMPLE_OP_1I1O(LengthsRangeFill)
-    //XXXFill
+    // XXXFill
     // DiagonalFill
     // UniformFill
     // UniformIntFill
@@ -552,20 +544,13 @@ namespace dd {
     // Train
     REGISTER_SIMPLE_OP(Iter)
     REGISTER_SIMPLE_OP(StopGradient)
-    REGISTER_OP(LearningRate,
-		INPUT(iter),
-		OUTPUT(rate),
-		ADD_ARG(policy); ADD_ARG(base_lr);
-		ADD_ARG(stepsize); ADD_ARG(max_iter);
-		ADD_ARG(gamma); ADD_ARG(power),
-		const std::string &iter,
-		const std::string &rate,
-		const std::string &policy,
-		float base_lr,
-		int stepsize,
-		int max_iter,
-		float gamma,
-		float power)
+    REGISTER_OP(LearningRate, INPUT(iter), OUTPUT(rate), ADD_ARG(policy);
+                ADD_ARG(base_lr); ADD_ARG(stepsize); ADD_ARG(max_iter);
+                ADD_ARG(gamma);
+                ADD_ARG(power), const std::string &iter,
+                const std::string &rate, const std::string &policy,
+                float base_lr, int stepsize, int max_iter, float gamma,
+                float power)
 
     // Test
     REGISTER_SIMPLE_OP_2I1O(LabelCrossEntropy)
@@ -577,23 +562,15 @@ namespace dd {
     REGISTER_SIMPLE_OP_1I1O(CopyFromCPUInput)
     REGISTER_SIMPLE_OP_1I1O(EnsureCPUOutput)
     REGISTER_SIMPLE_OP_3I1O(FC)
-    REGISTER_OP(Conv,
-		INPUT(input, w, b),
-		OUTPUT(output),
-		ADD_ARG(stride); ADD_ARG(pad); ADD_ARG(kernel); ADD_ARG_VALUE(order, "NCHW"),
-		const std::string &input,
-		const std::string &w,
-		const std::string &b,
-		const std::string &output,
-		int stride, int pad, int kernel)
-    REGISTER_OP(MaxPool,
-		INPUT(input),
-		OUTPUT(output),
-		ADD_ARG(stride); ADD_ARG(pad); ADD_ARG(kernel);
-		ADD_ARG_VALUE(order, "NCHW"); ADD_ARG_VALUE(legacy_pad, 3),
-		const std::string &input,
-		const std::string &output,
-		int stride, int pad, int kernel)
+    REGISTER_OP(Conv, INPUT(input, w, b), OUTPUT(output), ADD_ARG(stride);
+                ADD_ARG(pad); ADD_ARG(kernel);
+                ADD_ARG_VALUE(order, "NCHW"), const std::string &input,
+                const std::string &w, const std::string &b,
+                const std::string &output, int stride, int pad, int kernel)
+    REGISTER_OP(MaxPool, INPUT(input), OUTPUT(output), ADD_ARG(stride);
+                ADD_ARG(pad); ADD_ARG(kernel); ADD_ARG_VALUE(order, "NCHW");
+                ADD_ARG_VALUE(legacy_pad, 3), const std::string &input,
+                const std::string &output, int stride, int pad, int kernel)
 
 #undef ADD_ARG_VALUE
 #undef ADD_ARG
@@ -619,8 +596,10 @@ namespace dd {
 
     /* ------------------------- Add operators ------------------------- */
 
-    void insert_db_input_operator(const ModelContext &context, caffe2::NetDef &net_def,
-				  const caffe2::OperatorDef &dbinput) {
+    void insert_db_input_operator(const ModelContext &context,
+                                  caffe2::NetDef &net_def,
+                                  const caffe2::OperatorDef &dbinput)
+    {
 
       // The same DBReader is shared on every device
       net_def.add_external_input(dbinput.input(0));
@@ -628,41 +607,49 @@ namespace dd {
       net._rename_inputs = false;
 
 #ifndef CPU_ONLY
-      if (context._parallelized) {
-	for (const caffe2::DeviceOption &option : context._devices) {
-	  net._force_device = option.cuda_gpu_id();
-	  add_op(net, dbinput);
-	}
-      } else
+      if (context._parallelized)
+        {
+          for (const caffe2::DeviceOption &option : context._devices)
+            {
+              net._force_device = option.cuda_gpu_id();
+              add_op(net, dbinput);
+            }
+        }
+      else
 #endif
-	add_op(net, dbinput);
+        add_op(net, dbinput);
     }
 
     void insert_learning_operators(const ModelContext &context,
-				   caffe2::NetDef &net_def,
-				   caffe2::NetDef &init_def,
-				   const LROpModifier &lr_config) {
+                                   caffe2::NetDef &net_def,
+                                   caffe2::NetDef &init_def,
+                                   const LROpModifier &lr_config)
+    {
 
       ScopedNet net(context.scope_net(net_def));
       // Forcing the device (iter blobs must be run on CPU)
       ScopedNet init(init_def);
       caffe2::DeviceOption option;
       option.set_device_type(caffe2::DeviceTypeProto::PROTO_CPU);
-      init._devices = {option};
+      init._devices = { option };
 
       std::string main_iter;
 
       // Add iter blob
-      for (size_t i = 0; i < context.device_count(); ++i) {
-	std::string prefixed_iter = context.get_prefix(i) + blob_iter;
-	// Broadcasting
-	if (i) {
-	  Copy(init, main_iter, prefixed_iter);
-	} else {
-	  main_iter = prefixed_iter;
-	  ConstantFill(init, main_iter, {1}, context._loaded_iter);
-	}
-      }
+      for (size_t i = 0; i < context.device_count(); ++i)
+        {
+          std::string prefixed_iter = context.get_prefix(i) + blob_iter;
+          // Broadcasting
+          if (i)
+            {
+              Copy(init, main_iter, prefixed_iter);
+            }
+          else
+            {
+              main_iter = prefixed_iter;
+              ConstantFill(init, main_iter, { 1 }, context._loaded_iter);
+            }
+        }
 
       add_external_input(net, blob_iter);
       Iter(net, blob_iter);
@@ -671,47 +658,60 @@ namespace dd {
       add_op(net, lr);
     }
 
-    // Add all the operators on the main device and copy the outputs on the other devices
-    static void copy_and_broadcast_operators(const ModelContext &context, caffe2::NetDef &net_def,
-					     const std::vector<const caffe2::OperatorDef *> &ops) {
+    // Add all the operators on the main device and copy the outputs on the
+    // other devices
+    static void copy_and_broadcast_operators(
+        const ModelContext &context, caffe2::NetDef &net_def,
+        const std::vector<const caffe2::OperatorDef *> &ops)
+    {
       ScopedNet net = context.scope_net(net_def);
 #ifndef CPU_ONLY
       std::vector<std::string> sync;
       const caffe2::DeviceOption &main_device = context._devices[0];
-      bool is_sync =
-	main_device.device_type() == caffe2::DeviceTypeProto::PROTO_CUDA
-	&& context._parallelized;
+      bool is_sync
+          = main_device.device_type() == caffe2::DeviceTypeProto::PROTO_CUDA
+            && context._parallelized;
 
-      if (is_sync) {
-	net._force_device = main_device.cuda_gpu_id();
-      }
+      if (is_sync)
+        {
+          net._force_device = main_device.cuda_gpu_id();
+        }
 #endif
-      for (const caffe2::OperatorDef *op : ops) {
-	add_op(net, *op);
+      for (const caffe2::OperatorDef *op : ops)
+        {
+          add_op(net, *op);
 #ifndef CPU_ONLY
-	if (is_sync) {
-	  for (const std::string &output : op->output()) {
-	    sync.push_back(output);
-	  }
-	}
-      }
-      for (const std::string &blob : sync) {
-	broadcast(net, blob);
+          if (is_sync)
+            {
+              for (const std::string &output : op->output())
+                {
+                  sync.push_back(output);
+                }
+            }
+        }
+      for (const std::string &blob : sync)
+        {
+          broadcast(net, blob);
 #endif
-      }
+        }
     }
 
-    void copy_and_broadcast_operator(const ModelContext &context, caffe2::NetDef &net,
-				     const caffe2::OperatorDef &op) {
-      copy_and_broadcast_operators(context, net, {&op});
+    void copy_and_broadcast_operator(const ModelContext &context,
+                                     caffe2::NetDef &net,
+                                     const caffe2::OperatorDef &op)
+    {
+      copy_and_broadcast_operators(context, net, { &op });
     }
 
-    void copy_and_broadcast_operators(const ModelContext &context, caffe2::NetDef &net,
-				      const caffe2::NetDef &src) {
+    void copy_and_broadcast_operators(const ModelContext &context,
+                                      caffe2::NetDef &net,
+                                      const caffe2::NetDef &src)
+    {
       std::vector<const caffe2::OperatorDef *> ops;
-      for (const caffe2::OperatorDef &op : src.op()) {
-	ops.push_back(&op);
-      }
+      for (const caffe2::OperatorDef &op : src.op())
+        {
+          ops.push_back(&op);
+        }
       copy_and_broadcast_operators(context, net, ops);
     }
 
@@ -719,41 +719,49 @@ namespace dd {
      *  Pre-computation
      */
 
-    typedef std::function<void(caffe2::NetDef&,int)> EnsureIsBatchable;
-    extern const std::map<std::string, EnsureIsBatchable> ensure_op_is_batchable;
+    typedef std::function<void(caffe2::NetDef &, int)> EnsureIsBatchable;
+    extern const std::map<std::string, EnsureIsBatchable>
+        ensure_op_is_batchable;
 
     /*
      * Currently only the detectron models make us update the net
      * in order to make it batchable.
      *
-     * By default the 'batch_splits' blob is not used, so we need to place it into the net.
-     * See in https://github.com/pytorch/pytorch/blob/master/caffe2/operators :
+     * By default the 'batch_splits' blob is not used, so we need to place it
+     * into the net. See in
+     * https://github.com/pytorch/pytorch/blob/master/caffe2/operators :
      * box_with_nms_limit_op.cc and bbox_transform_op.cc
      *
      * Another problem occurs with CollectAndDistributeFpnRpnProposals
      * that do not keep the data grouped by batch item.
-     * See in https://github.com/chichaj/deepdetect/blob/master/patches/caffe2 :
-     * collect_proposals.patch
+     * See in https://github.com/chichaj/deepdetect/blob/master/patches/caffe2
+     * : collect_proposals.patch
      */
-    void ensure_is_batchable(caffe2::NetDef &net) {
+    void ensure_is_batchable(caffe2::NetDef &net)
+    {
       // Loop over the operators
       const auto &ops = net.op();
-      for (int idx = ops.size(); idx-- > 0;) {
-	auto it = ensure_op_is_batchable.find(ops[idx].type());
-	if (it != ensure_op_is_batchable.end()) {
-	  it->second(net, idx);
-	}
-      }
+      for (int idx = ops.size(); idx-- > 0;)
+        {
+          auto it = ensure_op_is_batchable.find(ops[idx].type());
+          if (it != ensure_op_is_batchable.end())
+            {
+              it->second(net, idx);
+            }
+        }
     }
 
-    static void make_input_batchable(caffe2::NetDef &net, int op_idx, int input_size,
-				     const std::string &prev_type, int input_idx,
-				     int output_idx) {
+    static void make_input_batchable(caffe2::NetDef &net, int op_idx,
+                                     int input_size,
+                                     const std::string &prev_type,
+                                     int input_idx, int output_idx)
+    {
       // Check if all the inputs are already present
       auto &inputs = *net.mutable_op(op_idx)->mutable_input();
-      if (inputs.size() == input_size) {
-	return;
-      }
+      if (inputs.size() == input_size)
+        {
+          return;
+        }
       CAFFE_ENFORCE(inputs.size() == input_size - 1);
       // Find a previous blob that can output the 'batch_splits' blob
       int prev_idx = find_previous_update(net, inputs[input_idx], op_idx - 1);
@@ -764,147 +772,183 @@ namespace dd {
       inputs.Add(std::string(prev.output(output_idx)));
     }
 
-    static void make_output_batchable(caffe2::NetDef &net, int op_idx, int output_size,
-				      int output_idx) {
+    static void make_output_batchable(caffe2::NetDef &net, int op_idx,
+                                      int output_size, int output_idx)
+    {
       // Check if all the outputs are already present
       auto &outputs = *net.mutable_op(op_idx)->mutable_output();
-      if (outputs.size() == output_size) {
-	return;
-      }
+      if (outputs.size() == output_size)
+        {
+          return;
+        }
       // Output a 'batch_splits' blob
       CAFFE_ENFORCE(outputs.size() == output_size - 1);
       outputs.Add(std::move(outputs[output_idx] + batch_splits_suffix));
     }
 
-    static void ensure_collect_proposals_is_batchable(caffe2::NetDef &net, int idx) {
+    static void ensure_collect_proposals_is_batchable(caffe2::NetDef &net,
+                                                      int idx)
+    {
       caffe2::OperatorDef &op = *net.mutable_op(idx);
-      for (caffe2::Argument &arg : *op.mutable_arg()) {
-	if (arg.name() == "keep_grouped") {
-	  arg.set_i(true);
-	  return;
-	}
-      }
+      for (caffe2::Argument &arg : *op.mutable_arg())
+        {
+          if (arg.name() == "keep_grouped")
+            {
+              arg.set_i(true);
+              return;
+            }
+        }
       add_arg(op, "keep_grouped", true);
     }
 
-    static inline void ensure_bbox_transform_is_batchable(caffe2::NetDef &net, int idx) {
+    static inline void ensure_bbox_transform_is_batchable(caffe2::NetDef &net,
+                                                          int idx)
+    {
       make_output_batchable(net, idx, 2, 0);
     }
 
-    static inline void ensure_box_nms_is_batchable(caffe2::NetDef &net, int idx) {
+    static inline void ensure_box_nms_is_batchable(caffe2::NetDef &net,
+                                                   int idx)
+    {
       make_input_batchable(net, idx, 3, "BBoxTransform", 1, 1);
       make_output_batchable(net, idx, 4, 0);
     }
 
-    static inline void ensure_bbox_rois_is_batchable(caffe2::NetDef &net, int idx) {
+    static inline void ensure_bbox_rois_is_batchable(caffe2::NetDef &net,
+                                                     int idx)
+    {
       make_input_batchable(net, idx, 3, "BoxWithNMSLimit", 0, 3);
     }
 
     const std::map<std::string, EnsureIsBatchable> ensure_op_is_batchable({
-	{ "CollectAndDistributeFpnRpnProposals", ensure_collect_proposals_is_batchable },
-	{ "BBoxTransform", ensure_bbox_transform_is_batchable },
-	{ "BoxWithNMSLimit", ensure_box_nms_is_batchable },
-	{ "BBoxToRoi", ensure_bbox_rois_is_batchable },
+        { "CollectAndDistributeFpnRpnProposals",
+          ensure_collect_proposals_is_batchable },
+        { "BBoxTransform", ensure_bbox_transform_is_batchable },
+        { "BoxWithNMSLimit", ensure_box_nms_is_batchable },
+        { "BBoxToRoi", ensure_bbox_rois_is_batchable },
     });
 
     /*
      *  Finalisation
      */
 
-    static void remove_duplicate_casts(caffe2::NetDef &net) {
+    static void remove_duplicate_casts(caffe2::NetDef &net)
+    {
 
       caffe2::NetDef new_net;
       std::map<std::string, std::string> casted_blobs;
       std::map<std::string, std::string> rename_blobs;
 
-      for (caffe2::OperatorDef &op : *net.mutable_op()) {
+      for (caffe2::OperatorDef &op : *net.mutable_op())
+        {
 
-	// Rename inputs
-	for (std::string &input : *op.mutable_input()) {
-	  auto rename = rename_blobs.find(input);
-	  if (rename != rename_blobs.end()) {
-	    input = rename->second;
-	  }
-	}
+          // Rename inputs
+          for (std::string &input : *op.mutable_input())
+            {
+              auto rename = rename_blobs.find(input);
+              if (rename != rename_blobs.end())
+                {
+                  input = rename->second;
+                }
+            }
 
-	// Cast operators
-	if (op.type() == "CopyFromCPUInput" || op.type() == "EnsureCPUOutput") {
-	  const std::string &input = op.input(0);
-	  const std::string &output = op.output(0);
+          // Cast operators
+          if (op.type() == "CopyFromCPUInput"
+              || op.type() == "EnsureCPUOutput")
+            {
+              const std::string &input = op.input(0);
+              const std::string &output = op.output(0);
 
-	  // Reuse the previous casts
-	  auto casted = casted_blobs.find(input);
-	  if (casted != casted_blobs.end()) {
-	    rename_blobs[output] = casted->second;
-	    continue;
-	  }
+              // Reuse the previous casts
+              auto casted = casted_blobs.find(input);
+              if (casted != casted_blobs.end())
+                {
+                  rename_blobs[output] = casted->second;
+                  continue;
+                }
 
-	  // Store the blobs name
-	  casted_blobs[input] = output;
-	  casted_blobs[output] = input;
+              // Store the blobs name
+              casted_blobs[input] = output;
+              casted_blobs[output] = input;
+            }
+          else
+            {
 
-	} else {
+              // Detect blob overrides
+              for (const std::string &output : op.output())
+                {
+                  // Do not rename anymore
+                  auto rename = rename_blobs.find(output);
+                  if (rename != rename_blobs.end())
+                    {
+                      rename_blobs.erase(rename);
+                    }
+                  // Do not reuse casts
+                  auto casted = casted_blobs.find(output);
+                  if (casted != casted_blobs.end())
+                    {
+                      casted_blobs.erase(casted_blobs.find(casted->second));
+                      casted_blobs.erase(casted);
+                    }
+                }
+            }
 
-	  // Detect blob overrides
-	  for (const std::string &output : op.output()) {
-	    // Do not rename anymore
-	    auto rename = rename_blobs.find(output);
-	    if (rename != rename_blobs.end()) {
-	      rename_blobs.erase(rename);
-	    }
-	    // Do not reuse casts
-	    auto casted = casted_blobs.find(output);
-	    if (casted != casted_blobs.end()) {
-	      casted_blobs.erase(casted_blobs.find(casted->second));
-	      casted_blobs.erase(casted);
-	    }
-	  }
-	}
-
-	// Apply modifications
-	add_op(new_net, op);
-      }
+          // Apply modifications
+          add_op(new_net, op);
+        }
       net.mutable_op()->Swap(new_net.mutable_op());
     }
 
     // We consider that nets are not splitted during a CPU/CUDA conversion
-    static void remove_useless_casts(caffe2::NetDef &net) {
+    static void remove_useless_casts(caffe2::NetDef &net)
+    {
 
       const auto &net_inputs(net.external_input());
-      const std::set<std::string> external_inputs(net_inputs.begin(), net_inputs.end());
+      const std::set<std::string> external_inputs(net_inputs.begin(),
+                                                  net_inputs.end());
 
-      for (int i = 0; i < net.op().size(); ++i) {
-	caffe2::OperatorDef &op = *net.mutable_op(i);
+      for (int i = 0; i < net.op().size(); ++i)
+        {
+          caffe2::OperatorDef &op = *net.mutable_op(i);
 
-	// Cast operators
-	if (op.type() == "CopyFromCPUInput" || op.type() == "EnsureCPUOutput") {
-	  const std::string &input = op.input(0);
-	  const std::string &output = op.output(0);
+          // Cast operators
+          if (op.type() == "CopyFromCPUInput"
+              || op.type() == "EnsureCPUOutput")
+            {
+              const std::string &input = op.input(0);
+              const std::string &output = op.output(0);
 
-	  bool internal = external_inputs.find(input) == external_inputs.end();
-	  if (!internal) {
-	    // The cast is not an external input, but may be an external output
+              bool internal
+                  = external_inputs.find(input) == external_inputs.end();
+              if (!internal)
+                {
+                  // The cast is not an external input, but may be an external
+                  // output
 
-	    // Check if the cast is used
-	    for (int j = i; j < net.op().size(); ++j) {
-	      if (has_input(net.op(j), output)) {
-		internal = true;
-		break;
-	      }
-	    }
-	  }
+                  // Check if the cast is used
+                  for (int j = i; j < net.op().size(); ++j)
+                    {
+                      if (has_input(net.op(j), output))
+                        {
+                          internal = true;
+                          break;
+                        }
+                    }
+                }
 
-	  // Transform into a simple alias
-	  if (!internal) {
-	    caffe2::OperatorDef new_op;
-	    Alias(new_op, input, output);
-	    op.Swap(&new_op);
-	  }
-	}
-      }
+              // Transform into a simple alias
+              if (!internal)
+                {
+                  caffe2::OperatorDef new_op;
+                  Alias(new_op, input, output);
+                  op.Swap(&new_op);
+                }
+            }
+        }
     }
 
-    void final_optimizations(caffe2::NetDef &net) {
+    void final_optimizations(caffe2::NetDef &net)
+    {
       // Prevent useless casts between CPU/GPU tensors
       remove_duplicate_casts(net);
       remove_useless_casts(net);

--- a/src/backends/caffe2/nettools/fillers_and_optimizers.cc
+++ b/src/backends/caffe2/nettools/fillers_and_optimizers.cc
@@ -21,8 +21,10 @@
 
 #include "backends/caffe2/nettools/internal.h"
 
-namespace dd {
-  namespace Caffe2NetTools {
+namespace dd
+{
+  namespace Caffe2NetTools
+  {
 
     /*
      *  Parameter fillers
@@ -30,39 +32,48 @@ namespace dd {
 
     // Fetch the 'idx'th output of an operator
     // Create the requested filler for it, and place it in the 'fillers' map
-    static caffe2::OperatorDef *add_filler(const caffe2::OperatorDef &op,
-					   std::map<std::string, caffe2::OperatorDef> &fillers,
-					   const std::string &ftype, int input_idx) {
+    static caffe2::OperatorDef *
+    add_filler(const caffe2::OperatorDef &op,
+               std::map<std::string, caffe2::OperatorDef> &fillers,
+               const std::string &ftype, int input_idx)
+    {
       caffe2::OperatorDef *filler = NULL;
-      if (input_idx < op.input().size()) {
-	const std::string &output = op.input(input_idx);
-	filler = &fillers[output];
-	filler->set_type(ftype);
-	filler->add_output(output);
-      }
+      if (input_idx < op.input().size())
+        {
+          const std::string &output = op.input(input_idx);
+          filler = &fillers[output];
+          filler->set_type(ftype);
+          filler->add_output(output);
+        }
       return filler;
     }
 
     // Same as above, but also adds a constant value to the filler
-    static caffe2::OperatorDef *add_filler(const caffe2::OperatorDef &op,
-					   std::map<std::string, caffe2::OperatorDef> &fillers,
-					   const std::string &ftype, int input_idx, float value) {
+    static caffe2::OperatorDef *
+    add_filler(const caffe2::OperatorDef &op,
+               std::map<std::string, caffe2::OperatorDef> &fillers,
+               const std::string &ftype, int input_idx, float value)
+    {
       caffe2::OperatorDef *filler = add_filler(op, fillers, ftype, input_idx);
-      if (filler) {
-	add_arg(*filler, "value", value);
-      }
+      if (filler)
+        {
+          add_arg(*filler, "value", value);
+        }
       return filler;
     }
 
-    // Filler functions take an operator, and create a filler for each input referenced
-    // as being a parameter of the net. Thoses inputs and their newly created fillers are storeds
-    // in the 'fillers' map.
-    using Filler = std::function<void(const caffe2::OperatorDef &, // Input
-				      std::map<std::string,caffe2::OperatorDef> & // Output
-				      )>;
+    // Filler functions take an operator, and create a filler for each input
+    // referenced as being a parameter of the net. Thoses inputs and their
+    // newly created fillers are storeds in the 'fillers' map.
+    using Filler = std::function<void(
+        const caffe2::OperatorDef &,                 // Input
+        std::map<std::string, caffe2::OperatorDef> & // Output
+        )>;
 
     // Just to make it more readable
-#define FILLER_LAMBDA [](const caffe2::OperatorDef &o, std::map<std::string,caffe2::OperatorDef> &f)
+#define FILLER_LAMBDA                                                         \
+  [](const caffe2::OperatorDef &o,                                            \
+     std::map<std::string, caffe2::OperatorDef> &f)
 #define ADD_FILLER(type, args...) add_filler(o, f, #type "Fill", args)
 
     // Map linking operator types to their filler lambda
@@ -71,507 +82,614 @@ namespace dd {
 	  "Conv", FILLER_LAMBDA {
 	    ADD_FILLER(Xavier, 1);
 	    ADD_FILLER(Constant, 2);
-	  }
-	}, {
-	  "FC", FILLER_LAMBDA {
-	    ADD_FILLER(Xavier, 1);
-	    ADD_FILLER(Constant, 2);
-	  }
-	}, {
-	  "SpatialBN", FILLER_LAMBDA {
-	    ADD_FILLER(Constant, 1, 1.0f);
-	    ADD_FILLER(Constant, 2, 0.0f);
-	    ADD_FILLER(Constant, 3, 0.0f);
-	    ADD_FILLER(Constant, 4, 1.0f);
-	  }
-	}
-      });
+  }
+}
+, { "FC", FILLER_LAMBDA{ ADD_FILLER(Xavier, 1);
+ADD_FILLER(Constant, 2);
+}
+}
+,
+{
+  "SpatialBN", FILLER_LAMBDA
+  {
+    ADD_FILLER(Constant, 1, 1.0f);
+    ADD_FILLER(Constant, 2, 0.0f);
+    ADD_FILLER(Constant, 3, 0.0f);
+    ADD_FILLER(Constant, 4, 1.0f);
+  }
+}
+});
 
 #undef FILLER_LAMBDA
 #undef ADD_FILLER
 
-    // Create fillers for every parameters of the net
-    static void collect_filler_types(const caffe2::NetDef &net,
-				     std::map<std::string, caffe2::OperatorDef> &fillers) {
-      for (const caffe2::OperatorDef &op : net.op()) {
-	auto it = op_fillers.find(op.type());
-	if (it != op_fillers.end()) {
-	  it->second(op, fillers);
-	}
+// Create fillers for every parameters of the net
+static void
+collect_filler_types(const caffe2::NetDef &net,
+                     std::map<std::string, caffe2::OperatorDef> &fillers)
+{
+  for (const caffe2::OperatorDef &op : net.op())
+    {
+      auto it = op_fillers.find(op.type());
+      if (it != op_fillers.end())
+        {
+          it->second(op, fillers);
+        }
+    }
+}
+
+// Replace the net current fillers (usually GivenTensorFills) with the ones
+// referenced in the 'fillers' map
+static void
+apply_filler_types(caffe2::NetDef &net,
+                   const std::map<std::string, caffe2::OperatorDef> &fillers)
+{
+  for (caffe2::OperatorDef &op : *net.mutable_op())
+    {
+      auto it = fillers.find(op.output(0));
+      if (it == fillers.end())
+        {
+          continue;
+        }
+      caffe2::OperatorDef copy = it->second;
+      for (const caffe2::Argument &arg : op.arg())
+        {
+          if (arg.name() == "shape")
+            {
+              copy.add_arg()->CopyFrom(arg);
+              break;
+            }
+        }
+      op.Swap(&copy);
+    }
+}
+
+/*
+ * \brief browse the net and list shapes of blobs initialized by filling
+ * operators
+ * @param net net to browse
+ * @param shapes used to store blobs name and shape
+ * @param prefix filter out blob names that don't start with this prefix
+ * @param remove_prefix whether the given prefix must be removed from the blob
+ * name
+ */
+static void
+collect_blob_shapes(const caffe2::NetDef &net,
+                    std::map<std::string, std::vector<int>> &shapes,
+                    const std::string &prefix = "", bool remove_prefix = true)
+{
+  for (const caffe2::OperatorDef &op : net.op())
+    {
+      auto it = non_trainable_ops.find(op.type());
+      if (it == non_trainable_ops.end() || !it->second
+          || // Not a filling operator
+          op.input().size() || op.output().size() != 1
+          || // Shape not stored in arguments
+          op.output(0).find(prefix))
+        { // Does not start with the given prefix
+          continue;
+        }
+      std::string output
+          = op.output(0).substr(remove_prefix * prefix.size(), -1);
+      for (const caffe2::Argument &arg : op.arg())
+        {
+          if (arg.name() == "shape")
+            {
+              shapes[output].assign(arg.ints().begin(), arg.ints().end());
+              break;
+            }
+        }
+    }
+}
+
+// Some values (e.g. the number of classes) are present several times inside
+// init nets. This class stores pointers to integers that represent the same
+// value. Some of them may be multiples of one another, so a coefficient is
+// linked to each pointer.
+class ShapePtrs
+{
+  std::vector<std::pair<const int *, float>> _ptrs;
+
+  // For the concerned blobs, two informations are stored:
+  //   - Which dimension of its shape corresponds to the desired value
+  //   - Its coefficient
+  std::map<std::string, std::pair<int, float>> _blobs;
+
+  // Store a pointer to the nth dimension of an input filler
+  void add_ptr(const caffe2::OperatorDef &filler, int dimension, float coef)
+  {
+
+    // Find the shape
+    for (const caffe2::Argument &arg : filler.arg())
+      {
+        if (arg.name() != "shape")
+          {
+            continue;
+          }
+
+        // Shapes should be small enough to fit into an integer (stored as long
+        // in caffe2)
+        if (dimension < arg.ints().size())
+          {
+            return _ptrs.emplace_back(
+                reinterpret_cast<const int *>(&arg.ints()[dimension]), coef);
+          }
+
+        CAFFE_THROW("Can't access ", filler.output(0), " shape at position ",
+                    dimension);
       }
+    CAFFE_THROW("Can't access ", filler.output(0), " shape");
+  }
+
+protected:
+  inline void register_blob(const std::string &blob, int dimension,
+                            float coefficient)
+  {
+    _blobs[blob] = { dimension, coefficient };
+  }
+
+  void fetch_pointers(const caffe2::NetDef &init_net)
+  {
+
+    // Make a copy
+    std::map<std::string, std::pair<int, float>> blobs = _blobs;
+
+    // Check if the fillers output are registered
+    for (const caffe2::OperatorDef &filler : init_net.op())
+      {
+        const auto &blob = blobs.find(filler.output(0));
+        if (blob == blobs.end())
+          {
+            continue;
+          }
+
+        // Keep a pointer to the shape
+        add_ptr(filler, blob->second.first, blob->second.second);
+        blobs.erase(blob);
+      }
+
+    // Assert that every blob was found
+    const auto &blob = blobs.begin();
+    if (blob != blobs.end())
+      {
+        CAFFE_THROW("Can't access ", blob->first, " shape");
+      }
+
+    // Assert that the retreived data is coherent
+    int value = *_ptrs[0].first / _ptrs[0].second;
+    for (const std::pair<const int *, int> &ptr : _ptrs)
+      {
+        if (*ptr.first % ptr.second || *ptr.first / ptr.second != value)
+          {
+            CAFFE_THROW("Couldn't fetch data from the initalization net");
+          }
+      }
+  }
+
+public:
+  inline void get_blobs(std::set<std::string> &blobs)
+  {
+    blobs.clear();
+    for (const std::pair<std::string, std::pair<int, float>> &it : _blobs)
+      {
+        blobs.insert(it.first);
+      }
+  }
+
+  inline int get_value() const
+  {
+    return *_ptrs[0].first / _ptrs[0].second;
+  }
+
+  void set_value(int value)
+  {
+    if (get_value() != value)
+      {
+        for (const std::pair<const int *, int> ptr : _ptrs)
+          {
+            *const_cast<int *>(ptr.first) = value * ptr.second;
+          }
+      }
+  }
+};
+
+// Group of function used to find which integers are defining the output shape
+// of a net Also contains maps used to know how an operator output shape is
+// defined (detailed right after the class)
+class OutputShapePtrs : public ShapePtrs
+{
+
+  /*
+   *  Some operators have their shape defined by previous operators.
+   */
+  //                    Operator              Input, Coef
+  static const std::map<std::string, std::map<int, float>> _forwarded_shapes;
+
+  /*
+   *  Other operators have their shape defined by external inputs.
+   *  Thoses shapes too may be multiples of one another, but it will be
+   * explicitly shown inside the 'shape' argument of the corresponding filler.
+   * Unfortunately we still need to know which dimension of thoses 'shape's is
+   * shared.
+   */
+  //                    Operator              Input, Dimension index
+  static const std::map<std::string, std::map<int, int>> _external_shapes;
+
+  // Recursive function that start browsing the net a specific index and
+  // coefficient
+  void compute(int op_idx, float coef)
+  {
+    const caffe2::OperatorDef &op = _net.op(op_idx);
+    const std::string &type = op.type();
+
+    if (_forwarded_shapes.find(type) != _forwarded_shapes.end())
+      {
+        // Shape defined by previous operators
+
+        for (const std::pair<int, float> &input_coef :
+             _forwarded_shapes.at(type))
+          {
+            // Recurse over them
+            const std::string &input_name
+                = _net.op(op_idx).input(input_coef.first);
+            compute(find_previous_update(_net, input_name, op_idx - 1),
+                    coef * input_coef.second);
+          }
+      }
+    else if (_external_shapes.find(type) != _external_shapes.end())
+      {
+        // Shape defined by external inputs
+
+        for (const std::pair<int, int> &input_dim : _external_shapes.at(type))
+          {
+            int input_idx = input_dim.first;
+            if (input_idx >= op.input().size())
+              {
+                CAFFE_THROW("Can't access ", op.type(), " input at position ",
+                            input_idx);
+              }
+            // Save the blob informations
+            register_blob(op.input(input_idx), input_dim.second, coef);
+          }
+      }
+    else
+      {
+        // XXX Handle more configurations
+        CAFFE_THROW("Can't access ", op.type(), " input shapes");
+      }
+  }
+
+public:
+  const caffe2::NetDef &_net;
+  OutputShapePtrs(const caffe2::NetDef &net, const caffe2::NetDef &init_net)
+      : _net(net)
+  {
+    // Start computing from the last operator whose shape is (by definition)
+    // the same as the net output shape (so coef=1)
+    compute(_net.op().size() - 1, 1);
+    fetch_pointers(init_net);
+  }
+};
+
+const std::map<std::string, std::map<int, float>>
+    OutputShapePtrs::_forwarded_shapes({
+
+        // One input, same shape
+        { "AveragePool",
+          { { 0, 1 } } }, // (An end-of-net pooling should be a global pooling)
+        { "CopyFromCPUInput", { { 0, 1 } } },
+        { "EnsureCPUOutput", { { 0, 1 } } },
+        { "Relu", { { 0, 1 } } },
+        { "Sigmoid", { { 0, 1 } } },
+        { "Softmax", { { 0, 1 } } },
+
+        // An input that is already a group of bbox
+        { "BBoxTransform", { { 1, 1 } } },
+
+        // 1 probablity per result
+        // 4 points per result
+        { "BoxWithNMSLimit", { { 0, 1 }, { 1, 4 } } }
+
+    });
+
+const std::map<std::string, std::map<int, int>>
+    OutputShapePtrs::_external_shapes({
+
+        // Weights have 2 dimensions (nb_output and nb_input), we want the
+        // first
+        // Bias have 1 dimension (nb_output), we also want the first
+        { "Conv", { { 1, 0 }, { 2, 0 } } },
+        { "FC", { { 1, 0 }, { 2, 0 } } } });
+
+// XXX Used by debug.cc
+void _reset_init_net(const caffe2::NetDef &net, caffe2::NetDef &init)
+{
+  std::map<std::string, caffe2::OperatorDef> fillers;
+  collect_filler_types(net, fillers);
+  apply_filler_types(init, fillers);
+}
+
+void set_nclasses(const caffe2::NetDef &net, caffe2::NetDef &init,
+                  int nclasses)
+{
+
+  // Reshape the blobs defining the output shape
+  std::set<std::string> shape;
+  OutputShapePtrs ptrs(net, init);
+  ptrs.set_value(nclasses);
+  ptrs.get_blobs(shape);
+
+  // Collect every fillers
+  std::map<std::string, caffe2::OperatorDef> fillers;
+  collect_filler_types(net, fillers);
+
+  // Filter them
+  for (auto it = fillers.begin(); it != fillers.end();)
+    {
+      if (shape.find(it->first) == shape.end())
+        {
+          it = fillers.erase(it);
+        }
+      else
+        {
+          ++it;
+        }
     }
 
-    // Replace the net current fillers (usually GivenTensorFills) with the ones
-    // referenced in the 'fillers' map
-    static void apply_filler_types(caffe2::NetDef &net,
-				   const std::map<std::string, caffe2::OperatorDef> &fillers) {
-      for (caffe2::OperatorDef &op : *net.mutable_op()) {
-	auto it = fillers.find(op.output(0));
-	if (it == fillers.end()) {
-	  continue;
-	}
-	caffe2::OperatorDef copy = it->second;
-	for (const caffe2::Argument &arg : op.arg()) {
-	  if (arg.name() == "shape") {
-	    copy.add_arg()->CopyFrom(arg);
-	    break;
-	  }
-	}
-	op.Swap(&copy);
+  // Reset them
+  apply_filler_types(init, fillers);
+}
+
+int get_nclasses(const caffe2::NetDef &net, const caffe2::NetDef &init)
+{
+  return OutputShapePtrs(net, init).get_value();
+}
+
+/*
+ *  Optimizers
+ */
+
+// Optimizers all need the same variables, and their workflow are similar.
+// Common behavior was put in a class to prevent code duplication
+class AbstractOptimizer
+{
+
+  // Keep an access to the nets
+  const ModelContext &_context;
+  caffe2::NetDef &_netdef;
+  caffe2::NetDef &_initdef;
+  std::map<std::string, std::vector<int>> _shapes;
+
+protected:
+  // Members the childs may need
+  ScopedNet _net;
+  std::string _param;
+  std::string _grad, _moment, _meansq; // Blob names
+  float _momentum, _decay;             // Configuration
+
+  // Create a new ConstantFill :
+  //  - On the main device of the init net
+  //  - Broadcasted on every device
+  //  - Tagged as 'external input' on the main net
+  void broadcast_external_constantfill(const std::string &name,
+                                       const std::vector<int> &shape,
+                                       float value)
+  {
+    caffe2::OperatorDef fill;
+    ConstantFill(fill, name, shape, value);
+    copy_and_broadcast_operator(_context, _initdef, fill);
+    add_external_input(_net, name);
+  }
+
+  // Same as above, but using current parameter size, and a fill of 0
+  void default_fillers(const std::vector<std::string> &names)
+  {
+    for (const std::string &name : names)
+      {
+        broadcast_external_constantfill(name, _shapes[_param], 0);
       }
-    }
+  }
 
-    /*
-     * \brief browse the net and list shapes of blobs initialized by filling operators
-     * @param net net to browse
-     * @param shapes used to store blobs name and shape
-     * @param prefix filter out blob names that don't start with this prefix
-     * @param remove_prefix whether the given prefix must be removed from the blob name
-     */
-    static void collect_blob_shapes(const caffe2::NetDef &net,
-				    std::map<std::string, std::vector<int> > &shapes,
-				    const std::string &prefix = "",
-				    bool remove_prefix = true) {
-      for (const caffe2::OperatorDef &op : net.op()) {
-	auto it = non_trainable_ops.find(op.type());
-	if (it == non_trainable_ops.end() || !it->second || // Not a filling operator
-	    op.input().size() || op.output().size() != 1 || // Shape not stored in arguments
-	    op.output(0).find(prefix)) { // Does not start with the given prefix
-	  continue;
-	}
-	std::string output = op.output(0).substr(remove_prefix * prefix.size(), -1);
-	for (const caffe2::Argument &arg : op.arg()) {
-	  if (arg.name() == "shape") {
-	    shapes[output].assign(arg.ints().begin(), arg.ints().end());
-	    break;
-	  }
-	}
-      }
-    }
+  // Functions supposed to be overloaded
 
-    // Some values (e.g. the number of classes) are present several times inside init nets.
-    // This class stores pointers to integers that represent the same value.
-    // Some of them may be multiples of one another, so a coefficient is linked to each pointer.
-    class ShapePtrs {
-      std::vector<std::pair<const int *, float>> _ptrs;
+  virtual void init()
+  {
+  }                            // Code executed only once per net
+  virtual void optimize() = 0; // Code executed for each parameter
+  virtual bool negative_base_lr()
+  {
+    return false;
+  }
+  virtual void set_default_momentum()
+  {
+  }
+  virtual void set_default_decay()
+  {
+  }
 
-      // For the concerned blobs, two informations are stored:
-      //   - Which dimension of its shape corresponds to the desired value
-      //   - Its coefficient
-      std::map<std::string, std::pair<int, float>> _blobs;
+public:
+  AbstractOptimizer(const ModelContext &context, caffe2::NetDef &netdef,
+                    caffe2::NetDef &initdef, float momentum, float decay)
+      : _context(context), _netdef(netdef), _initdef(initdef),
+        _net(context.scope_net(netdef)), _momentum(momentum), _decay(decay)
+  {
+  }
 
-      // Store a pointer to the nth dimension of an input filler
-      void add_ptr(const caffe2::OperatorDef &filler, int dimension, float coef) {
+  // Common code
+  void run()
+  {
 
-	// Find the shape
-	for (const caffe2::Argument &arg : filler.arg()) {
-	  if (arg.name() != "shape") {
-	    continue;
-	  }
+    // Set the default configuration
+    if (_momentum < 0)
+      set_default_momentum();
+    if (_decay < 0)
+      set_default_decay();
 
-	  // Shapes should be small enough to fit into an integer (stored as long in caffe2)
-	  if (dimension < arg.ints().size()) {
-	    return _ptrs.emplace_back(reinterpret_cast<const int *>(&arg.ints()[dimension]), coef);
-	  }
+    // Call child's 'negative_base_lr'
+    int base_lr_sign = negative_base_lr() ? -1 : 1;
 
-	  CAFFE_THROW("Can't access ", filler.output(0), " shape at position ", dimension);
-	}
-	CAFFE_THROW("Can't access ", filler.output(0), " shape");
-      }
-
-    protected:
-
-      inline void register_blob(const std::string &blob, int dimension, float coefficient) {
-	_blobs[blob] = { dimension, coefficient };
-      }
-
-      void fetch_pointers(const caffe2::NetDef &init_net) {
-
-	// Make a copy
-	std::map<std::string, std::pair<int, float>> blobs = _blobs;
-
-	// Check if the fillers output are registered
-	for (const caffe2::OperatorDef &filler : init_net.op()) {
-	  const auto &blob = blobs.find(filler.output(0));
-	  if (blob == blobs.end()) {
-	    continue;
-	  }
-
-	  // Keep a pointer to the shape
-	  add_ptr(filler, blob->second.first, blob->second.second);
-	  blobs.erase(blob);
-	}
-
-	// Assert that every blob was found
-	const auto &blob = blobs.begin();
-	if (blob != blobs.end()) {
-	  CAFFE_THROW("Can't access ", blob->first, " shape");
-	}
-
-	// Assert that the retreived data is coherent
-	int value = *_ptrs[0].first / _ptrs[0].second;
-	for (const std::pair<const int *, int> &ptr : _ptrs) {
-	  if (*ptr.first % ptr.second || *ptr.first / ptr.second != value) {
-	    CAFFE_THROW("Couldn't fetch data from the initalization net");
-	  }
-	}
+    // Find where are defined the 'base_lr's and force their sign
+    size_t base_lr_args = 0;
+    for (caffe2::OperatorDef &op : *_netdef.mutable_op())
+      {
+        if (op.type() == "LearningRate")
+          {
+            for (caffe2::Argument &arg : *op.mutable_arg())
+              {
+                if (arg.name() == "base_lr")
+                  {
+                    arg.set_f(base_lr_sign * std::abs(arg.f()));
+                    ++base_lr_args;
+                  }
+              }
+          }
       }
 
-    public:
+    // There should be exactly one 'LearningRate' operator per net and one
+    // base_lr per operator
+    CAFFE_ENFORCE(base_lr_args == _context.device_count());
 
-      inline void get_blobs(std::set<std::string> &blobs) {
-	blobs.clear();
-	for (const std::pair<std::string, std::pair<int, float>> &it : _blobs) {
-	  blobs.insert(it.first);
-	}
-      }
+    // Collect net's informations
+    std::set<std::string> params;
+    std::set<std::string> computed;
+    std::string main_prefix = _context.get_prefix(0);
+    collect_params(_netdef, params, computed, main_prefix);
+    _shapes.clear();
+    collect_blob_shapes(_initdef, _shapes, main_prefix);
 
-      inline int get_value() const {
-	return *_ptrs[0].first / _ptrs[0].second;
-      }
+    // Call child's "init" function
+    init();
 
-      void set_value(int value) {
-	if (get_value() != value) {
-	  for (const std::pair<const int *, int> ptr : _ptrs) {
-	    *const_cast<int *>(ptr.first) = value * ptr.second;
-	  }
-	}
+    for (const std::string &param : params)
+      {
+
+        // Set the current 'param' members
+        _param = param;
+        _grad = param + gradient_suffix;
+        _moment = param + momentum_suffix;
+        _meansq = param + mean_square_suffix;
+
+        // Call child's "optimize" function
+        optimize();
       }
+  }
+
+  // Transform a child into a callback
+  template <class C> static Optimizer callback()
+  {
+    return [](const ModelContext &context, caffe2::NetDef &netdef,
+              caffe2::NetDef &initdef, float momentum, float decay) {
+      C(context, netdef, initdef, momentum, decay).run();
     };
+  }
+};
 
-    // Group of function used to find which integers are defining the output shape of a net
-    // Also contains maps used to know how an operator output shape is defined
-    // (detailed right after the class)
-    class OutputShapePtrs : public ShapePtrs {
-
-      /*
-       *  Some operators have their shape defined by previous operators.
-       */
-      //                    Operator              Input, Coef
-      static const std::map<std::string, std::map<int,   float> > _forwarded_shapes;
-
-      /*
-       *  Other operators have their shape defined by external inputs.
-       *  Thoses shapes too may be multiples of one another, but it will be explicitly shown inside
-       *  the 'shape' argument of the corresponding filler. Unfortunately we still need to know
-       *  which dimension of thoses 'shape's is shared.
-       */
-      //                    Operator              Input, Dimension index
-      static const std::map<std::string, std::map<int,   int>> _external_shapes;
-
-      // Recursive function that start browsing the net a specific index and coefficient
-      void compute(int op_idx, float coef) {
-	const caffe2::OperatorDef &op = _net.op(op_idx);
-	const std::string &type = op.type();
-
-	if (_forwarded_shapes.find(type) != _forwarded_shapes.end()) {
-	  // Shape defined by previous operators
-
-	  for (const std::pair<int, float> &input_coef : _forwarded_shapes.at(type)) {
-	    // Recurse over them
-	    const std::string &input_name = _net.op(op_idx).input(input_coef.first);
-	    compute(find_previous_update(_net, input_name, op_idx - 1), coef * input_coef.second);
-	  }
-
-	} else if (_external_shapes.find(type) != _external_shapes.end()) {
-	  // Shape defined by external inputs
-
-	  for (const std::pair<int, int> &input_dim : _external_shapes.at(type)) {
-	    int input_idx = input_dim.first;
-	    if (input_idx >= op.input().size()) {
-	      CAFFE_THROW("Can't access ", op.type(), " input at position ", input_idx);
-	    }
-	    // Save the blob informations
-	    register_blob(op.input(input_idx), input_dim.second, coef);
-	  }
-
-	} else {
-	  //XXX Handle more configurations
-	  CAFFE_THROW("Can't access ", op.type(), " input shapes");
-	}
+class sgd : public AbstractOptimizer
+{
+  using AbstractOptimizer::AbstractOptimizer;
+  void set_default_momentum()
+  {
+    _momentum = 0.9f;
+  }
+  bool negative_base_lr()
+  {
+    return _momentum == 0.f;
+  }
+  void init()
+  {
+    if (_momentum == 0.f)
+      {
+        broadcast_external_constantfill(blob_one, std::vector<int>({ 1 }), 1);
       }
-
-    public:
-
-      const caffe2::NetDef &_net;
-      OutputShapePtrs(const caffe2::NetDef &net, const caffe2::NetDef &init_net): _net(net) {
-	// Start computing from the last operator whose shape is (by definition)
-	// the same as the net output shape (so coef=1)
-	compute(_net.op().size() - 1, 1);
-	fetch_pointers(init_net);
+  }
+  void optimize()
+  {
+    if (_momentum == 0.f)
+      {
+        WeightedSum(_net, { _param, blob_one, _grad, blob_lr }, _param);
       }
-    };
-
-    const std::map<std::string, std::map<int, float>> OutputShapePtrs::_forwarded_shapes({
-
-	// One input, same shape
-	{ "AveragePool", {{ 0, 1 }} }, // (An end-of-net pooling should be a global pooling)
-	{ "CopyFromCPUInput", {{ 0, 1 }} },
-	{ "EnsureCPUOutput", {{ 0, 1 }} },
-	{ "Relu", {{ 0, 1 }} },
-	{ "Sigmoid", {{ 0, 1 }} },
-	{ "Softmax", {{ 0, 1 }} },
-
-	// An input that is already a group of bbox
-	{ "BBoxTransform", {
-	    { 1, 1 }
-	  }},
-
-	// 1 probablity per result
-	// 4 points per result
-	{ "BoxWithNMSLimit", {
-	    { 0, 1 },
-	    { 1, 4 }
-	  }}
-
-      });
-
-    const std::map<std::string, std::map<int, int>> OutputShapePtrs::_external_shapes({
-
-	// Weights have 2 dimensions (nb_output and nb_input), we want the first
-	// Bias have 1 dimension (nb_output), we also want the first
-	{ "Conv", {
-	    { 1, 0 },
-	    { 2, 0 }
-	  }},
-	{ "FC", {
-	    { 1, 0 },
-	    { 2, 0 }
-	  }}
-      });
-
-    //XXX Used by debug.cc
-    void _reset_init_net(const caffe2::NetDef &net, caffe2::NetDef &init) {
-      std::map<std::string, caffe2::OperatorDef> fillers;
-      collect_filler_types(net, fillers);
-      apply_filler_types(init, fillers);
-    }
-
-    void set_nclasses(const caffe2::NetDef &net, caffe2::NetDef &init, int nclasses) {
-
-      // Reshape the blobs defining the output shape
-      std::set<std::string> shape;
-      OutputShapePtrs ptrs(net, init);
-      ptrs.set_value(nclasses);
-      ptrs.get_blobs(shape);
-
-      // Collect every fillers
-      std::map<std::string, caffe2::OperatorDef> fillers;
-      collect_filler_types(net, fillers);
-
-      // Filter them
-      for (auto it = fillers.begin(); it != fillers.end();) {
-	if (shape.find(it->first) == shape.end()) {
-	  it = fillers.erase(it);
-	} else {
-	  ++it;
-	}
+    else
+      {
+        default_fillers({ _moment });
+        MomentumSGDUpdate(_net, _param, _moment, _grad, blob_lr, _momentum);
       }
+  }
+};
 
-      // Reset them
-      apply_filler_types(init, fillers);
-    }
+class adagrad : public AbstractOptimizer
+{
+  using AbstractOptimizer::AbstractOptimizer;
+  void set_default_decay()
+  {
+    _decay = 1.f;
+  }
+  bool negative_base_lr()
+  {
+    return true;
+  }
+  void optimize()
+  {
+    default_fillers({ _moment });
+    Adagrad(_net, _param, _moment, _grad, blob_lr, _decay);
+  }
+};
 
-    int get_nclasses(const caffe2::NetDef &net, const caffe2::NetDef &init) {
-      return OutputShapePtrs(net, init).get_value();
-    }
+class adam : public AbstractOptimizer
+{
+  using AbstractOptimizer::AbstractOptimizer;
+  bool negative_base_lr()
+  {
+    return true;
+  }
+  void optimize()
+  {
+    std::string moment1(_moment + "_1");
+    std::string moment2(_moment + "_2");
+    default_fillers({ moment1, moment2 });
+    Adam(_net, _param, moment1, moment2, _grad, blob_lr, blob_iter);
+  }
+};
 
-    /*
-     *  Optimizers
-     */
+class rmsprop : public AbstractOptimizer
+{
+  using AbstractOptimizer::AbstractOptimizer;
+  void set_default_momentum()
+  {
+    _momentum = 0.f;
+  }
+  void set_default_decay()
+  {
+    _decay = 0.9f;
+  }
+  void init()
+  {
+    broadcast_external_constantfill(blob_one, std::vector<int>({ 1 }), 1);
+  }
+  void optimize()
+  {
+    default_fillers({ _moment, _meansq });
+    RmsProp(_net, _grad, _meansq, _moment, blob_one, _momentum, _decay);
+    MomentumSGDUpdate(_net, _param, _moment, _grad, blob_lr, _momentum);
+  }
+};
 
-    // Optimizers all need the same variables, and their workflow are similar.
-    // Common behavior was put in a class to prevent code duplication
-    class AbstractOptimizer {
-
-      // Keep an access to the nets
-      const ModelContext &_context;
-      caffe2::NetDef &_netdef;
-      caffe2::NetDef &_initdef;
-      std::map<std::string, std::vector<int> > _shapes;
-
-    protected:
-
-      // Members the childs may need
-      ScopedNet _net;
-      std::string _param;
-      std::string _grad, _moment, _meansq; // Blob names
-      float _momentum, _decay; // Configuration
-
-      // Create a new ConstantFill :
-      //  - On the main device of the init net
-      //  - Broadcasted on every device
-      //  - Tagged as 'external input' on the main net
-      void broadcast_external_constantfill(const std::string &name,
-					   const std::vector<int> &shape,
-					   float value) {
-	caffe2::OperatorDef fill;
-	ConstantFill(fill, name, shape, value);
-	copy_and_broadcast_operator(_context, _initdef, fill);
-	add_external_input(_net, name);
-      }
-
-      // Same as above, but using current parameter size, and a fill of 0
-      void default_fillers(const std::vector<std::string> &names) {
-	for (const std::string &name : names) {
-	  broadcast_external_constantfill(name, _shapes[_param], 0);
-	}
-      }
-
-      // Functions supposed to be overloaded
-
-      virtual void init() {} // Code executed only once per net
-      virtual void optimize() = 0; // Code executed for each parameter
-      virtual bool negative_base_lr() { return false; }
-      virtual void set_default_momentum() {}
-      virtual void set_default_decay() {}
-
-    public:
-
-      AbstractOptimizer(const ModelContext &context,
-			caffe2::NetDef &netdef,
-			caffe2::NetDef &initdef,
-			float momentum,
-			float decay) :
-	_context(context),
-	_netdef(netdef),
-	_initdef(initdef),
-	_net(context.scope_net(netdef)),
-	_momentum(momentum),
-	_decay(decay) {
-      }
-
-      // Common code
-      void run() {
-
-	// Set the default configuration
-	if (_momentum < 0) set_default_momentum();
-	if (_decay < 0) set_default_decay();
-
-	// Call child's 'negative_base_lr'
-	int base_lr_sign = negative_base_lr() ? -1 : 1;
-
-	// Find where are defined the 'base_lr's and force their sign
-	size_t base_lr_args = 0;
-	for (caffe2::OperatorDef &op : *_netdef.mutable_op()) {
-	  if (op.type() == "LearningRate") {
-	    for (caffe2::Argument &arg : *op.mutable_arg()) {
-	      if (arg.name() == "base_lr") {
-		arg.set_f(base_lr_sign * std::abs(arg.f()));
-		++base_lr_args;
-	      }
-	    }
-	  }
-	}
-
-	// There should be exactly one 'LearningRate' operator per net and one base_lr per operator
-	CAFFE_ENFORCE(base_lr_args == _context.device_count());
-
-	// Collect net's informations
-	std::set<std::string> params;
-	std::set<std::string> computed;
-	std::string main_prefix = _context.get_prefix(0);
-	collect_params(_netdef, params, computed, main_prefix);
-	_shapes.clear();
-	collect_blob_shapes(_initdef, _shapes, main_prefix);
-
-	// Call child's "init" function
-	init();
-
-	for (const std::string &param : params) {
-
-	  // Set the current 'param' members
-	  _param = param;
-	  _grad = param + gradient_suffix;
-	  _moment = param + momentum_suffix;
-	  _meansq = param + mean_square_suffix;
-
-	  // Call child's "optimize" function
-	  optimize();
-	}
-      }
-
-      // Transform a child into a callback
-      template <class C>
-      static Optimizer callback() {
-	return [](const ModelContext &context, caffe2::NetDef &netdef, caffe2::NetDef &initdef,
-		  float momentum, float decay) {
-	  C(context, netdef, initdef, momentum, decay).run();
-	};
-      }
-    };
-
-    class sgd : public AbstractOptimizer {
-      using AbstractOptimizer::AbstractOptimizer;
-      void set_default_momentum() { _momentum = 0.9f; }
-      bool negative_base_lr() { return _momentum == 0.f; }
-      void init() {
-	if (_momentum == 0.f) {
-	  broadcast_external_constantfill(blob_one, std::vector<int>({1}), 1);
-	}
-      }
-      void optimize() {
-	if (_momentum == 0.f) {
-	  WeightedSum(_net, { _param, blob_one, _grad, blob_lr }, _param);
-
-	} else {
-	  default_fillers({_moment});
-	  MomentumSGDUpdate(_net, _param, _moment, _grad, blob_lr, _momentum);
-	}
-      }
-    };
-
-    class adagrad : public AbstractOptimizer {
-      using AbstractOptimizer::AbstractOptimizer;
-      void set_default_decay() { _decay = 1.f; }
-      bool negative_base_lr() { return true; }
-      void optimize() {
-	default_fillers({_moment});
-	Adagrad(_net, _param, _moment, _grad, blob_lr, _decay);
-      }
-    };
-
-    class adam : public AbstractOptimizer {
-      using AbstractOptimizer::AbstractOptimizer;
-      bool negative_base_lr() { return true; }
-      void optimize() {
-	std::string moment1(_moment + "_1");
-	std::string moment2(_moment + "_2");
-	default_fillers({moment1, moment2});
-	Adam(_net, _param, moment1, moment2, _grad, blob_lr, blob_iter);
-      }
-    };
-
-    class rmsprop : public AbstractOptimizer {
-      using AbstractOptimizer::AbstractOptimizer;
-      void set_default_momentum() { _momentum = 0.f; }
-      void set_default_decay() { _decay = 0.9f; }
-      void init() {
-	broadcast_external_constantfill(blob_one, std::vector<int>({1}), 1);
-      }
-      void optimize() {
-	default_fillers({_moment, _meansq});
-	RmsProp(_net, _grad, _meansq, _moment, blob_one, _momentum, _decay);
-	MomentumSGDUpdate(_net, _param, _moment, _grad, blob_lr, _momentum);
-      }
-    };
-
-#define REGISTER_OPTIMIZER(name) { #name, AbstractOptimizer::callback<name>() }
-    const std::map<std::string, Optimizer> optimizers = {
-      REGISTER_OPTIMIZER(sgd),
-      REGISTER_OPTIMIZER(adagrad),
-      REGISTER_OPTIMIZER(adam),
-      REGISTER_OPTIMIZER(rmsprop)
-    };
+#define REGISTER_OPTIMIZER(name)                                              \
+  {                                                                           \
+#name, AbstractOptimizer::callback < name>()                              \
+  }
+const std::map<std::string, Optimizer> optimizers
+    = { REGISTER_OPTIMIZER(sgd), REGISTER_OPTIMIZER(adagrad),
+        REGISTER_OPTIMIZER(adam), REGISTER_OPTIMIZER(rmsprop) };
 #undef REGISTER_OPTIMIZER
 
-    const Optimizer &get_optimizer(const std::string &name) {
-      const auto it = optimizers.find(name);
-      if (it == optimizers.end()) {
-	CAFFE_THROW("Optimizer '", name, "' is not supported.");
-      }
-      return it->second;
+const Optimizer &get_optimizer(const std::string &name)
+{
+  const auto it = optimizers.find(name);
+  if (it == optimizers.end())
+    {
+      CAFFE_THROW("Optimizer '", name, "' is not supported.");
     }
-
-  }
+  return it->second;
+}
+}
 }

--- a/src/backends/caffe2/nettools/gradients.cc
+++ b/src/backends/caffe2/nettools/gradients.cc
@@ -19,7 +19,7 @@
  * along with deepdetect.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-//XXX Remove that to print the warnings
+// XXX Remove that to print the warnings
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsign-compare"
 #pragma GCC diagnostic ignored "-Wunused-parameter"
@@ -34,8 +34,10 @@
 
 #include "backends/caffe2/nettools/internal.h"
 
-namespace dd {
-  namespace Caffe2NetTools {
+namespace dd
+{
+  namespace Caffe2NetTools
+  {
 
     /*
      *  Gradient management
@@ -47,8 +49,8 @@ namespace dd {
      *
      *		- TOTAL
      *			How many time this blob was used as an input.
-     *			In other words, how many gradient will be used to compute
-     *                  the 'backward-pass' version of this blob
+     *			In other words, how many gradient will be used to
+     *compute the 'backward-pass' version of this blob
      *
      *		- CURRENT
      *			Number of gradient that still need
@@ -56,8 +58,8 @@ namespace dd {
      *                  ( 0 <= CURRENT <= TOTAL )
      *
      *		- INPLACE
-     *			How many of the previously mentionned gradient are sums that directly
-     *                  update the blob with 'inplace' operation
+     *			How many of the previously mentionned gradient are sums
+     *that directly update the blob with 'inplace' operation
      *
      *		- DEVICE
      *			GPU id on which the final gradient sum will be computed
@@ -66,269 +68,330 @@ namespace dd {
      *  Below are some classes to make this more explicit in the code
      */
 
-    class BlobInfo {
+    class BlobInfo
+    {
     public:
-
       int _current = 0;
       int _total = 0;
       int _inplace = 0;
       int _device = 0;
 
-      inline void add(int inplace, int device) {
-	++_current;
-	++_total;
-	_inplace += inplace;
-	_device = device;
+      inline void add(int inplace, int device)
+      {
+        ++_current;
+        ++_total;
+        _inplace += inplace;
+        _device = device;
       }
 
-      // When a blob isn't modified 'inplace', it is 'split' in several versions
-      // (each one with a specific prefix and suffix)
-      // When each 'split' is computed they're summed into the main blob.
-      inline void rename_if_splitted(std::string &name, int i) {
-	if (_total - _inplace > 1 && i) {
-	  name = "_" + name + "_autosplit_" + std::to_string(i - 1);
-	}
+      // When a blob isn't modified 'inplace', it is 'split' in several
+      // versions (each one with a specific prefix and suffix) When each
+      // 'split' is computed they're summed into the main blob.
+      inline void rename_if_splitted(std::string &name, int i)
+      {
+        if (_total - _inplace > 1 && i)
+          {
+            name = "_" + name + "_autosplit_" + std::to_string(i - 1);
+          }
       }
     };
 
-    class BlobsInfo: public std::map<std::string, BlobInfo> {
+    class BlobsInfo : public std::map<std::string, BlobInfo>
+    {
     public:
-
-      inline bool is_tagged(const std::string &name) {
-	return count(name);
+      inline bool is_tagged(const std::string &name)
+      {
+        return count(name);
       }
 
       // Fetch the next available 'split' of the given blob
-      inline void rename_if_multiple_use(std::string &name) {
+      inline void rename_if_multiple_use(std::string &name)
+      {
 
-	if (!is_tagged(name)) return; // Can't cause conflicts
+        if (!is_tagged(name))
+          return; // Can't cause conflicts
 
-	BlobInfo &info = at(name);
-	if (info._current < 1) return; // Won't be reused
+        BlobInfo &info = at(name);
+        if (info._current < 1)
+          return; // Won't be reused
 
-	int split_nb = info._total - info._current;
-	info._current--; // Use once
-	info.rename_if_splitted(name, split_nb);
+        int split_nb = info._total - info._current;
+        info._current--; // Use once
+        info.rename_if_splitted(name, split_nb);
       }
     };
 
-    // Because we want our gradients to be generated in the same way as caffe2's,
-    // sometimes our gradient sums don't create a new output but are done 'inplace'.
-    // To do this either inputs or output are renamed.
-    // This is a map containing the renamed blobs.
-    class RenamedBlobs: public std::map<std::string, std::string> {
+    // Because we want our gradients to be generated in the same way as
+    // caffe2's, sometimes our gradient sums don't create a new output but are
+    // done 'inplace'. To do this either inputs or output are renamed. This is
+    // a map containing the renamed blobs.
+    class RenamedBlobs : public std::map<std::string, std::string>
+    {
     public:
-
-      inline void rename_if_tagged(std::string &name) {
-	auto it = find(name);
-	if (it != end()) {
-	  name = it->second;
-	  erase(it);
-	}
+      inline void rename_if_tagged(std::string &name)
+      {
+        auto it = find(name);
+        if (it != end())
+          {
+            name = it->second;
+            erase(it);
+          }
       }
     };
 
     // Used once by add_gradient_ops
     // Moved in a function to make it more readable
-    static void collect_gradient_ops(caffe2::NetDef &net,
-				     std::vector<caffe2::OperatorDef> &gradient_ops,
-				     BlobsInfo &blobs_info) {
+    static void
+    collect_gradient_ops(caffe2::NetDef &net,
+                         std::vector<caffe2::OperatorDef> &gradient_ops,
+                         BlobsInfo &blobs_info)
+    {
 
       std::set<std::string> external_inputs(net.external_input().begin(),
-					    net.external_input().end());
+                                            net.external_input().end());
       std::map<std::string, int> input_count;
-      for (caffe2::OperatorDef &op : *net.mutable_op()) {
+      for (caffe2::OperatorDef &op : *net.mutable_op())
+        {
 
-	std::vector<std::string> new_outputs;
-	const TrainableOp *train_op;
-	if (!is_trainable(op, train_op)) {
-	  // If we don't know whether an operator should or shouldn't be part of the gradient,
-	  // we won't to the gradient at all and throw an error instead.
-	  CAFFE_ENFORCE(non_trainable_ops.find(op.type()) != non_trainable_ops.end(),
-			"Unknown operator: ", op.type());
-	  continue;
-	}
-	train_op->get_needed_outputs(op, new_outputs);
+          std::vector<std::string> new_outputs;
+          const TrainableOp *train_op;
+          if (!is_trainable(op, train_op))
+            {
+              // If we don't know whether an operator should or shouldn't be
+              // part of the gradient, we won't to the gradient at all and
+              // throw an error instead.
+              CAFFE_ENFORCE(non_trainable_ops.find(op.type())
+                                != non_trainable_ops.end(),
+                            "Unknown operator: ", op.type());
+              continue;
+            }
+          train_op->get_needed_outputs(op, new_outputs);
 
-	// Register the blobs and operators
-	for (const std::string &output : new_outputs) {
-	  op.add_output(output);
-	}
-	gradient_ops.push_back(op);
+          // Register the blobs and operators
+          for (const std::string &output : new_outputs)
+            {
+              op.add_output(output);
+            }
+          gradient_ops.push_back(op);
 
-	int device = -1;
+          int device = -1;
 #ifndef CPU_ONLY
-	if (op.device_option().device_type() == caffe2::DeviceTypeProto::PROTO_CUDA) {
-	  device = op.device_option().cuda_gpu_id();
-	}
+          if (op.device_option().device_type()
+              == caffe2::DeviceTypeProto::PROTO_CUDA)
+            {
+              device = op.device_option().cuda_gpu_id();
+            }
 #endif
-	for (const std::string &input : op.input()) {
-	  if (has_output(op, input)) {
-	    // If a blob is tagged as both an input and an output,
-	    // Then an inplace gradient will already be created (no need to it manually)
-	    continue;
-	  }
-	  // If the blob is used by several operators, then its gradient will have multiple source.
-	  // If those operators are Sums, then the gradient can be computed
-	  // using inplace operations.
-	  // If not we will need the manage a 'split' input and manually add a Sum.
-	  blobs_info[input + gradient_suffix].add(op.type() == "Sum", device);
-	}
-      }
-      // As we take an interest in the backward pass, we want the 'StopGradient' operator
-      // to be put after the gradient-related blobs (and not before them).
+          for (const std::string &input : op.input())
+            {
+              if (has_output(op, input))
+                {
+                  // If a blob is tagged as both an input and an output,
+                  // Then an inplace gradient will already be created (no need
+                  // to it manually)
+                  continue;
+                }
+              // If the blob is used by several operators, then its gradient
+              // will have multiple source. If those operators are Sums, then
+              // the gradient can be computed using inplace operations. If not
+              // we will need the manage a 'split' input and manually add a
+              // Sum.
+              blobs_info[input + gradient_suffix].add(op.type() == "Sum",
+                                                      device);
+            }
+        }
+      // As we take an interest in the backward pass, we want the
+      // 'StopGradient' operator to be put after the gradient-related blobs
+      // (and not before them).
       std::reverse(gradient_ops.begin(), gradient_ops.end());
     }
 
     // Used once by add_gradient_ops
     // Moved in a function to make it more readable
-    static bool stop_op(const caffe2::OperatorDef &op, std::set<std::string> &stop_inputs) {
+    static bool stop_op(const caffe2::OperatorDef &op,
+                        std::set<std::string> &stop_inputs)
+    {
       bool stop = op.type() == "StopGradient";
-      for (const std::string &output : op.output()) {
-	stop |= stop_inputs.find(output) != stop_inputs.end();
-      }
-      if (stop) {
-	for (const std::string &input : op.input()) {
-	  stop_inputs.insert(input);
-	}
-      }
+      for (const std::string &output : op.output())
+        {
+          stop |= stop_inputs.find(output) != stop_inputs.end();
+        }
+      if (stop)
+        {
+          for (const std::string &input : op.input())
+            {
+              stop_inputs.insert(input);
+            }
+        }
       return stop;
     }
 
     // Used once by add_gradient_ops
     // Moved in a function to make it more readable
-    static void add_gradient_for_op(caffe2::NetDef &net, const caffe2::OperatorDef &op,
-				    RenamedBlobs &renamed_blobs,
-				    BlobsInfo &blobs_info) {
+    static void add_gradient_for_op(caffe2::NetDef &net,
+                                    const caffe2::OperatorDef &op,
+                                    RenamedBlobs &renamed_blobs,
+                                    BlobsInfo &blobs_info)
+    {
       // Feed the gradient with the operator outputs
       std::vector<caffe2::GradientWrapper> output(op.output_size());
-      for (size_t i = 0; i < output.size(); ++i) {
-	std::string grad = op.output(i) + gradient_suffix;
-	if (blobs_info.is_tagged(grad)) { // This output must generate a gradient
-	  output[i].dense_ = grad;
-	}
-	//XXX Manage sparse gradients (GradientWrapper.indices_ & GradientWrapper.values_)
-	// See caffe2/python/core.py -- GradientRegistry._GetGradientForOpCC -- from_untyped
-      }
+      for (size_t i = 0; i < output.size(); ++i)
+        {
+          std::string grad = op.output(i) + gradient_suffix;
+          if (blobs_info.is_tagged(grad))
+            { // This output must generate a gradient
+              output[i].dense_ = grad;
+            }
+          // XXX Manage sparse gradients (GradientWrapper.indices_ &
+          // GradientWrapper.values_)
+          // See caffe2/python/core.py -- GradientRegistry._GetGradientForOpCC
+          // -- from_untyped
+        }
 
       // Assert that gradients exist for this operator
       caffe2::GradientOpsMeta meta = GetGradientForOp(op, output);
       CAFFE_ENFORCE(meta.ops_.size());
-      for (size_t i = 0; i < meta.ops_.size(); ++i) {
-	caffe2::OperatorDef &grad = *net.add_op();
-	grad.CopyFrom(meta.ops_[i]);
-	grad.clear_name();
-	grad.set_is_gradient_op(true);
-	for (std::string &output : *grad.mutable_output()) {
-	  blobs_info.rename_if_multiple_use(output);
-	}
-	for (std::string &input : *grad.mutable_input()) {
-	  renamed_blobs.rename_if_tagged(input);
-	}
-      }
+      for (size_t i = 0; i < meta.ops_.size(); ++i)
+        {
+          caffe2::OperatorDef &grad = *net.add_op();
+          grad.CopyFrom(meta.ops_[i]);
+          grad.clear_name();
+          grad.set_is_gradient_op(true);
+          for (std::string &output : *grad.mutable_output())
+            {
+              blobs_info.rename_if_multiple_use(output);
+            }
+          for (std::string &input : *grad.mutable_input())
+            {
+              renamed_blobs.rename_if_tagged(input);
+            }
+        }
     }
 
     // Used once by add_gradient_ops
     // Moved in a function to make it more readable
-    static void sum_gradients(caffe2::NetDef &net,
-			      RenamedBlobs &renamed_blobs,
-			      BlobsInfo &blobs_info) {
-      for (auto &it : blobs_info) {
-	const std::string &name = it.first;
-	BlobInfo &info = it.second;
-	if (info._current || info._total < 2) {
-	  // current > 0:
-	  //    Some operators still need to be computed before we do the final sum.
-	  // current < 0:
-	  //    The sum was already done.
-	  // total < 2:
-	  //    Nothing to sum
-	  continue;
-	}
-	// Merge the 'split' versions of this blob
-	std::vector<std::string> inputs;
-	for (int i = 0; i < info._total; i++) {
-	  std::string input = name;
-	  info.rename_if_splitted(input, i);
-	  renamed_blobs.rename_if_tagged(input);
-	  if (input == name) {
-	    inputs.insert(inputs.begin(), input); // Inplace
-	  } else {
-	    inputs.push_back(input);
-	  }
-	}
-	caffe2::OperatorDef &op = Sum(net, inputs, name);
+    static void sum_gradients(caffe2::NetDef &net, RenamedBlobs &renamed_blobs,
+                              BlobsInfo &blobs_info)
+    {
+      for (auto &it : blobs_info)
+        {
+          const std::string &name = it.first;
+          BlobInfo &info = it.second;
+          if (info._current || info._total < 2)
+            {
+              // current > 0:
+              //    Some operators still need to be computed before we do the
+              //    final sum.
+              // current < 0:
+              //    The sum was already done.
+              // total < 2:
+              //    Nothing to sum
+              continue;
+            }
+          // Merge the 'split' versions of this blob
+          std::vector<std::string> inputs;
+          for (int i = 0; i < info._total; i++)
+            {
+              std::string input = name;
+              info.rename_if_splitted(input, i);
+              renamed_blobs.rename_if_tagged(input);
+              if (input == name)
+                {
+                  inputs.insert(inputs.begin(), input); // Inplace
+                }
+              else
+                {
+                  inputs.push_back(input);
+                }
+            }
+          caffe2::OperatorDef &op = Sum(net, inputs, name);
 #ifndef CPU_ONLY
-	if (info._device >= 0) {
-	  op.mutable_device_option()->set_device_type(caffe2::DeviceTypeProto::PROTO_CUDA);
-	  op.mutable_device_option()->set_cuda_gpu_id(info._device);
-	} else
+          if (info._device >= 0)
+            {
+              op.mutable_device_option()->set_device_type(
+                  caffe2::DeviceTypeProto::PROTO_CUDA);
+              op.mutable_device_option()->set_cuda_gpu_id(info._device);
+            }
+          else
 #endif
-	  op.mutable_device_option()->set_device_type(caffe2::DeviceTypeProto::PROTO_CPU);
-	// Setting counter to a negative value so it won't trigger anymore
-	info._current--;
-      }
+            op.mutable_device_option()->set_device_type(
+                caffe2::DeviceTypeProto::PROTO_CPU);
+          // Setting counter to a negative value so it won't trigger anymore
+          info._current--;
+        }
     }
 
-    inline void _set_to_version(std::string &string, int version) {
-      if (version > 0) {
-	string += "_version_" + std::to_string(version);
-      }
+    inline void _set_to_version(std::string &string, int version)
+    {
+      if (version > 0)
+        {
+          string += "_version_" + std::to_string(version);
+        }
     }
 
     // Used once by add_gradient_ops
     // Moved in a function to make it more readable
-    static void remove_untrainable_blob_overwrites(caffe2::NetDef &net) {
+    static void remove_untrainable_blob_overwrites(caffe2::NetDef &net)
+    {
 
       // Initialize blobs' version to 0
       std::map<std::string, int> versions;
-      for (const std::string &input : net.external_input()) {
-	versions[input] = 0;
-      }
+      for (const std::string &input : net.external_input())
+        {
+          versions[input] = 0;
+        }
 
-      for (caffe2::OperatorDef &op : *net.mutable_op()) {
+      for (caffe2::OperatorDef &op : *net.mutable_op())
+        {
 
-	// Fetch legitimate overwrites
-	std::set<int> trainable_overwrites;
-	const TrainableOp *train_op;
-	if (is_trainable(op, train_op)) {
-	  train_op->get_trainable_overwrites(op, trainable_overwrites);
-	}
+          // Fetch legitimate overwrites
+          std::set<int> trainable_overwrites;
+          const TrainableOp *train_op;
+          if (is_trainable(op, train_op))
+            {
+              train_op->get_trainable_overwrites(op, trainable_overwrites);
+            }
 
-	// Rename inputs
-	for (std::string &input : *op.mutable_input()) {
-	  _set_to_version(input, versions[input]);
-	}
+          // Rename inputs
+          for (std::string &input : *op.mutable_input())
+            {
+              _set_to_version(input, versions[input]);
+            }
 
-	// Rename outputs
-	for (int idx = 0; idx < op.output().size(); ++idx) {
-	  std::string &output = *op.mutable_output(idx);
+          // Rename outputs
+          for (int idx = 0; idx < op.output().size(); ++idx)
+            {
+              std::string &output = *op.mutable_output(idx);
 
-	  // Initialize to 0
-	  if (versions.find(output) == versions.end()) {
-	    versions[output] = 0;
-	    continue;
-	  }
+              // Initialize to 0
+              if (versions.find(output) == versions.end())
+                {
+                  versions[output] = 0;
+                  continue;
+                }
 
-	  // Create a new version
-	  if (trainable_overwrites.find(idx) == trainable_overwrites.end()) {
-	    ++versions[output];
-	  }
-	  _set_to_version(output, versions[output]);
-	}
-      }
+              // Create a new version
+              if (trainable_overwrites.find(idx) == trainable_overwrites.end())
+                {
+                  ++versions[output];
+                }
+              _set_to_version(output, versions[output]);
+            }
+        }
     }
 
-    void add_gradient_ops(caffe2::NetDef &net, const std::set<std::string> &main_gradients) {
+    void add_gradient_ops(caffe2::NetDef &net,
+                          const std::set<std::string> &main_gradients)
+    {
 
-      // Except for a few 'inplace' operations, reusing a blob several times means
-      // loosing some versions of the tensor and being unable to compute the gradients.
-      // For this reason, we replace them with new blobs
+      // Except for a few 'inplace' operations, reusing a blob several times
+      // means loosing some versions of the tensor and being unable to compute
+      // the gradients. For this reason, we replace them with new blobs
       remove_untrainable_blob_overwrites(net);
 
-      // Because we want our gradients to be generated in the same way as caffe2's,
-      // sometimes our gradient sums don't create a new output but are done 'inplace'.
-      // To do this either inputs or output are renamed.
+      // Because we want our gradients to be generated in the same way as
+      // caffe2's, sometimes our gradient sums don't create a new output but
+      // are done 'inplace'. To do this either inputs or output are renamed.
       // This is a map containing the renamed blobs.
       RenamedBlobs renamed_blobs;
 
@@ -341,29 +404,36 @@ namespace dd {
 
       // See the BlobInfo definition for more details
       BlobsInfo blobs_info;
-      for (const std::string &grad : main_gradients) {
-	blobs_info[grad]._total = 1;
-      }
+      for (const std::string &grad : main_gradients)
+        {
+          blobs_info[grad]._total = 1;
+        }
 
       collect_gradient_ops(net, gradient_ops, blobs_info);
-      for (const caffe2::OperatorDef &op : gradient_ops) {
-	// Operator placed after StopGradient must not be computed
-	if (stop_op(op, stop_inputs)) {
-	  continue;
-	}
+      for (const caffe2::OperatorDef &op : gradient_ops)
+        {
+          // Operator placed after StopGradient must not be computed
+          if (stop_op(op, stop_inputs))
+            {
+              continue;
+            }
 
-	if (op.type() == "Sum") {
-	  // Make the first output as 'inplace' during the backward pass
-	  for (const std::string &input : op.input()) {
-	    std::string in = input + gradient_suffix;
-	    blobs_info.rename_if_multiple_use(in);
-	    renamed_blobs[in] = op.output(0) + gradient_suffix;
-	  }
-	} else {
-	  add_gradient_for_op(net, op, renamed_blobs, blobs_info);
-	}
-	sum_gradients(net, renamed_blobs, blobs_info);
-      }
+          if (op.type() == "Sum")
+            {
+              // Make the first output as 'inplace' during the backward pass
+              for (const std::string &input : op.input())
+                {
+                  std::string in = input + gradient_suffix;
+                  blobs_info.rename_if_multiple_use(in);
+                  renamed_blobs[in] = op.output(0) + gradient_suffix;
+                }
+            }
+          else
+            {
+              add_gradient_for_op(net, op, renamed_blobs, blobs_info);
+            }
+          sum_gradients(net, renamed_blobs, blobs_info);
+        }
     }
 
     /*
@@ -371,52 +441,62 @@ namespace dd {
      */
 
     void collect_params(const caffe2::NetDef &net,
-			std::set<std::string> &params,
-			std::set<std::string> &computed_params,
-			const std::string &prefix,
-			bool remove_prefix) {
+                        std::set<std::string> &params,
+                        std::set<std::string> &computed_params,
+                        const std::string &prefix, bool remove_prefix)
+    {
       std::set<std::string> external_inputs(net.external_input().begin(),
-					    net.external_input().end());
-      for (const caffe2::OperatorDef &op : net.op()) {
+                                            net.external_input().end());
+      for (const caffe2::OperatorDef &op : net.op())
+        {
 
-	// Anything found before 'StopGradient' cannot be a parameter
-	if (op.type() == "StopGradient") {
-	  params.clear();
-	  computed_params.clear();
-	  continue;
-	}
+          // Anything found before 'StopGradient' cannot be a parameter
+          if (op.type() == "StopGradient")
+            {
+              params.clear();
+              computed_params.clear();
+              continue;
+            }
 
-	std::set<std::string> trainable;
-	std::set<std::string> computed;
-	const TrainableOp *train_op;
-	if (!is_trainable(op, train_op)) {
-	  continue;
-	}
-	train_op->get_trainable_inputs(op, trainable);
-	train_op->get_computed_inputs(op, computed);
+          std::set<std::string> trainable;
+          std::set<std::string> computed;
+          const TrainableOp *train_op;
+          if (!is_trainable(op, train_op))
+            {
+              continue;
+            }
+          train_op->get_trainable_inputs(op, trainable);
+          train_op->get_computed_inputs(op, computed);
 
-	auto check_params = [&](std::set<std::string> &s_in, std::set<std::string> &s_out) {
-	  for (const std::string &input : s_in) {
-	    if (!input.find(prefix) && external_inputs.find(input) != external_inputs.end()) {
-	      s_out.insert(input.substr(remove_prefix * prefix.size(), -1));
-	    }
-	  }
-	};
-	check_params(trainable, params);
-	check_params(computed, computed_params);
-      }
+          auto check_params = [&](std::set<std::string> &s_in,
+                                  std::set<std::string> &s_out) {
+            for (const std::string &input : s_in)
+              {
+                if (!input.find(prefix)
+                    && external_inputs.find(input) != external_inputs.end())
+                  {
+                    s_out.insert(
+                        input.substr(remove_prefix * prefix.size(), -1));
+                  }
+              }
+          };
+          check_params(trainable, params);
+          check_params(computed, computed_params);
+        }
     }
 
 #ifndef CPU_ONLY
 
     // Check if gpus 'a' and 'b' have a quick access to each others
-    static bool cuda_access_pattern(int a, int b) {
+    static bool cuda_access_pattern(int a, int b)
+    {
       static bool init = false;
-      static std::vector<std::vector<bool> > access_pattern;
-      if (!init) {
-	CAFFE_ENFORCE(caffe2::GetCudaPeerAccessPattern(&access_pattern));
-	init = true;
-      }
+      static std::vector<std::vector<bool>> access_pattern;
+      if (!init)
+        {
+          CAFFE_ENFORCE(caffe2::GetCudaPeerAccessPattern(&access_pattern));
+          init = true;
+        }
       return access_pattern[a][b];
     }
 
@@ -425,56 +505,69 @@ namespace dd {
      *  See pytorch/caffe2/python/data_parallel_model.py (_AllReduce function)
      */
     static void gradient_sum_order(const std::vector<int> &device_ids,
-				   std::vector<std::vector<int> > &order) {
+                                   std::vector<std::vector<int>> &order)
+    {
       int nb_devices = device_ids.size();
-      if (nb_devices < 2 || nb_devices & (nb_devices - 1)) {
-	order.push_back(device_ids);
-	return;
-      }
+      if (nb_devices < 2 || nb_devices & (nb_devices - 1))
+        {
+          order.push_back(device_ids);
+          return;
+        }
 
-      for (int p = 1; p < nb_devices; p *= 2) {
-	for (int i = 0; i < nb_devices; i += p * 2) {
-	  order.push_back({device_ids[i], device_ids[i + p]});
-	}
-      }
+      for (int p = 1; p < nb_devices; p *= 2)
+        {
+          for (int i = 0; i < nb_devices; i += p * 2)
+            {
+              order.push_back({ device_ids[i], device_ids[i + p] });
+            }
+        }
     }
 
-    void broadcast(ScopedNet &net, const std::string &blob) {
+    void broadcast(ScopedNet &net, const std::string &blob)
+    {
 
       std::vector<int> device_ids;
-      for (const caffe2::DeviceOption &option : net._devices) {
-	CAFFE_ENFORCE(option.device_type() == caffe2::DeviceTypeProto::PROTO_CUDA);
-	device_ids.push_back(option.cuda_gpu_id());
-      }
+      for (const caffe2::DeviceOption &option : net._devices)
+        {
+          CAFFE_ENFORCE(option.device_type()
+                        == caffe2::DeviceTypeProto::PROTO_CUDA);
+          device_ids.push_back(option.cuda_gpu_id());
+        }
 
       ScopeKeeper sk(net);
       net._rename_inputs = net._rename_outputs = false;
-      if (blob == blob_iter) {
-	caffe2::DeviceOption option;
-	option.set_device_type(caffe2::DeviceTypeProto::PROTO_CPU);
-	net._devices = {option};
-      }
+      if (blob == blob_iter)
+        {
+          caffe2::DeviceOption option;
+          option.set_device_type(caffe2::DeviceTypeProto::PROTO_CPU);
+          net._devices = { option };
+        }
 
       std::string main_blob = device_id_to_prefix(device_ids[0]) + blob;
-      for (int device_id: device_ids) {
-	if (device_id != device_ids[0]) {
-	  net._force_device = device_id;
-	  Copy(net, main_blob, device_id_to_prefix(device_id) + blob);
-	}
-      }
+      for (int device_id : device_ids)
+        {
+          if (device_id != device_ids[0])
+            {
+              net._force_device = device_id;
+              Copy(net, main_blob, device_id_to_prefix(device_id) + blob);
+            }
+        }
     }
 
-    void reduce(ScopedNet &net) {
+    void reduce(ScopedNet &net)
+    {
 
       std::vector<int> device_ids;
       std::set<std::string> params;
       std::set<std::string> computed_params;
-      std::vector<std::vector<int> > sum_order;
+      std::vector<std::vector<int>> sum_order;
 
-      for (const caffe2::DeviceOption &option : net._devices) {
-	CAFFE_ENFORCE(option.device_type() == caffe2::DeviceTypeProto::PROTO_CUDA);
-	device_ids.push_back(option.cuda_gpu_id());
-      }
+      for (const caffe2::DeviceOption &option : net._devices)
+        {
+          CAFFE_ENFORCE(option.device_type()
+                        == caffe2::DeviceTypeProto::PROTO_CUDA);
+          device_ids.push_back(option.cuda_gpu_id());
+        }
 
       // Create a backup
       // Both rename-related and device-related tags will be changed
@@ -482,38 +575,49 @@ namespace dd {
       net._rename_inputs = net._rename_outputs = false;
 
       gradient_sum_order(device_ids, sum_order);
-      collect_params(net._net, params, computed_params, device_id_to_prefix(device_ids[0]), true);
+      collect_params(net._net, params, computed_params,
+                     device_id_to_prefix(device_ids[0]), true);
 
-      for (const std::string &param : params) {
-	std::string gradient = param + gradient_suffix;
-	for (const std::vector<int> &ordered_ids : sum_order) {
+      for (const std::string &param : params)
+        {
+          std::string gradient = param + gradient_suffix;
+          for (const std::vector<int> &ordered_ids : sum_order)
+            {
 
-	  // The sum will be computed on the first gpu of the list
-	  int host_id = ordered_ids[0];
-	  net._force_device = host_id;
-	  std::vector<std::string> blobs;
+              // The sum will be computed on the first gpu of the list
+              int host_id = ordered_ids[0];
+              net._force_device = host_id;
+              std::vector<std::string> blobs;
 
-	  for (int other_id : ordered_ids) {
+              for (int other_id : ordered_ids)
+                {
 
-	    // Copy each versions of the gradient on the first gpu
-	    // (except if cuda_access_pattern assert a quick communication over the gpus)
-	    std::string blob = device_id_to_prefix(other_id) + gradient;
-	    if (host_id == other_id || cuda_access_pattern(host_id, other_id)) {
-	      blobs.push_back(blob);
-	    } else {
-	      std::string copy = device_id_to_prefix(host_id) + gradient +
-		"_copy_" + std::to_string(other_id);
-	      Copy(net, blob, copy);
-	      blobs.push_back(copy);
-	    }
-	  }
-	  Sum(net, blobs, blobs[0]);
-	}
-	broadcast(net, gradient);
-      }
-      for (const std::string &param : computed_params) {
-	broadcast(net, param);
-      }
+                  // Copy each versions of the gradient on the first gpu
+                  // (except if cuda_access_pattern assert a quick
+                  // communication over the gpus)
+                  std::string blob = device_id_to_prefix(other_id) + gradient;
+                  if (host_id == other_id
+                      || cuda_access_pattern(host_id, other_id))
+                    {
+                      blobs.push_back(blob);
+                    }
+                  else
+                    {
+                      std::string copy = device_id_to_prefix(host_id)
+                                         + gradient + "_copy_"
+                                         + std::to_string(other_id);
+                      Copy(net, blob, copy);
+                      blobs.push_back(copy);
+                    }
+                }
+              Sum(net, blobs, blobs[0]);
+            }
+          broadcast(net, gradient);
+        }
+      for (const std::string &param : computed_params)
+        {
+          broadcast(net, param);
+        }
     }
 #endif
 

--- a/src/backends/caffe2/nettools/internal.cc
+++ b/src/backends/caffe2/nettools/internal.cc
@@ -21,135 +21,174 @@
 
 #include "backends/caffe2/nettools/internal.h"
 
-namespace dd {
-  namespace Caffe2NetTools {
+namespace dd
+{
+  namespace Caffe2NetTools
+  {
 
     // Note if another operator needs to be registered here :
-    // A quick way to check if it has or not a gradient is to check if its type is in
-    // caffe2::GradientRegistry()->Keys()
+    // A quick way to check if it has or not a gradient is to check if its type
+    // is in caffe2::GradientRegistry()->Keys()
 
     const std::map<std::string, bool> non_trainable_ops({
 
-	{"ConstantFill", true},
-	{"GivenTensorFill", true},
-	{"XavierFill", true},
-	{"GaussianFill", true},
-	{"MSRAFill", true},
-	{"RangeFill", true},
-	{"LengthsRangeFill", true},
-	{"DiagonalFill", true},
-	{"UniformFill", true},
-	{"UniformIntFill", true},
-	{"UniqueUniformFill", true},
+        { "ConstantFill", true },
+        { "GivenTensorFill", true },
+        { "XavierFill", true },
+        { "GaussianFill", true },
+        { "MSRAFill", true },
+        { "RangeFill", true },
+        { "LengthsRangeFill", true },
+        { "DiagonalFill", true },
+        { "UniformFill", true },
+        { "UniformIntFill", true },
+        { "UniqueUniformFill", true },
 
-	{"Accuracy", false},
-	{"Cast", false},
-	{"Cout", false},
-	{"Iter", false},
-	{"TensorProtosDBInput", false},
-	{"ImageInput", false},
-	{"TimePlot", false},
-	{"ShowWorst", false},
-	{"NHWC2NCHW", false}
+        { "Accuracy", false },
+        { "Cast", false },
+        { "Cout", false },
+        { "Iter", false },
+        { "TensorProtosDBInput", false },
+        { "ImageInput", false },
+        { "TimePlot", false },
+        { "ShowWorst", false },
+        { "NHWC2NCHW", false }
 
-      });
+    });
 
     void TrainableOp::get_trainable_inputs(const caffe2::OperatorDef &op,
-					   std::set<std::string> &inputs) const {
+                                           std::set<std::string> &inputs) const
+    {
       auto index = _computed_inputs.begin();
       auto end = _computed_inputs.end();
       int i = 0;
-      for (const std::string &input : op.input()) {
-	if (index != end && *index == i++) {
-	  ++index;
-	} else {
-	  inputs.insert(input);
-	}
-      }
+      for (const std::string &input : op.input())
+        {
+          if (index != end && *index == i++)
+            {
+              ++index;
+            }
+          else
+            {
+              inputs.insert(input);
+            }
+        }
     }
 
     void TrainableOp::get_computed_inputs(const caffe2::OperatorDef &op,
-					  std::set<std::string> &inputs) const {
+                                          std::set<std::string> &inputs) const
+    {
       auto index = _computed_inputs.begin();
       auto end = _computed_inputs.end();
       int i = 0;
-      for (const std::string &input : op.input()) {
-	if (index != end && *index == i++) {
-	  ++index;
-	  inputs.insert(input);
-	}
-      }
+      for (const std::string &input : op.input())
+        {
+          if (index != end && *index == i++)
+            {
+              ++index;
+              inputs.insert(input);
+            }
+        }
     }
 
-    void TrainableOp::get_needed_outputs(const caffe2::OperatorDef &op,
-					 std::vector<std::string> &outputs) const {
+    void
+    TrainableOp::get_needed_outputs(const caffe2::OperatorDef &op,
+                                    std::vector<std::string> &outputs) const
+    {
       // Skip the already existing outputs
       const auto &op_inputs = op.input();
       const auto &op_outputs = op.output();
       int nb_outputs = op_outputs.size();
-      for (const auto &output : _outputs) {
-	if (nb_outputs-- > 0) {
-	  continue;
-	}
+      for (const auto &output : _outputs)
+        {
+          if (nb_outputs-- > 0)
+            {
+              continue;
+            }
 
-	// Should not be a prediction output
-	CAFFE_ENFORCE(output._training_only);
+          // Should not be a prediction output
+          CAFFE_ENFORCE(output._training_only);
 
-	// Get the base name
-	std::string base_name;
-	if (output._based_on_input) {
-	  base_name = op_inputs[output._based_on_index];
-	} else {
-	  base_name = op_outputs[output._based_on_index];
-	}
+          // Get the base name
+          std::string base_name;
+          if (output._based_on_input)
+            {
+              base_name = op_inputs[output._based_on_index];
+            }
+          else
+            {
+              base_name = op_outputs[output._based_on_index];
+            }
 
-	// Store the new blob
-	outputs.push_back(base_name + output._suffix);
-      }
+          // Store the new blob
+          outputs.push_back(base_name + output._suffix);
+        }
     }
 
     void TrainableOp::get_trainable_overwrites(const caffe2::OperatorDef &op,
-					       std::set<int> &outputs) const {
-      int out_size = std::min(static_cast<int>(_outputs.size()), op.output().size());
+                                               std::set<int> &outputs) const
+    {
+      int out_size
+          = std::min(static_cast<int>(_outputs.size()), op.output().size());
       int in_size = op.input().size();
-      for (int out_idx = 0; out_idx < out_size; ++out_idx) {
-	int can_overwrite = _outputs[out_idx]._can_overwrite;
-	if (can_overwrite >= 0 && can_overwrite < in_size &&
-	    op.output(out_idx) == op.input(can_overwrite)) {
-	  outputs.insert(out_idx);
-	}
-      }
+      for (int out_idx = 0; out_idx < out_size; ++out_idx)
+        {
+          int can_overwrite = _outputs[out_idx]._can_overwrite;
+          if (can_overwrite >= 0 && can_overwrite < in_size
+              && op.output(out_idx) == op.input(can_overwrite))
+            {
+              outputs.insert(out_idx);
+            }
+        }
     }
 
     // Inplace
-    class TrainableInplaceOp : public TrainableOp { public:
-      TrainableInplaceOp(): TrainableOp({
-	}, {
-	  Output(false, false, 0, "", 0) // No partcular restriction, but can be inplace
-	}) {}
+    class TrainableInplaceOp : public TrainableOp
+    {
+    public:
+      TrainableInplaceOp()
+          : TrainableOp(
+              {}, {
+                      Output(false, false, 0, "",
+                             0) // No partcular restriction, but can be inplace
+                  })
+      {
+      }
     };
 
     // Instance normalization
-    class TrainableInstanceNormOp : public TrainableOp { public:
-      TrainableInstanceNormOp(): TrainableOp({
-	}, {
-	  Output(false, false, 0, "", -1), // output (default)
-	  Output(true, false, 0, "_sm", -1), // saved_min
-	  Output(true, false, 0, "_siv", -1) // saved_inv_stdev
-	}) {}
+    class TrainableInstanceNormOp : public TrainableOp
+    {
+    public:
+      TrainableInstanceNormOp()
+          : TrainableOp(
+              {}, {
+                      Output(false, false, 0, "", -1),   // output (default)
+                      Output(true, false, 0, "_sm", -1), // saved_min
+                      Output(true, false, 0, "_siv", -1) // saved_inv_stdev
+                  })
+      {
+      }
     };
 
     // Batch normalization
-    class TrainableSpatialBNOp : public TrainableOp { public:
-      TrainableSpatialBNOp(): TrainableOp({
-	  3, 4 // Mean & Var
-	}, {
-	  Output(false, false, 0, "", -1), // output (default)
-	  Output(true, true, 3, "", 3), // mean (inplace)
-	  Output(true, true, 4, "", 4), // var (inplace)
-	  Output(true, false, 0, "_sm", -1), // saved_mean
-	  Output(true, false, 0, "_siv", -1) // saved_var
-	}) {}
+    class TrainableSpatialBNOp : public TrainableOp
+    {
+    public:
+      TrainableSpatialBNOp()
+          : TrainableOp(
+              {
+                  3, 4 // Mean & Var
+              },
+              {
+                  Output(false, false, 0, "", -1),   // output (default)
+                  Output(true, true, 3, "", 3),      // mean (inplace)
+                  Output(true, true, 4, "", 4),      // var (inplace)
+                  Output(true, false, 0, "_sm", -1), // saved_mean
+                  Output(true, false, 0, "_siv", -1) // saved_var
+              })
+      {
+      }
     };
 
     // Register
@@ -159,37 +198,36 @@ namespace dd {
     const TrainableOp _instance_norm_op = TrainableInstanceNormOp();
     const TrainableOp _spatial_bn_op = TrainableSpatialBNOp();
 
-    const std::map<std::string, TrainableOp> trainable_ops({
-	{"Add", _default_op},
-	{"AffineScale", _default_op},
-	{"AveragedLoss", _default_op},
-	{"AveragePool", _default_op},
-	{"BackMean", _default_op},
-	{"Concat", _default_op},
-	{"Conv", _default_op},
-	{"Diagonal", _default_op},
-	{"Dropout", _inplace_op},
-	{"EnsureCPUOutput", _default_op},
-	{"FC", _default_op},
-	{"InstanceNorm", _instance_norm_op},
-	{"LabelCrossEntropy", _default_op},
-	{"LRN", _default_op},
-	{"MaxPool", _default_op},
-	{"Mul", _default_op},
-	{"RecurrentNetwork", _default_op},
-	{"Relu", _inplace_op},
-	{"Reshape", _default_op},
-	{"Scale", _default_op},
-	{"Sigmoid", _default_op},
-	{"Slice", _default_op},
-	{"Softmax", _default_op},
-	{"SpatialBN", _spatial_bn_op},
-	{"SquaredL2", _default_op},
-	{"SquaredL2Channel", _default_op},
-	{"StopGradient", _default_op},
-	{"Sub", _default_op},
-	{"Sum", _inplace_op}
-      });
+    const std::map<std::string, TrainableOp>
+        trainable_ops({ { "Add", _default_op },
+                        { "AffineScale", _default_op },
+                        { "AveragedLoss", _default_op },
+                        { "AveragePool", _default_op },
+                        { "BackMean", _default_op },
+                        { "Concat", _default_op },
+                        { "Conv", _default_op },
+                        { "Diagonal", _default_op },
+                        { "Dropout", _inplace_op },
+                        { "EnsureCPUOutput", _default_op },
+                        { "FC", _default_op },
+                        { "InstanceNorm", _instance_norm_op },
+                        { "LabelCrossEntropy", _default_op },
+                        { "LRN", _default_op },
+                        { "MaxPool", _default_op },
+                        { "Mul", _default_op },
+                        { "RecurrentNetwork", _default_op },
+                        { "Relu", _inplace_op },
+                        { "Reshape", _default_op },
+                        { "Scale", _default_op },
+                        { "Sigmoid", _default_op },
+                        { "Slice", _default_op },
+                        { "Softmax", _default_op },
+                        { "SpatialBN", _spatial_bn_op },
+                        { "SquaredL2", _default_op },
+                        { "SquaredL2Channel", _default_op },
+                        { "StopGradient", _default_op },
+                        { "Sub", _default_op },
+                        { "Sum", _inplace_op } });
 
     const std::string batch_splits_suffix("_batch_splits");
     const std::string force_device_suffix("_force_device");
@@ -205,11 +243,14 @@ namespace dd {
     const std::string blob_loss("loss");
     const std::string blob_loss_scale(blob_loss + scale_suffix);
 
-    bool is_trainable(const caffe2::OperatorDef &op, const TrainableOp* &train_op) {
+    bool is_trainable(const caffe2::OperatorDef &op,
+                      const TrainableOp *&train_op)
+    {
       const auto &it = trainable_ops.find(op.type());
-      if (it == trainable_ops.end()) {
-	return false;
-      }
+      if (it == trainable_ops.end())
+        {
+          return false;
+        }
       train_op = &it->second;
       return true;
     }

--- a/src/backends/caffe2/nettools/internal.h
+++ b/src/backends/caffe2/nettools/internal.h
@@ -24,67 +24,84 @@
 
 #include "backends/caffe2/nettools.h"
 
-namespace dd {
-  namespace Caffe2NetTools {
+namespace dd
+{
+  namespace Caffe2NetTools
+  {
 
     /*
-     * Operators that don't have a gradient. The associated boolean is set to true for
-     * filling operators (only used to initialize blobs) and false for other operator types
+     * Operators that don't have a gradient. The associated boolean is set to
+     * true for filling operators (only used to initialize blobs) and false for
+     * other operator types
      */
     extern const std::map<std::string, bool> non_trainable_ops;
 
     /*
      * Gives informations about the training behavior of a given operator
      */
-    class TrainableOp {
+    class TrainableOp
+    {
     protected:
-
       /*
        * Describes the properties of a specific output of the operator
        */
-      class Output {
+      class Output
+      {
       public:
-	bool _training_only; // Should not exist in prediction
-	bool _based_on_input; // Whether the name is based on an input or an output
-	int _based_on_index; // Index of the blob used to generate the name
-	std::string _suffix; // String appended to the base name
-	int _can_overwrite; // Index of the input it can overwrite (< 0 means none)
-      Output(bool training, bool input, int index, const std::string &suffix, int overwrite):
-	_training_only(training), _based_on_input(input), _based_on_index(index),
-	  _suffix(suffix), _can_overwrite(overwrite) {}
+        bool _training_only;  // Should not exist in prediction
+        bool _based_on_input; // Whether the name is based on an input or an
+                              // output
+        int _based_on_index;  // Index of the blob used to generate the name
+        std::string _suffix;  // String appended to the base name
+        int _can_overwrite;   // Index of the input it can overwrite (< 0 means
+                              // none)
+        Output(bool training, bool input, int index, const std::string &suffix,
+               int overwrite)
+            : _training_only(training), _based_on_input(input),
+              _based_on_index(index), _suffix(suffix),
+              _can_overwrite(overwrite)
+        {
+        }
       };
 
-      const std::set<int> _computed_inputs; // Indices of 'computed parameter' tagged inputs
+      const std::set<int>
+          _computed_inputs; // Indices of 'computed parameter' tagged inputs
       const std::vector<Output> _outputs;
-    TrainableOp(const std::set<int> &inputs, const std::vector<Output> &outputs):
-      _computed_inputs(inputs), _outputs(outputs) {}
+      TrainableOp(const std::set<int> &inputs,
+                  const std::vector<Output> &outputs)
+          : _computed_inputs(inputs), _outputs(outputs)
+      {
+      }
 
     public:
-
-    TrainableOp(): TrainableOp({}, {}) {}
+      TrainableOp() : TrainableOp({}, {})
+      {
+      }
 
       /*
        * Inputs that will be part of the gradient
        */
       void get_trainable_inputs(const caffe2::OperatorDef &op,
-				std::set<std::string> &inputs) const;
+                                std::set<std::string> &inputs) const;
 
       /*
        * Inputs that should be treated as 'computed parameters'
        *
        * Quote from 'model_helper.py':
        *
-       *       'Computed params' are such parameters that are not optimized via gradient descent
-       *       but are directly computed from data, such as the running mean and variance of
-       *       Spatial Batch Normalization.
+       *       'Computed params' are such parameters that are not optimized via
+       * gradient descent but are directly computed from data, such as the
+       * running mean and variance of Spatial Batch Normalization.
        *
-       * See 'ParameterTags' in pytorch/caffe2/python/modeling/parameter_info.py
+       * See 'ParameterTags' in
+       * pytorch/caffe2/python/modeling/parameter_info.py
        */
       void get_computed_inputs(const caffe2::OperatorDef &op,
-			       std::set<std::string> &inputs) const;
+                               std::set<std::string> &inputs) const;
 
       /*
-       * Outputs that must be added (in the given order) for the operator to be trainable.
+       * Outputs that must be added (in the given order) for the operator to be
+       * trainable.
        *
        * The following quote from the SpatialBN documentation:
        *
@@ -93,21 +110,23 @@ namespace dd {
        *        Must be in-place with the input var.
        *        Should not be used for testing.
        *
-       * Means that this output won't be present in prediciton, but must be set to a specific value
-       * when training.
+       * Means that this output won't be present in prediciton, but must be set
+       * to a specific value when training.
        *
-       * (See https://github.com/pytorch/pytorch/blob/master/caffe2/operators/spatial_batch_norm_op.cc
-       *  or https://github.com/pytorch/pytorch/blob/master/caffe2/operators/instance_norm_op.cc
+       * (See
+       * https://github.com/pytorch/pytorch/blob/master/caffe2/operators/spatial_batch_norm_op.cc
+       *  or
+       * https://github.com/pytorch/pytorch/blob/master/caffe2/operators/instance_norm_op.cc
        *  for concrete examples)
        */
       void get_needed_outputs(const caffe2::OperatorDef &op,
-			      std::vector<std::string> &outputs) const;
+                              std::vector<std::string> &outputs) const;
 
       /*
        * Outputs that overwrite an input while keeping the operator trainable
        */
       void get_trainable_overwrites(const caffe2::OperatorDef &op,
-				    std::set<int> &outputs) const;
+                                    std::set<int> &outputs) const;
     };
 
     /*
@@ -123,16 +142,18 @@ namespace dd {
     extern const std::string scale_suffix;
 
     extern const std::string blob_lr;
-    extern const std::string blob_one;    
+    extern const std::string blob_one;
     extern const std::string blob_iter;
     extern const std::string blob_xent;
     extern const std::string blob_loss;
     extern const std::string blob_loss_scale;
 
     /*
-     * Checks if the operator have a gradient and store a pointer to the 'TrainableOp' if any
+     * Checks if the operator have a gradient and store a pointer to the
+     * 'TrainableOp' if any
      */
-    bool is_trainable(const caffe2::OperatorDef &op, const TrainableOp* &train_op);
+    bool is_trainable(const caffe2::OperatorDef &op,
+                      const TrainableOp *&train_op);
   }
 }
 

--- a/src/backends/caffe2/nettools/netgroup.cc
+++ b/src/backends/caffe2/nettools/netgroup.cc
@@ -21,39 +21,45 @@
 
 #include "backends/caffe2/nettools.h"
 
-namespace dd {
-  namespace Caffe2NetTools {
+namespace dd
+{
+  namespace Caffe2NetTools
+  {
 
     /*
      *  NetGroup
      */
 
-    void NetGroup::swap(NetGroup &nets) {
+    void NetGroup::swap(NetGroup &nets)
+    {
       _init.Swap(&nets._init);
       _train.Swap(&nets._train);
       _predict.Swap(&nets._predict);
     }
 
-    void NetGroup::rename(const std::string &name) {
+    void NetGroup::rename(const std::string &name)
+    {
       std::string prefix("(" + _type + ")" + name);
       _init.set_name(prefix + "_init");
       _train.set_name(prefix + "_train");
       _predict.set_name(prefix + "_predict");
     }
 
-    void NetGroup::import(const std::string &init,
-			  const std::string &predict,
-			  const std::string &train) {
-      if (init.size()) import_net(_init, init);
-      if (predict.size()) import_net(_predict, predict);
-      if (train.size()) import_net(_train, train);
+    void NetGroup::import(const std::string &init, const std::string &predict,
+                          const std::string &train)
+    {
+      if (init.size())
+        import_net(_init, init);
+      if (predict.size())
+        import_net(_predict, predict);
+      if (train.size())
+        import_net(_train, train);
     }
 
-    NetGroup::NetGroup(const std::string &type,
-		       const std::string &init,
-		       const std::string &predict,
-		       const std::string &train)
-      : _type(type) {
+    NetGroup::NetGroup(const std::string &type, const std::string &init,
+                       const std::string &predict, const std::string &train)
+        : _type(type)
+    {
       import(init, predict, train);
     }
 

--- a/src/backends/caffe2/nettools/workspace_and_nets.cc
+++ b/src/backends/caffe2/nettools/workspace_and_nets.cc
@@ -19,7 +19,7 @@
  * along with deepdetect.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-//XXX Remove that to print the warnings
+// XXX Remove that to print the warnings
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsign-compare"
 #pragma GCC diagnostic ignored "-Wunused-parameter"
@@ -34,25 +34,32 @@
 #include "caffe2/core/typeid.h"
 #include "backends/caffe2/nettools/internal.h"
 
-namespace dd {
-  namespace Caffe2NetTools {
+namespace dd
+{
+  namespace Caffe2NetTools
+  {
 
     /*
      *  Workspace initialization
      */
 
-    ScopedNet ModelContext::scope_net(caffe2::NetDef &net) const {
+    ScopedNet ModelContext::scope_net(caffe2::NetDef &net) const
+    {
       ScopedNet scoped(net);
-      if (_parallelized) {
-	scoped._devices = _devices;
-      } else {
-	scoped._devices = { _devices[0] };
-	scoped._rename_inputs = scoped._rename_outputs = false;
-      }
+      if (_parallelized)
+        {
+          scoped._devices = _devices;
+        }
+      else
+        {
+          scoped._devices = { _devices[0] };
+          scoped._rename_inputs = scoped._rename_outputs = false;
+        }
       return scoped;
     }
 
-    void ModelContext::reset_devices() {
+    void ModelContext::reset_devices()
+    {
       _devices.clear();
       caffe2::DeviceOption option;
       option.set_device_type(caffe2::DeviceTypeProto::PROTO_CPU);
@@ -61,266 +68,331 @@ namespace dd {
     }
 
 #ifndef CPU_ONLY
-    void ModelContext::reset_devices(const std::vector<int> &gpu_ids) {
+    void ModelContext::reset_devices(const std::vector<int> &gpu_ids)
+    {
       _devices.clear();
       caffe2::DeviceOption option;
       option.set_device_type(caffe2::DeviceTypeProto::PROTO_CUDA);
-      for (int gpu_id : gpu_ids) {
-	option.set_cuda_gpu_id(gpu_id);
-	_devices.push_back(option);
-      }
+      for (int gpu_id : gpu_ids)
+        {
+          option.set_cuda_gpu_id(gpu_id);
+          _devices.push_back(option);
+        }
       _parallelized = (_devices.size() > 1);
     }
 #endif
 
-    bool ModelContext::extract_tensor(int device_idx,
-				      const std::string &name,
-				      caffe2::Tensor &tensor) const {
-      const caffe2::Blob &blob = *_workspace->GetBlob(get_prefix(device_idx) + name);
+    bool ModelContext::extract_tensor(int device_idx, const std::string &name,
+                                      caffe2::Tensor &tensor) const
+    {
+      const caffe2::Blob &blob
+          = *_workspace->GetBlob(get_prefix(device_idx) + name);
       bool init = blob.meta().Match<caffe2::Tensor>();
-      if (init) {
-	tensor.CopyFrom(blob.Get<caffe2::Tensor>());
-      }
+      if (init)
+        {
+          tensor.CopyFrom(blob.Get<caffe2::Tensor>());
+        }
       return init;
     }
 
-    void ModelContext::insert_tensor(int device_idx,
-				     const std::string &name,
-				     const caffe2::Tensor &tensor) {
-      caffe2::Blob &blob = *_workspace->CreateBlob(get_prefix(device_idx) + name);
-      caffe2::DeviceType type(caffe2::ProtoToType(_devices[device_idx].device_type()));
+    void ModelContext::insert_tensor(int device_idx, const std::string &name,
+                                     const caffe2::Tensor &tensor)
+    {
+      caffe2::Blob &blob
+          = *_workspace->CreateBlob(get_prefix(device_idx) + name);
+      caffe2::DeviceType type(
+          caffe2::ProtoToType(_devices[device_idx].device_type()));
       caffe2::BlobGetMutableTensor(&blob, type)->CopyFrom(tensor);
     }
 
-    void ModelContext::broadcast_tensor(const std::string &name, const caffe2::Tensor &tensor) {
-      for (size_t i = 0; i < device_count(); ++i) {
-	insert_tensor(i, name, tensor);
-      }
+    void ModelContext::broadcast_tensor(const std::string &name,
+                                        const caffe2::Tensor &tensor)
+    {
+      for (size_t i = 0; i < device_count(); ++i)
+        {
+          insert_tensor(i, name, tensor);
+        }
     }
 
-    static bool deserialize_blob(caffe2::Blob &blob, const std::string &path) {
+    static bool deserialize_blob(caffe2::Blob &blob, const std::string &path)
+    {
       std::ifstream f(path);
       CAFFE_ENFORCE(f.good());
       std::stringstream s;
       s << f.rdbuf();
       std::string str(s.str());
-      if (str == caffe2::TypeMeta().name()) {
-	return false; // nullptr (uninitialized)
-      }
+      if (str == caffe2::TypeMeta().name())
+        {
+          return false; // nullptr (uninitialized)
+        }
       caffe2::DeserializeBlob(str, &blob);
       return true;
     }
 
-    void ModelContext::load_iter(const std::string &path) {
+    void ModelContext::load_iter(const std::string &path)
+    {
       caffe2::Blob blob;
       CAFFE_ENFORCE(deserialize_blob(blob, path));
       _loaded_iter = *blob.Get<caffe2::Tensor>().data<long>();
     }
 
-    void ModelContext::load_blob(const std::string &path, const std::string &name) {
+    void ModelContext::load_blob(const std::string &path,
+                                 const std::string &name)
+    {
       CAFFE_ENFORCE(deserialize_blob(*_workspace->CreateBlob(name), path));
     }
 
-    void ModelContext::load_lr(const std::string &path) {
+    void ModelContext::load_lr(const std::string &path)
+    {
       caffe2::Blob blob;
-      // A learning rate serialized during the first iteration is still uninitialized
-      // In that case we just ignore it
-      if (deserialize_blob(blob, path)) {
-	broadcast_tensor(blob_lr, blob.Get<caffe2::Tensor>());
-      }
+      // A learning rate serialized during the first iteration is still
+      // uninitialized In that case we just ignore it
+      if (deserialize_blob(blob, path))
+        {
+          broadcast_tensor(blob_lr, blob.Get<caffe2::Tensor>());
+        }
     }
 
     /*
      *  Information extraction
      */
 
-    size_t ModelContext::extract_tensors(const std::string &name,
-					 std::vector<caffe2::Tensor> &tensors) const {
+    size_t
+    ModelContext::extract_tensors(const std::string &name,
+                                  std::vector<caffe2::Tensor> &tensors) const
+    {
       size_t size = 0;
       int devices = device_count();
       tensors.reserve(devices);
-      for (int i = 0; i < devices; ++i) {
-	tensors.emplace_back(caffe2::CPU);
-	caffe2::Tensor &tensor(tensors[i]);
-	CAFFE_ENFORCE(extract_tensor(i, name, tensor));
-	size += tensor.size();
-      }
+      for (int i = 0; i < devices; ++i)
+        {
+          tensors.emplace_back(caffe2::CPU);
+          caffe2::Tensor &tensor(tensors[i]);
+          CAFFE_ENFORCE(extract_tensor(i, name, tensor));
+          size += tensor.size();
+        }
       return size;
     }
 
     template <typename Result, typename Data>
-    void ModelContext::split_tensors(std::vector<Result> &results,
-				     const std::vector<caffe2::Tensor> &tensors,
-				     const std::vector<size_t> &sizes,
-				     const Stockage<Result, Data> &store) const {
+    void
+    ModelContext::split_tensors(std::vector<Result> &results,
+                                const std::vector<caffe2::Tensor> &tensors,
+                                const std::vector<size_t> &sizes,
+                                const Stockage<Result, Data> &store) const
+    {
 
       // Assign a value to each result
       typename std::vector<Result>::iterator result = results.begin();
       std::vector<size_t>::const_iterator size = sizes.begin();
 
       // Loop over the tensors
-      for (const caffe2::Tensor &tensor : tensors) {
-	CAFFE_ENFORCE(tensor.IsType<Data>());
-	const Data *data = tensor.data<Data>();
-	const Data *data_end = data + tensor.size();
-	// Loop over the current batch
-	for (; data < data_end; data += *size, ++result, ++size) {
-	  store(*result, data, *size);
-	}
-      }
+      for (const caffe2::Tensor &tensor : tensors)
+        {
+          CAFFE_ENFORCE(tensor.IsType<Data>());
+          const Data *data = tensor.data<Data>();
+          const Data *data_end = data + tensor.size();
+          // Loop over the current batch
+          for (; data < data_end; data += *size, ++result, ++size)
+            {
+              store(*result, data, *size);
+            }
+        }
     }
 
     template <typename T>
-    static void _store_single_value(T &result, const T *data, size_t size) {
+    static void _store_single_value(T &result, const T *data, size_t size)
+    {
       CAFFE_ENFORCE(size == 1);
       result = *data;
     }
 
     template <typename T>
-    static void _store_vector(std::vector<T> &result, const T *data, size_t size) {
+    static void _store_vector(std::vector<T> &result, const T *data,
+                              size_t size)
+    {
       result.assign(data, data + size);
     }
 
     template <typename Result, typename Data>
-    static void assign_results(std::vector<Result> &results, const std::vector<Data> &datas) {
+    static void assign_results(std::vector<Result> &results,
+                               const std::vector<Data> &datas)
+    {
       results.assign(datas.begin(), datas.end());
     }
 
     template <typename Result, typename Data>
     static void assign_results(std::vector<std::vector<Result>> &results,
-			       const std::vector<std::vector<Data>> &datas) {
-      for (size_t i = 0; i < results.size(); ++i) {
-	results[i].assign(datas[i].begin(), datas[i].end());
-      }
+                               const std::vector<std::vector<Data>> &datas)
+    {
+      for (size_t i = 0; i < results.size(); ++i)
+        {
+          results[i].assign(datas[i].begin(), datas[i].end());
+        }
     }
 
     template <typename T>
-    void ModelContext::split_tensors(std::vector<T> &results,
-				     const std::vector<caffe2::Tensor> &tensors,
-				     const std::vector<size_t> &sizes) const {
-      split_tensors(results, tensors, sizes, Stockage<T, T>(_store_single_value<T>));
+    void
+    ModelContext::split_tensors(std::vector<T> &results,
+                                const std::vector<caffe2::Tensor> &tensors,
+                                const std::vector<size_t> &sizes) const
+    {
+      split_tensors(results, tensors, sizes,
+                    Stockage<T, T>(_store_single_value<T>));
     }
 
     template <typename T>
-    void ModelContext::split_tensors(std::vector<std::vector<T>> &results,
-				     const std::vector<caffe2::Tensor> &tensors,
-				     const std::vector<size_t> &sizes) const {
-      split_tensors(results, tensors, sizes, Stockage<std::vector<T>, T>(_store_vector<T>));
+    void
+    ModelContext::split_tensors(std::vector<std::vector<T>> &results,
+                                const std::vector<caffe2::Tensor> &tensors,
+                                const std::vector<size_t> &sizes) const
+    {
+      split_tensors(results, tensors, sizes,
+                    Stockage<std::vector<T>, T>(_store_vector<T>));
     }
 
     template <typename T>
     void ModelContext::extract_results(std::vector<T> &results,
-				       const std::string &name,
-				       size_t size) const {
+                                       const std::string &name,
+                                       size_t size) const
+    {
       std::vector<caffe2::Tensor> tensors;
       size_t data_size = extract_tensors(name, tensors);
       size_t data_count = results.size();
-      if (!size) {
-	size = data_size / data_count;
-      }
+      if (!size)
+        {
+          size = data_size / data_count;
+        }
       CAFFE_ENFORCE(data_size == size * data_count);
       split_tensors(results, tensors, std::vector<size_t>(data_count, size));
     }
 
     template <typename T>
     void ModelContext::extract_results(std::vector<T> &results,
-				       const std::string &name,
-				       const std::vector<size_t> &sizes,
-				       size_t scale) const {
+                                       const std::string &name,
+                                       const std::vector<size_t> &sizes,
+                                       size_t scale) const
+    {
       std::vector<caffe2::Tensor> tensors;
       size_t data_count = results.size();
       CAFFE_ENFORCE(data_count == sizes.size());
       size_t data_size1 = extract_tensors(name, tensors);
-      size_t data_size2 = std::accumulate(sizes.begin(), sizes.end(), static_cast<size_t>(0));
-      if (!scale && data_size1) {
-	scale = data_size1 / data_size2;
-      }
+      size_t data_size2 = std::accumulate(sizes.begin(), sizes.end(),
+                                          static_cast<size_t>(0));
+      if (!scale && data_size1)
+        {
+          scale = data_size1 / data_size2;
+        }
       CAFFE_ENFORCE(data_size1 == data_size2 * scale);
       std::vector<size_t> scaled_sizes(data_count);
       std::transform(sizes.begin(), sizes.end(), scaled_sizes.begin(),
-		     [&](float size){ return scale * size; });
+                     [&](float size) { return scale * size; });
       split_tensors(results, tensors, scaled_sizes);
     }
 
     template <typename Result, typename Data, typename Size>
     void ModelContext::extract_and_cast_results(std::vector<Result> &results,
-						const std::string &name,
-						const Size &size) const {
+                                                const std::string &name,
+                                                const Size &size) const
+    {
       std::vector<Data> raw(results.size());
       extract_results(raw, name, size);
       assign_results(results, raw);
     }
 
-    float ModelContext::extract_loss() const {
+    float ModelContext::extract_loss() const
+    {
       std::vector<float> losses(device_count());
       extract_results(losses, blob_loss_scale, 1);
       return std::accumulate(losses.begin(), losses.end(), 0.f);
     }
 
-    int ModelContext::extract_iter() const {
+    int ModelContext::extract_iter() const
+    {
       std::vector<long> iters(device_count());
       extract_results(iters, blob_iter, 1);
       return iters[0];
     }
 
-    void ModelContext::extract_labels(std::vector<float> &labels) const {
+    void ModelContext::extract_labels(std::vector<float> &labels) const
+    {
       extract_and_cast_results<float, int>(labels, _blob_label, 1);
     }
 
-    void ModelContext::extract_state(std::map<std::string, std::string> &blobs) const {
-      for (const std::string &name : _workspace->Blobs()) {
-	const caffe2::Blob &blob = *_workspace->GetBlob(name);
-    	if (blob.IsType<caffe2::db::DBReader>()) {
-	  blobs[name] = caffe2::SerializeBlob(blob, name);
-	}
-      }
-      const caffe2::Blob &iter(*_workspace->GetBlob(get_prefix(0) + blob_iter));
+    void ModelContext::extract_state(
+        std::map<std::string, std::string> &blobs) const
+    {
+      for (const std::string &name : _workspace->Blobs())
+        {
+          const caffe2::Blob &blob = *_workspace->GetBlob(name);
+          if (blob.IsType<caffe2::db::DBReader>())
+            {
+              blobs[name] = caffe2::SerializeBlob(blob, name);
+            }
+        }
+      const caffe2::Blob &iter(
+          *_workspace->GetBlob(get_prefix(0) + blob_iter));
       blobs["iter"] = caffe2::SerializeBlob(iter, "iter");
       caffe2::Blob lr;
-      if (extract_tensor(0, blob_lr, *caffe2::BlobGetMutableTensor(&lr, caffe2::CPU))) {
-	blobs["lr"] = caffe2::SerializeBlob(lr, "lr");
-      } else { // Can fail during the first iteration of the net
-	blobs["lr"] = caffe2::TypeMeta().name(); // nullptr (uninitialized)
-      }
+      if (extract_tensor(0, blob_lr,
+                         *caffe2::BlobGetMutableTensor(&lr, caffe2::CPU)))
+        {
+          blobs["lr"] = caffe2::SerializeBlob(lr, "lr");
+        }
+      else
+        { // Can fail during the first iteration of the net
+          blobs["lr"] = caffe2::TypeMeta().name(); // nullptr (uninitialized)
+        }
     }
 
     void ModelContext::extract(std::vector<std::vector<float>> &results,
-			       const std::string &name,
-			       const std::vector<size_t> &sizes,
-			       size_t scale) const {
-      if (sizes.size()) {
-	extract_results(results, name, sizes, scale);
-      } else {
-	extract_results(results, name);
-      }
+                               const std::string &name,
+                               const std::vector<size_t> &sizes,
+                               size_t scale) const
+    {
+      if (sizes.size())
+        {
+          extract_results(results, name, sizes, scale);
+        }
+      else
+        {
+          extract_results(results, name);
+        }
     }
 
     /*
      *  Network manipulation
      */
 
-    void ModelContext::create_init_net(const caffe2::NetDef &net, caffe2::NetDef &init) const {
+    void ModelContext::create_init_net(const caffe2::NetDef &net,
+                                       caffe2::NetDef &init) const
+    {
       std::set<std::string> params;
       caffe2::Tensor tensor(caffe2::CPU);
       collect_params(net, params, params, get_prefix(0));
-      for (const std::string &param : params) {
-	CAFFE_ENFORCE(extract_tensor(0, param, tensor));
-	const float *data = tensor.data<float>();
-	const std::vector<long int> &dims = tensor.dims();
-	GivenTensorFill(init, param,
-			std::vector<int>(dims.begin(), dims.end()),
-			std::vector<float>(data, data + tensor.size()));
-      }
+      for (const std::string &param : params)
+        {
+          CAFFE_ENFORCE(extract_tensor(0, param, tensor));
+          const float *data = tensor.data<float>();
+          const std::vector<long int> &dims = tensor.dims();
+          GivenTensorFill(init, param,
+                          std::vector<int>(dims.begin(), dims.end()),
+                          std::vector<float>(data, data + tensor.size()));
+        }
     }
 
-    void ModelContext::append_net(caffe2::NetDef &dst, const caffe2::NetDef &src) const {
+    void ModelContext::append_net(caffe2::NetDef &dst,
+                                  const caffe2::NetDef &src) const
+    {
       ScopedNet net = scope_net(dst);
       add_ops_and_inputs(net, src);
       dst.add_external_input(_input_blob);
     }
 
-    void ModelContext::append_trainable_net(caffe2::NetDef &dst, const caffe2::NetDef &src,
-					    const std::vector<std::string> &output_blobs) const {
+    void ModelContext::append_trainable_net(
+        caffe2::NetDef &dst, const caffe2::NetDef &src,
+        const std::vector<std::string> &output_blobs) const
+    {
 
       // Prevent the gradients from reaching previous operators
       ScopedNet net = scope_net(dst);
@@ -328,17 +400,20 @@ namespace dd {
 
       // Assert that operators will generate the correct gradients
       caffe2::NetDef ref(src);
-      for (caffe2::OperatorDef &op : *ref.mutable_op()) {
-	for (caffe2::Argument &arg : *op.mutable_arg()) {
-	  if (arg.name() == "is_test") {
-	    arg.set_i(0);
-	  }
-	}
-      }
+      for (caffe2::OperatorDef &op : *ref.mutable_op())
+        {
+          for (caffe2::Argument &arg : *op.mutable_arg())
+            {
+              if (arg.name() == "is_test")
+                {
+                  arg.set_i(0);
+                }
+            }
+        }
 
       add_ops_and_inputs(net, ref, { _input_blob });
 
-      //XXX Manage other kinds of outputs (no-label, multi-label, bbox, etc.)
+      // XXX Manage other kinds of outputs (no-label, multi-label, bbox, etc.)
       CAFFE_ENFORCE(output_blobs.size() == 1);
       LabelCrossEntropy(net, output_blobs[0], _blob_label, blob_xent);
 
@@ -351,14 +426,16 @@ namespace dd {
 
       // Add the gradients and sum them over the devices
       std::set<std::string> main_gradients;
-      for (size_t i = 0; i < device_count(); ++i) {
-	main_gradients.insert(get_prefix(i) + loss_grad);
-      }
+      for (size_t i = 0; i < device_count(); ++i)
+        {
+          main_gradients.insert(get_prefix(i) + loss_grad);
+        }
       add_gradient_ops(dst, main_gradients);
 #ifndef CPU_ONLY
-      if (device_count() > 1) {
-	reduce(net);
-      }
+      if (device_count() > 1)
+        {
+          reduce(net);
+        }
 #endif
     }
 
@@ -366,65 +443,89 @@ namespace dd {
      *  Other net manipulations
      */
 
-    void truncate_net(const caffe2::NetDef &net, caffe2::NetDef &out, const std::string &blob) {
+    void truncate_net(const caffe2::NetDef &net, caffe2::NetDef &out,
+                      const std::string &blob)
+    {
       auto ops = net.op();
       int last_op = find_previous_update(net, blob, ops.size() - 1);
 
       // Fill the new net
-      for (int i = 0; i <= last_op; ++i) {
-	out.add_op()->CopyFrom(ops[i]);
-      }
+      for (int i = 0; i <= last_op; ++i)
+        {
+          out.add_op()->CopyFrom(ops[i]);
+        }
       out.mutable_external_input()->CopyFrom(net.external_input());
       out.add_external_output(blob);
     }
 
-    void truncate_net(caffe2::NetDef &net, const std::string &blob) {
+    void truncate_net(caffe2::NetDef &net, const std::string &blob)
+    {
       caffe2::NetDef short_net;
       truncate_net(net, short_net, blob);
       net.Swap(&short_net);
     }
 
-    inline void unscope(std::string &s, const std::string &prefix) {
-      if (!s.find(prefix)) {
-	s.erase(0, prefix.size());
-      }
+    inline void unscope(std::string &s, const std::string &prefix)
+    {
+      if (!s.find(prefix))
+        {
+          s.erase(0, prefix.size());
+        }
     }
 
-    void import_net(caffe2::NetDef &net, const std::string &file, bool unscoped) {
+    void import_net(caffe2::NetDef &net, const std::string &file,
+                    bool unscoped)
+    {
       CAFFE_ENFORCE(caffe2::ReadProtoFromFile(file, &net));
-      if (unscoped) {
-	// Some net templates begin with a prefix on each blob ('gpu_0/')
-	// We may want to remove it early to prevent conflicts
-	const char *prefix = "gpu_0/";
-	for (std::string &s : *net.mutable_external_input()) unscope(s, prefix);
-	for (std::string &s : *net.mutable_external_output()) unscope(s, prefix);
-	for (caffe2::OperatorDef &op : *net.mutable_op()) {
-	  for (std::string &s : *op.mutable_input()) unscope(s, prefix);
-	  for (std::string &s : *op.mutable_output()) unscope(s, prefix);
-	}
-      }
+      if (unscoped)
+        {
+          // Some net templates begin with a prefix on each blob ('gpu_0/')
+          // We may want to remove it early to prevent conflicts
+          const char *prefix = "gpu_0/";
+          for (std::string &s : *net.mutable_external_input())
+            unscope(s, prefix);
+          for (std::string &s : *net.mutable_external_output())
+            unscope(s, prefix);
+          for (caffe2::OperatorDef &op : *net.mutable_op())
+            {
+              for (std::string &s : *op.mutable_input())
+                unscope(s, prefix);
+              for (std::string &s : *op.mutable_output())
+                unscope(s, prefix);
+            }
+        }
     }
 
-    void export_net(const caffe2::NetDef &net, const std::string &file, bool human_readable) {
+    void export_net(const caffe2::NetDef &net, const std::string &file,
+                    bool human_readable)
+    {
       std::ofstream f(file);
-      if (human_readable) {
-	f << net.DebugString();
-      } else {
-	net.SerializeToOstream(&f);
-      }
+      if (human_readable)
+        {
+          f << net.DebugString();
+        }
+      else
+        {
+          net.SerializeToOstream(&f);
+        }
     }
 
     void append_model(caffe2::NetDef &dst_net, caffe2::NetDef &dst_init,
-		      const caffe2::NetDef &src_net, const caffe2::NetDef &src_init) {
-      for (auto op : src_init.op()) {
-	dst_init.add_op()->CopyFrom(op);
-	for (const std::string blob : op.output()) {
-	  dst_net.add_external_input(blob);
-	}
-      }
-      for (auto op : src_net.op()) {
-	dst_net.add_op()->CopyFrom(op);
-      }
+                      const caffe2::NetDef &src_net,
+                      const caffe2::NetDef &src_init)
+    {
+      for (auto op : src_init.op())
+        {
+          dst_init.add_op()->CopyFrom(op);
+          for (const std::string blob : op.output())
+            {
+              dst_net.add_external_input(blob);
+            }
+        }
+      for (auto op : src_net.op())
+        {
+          dst_net.add_op()->CopyFrom(op);
+        }
     }
 
   }

--- a/src/backends/dlib/DNNStructures.h
+++ b/src/backends/dlib/DNNStructures.h
@@ -24,66 +24,83 @@
 
 #include <dlib/dnn.h>
 
-
 // --------      Common layers        ------- //
-template <long num_filters, typename SUBNET> using con5d = dlib::con<num_filters,5,5,2,2,SUBNET>;
-template <long num_filters, typename SUBNET> using con5  = dlib::con<num_filters,5,5,1,1,SUBNET>;
+template <long num_filters, typename SUBNET>
+using con5d = dlib::con<num_filters, 5, 5, 2, 2, SUBNET>;
+template <long num_filters, typename SUBNET>
+using con5 = dlib::con<num_filters, 5, 5, 1, 1, SUBNET>;
 
-template <typename SUBNET> using downsampler  = dlib::relu<
-dlib::affine<
-        con5d<
-                32, dlib::relu<
-                    dlib::affine<
-                    con5d<
-                            32, dlib::relu<
-                                dlib::affine<
-                                con5d<16,SUBNET>>>>>>>>>;
-
+template <typename SUBNET>
+using downsampler = dlib::relu<dlib::affine<
+    con5d<32, dlib::relu<dlib::affine<
+                  con5d<32, dlib::relu<dlib::affine<con5d<16, SUBNET>>>>>>>>>;
 
 // ------- Obj detect deep neural net ------- //
-// Download and uncompress pretrained model from: http://dlib.net/files/mmod_front_and_rear_end_vehicle_detector.dat.bz2
-// Check https://github.com/davisking/dlib-models for more models
+// Download and uncompress pretrained model from:
+// http://dlib.net/files/mmod_front_and_rear_end_vehicle_detector.dat.bz2 Check
+// https://github.com/davisking/dlib-models for more models
 
-template <typename SUBNET> using rconObj5  = dlib::relu<dlib::affine<con5<55,SUBNET>>>;
+template <typename SUBNET>
+using rconObj5 = dlib::relu<dlib::affine<con5<55, SUBNET>>>;
 
-using net_type_objDetector = dlib::loss_mmod<dlib::con<1,9,9,1,1,rconObj5<rconObj5<rconObj5<downsampler<dlib::input_rgb_image_pyramid<dlib::pyramid_down<6>>>>>>>>;
-
+using net_type_objDetector = dlib::loss_mmod<
+    dlib::con<1, 9, 9, 1, 1,
+              rconObj5<rconObj5<rconObj5<downsampler<
+                  dlib::input_rgb_image_pyramid<dlib::pyramid_down<6>>>>>>>>;
 
 //// ------- Face detect deep neural net ------- //
-// Download and uncompress pretrained model from: http://dlib.net/files/mmod_human_face_detector.dat.bz2
-template <typename SUBNET> using rconFace5  = dlib::relu<dlib::affine<con5<45,SUBNET>>>;
+// Download and uncompress pretrained model from:
+// http://dlib.net/files/mmod_human_face_detector.dat.bz2
+template <typename SUBNET>
+using rconFace5 = dlib::relu<dlib::affine<con5<45, SUBNET>>>;
 
-using net_type_faceDetector = dlib::loss_mmod<dlib::con<1,9,9,1,1,rconFace5<rconFace5<rconFace5<downsampler<dlib::input_rgb_image_pyramid<dlib::pyramid_down<6>>>>>>>>;
+using net_type_faceDetector = dlib::loss_mmod<
+    dlib::con<1, 9, 9, 1, 1,
+              rconFace5<rconFace5<rconFace5<downsampler<
+                  dlib::input_rgb_image_pyramid<dlib::pyramid_down<6>>>>>>>>;
 
+// ------- Face recognition feature extraction deep neural net (ResNet)
+// -------- // Download and uncompress pretrained model from:
+// http://dlib.net/files/dlib_face_recognition_resnet_model_v1.dat.bz2
+template <template <int, template <typename> class, int, typename>
+          class dlibblock,
+          int N, template <typename> class BN, typename SUBNET>
+using residual = dlib::add_prev1<dlibblock<N, BN, 1, dlib::tag1<SUBNET>>>;
 
-// ------- Face recognition feature extraction deep neural net (ResNet) -------- //
-// Download and uncompress pretrained model from: http://dlib.net/files/dlib_face_recognition_resnet_model_v1.dat.bz2
-template <template <int,template<typename>class,int,typename> class dlibblock, int N, template<typename>class BN, typename SUBNET>
-using residual = dlib::add_prev1<dlibblock<N,BN,1,dlib::tag1<SUBNET>>>;
-
-template <template <int,template<typename>class,int,typename> class dlibblock, int N, template<typename>class BN, typename SUBNET>
-using residual_down = dlib::add_prev2<dlib::avg_pool<2,2,2,2,dlib::skip1<dlib::tag2<dlibblock<N,BN,2,dlib::tag1<SUBNET>>>>>>;
+template <template <int, template <typename> class, int, typename>
+          class dlibblock,
+          int N, template <typename> class BN, typename SUBNET>
+using residual_down = dlib::add_prev2<dlib::avg_pool<
+    2, 2, 2, 2,
+    dlib::skip1<dlib::tag2<dlibblock<N, BN, 2, dlib::tag1<SUBNET>>>>>>;
 
 template <int N, template <typename> class BN, int stride, typename SUBNET>
-using dlibblock  = BN<dlib::con<N,3,3,1,1,dlib::relu<BN<dlib::con<N,3,3,stride,stride,SUBNET>>>>>;
+using dlibblock = BN<
+    dlib::con<N, 3, 3, 1, 1,
+              dlib::relu<BN<dlib::con<N, 3, 3, stride, stride, SUBNET>>>>>;
 
-template <int N, typename SUBNET> using ares      = dlib::relu<residual<dlibblock,N,dlib::affine,SUBNET>>;
-template <int N, typename SUBNET> using ares_down = dlib::relu<residual_down<dlibblock,N,dlib::affine,SUBNET>>;
+template <int N, typename SUBNET>
+using ares = dlib::relu<residual<dlibblock, N, dlib::affine, SUBNET>>;
+template <int N, typename SUBNET>
+using ares_down
+    = dlib::relu<residual_down<dlibblock, N, dlib::affine, SUBNET>>;
 
-template <typename SUBNET> using alevel0 = ares_down<256,SUBNET>;
-template <typename SUBNET> using alevel1 = ares<256,ares<256,ares_down<256,SUBNET>>>;
-template <typename SUBNET> using alevel2 = ares<128,ares<128,ares_down<128,SUBNET>>>;
-template <typename SUBNET> using alevel3 = ares<64,ares<64,ares<64,ares_down<64,SUBNET>>>>;
-template <typename SUBNET> using alevel4 = ares<32,ares<32,ares<32,SUBNET>>>;
+template <typename SUBNET> using alevel0 = ares_down<256, SUBNET>;
+template <typename SUBNET>
+using alevel1 = ares<256, ares<256, ares_down<256, SUBNET>>>;
+template <typename SUBNET>
+using alevel2 = ares<128, ares<128, ares_down<128, SUBNET>>>;
+template <typename SUBNET>
+using alevel3 = ares<64, ares<64, ares<64, ares_down<64, SUBNET>>>>;
+template <typename SUBNET>
+using alevel4 = ares<32, ares<32, ares<32, SUBNET>>>;
 
-using net_type_faceFeatureExtractor = dlib::loss_metric<dlib::fc_no_bias<128,dlib::avg_pool_everything<
-                                                         alevel0<
-                                                                 alevel1<
-                                                                         alevel2<
-                                                                                 alevel3<
-                                                                                         alevel4<
-                                                                                                 dlib::max_pool<3,3,2,2,dlib::relu<dlib::affine<dlib::con<32,7,7,2,2,
-                                                                                                 dlib::input_rgb_image_sized<150>
-                                                                                 >>>>>>>>>>>>;
+using net_type_faceFeatureExtractor = dlib::loss_metric<dlib::fc_no_bias<
+    128,
+    dlib::avg_pool_everything<
+        alevel0<alevel1<alevel2<alevel3<alevel4<dlib::max_pool<
+            3, 3, 2, 2,
+            dlib::relu<dlib::affine<dlib::con<
+                32, 7, 7, 2, 2, dlib::input_rgb_image_sized<150>>>>>>>>>>>>>;
 
 #endif

--- a/src/backends/dlib/dlib_actions.cpp
+++ b/src/backends/dlib/dlib_actions.cpp
@@ -32,99 +32,125 @@
 
 #include "utils/utils.hpp"
 
-namespace dd {
-    void DlibAlignCropAction::apply(APIData &model_out,
-                                    ChainData &cdata) {
-        std::vector <APIData> vad = model_out.getv("predictions");
-        std::vector <cv::Mat> imgs = model_out.getobj("input").get("imgs").get < std::vector < cv::Mat >> ();
-        std::vector < std::pair < int,
-                int >> imgs_size = model_out.getobj("input").get("imgs_size").get < std::vector < std::pair < int,
-                int >> > ();
-        std::vector <cv::Mat> cropped_imgs;
-        std::vector <std::string> bbox_ids;
+namespace dd
+{
+  void DlibAlignCropAction::apply(APIData &model_out, ChainData &cdata)
+  {
+    std::vector<APIData> vad = model_out.getv("predictions");
+    std::vector<cv::Mat> imgs
+        = model_out.getobj("input").get("imgs").get<std::vector<cv::Mat>>();
+    std::vector<std::pair<int, int>> imgs_size
+        = model_out.getobj("input")
+              .get("imgs_size")
+              .get<std::vector<std::pair<int, int>>>();
+    std::vector<cv::Mat> cropped_imgs;
+    std::vector<std::string> bbox_ids;
 
-        // check for action parameters
-        double bratio = 0.25;
-        int chip_size = 150;
-        if (_params.has("padding_ratio")) {
-            bratio = _params.get("padding_ratio").get<double>(); // e.g. 0.055
-        }
-        if (_params.has("chip_size")) {
-            chip_size = _params.get("chip_size").get<int>(); // in pixels
-        }
-        std::vector <APIData> cvad;
+    // check for action parameters
+    double bratio = 0.25;
+    int chip_size = 150;
+    if (_params.has("padding_ratio"))
+      {
+        bratio = _params.get("padding_ratio").get<double>(); // e.g. 0.055
+      }
+    if (_params.has("chip_size"))
+      {
+        chip_size = _params.get("chip_size").get<int>(); // in pixels
+      }
+    std::vector<APIData> cvad;
 
-        bool save_crops = false;
-        if (_params.has("save_crops")) {
-            save_crops = _params.get("save_crops").get<bool>();
-        }
+    bool save_crops = false;
+    if (_params.has("save_crops"))
+      {
+        save_crops = _params.get("save_crops").get<bool>();
+      }
 
-        // iterate image batch
-        for (size_t i = 0; i < vad.size(); i++) {
-            std::string uri = vad.at(i).get("uri").get<std::string>();
+    // iterate image batch
+    for (size_t i = 0; i < vad.size(); i++)
+      {
+        std::string uri = vad.at(i).get("uri").get<std::string>();
 
-            cv::Mat cvimg = imgs.at(i);
-            dlib::matrix <dlib::rgb_pixel> img;
-            dlib::assign_image(img, dlib::cv_image<dlib::rgb_pixel>(cvimg));
+        cv::Mat cvimg = imgs.at(i);
+        dlib::matrix<dlib::rgb_pixel> img;
+        dlib::assign_image(img, dlib::cv_image<dlib::rgb_pixel>(cvimg));
 
-            std::vector <APIData> ad_cls = vad.at(i).getv("classes");
-            std::vector <APIData> cad_cls;
+        std::vector<APIData> ad_cls = vad.at(i).getv("classes");
+        std::vector<APIData> cad_cls;
 
-            // iterate bboxes per image
-            for (size_t j = 0; j < ad_cls.size(); j++) {
-                APIData bbox = ad_cls.at(j).getobj("bbox");
-                if (bbox.empty()) {
-                  _chain_logger->warn("align/crop action cannot find bbox object for uri " + uri);
-                  throw ActionBadParamException("align/crop action cannot find bbox object for uri " + uri);
-                }
-                APIData ad_shape = bbox.getobj("shape");
-                if (ad_shape.empty()) {
-                  _chain_logger->warn("align/crop action cannot find shape object for uri " + uri);
-                  throw ActionBadParamException("align/crop action cannot find shape object for uri " + uri);
-                }
+        // iterate bboxes per image
+        for (size_t j = 0; j < ad_cls.size(); j++)
+          {
+            APIData bbox = ad_cls.at(j).getobj("bbox");
+            if (bbox.empty())
+              {
+                _chain_logger->warn(
+                    "align/crop action cannot find bbox object for uri "
+                    + uri);
+                throw ActionBadParamException(
+                    "align/crop action cannot find bbox object for uri "
+                    + uri);
+              }
+            APIData ad_shape = bbox.getobj("shape");
+            if (ad_shape.empty())
+              {
+                _chain_logger->warn(
+                    "align/crop action cannot find shape object for uri "
+                    + uri);
+                throw ActionBadParamException(
+                    "align/crop action cannot find shape object for uri "
+                    + uri);
+              }
 
-                // adding bbox id
-                std::string bbox_id = genid(uri, "bbox" + std::to_string(j));
-                bbox_ids.push_back(bbox_id);
-                APIData ad_cid;
-                ad_cls.at(j).add(bbox_id, ad_cid);
-                cad_cls.push_back(ad_cls.at(j));
-                const dlib::rectangle shape_rect(ad_shape.get("left").get<long>(),
-                                                 ad_shape.get("top").get<long>(),
-                                                 ad_shape.get("right").get<long>(),
-                                                 ad_shape.get("bottom").get<long>());
-                std::vector <dlib::point> parts;
-                std::vector<double> points = ad_shape.get("points").get < std::vector < double >> ();
-                for (size_t idx = 0; idx < points.size() - 1; idx += 2) {
-                    parts.push_back(dlib::point(static_cast<long>(points[idx]), static_cast<long>(points[idx + 1])));
-                }
+            // adding bbox id
+            std::string bbox_id = genid(uri, "bbox" + std::to_string(j));
+            bbox_ids.push_back(bbox_id);
+            APIData ad_cid;
+            ad_cls.at(j).add(bbox_id, ad_cid);
+            cad_cls.push_back(ad_cls.at(j));
+            const dlib::rectangle shape_rect(
+                ad_shape.get("left").get<long>(),
+                ad_shape.get("top").get<long>(),
+                ad_shape.get("right").get<long>(),
+                ad_shape.get("bottom").get<long>());
+            std::vector<dlib::point> parts;
+            std::vector<double> points
+                = ad_shape.get("points").get<std::vector<double>>();
+            for (size_t idx = 0; idx < points.size() - 1; idx += 2)
+              {
+                parts.push_back(
+                    dlib::point(static_cast<long>(points[idx]),
+                                static_cast<long>(points[idx + 1])));
+              }
 
-                dlib::full_object_detection shape(shape_rect, parts);
-                dlib::matrix <dlib::rgb_pixel> r;
-                dlib::extract_image_chip(img, dlib::get_face_chip_details(shape, chip_size, bratio), r);
-                cv::Mat cropped_img = dlib::toMat(r);
+            dlib::full_object_detection shape(shape_rect, parts);
+            dlib::matrix<dlib::rgb_pixel> r;
+            dlib::extract_image_chip(
+                img, dlib::get_face_chip_details(shape, chip_size, bratio), r);
+            cv::Mat cropped_img = dlib::toMat(r);
 
-                // save crops if requested
-                if (save_crops) {
-                    std::string puri = dd_utils::split(uri, '/').back();
-                    cv::imwrite("crop_" + puri + "_" + std::to_string(j) + ".png", cropped_img);
-                }
-                cropped_imgs.push_back(std::move(cropped_img));
-            }
-            APIData ccls;
-            ccls.add("uri", uri);
-            if (vad.at(i).has("index_uri"))
-                ccls.add("index_uri", vad.at(i).get("index_uri").get<std::string>());
-            ccls.add("classes", cad_cls);
-            cvad.push_back(ccls);
-        }
-        // store serialized crops into action output store
-        APIData action_out;
-        action_out.add("data_raw_img", cropped_imgs);
-        action_out.add("cids", bbox_ids);
-        cdata.add_action_data(_action_id, action_out);
+            // save crops if requested
+            if (save_crops)
+              {
+                std::string puri = dd_utils::split(uri, '/').back();
+                cv::imwrite("crop_" + puri + "_" + std::to_string(j) + ".png",
+                            cropped_img);
+              }
+            cropped_imgs.push_back(std::move(cropped_img));
+          }
+        APIData ccls;
+        ccls.add("uri", uri);
+        if (vad.at(i).has("index_uri"))
+          ccls.add("index_uri", vad.at(i).get("index_uri").get<std::string>());
+        ccls.add("classes", cad_cls);
+        cvad.push_back(ccls);
+      }
+    // store serialized crops into action output store
+    APIData action_out;
+    action_out.add("data_raw_img", cropped_imgs);
+    action_out.add("cids", bbox_ids);
+    cdata.add_action_data(_action_id, action_out);
 
-        // updated model data with chain ids
-        model_out.add("predictions", cvad);
-    }
+    // updated model data with chain ids
+    model_out.add("predictions", cvad);
+  }
 }

--- a/src/backends/dlib/dlib_actions.h
+++ b/src/backends/dlib/dlib_actions.h
@@ -23,22 +23,25 @@
 
 #include "chain_actions.h"
 
-namespace dd {
+namespace dd
+{
 
-    class DlibAlignCropAction : public ChainAction
+  class DlibAlignCropAction : public ChainAction
+  {
+  public:
+    DlibAlignCropAction(const APIData &adc, const std::string &action_id,
+                        const std::string &action_type,
+                        const std::shared_ptr<spdlog::logger> chain_logger)
+        : ChainAction(adc, action_id, action_type, chain_logger)
     {
-    public:
-        DlibAlignCropAction(const APIData &adc,
-                            const std::string &action_id,
-                            const std::string &action_type,
-                            const std::shared_ptr<spdlog::logger> chain_logger)
-          :ChainAction(adc,action_id,action_type,chain_logger) {}
+    }
 
-        ~DlibAlignCropAction() {}
+    ~DlibAlignCropAction()
+    {
+    }
 
-        void apply(APIData &model_out,
-                   ChainData &cdata);
-    };
+    void apply(APIData &model_out, ChainData &cdata);
+  };
 }
 
-#endif //DEEPDETECT_DLIB_ACTIONS_H
+#endif // DEEPDETECT_DLIB_ACTIONS_H

--- a/src/backends/dlib/dlibinputconns.h
+++ b/src/backends/dlib/dlibinputconns.h
@@ -31,118 +31,153 @@
 #include "dlib/opencv/to_open_cv.h"
 #include "dlib/opencv/cv_image.h"
 
-
 #include "inputconnectorstrategy.h"
 #include "ext/base64/base64.h"
 
-namespace dd {
-    class DlibInputInterface {
-    public:
-        DlibInputInterface() {}
+namespace dd
+{
+  class DlibInputInterface
+  {
+  public:
+    DlibInputInterface()
+    {
+    }
 
-        DlibInputInterface(const DlibInputInterface &tii)
-                : _dv(tii._dv) {}
+    DlibInputInterface(const DlibInputInterface &tii) : _dv(tii._dv)
+    {
+    }
 
-        ~DlibInputInterface() {}
+    ~DlibInputInterface()
+    {
+    }
 
-    public:
-        // parameters common to all Dlib input connectors
-        std::vector<dlib::matrix<dlib::rgb_pixel>> _dv;
-        std::vector<dlib::matrix<dlib::rgb_pixel>> _dv_test;
-        std::unordered_map<std::string,std::pair<int,int>> _imgs_size; /**< image sizes, used in detection. */
-    };
+  public:
+    // parameters common to all Dlib input connectors
+    std::vector<dlib::matrix<dlib::rgb_pixel>> _dv;
+    std::vector<dlib::matrix<dlib::rgb_pixel>> _dv_test;
+    std::unordered_map<std::string, std::pair<int, int>>
+        _imgs_size; /**< image sizes, used in detection. */
+  };
 
-    class ImgDlibInputFileConn : public ImgInputFileConn, public DlibInputInterface {
-    public:
-        ImgDlibInputFileConn()
-                : ImgInputFileConn() {
-            reset_dv();
-        }
+  class ImgDlibInputFileConn : public ImgInputFileConn,
+                               public DlibInputInterface
+  {
+  public:
+    ImgDlibInputFileConn() : ImgInputFileConn()
+    {
+      reset_dv();
+    }
 
-        ImgDlibInputFileConn(const ImgDlibInputFileConn &i)
-                : ImgInputFileConn(i), DlibInputInterface(i){}
+    ImgDlibInputFileConn(const ImgDlibInputFileConn &i)
+        : ImgInputFileConn(i), DlibInputInterface(i)
+    {
+    }
 
-        ~ImgDlibInputFileConn() {}
+    ~ImgDlibInputFileConn()
+    {
+    }
 
-        int channels() const {
-            if (_bw) return 1;
-            else return 3; // RGB
-        }
+    int channels() const
+    {
+      if (_bw)
+        return 1;
+      else
+        return 3; // RGB
+    }
 
-        int height() const {
-            return _height;
-        }
+    int height() const
+    {
+      return _height;
+    }
 
-        int width() const {
-            return _width;
-        }
+    int width() const
+    {
+      return _width;
+    }
 
-        int batch_size() const {
-            if (!_dv.empty())
-                return _dv.size();
-            else return ImgInputFileConn::batch_size();
-        }
+    int batch_size() const
+    {
+      if (!_dv.empty())
+        return _dv.size();
+      else
+        return ImgInputFileConn::batch_size();
+    }
 
-        int test_batch_size() const {
-            if (!_dv_test.empty())
-                return _dv_test.size();
-            else return ImgInputFileConn::test_batch_size();
-        }
+    int test_batch_size() const
+    {
+      if (!_dv_test.empty())
+        return _dv_test.size();
+      else
+        return ImgInputFileConn::test_batch_size();
+    }
 
-        void init(const APIData &ad) {
-            ImgInputFileConn::init(ad);
-        }
+    void init(const APIData &ad)
+    {
+      ImgInputFileConn::init(ad);
+    }
 
-        void transform(const APIData &ad) {
-            try {
-                ImgInputFileConn::transform(ad);
-            }
-            catch (InputConnectorBadParamException &e) {
-                throw;
-            }
-	    // ids
-	    bool set_ids = false;
-	    if (this->_ids.empty())
-	      set_ids = true;
-            for (size_t i = 0; i < _images.size(); i++) {
-                dlib::matrix<dlib::rgb_pixel> inputImg;
-                if (_bw) {
-                    dlib::assign_image(inputImg, dlib::cv_image<unsigned char>(_images.at(i)));
-                } else {
-                    dlib::assign_image(inputImg, dlib::cv_image<dlib::rgb_pixel>(_images.at(i)));
-                }
-                _dv.push_back(inputImg);
-		        if (set_ids) this->_ids.push_back(_uris.at(i));
-                _imgs_size.insert(std::pair<std::string,std::pair<int,int>>(this->_uris.at(i),this->_images_size.at(i)));
-            }
-            if (!ad.has("chain")) {
-                this->_images.clear();
-                this->_images_size.clear();
-            }
-        }
-
-        std::vector<dlib::matrix<dlib::rgb_pixel>> get_dv(const int &num) {
-            int i = 0;
-            std::vector<dlib::matrix<dlib::rgb_pixel>> dv;
-            while(_dt_vit!=_dv.end() && i < num) {
-                dv.push_back((*_dt_vit));
-                ++i;
-                ++_dt_vit;
-            }
-            return dv;
-        }
-
-        void reset_dv()
+    void transform(const APIData &ad)
+    {
+      try
         {
-            _dt_vit = _dv.begin();
+          ImgInputFileConn::transform(ad);
         }
+      catch (InputConnectorBadParamException &e)
+        {
+          throw;
+        }
+      // ids
+      bool set_ids = false;
+      if (this->_ids.empty())
+        set_ids = true;
+      for (size_t i = 0; i < _images.size(); i++)
+        {
+          dlib::matrix<dlib::rgb_pixel> inputImg;
+          if (_bw)
+            {
+              dlib::assign_image(inputImg,
+                                 dlib::cv_image<unsigned char>(_images.at(i)));
+            }
+          else
+            {
+              dlib::assign_image(
+                  inputImg, dlib::cv_image<dlib::rgb_pixel>(_images.at(i)));
+            }
+          _dv.push_back(inputImg);
+          if (set_ids)
+            this->_ids.push_back(_uris.at(i));
+          _imgs_size.insert(std::pair<std::string, std::pair<int, int>>(
+              this->_uris.at(i), this->_images_size.at(i)));
+        }
+      if (!ad.has("chain"))
+        {
+          this->_images.clear();
+          this->_images_size.clear();
+        }
+    }
 
-    public:
-        std::vector<dlib::matrix<dlib::rgb_pixel>>::const_iterator _dt_vit;
+    std::vector<dlib::matrix<dlib::rgb_pixel>> get_dv(const int &num)
+    {
+      int i = 0;
+      std::vector<dlib::matrix<dlib::rgb_pixel>> dv;
+      while (_dt_vit != _dv.end() && i < num)
+        {
+          dv.push_back((*_dt_vit));
+          ++i;
+          ++_dt_vit;
+        }
+      return dv;
+    }
 
-    };
+    void reset_dv()
+    {
+      _dt_vit = _dv.begin();
+    }
+
+  public:
+    std::vector<dlib::matrix<dlib::rgb_pixel>>::const_iterator _dt_vit;
+  };
 
 }
 
 #endif
-

--- a/src/backends/dlib/dliblib.cc
+++ b/src/backends/dlib/dliblib.cc
@@ -24,275 +24,410 @@
 #include "imginputfileconn.h"
 #include "outputconnectorstrategy.h"
 
-namespace dd {
+namespace dd
+{
 
-    template<class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-    DlibLib<TInputConnectorStrategy, TOutputConnectorStrategy, TMLModel>::DlibLib(const DlibModel &cmodel)
-            :MLLib<TInputConnectorStrategy, TOutputConnectorStrategy, DlibModel>(cmodel) {
-        this->_libname = "dlib";
-    }
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  DlibLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+          TMLModel>::DlibLib(const DlibModel &cmodel)
+      : MLLib<TInputConnectorStrategy, TOutputConnectorStrategy, DlibModel>(
+          cmodel)
+  {
+    this->_libname = "dlib";
+  }
 
-    template<class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-    DlibLib<TInputConnectorStrategy, TOutputConnectorStrategy, TMLModel>::DlibLib(DlibLib &&cl) noexcept
-            :MLLib<TInputConnectorStrategy, TOutputConnectorStrategy, DlibModel>(std::move(cl)) {
-        this->_libname = "dlib";
-        _net_type = cl._net_type;
-        this->_mltype = "detection";
-    }
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  DlibLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+          TMLModel>::DlibLib(DlibLib &&cl) noexcept
+      : MLLib<TInputConnectorStrategy, TOutputConnectorStrategy, DlibModel>(
+          std::move(cl))
+  {
+    this->_libname = "dlib";
+    _net_type = cl._net_type;
+    this->_mltype = "detection";
+  }
 
-    template<class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-    DlibLib<TInputConnectorStrategy, TOutputConnectorStrategy, TMLModel>::~DlibLib() {
-        std::lock_guard <std::mutex> lock(_net_mutex);
-    }
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  DlibLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+          TMLModel>::~DlibLib()
+  {
+    std::lock_guard<std::mutex> lock(_net_mutex);
+  }
 
-    template<class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-    void DlibLib<TInputConnectorStrategy, TOutputConnectorStrategy, TMLModel>::init_mllib(const APIData &ad) {
-        if (ad.has("model_type")) {
-            _net_type = ad.get("model_type").get<std::string>();
-        }
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void DlibLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+               TMLModel>::init_mllib(const APIData &ad)
+  {
+    if (ad.has("model_type"))
+      {
+        _net_type = ad.get("model_type").get<std::string>();
+      }
 
-        if (_net_type.empty() ||
-            (_net_type != "obj_detector" && _net_type != "face_detector" && _net_type != "face_feature_extractor")) {
-            throw MLLibBadParamException("Must specify model type (obj_detector, face_detector, or face_feature_extractor)");
-        }
+    if (_net_type.empty()
+        || (_net_type != "obj_detector" && _net_type != "face_detector"
+            && _net_type != "face_feature_extractor"))
+      {
+        throw MLLibBadParamException(
+            "Must specify model type (obj_detector, face_detector, or "
+            "face_feature_extractor)");
+      }
 
-        if (ad.has("shape_predictor") && ad.get("shape_predictor").get<bool>()) {
-            this->_mlmodel._hasShapePredictor = true;
-        }
+    if (ad.has("shape_predictor") && ad.get("shape_predictor").get<bool>())
+      {
+        this->_mlmodel._hasShapePredictor = true;
+      }
 
-        this->_mlmodel.read_from_repository(this->_mlmodel._repo, this->_logger);
-        // If provided, use this as the chip_size for the shape predictor. Default: 150
-        if (ad.has("chip_size")) {
-            _chip_size = ad.get("chip_size").get<int>();
-        }
-        // If provided, use this as the padding ratio for the shape predictor. Default: 0.25
-        if (ad.has("padding")) {
-            _padding = ad.get("padding").get<double>();
-        }
-    }
+    this->_mlmodel.read_from_repository(this->_mlmodel._repo, this->_logger);
+    // If provided, use this as the chip_size for the shape predictor. Default:
+    // 150
+    if (ad.has("chip_size"))
+      {
+        _chip_size = ad.get("chip_size").get<int>();
+      }
+    // If provided, use this as the padding ratio for the shape predictor.
+    // Default: 0.25
+    if (ad.has("padding"))
+      {
+        _padding = ad.get("padding").get<double>();
+      }
+  }
 
-    template<class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-    void DlibLib<TInputConnectorStrategy, TOutputConnectorStrategy, TMLModel>::clear_mllib(const APIData &ad) {
-        // NOT IMPLEMENTED
-    }
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void DlibLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+               TMLModel>::clear_mllib(const APIData &ad)
+  {
+    // NOT IMPLEMENTED
+  }
 
-    template<class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-    int DlibLib<TInputConnectorStrategy, TOutputConnectorStrategy, TMLModel>::train(const APIData &ad,
-                                                                                    APIData &out) {
-        // NOT IMPLEMENTED
-        return 0;
-    }
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  int DlibLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+              TMLModel>::train(const APIData &ad, APIData &out)
+  {
+    // NOT IMPLEMENTED
+    return 0;
+  }
 
-    template<class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-    void DlibLib<TInputConnectorStrategy, TOutputConnectorStrategy, TMLModel>::test(const APIData &ad,
-                                                                                    APIData &out) {
-        // NOT IMPLEMENTED
-    }
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void
+  DlibLib<TInputConnectorStrategy, TOutputConnectorStrategy, TMLModel>::test(
+      const APIData &ad, APIData &out)
+  {
+    // NOT IMPLEMENTED
+  }
 
-    template<class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-    int DlibLib<TInputConnectorStrategy, TOutputConnectorStrategy, TMLModel>::predict(const APIData &ad,
-                                                                                      APIData &out) {
-        std::lock_guard <std::mutex> lock(_net_mutex);
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  int DlibLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+              TMLModel>::predict(const APIData &ad, APIData &out)
+  {
+    std::lock_guard<std::mutex> lock(_net_mutex);
 
-        APIData ad_output = ad.getobj("parameters").getobj("output");
+    APIData ad_output = ad.getobj("parameters").getobj("output");
 
-        double confidence_threshold = 0.0;
-        if (ad_output.has("confidence_threshold")) {
-            confidence_threshold = ad_output.get("confidence_threshold").get<double>();
-        }
-        TInputConnectorStrategy inputc(this->_inputc);
-        TOutputConnectorStrategy tout(this->_outputc);
-        APIData cad = ad;
-        cad.add("model_repo", this->_mlmodel._repo);
-        try {
-            inputc.transform(cad);
-        }
-        catch (std::exception &e) {
-            throw;
-        }
+    double confidence_threshold = 0.0;
+    if (ad_output.has("confidence_threshold"))
+      {
+        confidence_threshold
+            = ad_output.get("confidence_threshold").get<double>();
+      }
+    TInputConnectorStrategy inputc(this->_inputc);
+    TOutputConnectorStrategy tout(this->_outputc);
+    APIData cad = ad;
+    cad.add("model_repo", this->_mlmodel._repo);
+    try
+      {
+        inputc.transform(cad);
+      }
+    catch (std::exception &e)
+      {
+        throw;
+      }
 
-        APIData ad_mllib = ad.getobj("parameters").getobj("mllib");
-        int batch_size = inputc.batch_size();
-        if (ad_mllib.has("test_batch_size")) {
-            batch_size = ad_mllib.get("test_batch_size").get<int>();
-        }
+    APIData ad_mllib = ad.getobj("parameters").getobj("mllib");
+    int batch_size = inputc.batch_size();
+    if (ad_mllib.has("test_batch_size"))
+      {
+        batch_size = ad_mllib.get("test_batch_size").get<int>();
+      }
 
-        bool bbox = false;
-        if (ad_output.has("bbox") && ad_output.get("bbox").get<bool>()) {
-            bbox = true;
-        }
+    bool bbox = false;
+    if (ad_output.has("bbox") && ad_output.get("bbox").get<bool>())
+      {
+        bbox = true;
+      }
 
-        const std::string modelFile = this->_mlmodel._modelName;
-        if (modelFile.empty()) {
-            throw MLLibBadParamException("No pre-trained model found in model repository");
-        }
-        const std::string shapePredictorFile = this->_mlmodel._shapePredictorName;
+    const std::string modelFile = this->_mlmodel._modelName;
+    if (modelFile.empty())
+      {
+        throw MLLibBadParamException(
+            "No pre-trained model found in model repository");
+      }
+    const std::string shapePredictorFile = this->_mlmodel._shapePredictorName;
 
-        this->_logger->info("predict: using modelFile dir={}", modelFile);
+    this->_logger->info("predict: using modelFile dir={}", modelFile);
 
-        // Load the model into memory if not already
-        if (!_modelLoaded) {
-            this->_logger->info("predict: loading model into memory ({})", modelFile);
-            if (_net_type.empty()) {
-                throw MLLibBadParamException("Net type not specified");
-            } else if (_net_type == "obj_detector") {
-                dlib::deserialize(modelFile) >> _objDetector;
-            } else if (_net_type == "face_detector") {
-                dlib::deserialize(modelFile) >> _faceDetector;
-            } else if (_net_type == "face_feature_extractor") {
-                dlib::deserialize(modelFile) >> _faceFeatureExtractor;
-            } else {
-                throw MLLibBadParamException("Unrecognized net type: " + _net_type);
-            }
-            if (!shapePredictorFile.empty()) {
-                dlib::deserialize(shapePredictorFile) >> _shapePredictor;
-                this->_logger->info("predict: loaded shape predictor into memory ({})", shapePredictorFile);
-            }
-            _modelLoaded = true;
-        }
+    // Load the model into memory if not already
+    if (!_modelLoaded)
+      {
+        this->_logger->info("predict: loading model into memory ({})",
+                            modelFile);
+        if (_net_type.empty())
+          {
+            throw MLLibBadParamException("Net type not specified");
+          }
+        else if (_net_type == "obj_detector")
+          {
+            dlib::deserialize(modelFile) >> _objDetector;
+          }
+        else if (_net_type == "face_detector")
+          {
+            dlib::deserialize(modelFile) >> _faceDetector;
+          }
+        else if (_net_type == "face_feature_extractor")
+          {
+            dlib::deserialize(modelFile) >> _faceFeatureExtractor;
+          }
+        else
+          {
+            throw MLLibBadParamException("Unrecognized net type: "
+                                         + _net_type);
+          }
+        if (!shapePredictorFile.empty())
+          {
+            dlib::deserialize(shapePredictorFile) >> _shapePredictor;
+            this->_logger->info(
+                "predict: loaded shape predictor into memory ({})",
+                shapePredictorFile);
+          }
+        _modelLoaded = true;
+      }
 
-        // vector for storing  the outputAPI of the file
-        std::vector <APIData> vrad;
+    // vector for storing  the outputAPI of the file
+    std::vector<APIData> vrad;
 
-        inputc.reset_dv();
-        int idoffset = 0;
-        while (true) {
-            std::vector <dlib::matrix<dlib::rgb_pixel>> dv = inputc.get_dv(batch_size);
-            if (dv.empty()) break;
+    inputc.reset_dv();
+    int idoffset = 0;
+    while (true)
+      {
+        std::vector<dlib::matrix<dlib::rgb_pixel>> dv
+            = inputc.get_dv(batch_size);
+        if (dv.empty())
+          break;
 
-            // running the loaded model and saving the generated output
-            std::chrono::time_point <std::chrono::system_clock> tstart = std::chrono::system_clock::now();
-            std::vector <std::vector<dlib::mmod_rect>> detections;
-            std::vector<dlib::matrix<float, 0, 1>> face_descriptors;
-            if (_net_type == "obj_detector") {
-                try {
-                    detections = _objDetector(dv, batch_size);
-                } catch (dlib::error &e) {
-                    throw MLLibInternalException(e.what());
-                }
-            } else if (_net_type == "face_detector") {
-                try {
-                    detections = _faceDetector(dv, batch_size);
-                } catch (dlib::error &e) {
-                    throw MLLibInternalException(e.what());
-                }
-            } else if (_net_type == "face_feature_extractor"){
-                try {
-                    face_descriptors = _faceFeatureExtractor(dv, batch_size);
-                } catch (dlib::error &e) {
-                    throw MLLibInternalException(e.what());
-                }
-            } else {
-                throw MLLibBadParamException("Unrecognized net type: " + _net_type);
-            }
-            std::chrono::time_point <std::chrono::system_clock> tstop = std::chrono::system_clock::now();
-            this->_logger->info("predict: forward pass time={}",
-                                std::chrono::duration_cast<std::chrono::milliseconds>(tstop - tstart).count());
-            APIData rad;
+        // running the loaded model and saving the generated output
+        std::chrono::time_point<std::chrono::system_clock> tstart
+            = std::chrono::system_clock::now();
+        std::vector<std::vector<dlib::mmod_rect>> detections;
+        std::vector<dlib::matrix<float, 0, 1>> face_descriptors;
+        if (_net_type == "obj_detector")
+          {
+            try
+              {
+                detections = _objDetector(dv, batch_size);
+              }
+            catch (dlib::error &e)
+              {
+                throw MLLibInternalException(e.what());
+              }
+          }
+        else if (_net_type == "face_detector")
+          {
+            try
+              {
+                detections = _faceDetector(dv, batch_size);
+              }
+            catch (dlib::error &e)
+              {
+                throw MLLibInternalException(e.what());
+              }
+          }
+        else if (_net_type == "face_feature_extractor")
+          {
+            try
+              {
+                face_descriptors = _faceFeatureExtractor(dv, batch_size);
+              }
+            catch (dlib::error &e)
+              {
+                throw MLLibInternalException(e.what());
+              }
+          }
+        else
+          {
+            throw MLLibBadParamException("Unrecognized net type: "
+                                         + _net_type);
+          }
+        std::chrono::time_point<std::chrono::system_clock> tstop
+            = std::chrono::system_clock::now();
+        this->_logger->info(
+            "predict: forward pass time={}",
+            std::chrono::duration_cast<std::chrono::milliseconds>(tstop
+                                                                  - tstart)
+                .count());
+        APIData rad;
 
-            for (size_t i = 0; i < dv.size(); i++) {
-                size_t height = dv[i].nr(), width = dv[i].nc(); // nr() is number of rows, nc() is number of columns
-                std::string uri = inputc._ids.at(idoffset + i);
-                rad.add("uri", uri);
-                auto foundImg = inputc._imgs_size.find(uri);
-                int rows = 1;
-                int cols = 1;
-                if (foundImg != inputc._imgs_size.end()) {
-                    // original image size
-                    rows = foundImg->second.first;
-                    cols = foundImg->second.second;
-                } else {
-                    this->_logger->error("couldn't find original image size for {}",uri);
-                }
-                std::vector<double> probs;
-                std::vector <std::string> cats;
-                std::vector <APIData> bboxes;
-                if (_net_type == "face_feature_extractor") {
-                    // Only for feature extractor models
-                    this->_logger->info("[Input {}] Extracted feature representation of size {}", i, face_descriptors[i].size());
-                    std::vector<double> vals(face_descriptors[i].begin(), face_descriptors[i].end());
-                    rad.add("vals",vals);
-                } else {
-                    // Only for detector-type models
-                    this->_logger->info("[Input {}] Found {} objects", i, detections[i].size());
-                    for (size_t j=0; j < detections[i].size(); j++) {
-                        auto d = detections[i][j];
-                        this->_logger->info("Found obj: {} - {} ([({}, {}) ({}, {})])", d.label, d.detection_confidence, d.rect.left(), d.rect.top(), d.rect.right(), d.rect.bottom());
+        for (size_t i = 0; i < dv.size(); i++)
+          {
+            size_t height = dv[i].nr(),
+                   width = dv[i].nc(); // nr() is number of rows, nc() is
+                                       // number of columns
+            std::string uri = inputc._ids.at(idoffset + i);
+            rad.add("uri", uri);
+            auto foundImg = inputc._imgs_size.find(uri);
+            int rows = 1;
+            int cols = 1;
+            if (foundImg != inputc._imgs_size.end())
+              {
+                // original image size
+                rows = foundImg->second.first;
+                cols = foundImg->second.second;
+              }
+            else
+              {
+                this->_logger->error(
+                    "couldn't find original image size for {}", uri);
+              }
+            std::vector<double> probs;
+            std::vector<std::string> cats;
+            std::vector<APIData> bboxes;
+            if (_net_type == "face_feature_extractor")
+              {
+                // Only for feature extractor models
+                this->_logger->info(
+                    "[Input {}] Extracted feature representation of size {}",
+                    i, face_descriptors[i].size());
+                std::vector<double> vals(face_descriptors[i].begin(),
+                                         face_descriptors[i].end());
+                rad.add("vals", vals);
+              }
+            else
+              {
+                // Only for detector-type models
+                this->_logger->info("[Input {}] Found {} objects", i,
+                                    detections[i].size());
+                for (size_t j = 0; j < detections[i].size(); j++)
+                  {
+                    auto d = detections[i][j];
+                    this->_logger->info(
+                        "Found obj: {} - {} ([({}, {}) ({}, {})])", d.label,
+                        d.detection_confidence, d.rect.left(), d.rect.top(),
+                        d.rect.right(), d.rect.bottom());
 
-                        if (d.detection_confidence < confidence_threshold)
-                            continue; // Skip if it doesn't pass the conf threshold
+                    if (d.detection_confidence < confidence_threshold)
+                      continue; // Skip if it doesn't pass the conf threshold
 
-                        probs.push_back(d.detection_confidence);
-                        cats.push_back((d.label == "") ? "1" : d.label);
+                    probs.push_back(d.detection_confidence);
+                    cats.push_back((d.label == "") ? "1" : d.label);
 
-                        if (bbox) {
-                            // bbox can be formed with d.rect.left()/top()/right()/bottom()
-                            APIData ad_bbox;
-                            ad_bbox.add("xmin", std::round(
-                                    (static_cast<double>(d.rect.left()) / static_cast<double>(width)) * cols));
-                            ad_bbox.add("ymax", std::round(
-                                    (static_cast<double>(height - d.rect.top()) / static_cast<double>(height)) * rows));
-                            ad_bbox.add("xmax", std::round(
-                                    (static_cast<double>(d.rect.right()) / static_cast<double>(width)) * cols));
-                            ad_bbox.add("ymin", std::round(
-                                    (static_cast<double>(height - d.rect.bottom()) / static_cast<double>(height)) *
-                                    rows));
+                    if (bbox)
+                      {
+                        // bbox can be formed with
+                        // d.rect.left()/top()/right()/bottom()
+                        APIData ad_bbox;
+                        ad_bbox.add(
+                            "xmin",
+                            std::round((static_cast<double>(d.rect.left())
+                                        / static_cast<double>(width))
+                                       * cols));
+                        ad_bbox.add("ymax",
+                                    std::round((static_cast<double>(
+                                                    height - d.rect.top())
+                                                / static_cast<double>(height))
+                                               * rows));
+                        ad_bbox.add(
+                            "xmax",
+                            std::round((static_cast<double>(d.rect.right())
+                                        / static_cast<double>(width))
+                                       * cols));
+                        ad_bbox.add("ymin",
+                                    std::round((static_cast<double>(
+                                                    height - d.rect.bottom())
+                                                / static_cast<double>(height))
+                                               * rows));
 
-                            if (!shapePredictorFile.empty()) {
-                                auto shape = _shapePredictor(dv[i], d.rect);
-                                const auto &shape_rect = shape.get_rect();
-                                APIData ad_shape;
-                                ad_shape.add("left", shape_rect.left());
-                                ad_shape.add("top", shape_rect.top());
-                                ad_shape.add("right", shape_rect.right());
-                                ad_shape.add("bottom", shape_rect.bottom());
-                                std::vector<double> points;
-                                for (size_t idx = 0; idx < shape.num_parts(); idx++) {
-                                    const auto &p = shape.part(idx);
-                                    if (p == dlib::OBJECT_PART_NOT_PRESENT) {
-                                        // Push (-1, -1) to indicate the part is not present
-                                        points.push_back(-1.0);
-                                        points.push_back(-1.0);
-                                    } else {
-                                        points.push_back(static_cast<double>(p.x()));
-                                        points.push_back(static_cast<double>(p.y()));
-                                    }
-                                }
-                                this->_logger->info("num points: {}", points.size());
-                                ad_shape.add("points", points);
-                                ad_bbox.add("shape", ad_shape);
-                            }
+                        if (!shapePredictorFile.empty())
+                          {
+                            auto shape = _shapePredictor(dv[i], d.rect);
+                            const auto &shape_rect = shape.get_rect();
+                            APIData ad_shape;
+                            ad_shape.add("left", shape_rect.left());
+                            ad_shape.add("top", shape_rect.top());
+                            ad_shape.add("right", shape_rect.right());
+                            ad_shape.add("bottom", shape_rect.bottom());
+                            std::vector<double> points;
+                            for (size_t idx = 0; idx < shape.num_parts();
+                                 idx++)
+                              {
+                                const auto &p = shape.part(idx);
+                                if (p == dlib::OBJECT_PART_NOT_PRESENT)
+                                  {
+                                    // Push (-1, -1) to indicate the part is
+                                    // not present
+                                    points.push_back(-1.0);
+                                    points.push_back(-1.0);
+                                  }
+                                else
+                                  {
+                                    points.push_back(
+                                        static_cast<double>(p.x()));
+                                    points.push_back(
+                                        static_cast<double>(p.y()));
+                                  }
+                              }
+                            this->_logger->info("num points: {}",
+                                                points.size());
+                            ad_shape.add("points", points);
+                            ad_bbox.add("shape", ad_shape);
+                          }
 
-                            bboxes.push_back(ad_bbox);
-                        }
-                    }
-                }
-                rad.add("probs", probs);
-                rad.add("cats", cats);
-                rad.add("loss", 0.0);
-                if (bbox) rad.add("bboxes", bboxes);
-                vrad.push_back(rad);
-            }
-            idoffset += dv.size();
-        } // end prediction loop over batches
-        tout.add_results(vrad);
-        out.add("bbox", bbox);
-        tout.finalize(ad.getobj("parameters").getobj("output"), out, static_cast<MLModel *>(&this->_mlmodel));
-        if (ad.has("chain") && ad.get("chain").get<bool>()) {
-            if (typeid(inputc) == typeid(ImgDlibInputFileConn)) {
-                APIData chain_input;
-                if (!reinterpret_cast<ImgDlibInputFileConn*>(&inputc)->_orig_images.empty())
-                    chain_input.add("imgs",reinterpret_cast<ImgDlibInputFileConn*>(&inputc)->_orig_images);
-                else
-                    chain_input.add("imgs",reinterpret_cast<ImgDlibInputFileConn*>(&inputc)->_images);
-                chain_input.add("imgs_size",reinterpret_cast<ImgDlibInputFileConn*>(&inputc)->_images_size);
-                out.add("input",chain_input);
-            }
-        }
-        out.add("status", 0);
-        return 0;
-    }
+                        bboxes.push_back(ad_bbox);
+                      }
+                  }
+              }
+            rad.add("probs", probs);
+            rad.add("cats", cats);
+            rad.add("loss", 0.0);
+            if (bbox)
+              rad.add("bboxes", bboxes);
+            vrad.push_back(rad);
+          }
+        idoffset += dv.size();
+      } // end prediction loop over batches
+    tout.add_results(vrad);
+    out.add("bbox", bbox);
+    tout.finalize(ad.getobj("parameters").getobj("output"), out,
+                  static_cast<MLModel *>(&this->_mlmodel));
+    if (ad.has("chain") && ad.get("chain").get<bool>())
+      {
+        if (typeid(inputc) == typeid(ImgDlibInputFileConn))
+          {
+            APIData chain_input;
+            if (!reinterpret_cast<ImgDlibInputFileConn *>(&inputc)
+                     ->_orig_images.empty())
+              chain_input.add("imgs",
+                              reinterpret_cast<ImgDlibInputFileConn *>(&inputc)
+                                  ->_orig_images);
+            else
+              chain_input.add(
+                  "imgs",
+                  reinterpret_cast<ImgDlibInputFileConn *>(&inputc)->_images);
+            chain_input.add("imgs_size",
+                            reinterpret_cast<ImgDlibInputFileConn *>(&inputc)
+                                ->_images_size);
+            out.add("input", chain_input);
+          }
+      }
+    out.add("status", 0);
+    return 0;
+  }
 
-    template class DlibLib<ImgDlibInputFileConn, SupervisedOutput, DlibModel>;
-    template class DlibLib<ImgDlibInputFileConn, UnsupervisedOutput, DlibModel>;
+  template class DlibLib<ImgDlibInputFileConn, SupervisedOutput, DlibModel>;
+  template class DlibLib<ImgDlibInputFileConn, UnsupervisedOutput, DlibModel>;
 }

--- a/src/backends/dlib/dliblib.h
+++ b/src/backends/dlib/dliblib.h
@@ -29,43 +29,48 @@
 
 #include <string>
 
-namespace dd {
-    template<class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel=DlibModel>
-    class DlibLib : public MLLib<TInputConnectorStrategy, TOutputConnectorStrategy, TMLModel> {
-    public:
-        DlibLib(const DlibModel &tfmodel);
+namespace dd
+{
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel = DlibModel>
+  class DlibLib : public MLLib<TInputConnectorStrategy,
+                               TOutputConnectorStrategy, TMLModel>
+  {
+  public:
+    DlibLib(const DlibModel &tfmodel);
 
-        DlibLib(DlibLib &&tl) noexcept;
+    DlibLib(DlibLib &&tl) noexcept;
 
-        ~DlibLib();
+    ~DlibLib();
 
-        /*- from mllib -*/
-        void init_mllib(const APIData &ad);
+    /*- from mllib -*/
+    void init_mllib(const APIData &ad);
 
-        void clear_mllib(const APIData &d);
+    void clear_mllib(const APIData &d);
 
-        int train(const APIData &ad, APIData &out);
+    int train(const APIData &ad, APIData &out);
 
-        void test(const APIData &ad, APIData &out);
+    void test(const APIData &ad, APIData &out);
 
-        int predict(const APIData &ad, APIData &out);
+    int predict(const APIData &ad, APIData &out);
 
+  public:
+    // general parameters
 
-    public:
-        // general parameters
-
-        std::string _net_type; // model type
-        // model, depending on type specified
-        net_type_objDetector _objDetector;
-        net_type_faceDetector _faceDetector;
-        net_type_faceFeatureExtractor _faceFeatureExtractor;
-        dlib::shape_predictor _shapePredictor;
-        int _chip_size = 150;
-        double _padding = 0.25;
-        // whether the model has been loaded yet
-        bool _modelLoaded = false;
-        std::mutex _net_mutex; /**< mutex around net, e.g. no concurrent predict calls as net is not re-instantiated. Use batches instead. */
-    };
+    std::string _net_type; // model type
+    // model, depending on type specified
+    net_type_objDetector _objDetector;
+    net_type_faceDetector _faceDetector;
+    net_type_faceFeatureExtractor _faceFeatureExtractor;
+    dlib::shape_predictor _shapePredictor;
+    int _chip_size = 150;
+    double _padding = 0.25;
+    // whether the model has been loaded yet
+    bool _modelLoaded = false;
+    std::mutex
+        _net_mutex; /**< mutex around net, e.g. no concurrent predict calls as
+                       net is not re-instantiated. Use batches instead. */
+  };
 
 }
 

--- a/src/backends/dlib/dlibmodel.cc
+++ b/src/backends/dlib/dlibmodel.cc
@@ -23,53 +23,66 @@
 #include <utils/fileops.hpp>
 #include <string>
 
-namespace dd {
-     DlibModel::DlibModel(const APIData &ad, APIData &adg,
-		       const std::shared_ptr<spdlog::logger> &logger)
-       :MLModel(ad,adg,logger)
-     {
-        if (ad.has("repository")) {
-            read_from_repository(ad.get("repository").get<std::string>(),
-                                 spdlog::get("api")); // XXX: beware, error not caught
-            this->_modelRepo = ad.get("repository").get<std::string>();
-        }
-    }
+namespace dd
+{
+  DlibModel::DlibModel(const APIData &ad, APIData &adg,
+                       const std::shared_ptr<spdlog::logger> &logger)
+      : MLModel(ad, adg, logger)
+  {
+    if (ad.has("repository"))
+      {
+        read_from_repository(
+            ad.get("repository").get<std::string>(),
+            spdlog::get("api")); // XXX: beware, error not caught
+        this->_modelRepo = ad.get("repository").get<std::string>();
+      }
+  }
 
-    int DlibModel::read_from_repository(const std::string &repo,
-                                        const std::shared_ptr<spdlog::logger> &logger) {
-        std::string modelName = ".dat";
-        std::string shapePredictorName = ".shapepredictor";
-        this->_repo = repo;
-        std::unordered_set<std::string> lfiles;
-        int e = fileops::list_directory(repo, true, false, false, lfiles);
-        if (e != 0) {
-            logger->error("error reading or listing dlib models in repository {}", repo);
-            throw MLLibBadParamException("error reading or listing dlib models in repository " + _repo);
-        }
+  int DlibModel::read_from_repository(
+      const std::string &repo, const std::shared_ptr<spdlog::logger> &logger)
+  {
+    std::string modelName = ".dat";
+    std::string shapePredictorName = ".shapepredictor";
+    this->_repo = repo;
+    std::unordered_set<std::string> lfiles;
+    int e = fileops::list_directory(repo, true, false, false, lfiles);
+    if (e != 0)
+      {
+        logger->error("error reading or listing dlib models in repository {}",
+                      repo);
+        throw MLLibBadParamException(
+            "error reading or listing dlib models in repository " + _repo);
+      }
 
-        auto hit = lfiles.begin();
-        std::string modelf;
-        long int state_t = -1, state_t_sp = -1;
-        while (hit != lfiles.end()) {
-            if ((*hit).find(modelName) != std::string::npos) {
-                // stat file to pick the latest one
-                long int st = fileops::file_last_modif((*hit));
-                if (st > state_t) {
-                    modelf = (*hit);
-                    state_t = st;
-                }
-            }
-            if (_hasShapePredictor && (*hit).find(shapePredictorName) != std::string::npos) {
-                long int st = fileops::file_last_modif((*hit));
-                if (st > state_t_sp) {
-                    _shapePredictorName = (*hit);
-                    state_t_sp = st;
-                }
-            }
-            ++hit;
-        }
-        _modelName = modelf;
+    auto hit = lfiles.begin();
+    std::string modelf;
+    long int state_t = -1, state_t_sp = -1;
+    while (hit != lfiles.end())
+      {
+        if ((*hit).find(modelName) != std::string::npos)
+          {
+            // stat file to pick the latest one
+            long int st = fileops::file_last_modif((*hit));
+            if (st > state_t)
+              {
+                modelf = (*hit);
+                state_t = st;
+              }
+          }
+        if (_hasShapePredictor
+            && (*hit).find(shapePredictorName) != std::string::npos)
+          {
+            long int st = fileops::file_last_modif((*hit));
+            if (st > state_t_sp)
+              {
+                _shapePredictorName = (*hit);
+                state_t_sp = st;
+              }
+          }
+        ++hit;
+      }
+    _modelName = modelf;
 
-        return 0;
-    }
+    return 0;
+  }
 }

--- a/src/backends/dlib/dlibmodel.h
+++ b/src/backends/dlib/dlibmodel.h
@@ -27,27 +27,34 @@
 #include <spdlog/spdlog.h>
 #include <string>
 
-namespace dd {
-    class DlibModel : public MLModel {
-    public:
-        DlibModel() : MLModel() {}
+namespace dd
+{
+  class DlibModel : public MLModel
+  {
+  public:
+    DlibModel() : MLModel()
+    {
+    }
 
-        DlibModel(const APIData &ad, APIData &adg,
-		  const std::shared_ptr<spdlog::logger> &logger);
+    DlibModel(const APIData &ad, APIData &adg,
+              const std::shared_ptr<spdlog::logger> &logger);
 
-        DlibModel(const std::string &repo)
-                : MLModel(repo) {}
+    DlibModel(const std::string &repo) : MLModel(repo)
+    {
+    }
 
-        ~DlibModel() {}
+    ~DlibModel()
+    {
+    }
 
-        int read_from_repository(const std::string &repo,
-                                 const std::shared_ptr<spdlog::logger> &logger);
+    int read_from_repository(const std::string &repo,
+                             const std::shared_ptr<spdlog::logger> &logger);
 
-        std::string _modelName; // Name of the graph
-        std::string _modelRepo;
-        bool _hasShapePredictor = false;
-        std::string _shapePredictorName;
-    };
+    std::string _modelName; // Name of the graph
+    std::string _modelRepo;
+    bool _hasShapePredictor = false;
+    std::string _shapePredictorName;
+  };
 
 }
 

--- a/src/backends/ncnn/caffe2ncnn.cc
+++ b/src/backends/ncnn/caffe2ncnn.cc
@@ -1,16 +1,19 @@
-// Tencent is pleased to support the open source community by making ncnn available.
+// Tencent is pleased to support the open source community by making ncnn
+// available.
 //
 // Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
 //
-// Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
-// in compliance with the License. You may obtain a copy of the License at
+// Licensed under the BSD 3-Clause License (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of
+// the License at
 //
 // https://opensource.org/licenses/BSD-3-Clause
 //
-// Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the
-// specific language governing permissions and limitations under the License.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
 
 #include <stdio.h>
 #include <limits.h>
@@ -30,277 +33,295 @@
 #include "src/caffe.pb.h"
 #include "upgrade_proto.hpp"
 
-
-
 static inline size_t alignSize(size_t sz, int n)
 {
-    return (sz + n-1) & -n;
+  return (sz + n - 1) & -n;
 }
 
 // convert float to half precision floating point
 static unsigned short float2half(float value)
 {
-    // 1 : 8 : 23
-    union
+  // 1 : 8 : 23
+  union
+  {
+    unsigned int u;
+    float f;
+  } tmp;
+
+  tmp.f = value;
+
+  // 1 : 8 : 23
+  unsigned short sign = (tmp.u & 0x80000000) >> 31;
+  unsigned short exponent = (tmp.u & 0x7F800000) >> 23;
+  unsigned int significand = tmp.u & 0x7FFFFF;
+
+  //     fprintf(stderr, "%d %d %d\n", sign, exponent, significand);
+
+  // 1 : 5 : 10
+  unsigned short fp16;
+  if (exponent == 0)
     {
-        unsigned int u;
-        float f;
-    } tmp;
-
-    tmp.f = value;
-
-    // 1 : 8 : 23
-    unsigned short sign = (tmp.u & 0x80000000) >> 31;
-    unsigned short exponent = (tmp.u & 0x7F800000) >> 23;
-    unsigned int significand = tmp.u & 0x7FFFFF;
-
-//     fprintf(stderr, "%d %d %d\n", sign, exponent, significand);
-
-    // 1 : 5 : 10
-    unsigned short fp16;
-    if (exponent == 0)
-    {
-        // zero or denormal, always underflow
-        fp16 = (sign << 15) | (0x00 << 10) | 0x00;
+      // zero or denormal, always underflow
+      fp16 = (sign << 15) | (0x00 << 10) | 0x00;
     }
-    else if (exponent == 0xFF)
+  else if (exponent == 0xFF)
     {
-        // infinity or NaN
-        fp16 = (sign << 15) | (0x1F << 10) | (significand ? 0x200 : 0x00);
+      // infinity or NaN
+      fp16 = (sign << 15) | (0x1F << 10) | (significand ? 0x200 : 0x00);
     }
-    else
+  else
     {
-        // normalized
-        short newexp = exponent + (- 127 + 15);
-        if (newexp >= 31)
+      // normalized
+      short newexp = exponent + (-127 + 15);
+      if (newexp >= 31)
         {
-            // overflow, return infinity
-            fp16 = (sign << 15) | (0x1F << 10) | 0x00;
+          // overflow, return infinity
+          fp16 = (sign << 15) | (0x1F << 10) | 0x00;
         }
-        else if (newexp <= 0)
+      else if (newexp <= 0)
         {
-            // underflow
-            if (newexp >= -10)
+          // underflow
+          if (newexp >= -10)
             {
-                // denormal half-precision
-                unsigned short sig = (significand | 0x800000) >> (14 - newexp);
-                fp16 = (sign << 15) | (0x00 << 10) | sig;
+              // denormal half-precision
+              unsigned short sig = (significand | 0x800000) >> (14 - newexp);
+              fp16 = (sign << 15) | (0x00 << 10) | sig;
             }
-            else
+          else
             {
-                // underflow
-                fp16 = (sign << 15) | (0x00 << 10) | 0x00;
+              // underflow
+              fp16 = (sign << 15) | (0x00 << 10) | 0x00;
             }
         }
-        else
+      else
         {
-            fp16 = (sign << 15) | (newexp << 10) | (significand >> 13);
+          fp16 = (sign << 15) | (newexp << 10) | (significand >> 13);
         }
     }
 
-    return fp16;
+  return fp16;
 }
 
 // round to nearest
 static signed char float2int8(float value)
 {
-    float tmp;
-    if (value >= 0.f) tmp = value + 0.5;
-    else tmp = value - 0.5;
+  float tmp;
+  if (value >= 0.f)
+    tmp = value + 0.5;
+  else
+    tmp = value - 0.5;
 
-    if (tmp > 127)
-        return 127;
-    if (tmp < -128)
-        return -128;
+  if (tmp > 127)
+    return 127;
+  if (tmp < -128)
+    return -128;
 
-    return tmp;
+  return tmp;
 }
 
-static bool read_int8scale_table(const char* filepath, std::map<std::string, std::vector<float> >& blob_int8scale_table, std::map<std::string, std::vector<float> >& weight_int8scale_table)
+static bool read_int8scale_table(
+    const char *filepath,
+    std::map<std::string, std::vector<float>> &blob_int8scale_table,
+    std::map<std::string, std::vector<float>> &weight_int8scale_table)
 {
-    blob_int8scale_table.clear();
-    weight_int8scale_table.clear();
+  blob_int8scale_table.clear();
+  weight_int8scale_table.clear();
 
-    FILE* fp = fopen(filepath, "rb");
-    if (!fp)
+  FILE *fp = fopen(filepath, "rb");
+  if (!fp)
     {
-        fprintf(stderr, "fopen %s failed\n", filepath);
-        return false;
+      fprintf(stderr, "fopen %s failed\n", filepath);
+      return false;
     }
 
-    bool in_scale_vector = false;
+  bool in_scale_vector = false;
 
-    std::string keystr;
-    std::vector<float> scales;
+  std::string keystr;
+  std::vector<float> scales;
 
-    while (!feof(fp))
+  while (!feof(fp))
     {
-        char key[256];
-        int nscan = fscanf(fp, "%255s", key);
-        if (nscan != 1)
+      char key[256];
+      int nscan = fscanf(fp, "%255s", key);
+      if (nscan != 1)
         {
-            break;
+          break;
         }
 
-        if (in_scale_vector)
+      if (in_scale_vector)
         {
-            float scale = 1.f;
-            int nscan = sscanf(key, "%f", &scale);
-            if (nscan == 1)
+          float scale = 1.f;
+          int nscan = sscanf(key, "%f", &scale);
+          if (nscan == 1)
             {
-                scales.push_back(scale);
-                continue;
+              scales.push_back(scale);
+              continue;
             }
-            else
+          else
             {
-                // XYZ_param_N pattern
-                if (strstr(keystr.c_str(), "_param_"))
+              // XYZ_param_N pattern
+              if (strstr(keystr.c_str(), "_param_"))
                 {
-                    weight_int8scale_table[ keystr ] = scales;
+                  weight_int8scale_table[keystr] = scales;
                 }
-                else
+              else
                 {
-                    blob_int8scale_table[ keystr ] = scales;
+                  blob_int8scale_table[keystr] = scales;
                 }
 
-                keystr.clear();
-                scales.clear();
+              keystr.clear();
+              scales.clear();
 
-                in_scale_vector = false;
+              in_scale_vector = false;
             }
         }
 
-        if (!in_scale_vector)
+      if (!in_scale_vector)
         {
-            keystr = key;
+          keystr = key;
 
-            in_scale_vector = true;
+          in_scale_vector = true;
         }
     }
 
-    if (in_scale_vector)
+  if (in_scale_vector)
     {
-        // XYZ_param_N pattern
-        if (strstr(keystr.c_str(), "_param_"))
+      // XYZ_param_N pattern
+      if (strstr(keystr.c_str(), "_param_"))
         {
-            weight_int8scale_table[ keystr ] = scales;
+          weight_int8scale_table[keystr] = scales;
         }
-        else
+      else
         {
-            blob_int8scale_table[ keystr ] = scales;
+          blob_int8scale_table[keystr] = scales;
         }
     }
 
-    fclose(fp);
+  fclose(fp);
 
-    return true;
+  return true;
 }
 
-static int quantize_weight(float *data, size_t data_length, std::vector<unsigned short>& float16_weights)
+static int quantize_weight(float *data, size_t data_length,
+                           std::vector<unsigned short> &float16_weights)
 {
-    float16_weights.resize(data_length);
+  float16_weights.resize(data_length);
 
-    for (size_t i = 0; i < data_length; i++)
+  for (size_t i = 0; i < data_length; i++)
     {
-        float f = data[i];
+      float f = data[i];
 
-        unsigned short fp16 = float2half(f);
+      unsigned short fp16 = float2half(f);
 
-        float16_weights[i] = fp16;
+      float16_weights[i] = fp16;
     }
 
-    // magic tag for half-precision floating point
-    return 0x01306B47;
+  // magic tag for half-precision floating point
+  return 0x01306B47;
 }
 
-static int quantize_weight(float *data, size_t data_length, std::vector<float> scales, std::vector<signed char>& int8_weights)
+static int quantize_weight(float *data, size_t data_length,
+                           std::vector<float> scales,
+                           std::vector<signed char> &int8_weights)
 {
-    int8_weights.resize(data_length);
+  int8_weights.resize(data_length);
 
-    int length_per_group = data_length / scales.size();
+  int length_per_group = data_length / scales.size();
 
-    for (size_t i = 0; i < data_length; i++)
+  for (size_t i = 0; i < data_length; i++)
     {
-        float f = data[i];
+      float f = data[i];
 
-        signed char int8 = float2int8(f * scales[ i / length_per_group ]);
+      signed char int8 = float2int8(f * scales[i / length_per_group]);
 
-        int8_weights[i] = int8;
+      int8_weights[i] = int8;
     }
 
-    // magic tag for int8
-    return 0x000D4B38;
+  // magic tag for int8
+  return 0x000D4B38;
 }
 
-static bool quantize_weight(float *data, size_t data_length, int quantize_level, std::vector<float> &quantize_table, std::vector<unsigned char> &quantize_index) {
-
-    assert(quantize_level != 0);
-    assert(data != NULL);
-    assert(data_length > 0);
-
-    if (data_length < static_cast<size_t>(quantize_level)) {
-        fprintf(stderr, "No need quantize,because: data_length < quantize_level");
-        return false;
-    }
-
-    quantize_table.reserve(quantize_level);
-    quantize_index.reserve(data_length);
-
-    // 1. Find min and max value
-    float max_value = std::numeric_limits<float>::min();
-    float min_value = std::numeric_limits<float>::max();
-
-    for (size_t i = 0; i < data_length; ++i)
-    {
-        if (max_value < data[i]) max_value = data[i];
-        if (min_value > data[i]) min_value = data[i];
-    }
-    float strides = (max_value - min_value) / quantize_level;
-
-    // 2. Generate quantize table
-    for (int i = 0; i < quantize_level; ++i)
-    {
-        quantize_table.push_back(min_value + i * strides);
-    }
-
-    // 3. Align data to the quantized value
-    for (size_t i = 0; i < data_length; ++i)
-    {
-        size_t table_index = int((data[i] - min_value) / strides);
-        table_index = std::min<float>(table_index, quantize_level - 1);
-
-        float low_value  = quantize_table[table_index];
-        float high_value = low_value + strides;
-
-        // find a nearest value between low and high value.
-        float targetValue = data[i] - low_value < high_value - data[i] ? low_value : high_value;
-
-        table_index = int((targetValue - min_value) / strides);
-        table_index = std::min<float>(table_index, quantize_level - 1);
-        quantize_index.push_back(table_index);
-    }
-
-    return true;
-}
-
-static bool read_proto_from_text(const char* filepath, google::protobuf::Message* message)
+static bool quantize_weight(float *data, size_t data_length,
+                            int quantize_level,
+                            std::vector<float> &quantize_table,
+                            std::vector<unsigned char> &quantize_index)
 {
-    std::ifstream fs(filepath, std::ifstream::in);
-    if (!fs.is_open())
+
+  assert(quantize_level != 0);
+  assert(data != NULL);
+  assert(data_length > 0);
+
+  if (data_length < static_cast<size_t>(quantize_level))
     {
-        fprintf(stderr, "open failed %s\n", filepath);
-        return false;
+      fprintf(stderr,
+              "No need quantize,because: data_length < quantize_level");
+      return false;
     }
 
-    google::protobuf::io::IstreamInputStream input(&fs);
-    bool success = google::protobuf::TextFormat::Parse(&input, message);
+  quantize_table.reserve(quantize_level);
+  quantize_index.reserve(data_length);
 
-    fs.close();
+  // 1. Find min and max value
+  float max_value = std::numeric_limits<float>::min();
+  float min_value = std::numeric_limits<float>::max();
 
-    return success;
+  for (size_t i = 0; i < data_length; ++i)
+    {
+      if (max_value < data[i])
+        max_value = data[i];
+      if (min_value > data[i])
+        min_value = data[i];
+    }
+  float strides = (max_value - min_value) / quantize_level;
+
+  // 2. Generate quantize table
+  for (int i = 0; i < quantize_level; ++i)
+    {
+      quantize_table.push_back(min_value + i * strides);
+    }
+
+  // 3. Align data to the quantized value
+  for (size_t i = 0; i < data_length; ++i)
+    {
+      size_t table_index = int((data[i] - min_value) / strides);
+      table_index = std::min<float>(table_index, quantize_level - 1);
+
+      float low_value = quantize_table[table_index];
+      float high_value = low_value + strides;
+
+      // find a nearest value between low and high value.
+      float targetValue = data[i] - low_value < high_value - data[i]
+                              ? low_value
+                              : high_value;
+
+      table_index = int((targetValue - min_value) / strides);
+      table_index = std::min<float>(table_index, quantize_level - 1);
+      quantize_index.push_back(table_index);
+    }
+
+  return true;
 }
 
-static bool read_proto_from_binary(const char* filepath, caffe::NetParameter* message)
+static bool read_proto_from_text(const char *filepath,
+                                 google::protobuf::Message *message)
+{
+  std::ifstream fs(filepath, std::ifstream::in);
+  if (!fs.is_open())
+    {
+      fprintf(stderr, "open failed %s\n", filepath);
+      return false;
+    }
+
+  google::protobuf::io::IstreamInputStream input(&fs);
+  bool success = google::protobuf::TextFormat::Parse(&input, message);
+
+  fs.close();
+
+  return success;
+}
+
+static bool read_proto_from_binary(const char *filepath,
+                                   caffe::NetParameter *message)
 {
   std::ifstream fs(filepath, std::ifstream::in | std::ifstream::binary);
   if (!fs.is_open())
@@ -326,1341 +347,1476 @@ static bool read_proto_from_binary(const char* filepath, caffe::NetParameter* me
   return success;
 }
 
-int convert_caffe_to_ncnn(bool ocr, const char* caffeproto, const char* caffemodel,
-                          const char* ncnn_prototxt, const char* ncnn_modelbin,
-                          int quantize_level, const char* int8scale_table_path)
+int convert_caffe_to_ncnn(bool ocr, const char *caffeproto,
+                          const char *caffemodel, const char *ncnn_prototxt,
+                          const char *ncnn_modelbin, int quantize_level,
+                          const char *int8scale_table_path)
 {
-    caffe::NetParameter proto;
-    caffe::NetParameter net;
+  caffe::NetParameter proto;
+  caffe::NetParameter net;
 
-    // load
-    bool s0 = read_proto_from_text(caffeproto, &proto);
-    if (!s0)
+  // load
+  bool s0 = read_proto_from_text(caffeproto, &proto);
+  if (!s0)
     {
-        return -1;
+      return -1;
     }
 
-    bool s1 = read_proto_from_binary(caffemodel, &net);
-    if (!s1)
+  bool s1 = read_proto_from_binary(caffemodel, &net);
+  if (!s1)
     {
-        return -1;
+      return -1;
     }
 
-    std::map<std::string, std::vector<float> > blob_int8scale_table;
-    std::map<std::string, std::vector<float> > weight_int8scale_table;
-    if (int8scale_table_path)
+  std::map<std::string, std::vector<float>> blob_int8scale_table;
+  std::map<std::string, std::vector<float>> weight_int8scale_table;
+  if (int8scale_table_path)
     {
-        bool s2 = read_int8scale_table(int8scale_table_path, blob_int8scale_table, weight_int8scale_table);
-        if (!s2)
+      bool s2 = read_int8scale_table(
+          int8scale_table_path, blob_int8scale_table, weight_int8scale_table);
+      if (!s2)
         {
-            fprintf(stderr, "read_int8scale_table failed\n");
-            return -1;
+          fprintf(stderr, "read_int8scale_table failed\n");
+          return -1;
         }
     }
 
-    FILE* pp = fopen(ncnn_prototxt, "wb");
-    FILE* bp = fopen(ncnn_modelbin, "wb");
+  FILE *pp = fopen(ncnn_prototxt, "wb");
+  FILE *bp = fopen(ncnn_modelbin, "wb");
 
-    // magic
-    fprintf(pp, "7767517\n");
+  // magic
+  fprintf(pp, "7767517\n");
 
-    // rename mapping for identical bottom top style
-    std::map<std::string, std::string> blob_name_decorated;
+  // rename mapping for identical bottom top style
+  std::map<std::string, std::string> blob_name_decorated;
 
-    // bottom blob reference
-    std::map<std::string, int> bottom_reference;
+  // bottom blob reference
+  std::map<std::string, int> bottom_reference;
 
-    // global definition line
-    // [layer count] [blob count]
-    int layer_count = proto.layer_size();
-    std::set<std::string> blob_names;
-    for (int i=0; i<layer_count; i++)
+  // global definition line
+  // [layer count] [blob count]
+  int layer_count = proto.layer_size();
+  std::set<std::string> blob_names;
+  for (int i = 0; i < layer_count; i++)
     {
-        const caffe::LayerParameter& layer = proto.layer(i);
+      const caffe::LayerParameter &layer = proto.layer(i);
 
-        for (int j=0; j<layer.bottom_size(); j++)
+      for (int j = 0; j < layer.bottom_size(); j++)
         {
-            std::string blob_name = layer.bottom(j);
-            if (blob_name_decorated.find(blob_name) != blob_name_decorated.end())
+          std::string blob_name = layer.bottom(j);
+          if (blob_name_decorated.find(blob_name) != blob_name_decorated.end())
             {
-                blob_name = blob_name_decorated[blob_name];
+              blob_name = blob_name_decorated[blob_name];
             }
 
-            blob_names.insert(blob_name);
+          blob_names.insert(blob_name);
 
-            if (bottom_reference.find(blob_name) == bottom_reference.end())
+          if (bottom_reference.find(blob_name) == bottom_reference.end())
             {
-                bottom_reference[blob_name] = 1;
+              bottom_reference[blob_name] = 1;
             }
-            else
+          else
             {
-                bottom_reference[blob_name] = bottom_reference[blob_name] + 1;
+              bottom_reference[blob_name] = bottom_reference[blob_name] + 1;
             }
         }
 
-        if (layer.bottom_size() == 1 && layer.top_size() == 1 && layer.bottom(0) == layer.top(0))
+      if (layer.bottom_size() == 1 && layer.top_size() == 1
+          && layer.bottom(0) == layer.top(0))
         {
-            std::string blob_name = layer.top(0) + "_" + layer.name();
-            blob_name_decorated[layer.top(0)] = blob_name;
-            blob_names.insert(blob_name);
+          std::string blob_name = layer.top(0) + "_" + layer.name();
+          blob_name_decorated[layer.top(0)] = blob_name;
+          blob_names.insert(blob_name);
         }
-        else
+      else
         {
-            for (int j=0; j<layer.top_size(); j++)
+          for (int j = 0; j < layer.top_size(); j++)
             {
-                std::string blob_name = layer.top(j);
-                blob_names.insert(blob_name);
+              std::string blob_name = layer.top(j);
+              blob_names.insert(blob_name);
             }
         }
     }
-    // remove bottom_reference entry with reference equals to one
-    int splitncnn_blob_count = 0;
-    std::map<std::string, int>::iterator it = bottom_reference.begin();
-    while (it != bottom_reference.end())
+  // remove bottom_reference entry with reference equals to one
+  int splitncnn_blob_count = 0;
+  std::map<std::string, int>::iterator it = bottom_reference.begin();
+  while (it != bottom_reference.end())
     {
-        if (it->second == 1)
+      if (it->second == 1)
         {
-            bottom_reference.erase(it++);
+          bottom_reference.erase(it++);
         }
-        else
+      else
         {
-            splitncnn_blob_count += it->second;
-//             fprintf(stderr, "%s %d\n", it->first.c_str(), it->second);
-            ++it;
+          splitncnn_blob_count += it->second;
+          //             fprintf(stderr, "%s %d\n", it->first.c_str(),
+          //             it->second);
+          ++it;
         }
     }
-    fprintf(pp, "%lu %lu\n", layer_count + bottom_reference.size(), blob_names.size() + splitncnn_blob_count);
+  fprintf(pp, "%lu %lu\n", layer_count + bottom_reference.size(),
+          blob_names.size() + splitncnn_blob_count);
 
-    // populate
-    blob_name_decorated.clear();
-    int internal_split = 0;
-    for (int i=0; i<layer_count; i++)
+  // populate
+  blob_name_decorated.clear();
+  int internal_split = 0;
+  for (int i = 0; i < layer_count; i++)
     {
-        const caffe::LayerParameter& layer = proto.layer(i);
+      const caffe::LayerParameter &layer = proto.layer(i);
 
-        // layer definition line, repeated
-        // [type] [name] [bottom blob count] [top blob count] [bottom blobs] [top blobs] [layer specific params]
-        if (layer.type() == "BN")
+      // layer definition line, repeated
+      // [type] [name] [bottom blob count] [top blob count] [bottom blobs] [top
+      // blobs] [layer specific params]
+      if (layer.type() == "BN")
         {
-            fprintf(pp, "%-16s", "Scale");
+          fprintf(pp, "%-16s", "Scale");
         }
-        else if (layer.type() == "Convolution")
+      else if (layer.type() == "Convolution")
         {
-            const caffe::ConvolutionParameter& convolution_param = layer.convolution_param();
-            if (convolution_param.group() != 1)
-                fprintf(pp, "%-16s", "ConvolutionDepthWise");
-            else
-                fprintf(pp, "%-16s", "Convolution");
-        }
-        else if (layer.type() == "ConvolutionDepthwise" || layer.type() == "DepthwiseConvolution")
-        {
+          const caffe::ConvolutionParameter &convolution_param
+              = layer.convolution_param();
+          if (convolution_param.group() != 1)
             fprintf(pp, "%-16s", "ConvolutionDepthWise");
+          else
+            fprintf(pp, "%-16s", "Convolution");
         }
-        else if (layer.type() == "Deconvolution")
+      else if (layer.type() == "ConvolutionDepthwise"
+               || layer.type() == "DepthwiseConvolution")
         {
-            const caffe::ConvolutionParameter& convolution_param = layer.convolution_param();
-            if (convolution_param.group() != 1)
-                fprintf(pp, "%-16s", "DeconvolutionDepthWise");
-            else
-                fprintf(pp, "%-16s", "Deconvolution");
+          fprintf(pp, "%-16s", "ConvolutionDepthWise");
         }
-        else if (layer.type() == "MemoryData")
+      else if (layer.type() == "Deconvolution")
         {
-            fprintf(pp, "%-16s", "Input");
+          const caffe::ConvolutionParameter &convolution_param
+              = layer.convolution_param();
+          if (convolution_param.group() != 1)
+            fprintf(pp, "%-16s", "DeconvolutionDepthWise");
+          else
+            fprintf(pp, "%-16s", "Deconvolution");
         }
-        else if (layer.type() == "Python")
+      else if (layer.type() == "MemoryData")
         {
-            const caffe::PythonParameter& python_param = layer.python_param();
-            std::string python_layer_name = python_param.layer();
-            if (python_layer_name == "ProposalLayer")
-                fprintf(pp, "%-16s", "Proposal");
-            else
-                fprintf(pp, "%-16s", python_layer_name.c_str());
+          fprintf(pp, "%-16s", "Input");
         }
-        else if (layer.type() == "ReLU6")
+      else if (layer.type() == "Python")
         {
-            fprintf(pp, "%-16s", "Clip");
+          const caffe::PythonParameter &python_param = layer.python_param();
+          std::string python_layer_name = python_param.layer();
+          if (python_layer_name == "ProposalLayer")
+            fprintf(pp, "%-16s", "Proposal");
+          else
+            fprintf(pp, "%-16s", python_layer_name.c_str());
         }
-        else
+      else if (layer.type() == "ReLU6")
         {
-            fprintf(pp, "%-16s", layer.type().c_str());
+          fprintf(pp, "%-16s", "Clip");
         }
-        fprintf(pp, " %-16s %d %d", layer.name().c_str(), layer.bottom_size(), layer.top_size());
+      else
+        {
+          fprintf(pp, "%-16s", layer.type().c_str());
+        }
+      fprintf(pp, " %-16s %d %d", layer.name().c_str(), layer.bottom_size(),
+              layer.top_size());
 
-        for (int j=0; j<layer.bottom_size(); j++)
+      for (int j = 0; j < layer.bottom_size(); j++)
         {
-            std::string blob_name = layer.bottom(j);
-            if (blob_name_decorated.find(layer.bottom(j)) != blob_name_decorated.end())
+          std::string blob_name = layer.bottom(j);
+          if (blob_name_decorated.find(layer.bottom(j))
+              != blob_name_decorated.end())
             {
-                blob_name = blob_name_decorated[layer.bottom(j)];
+              blob_name = blob_name_decorated[layer.bottom(j)];
             }
 
-            if (bottom_reference.find(blob_name) != bottom_reference.end())
+          if (bottom_reference.find(blob_name) != bottom_reference.end())
             {
-                int refidx = bottom_reference[blob_name] - 1;
-                bottom_reference[blob_name] = refidx;
+              int refidx = bottom_reference[blob_name] - 1;
+              bottom_reference[blob_name] = refidx;
 
-                char splitsuffix[256];
-                sprintf(splitsuffix, "_splitncnn_%d", refidx);
-                blob_name = blob_name + splitsuffix;
+              char splitsuffix[256];
+              sprintf(splitsuffix, "_splitncnn_%d", refidx);
+              blob_name = blob_name + splitsuffix;
             }
 
-            fprintf(pp, " %s", blob_name.c_str());
+          fprintf(pp, " %s", blob_name.c_str());
         }
 
-        // decorated
-        if (layer.bottom_size() == 1 && layer.top_size() == 1 && layer.bottom(0) == layer.top(0))
+      // decorated
+      if (layer.bottom_size() == 1 && layer.top_size() == 1
+          && layer.bottom(0) == layer.top(0))
         {
-            std::string blob_name = layer.top(0) + "_" + layer.name();
-            blob_name_decorated[layer.top(0)] = blob_name;
+          std::string blob_name = layer.top(0) + "_" + layer.name();
+          blob_name_decorated[layer.top(0)] = blob_name;
 
-            fprintf(pp, " %s", blob_name.c_str());
+          fprintf(pp, " %s", blob_name.c_str());
         }
-        else
+      else
         {
-            for (int j=0; j<layer.top_size(); j++)
+          for (int j = 0; j < layer.top_size(); j++)
             {
-                std::string blob_name = layer.top(j);
-                fprintf(pp, " %s", blob_name.c_str());
-            }
-        }
-
-        // find blob binary by layer name
-        int netidx;
-        for (netidx=0; netidx<net.layer_size(); netidx++)
-        {
-            if (net.layer(netidx).name() == layer.name())
-            {
-                break;
+              std::string blob_name = layer.top(j);
+              fprintf(pp, " %s", blob_name.c_str());
             }
         }
 
-        // layer specific params
-        if (layer.type() == "BatchNorm")
+      // find blob binary by layer name
+      int netidx;
+      for (netidx = 0; netidx < net.layer_size(); netidx++)
         {
-            const caffe::LayerParameter& binlayer = net.layer(netidx);
-
-            const caffe::BlobProto& mean_blob = binlayer.blobs(0);
-            const caffe::BlobProto& var_blob = binlayer.blobs(1);
-            fprintf(pp, " 0=%d", (int)mean_blob.data_size());
-
-            const caffe::BatchNormParameter& batch_norm_param = layer.batch_norm_param();
-            float eps = batch_norm_param.eps();
-
-            std::vector<float> ones(mean_blob.data_size(), 1.f);
-            fwrite(ones.data(), sizeof(float), ones.size(), bp);// slope
-
-            if (binlayer.blobs_size() < 3)
+          if (net.layer(netidx).name() == layer.name())
             {
-                fwrite(mean_blob.data().data(), sizeof(float), mean_blob.data_size(), bp);
-                float tmp;
-                for (int j=0; j<var_blob.data_size(); j++)
+              break;
+            }
+        }
+
+      // layer specific params
+      if (layer.type() == "BatchNorm")
+        {
+          const caffe::LayerParameter &binlayer = net.layer(netidx);
+
+          const caffe::BlobProto &mean_blob = binlayer.blobs(0);
+          const caffe::BlobProto &var_blob = binlayer.blobs(1);
+          fprintf(pp, " 0=%d", (int)mean_blob.data_size());
+
+          const caffe::BatchNormParameter &batch_norm_param
+              = layer.batch_norm_param();
+          float eps = batch_norm_param.eps();
+
+          std::vector<float> ones(mean_blob.data_size(), 1.f);
+          fwrite(ones.data(), sizeof(float), ones.size(), bp); // slope
+
+          if (binlayer.blobs_size() < 3)
+            {
+              fwrite(mean_blob.data().data(), sizeof(float),
+                     mean_blob.data_size(), bp);
+              float tmp;
+              for (int j = 0; j < var_blob.data_size(); j++)
                 {
-                    tmp = var_blob.data().data()[j] + eps;
-                    fwrite(&tmp, sizeof(float), 1, bp);
+                  tmp = var_blob.data().data()[j] + eps;
+                  fwrite(&tmp, sizeof(float), 1, bp);
                 }
             }
-            else
+          else
             {
-                float scale_factor = binlayer.blobs(2).data().data()[0] == 0 ? 0 : 1 / binlayer.blobs(2).data().data()[0];
-                // premultiply scale_factor to mean and variance
-                float tmp;
-                for (int j=0; j<mean_blob.data_size(); j++)
+              float scale_factor
+                  = binlayer.blobs(2).data().data()[0] == 0
+                        ? 0
+                        : 1 / binlayer.blobs(2).data().data()[0];
+              // premultiply scale_factor to mean and variance
+              float tmp;
+              for (int j = 0; j < mean_blob.data_size(); j++)
                 {
-                    tmp = mean_blob.data().data()[j] * scale_factor;
-                    fwrite(&tmp, sizeof(float), 1, bp);
+                  tmp = mean_blob.data().data()[j] * scale_factor;
+                  fwrite(&tmp, sizeof(float), 1, bp);
                 }
-                for (int j=0; j<var_blob.data_size(); j++)
+              for (int j = 0; j < var_blob.data_size(); j++)
                 {
-                    tmp = var_blob.data().data()[j] * scale_factor + eps;
-                    fwrite(&tmp, sizeof(float), 1, bp);
+                  tmp = var_blob.data().data()[j] * scale_factor + eps;
+                  fwrite(&tmp, sizeof(float), 1, bp);
                 }
             }
 
-            std::vector<float> zeros(mean_blob.data_size(), 0.f);
-            fwrite(zeros.data(), sizeof(float), zeros.size(), bp);// bias
+          std::vector<float> zeros(mean_blob.data_size(), 0.f);
+          fwrite(zeros.data(), sizeof(float), zeros.size(), bp); // bias
         }
-        else if (layer.type() == "BN")
+      else if (layer.type() == "BN")
         {
-            const caffe::LayerParameter& binlayer = net.layer(netidx);
+          const caffe::LayerParameter &binlayer = net.layer(netidx);
 
-            const caffe::BlobProto& scale_blob = binlayer.blobs(0);
-            const caffe::BlobProto& shift_blob = binlayer.blobs(1);
-            fprintf(pp, " 0=%d", (int)scale_blob.data_size());
-            fprintf(pp, " 1=1");
+          const caffe::BlobProto &scale_blob = binlayer.blobs(0);
+          const caffe::BlobProto &shift_blob = binlayer.blobs(1);
+          fprintf(pp, " 0=%d", (int)scale_blob.data_size());
+          fprintf(pp, " 1=1");
 
-            fwrite(scale_blob.data().data(), sizeof(float), scale_blob.data_size(), bp);
-            fwrite(shift_blob.data().data(), sizeof(float), shift_blob.data_size(), bp);
+          fwrite(scale_blob.data().data(), sizeof(float),
+                 scale_blob.data_size(), bp);
+          fwrite(shift_blob.data().data(), sizeof(float),
+                 shift_blob.data_size(), bp);
         }
-	else if (layer.type() == "ContinuationIndicator")
-	  {
-	    const caffe::ContinuationIndicatorParameter &ci_param = layer.continuation_indicator_param();
-	    int time_step = ci_param.time_step();
-	    int axis = ci_param.axis();
-	    fprintf(pp, " 0=%d", time_step);
-	    fprintf(pp, " 1=%d", axis);
-	  }
-        else if (layer.type() == "Concat")
+      else if (layer.type() == "ContinuationIndicator")
         {
-            const caffe::ConcatParameter& concat_param = layer.concat_param();
-            int dim = concat_param.axis() - 1;
-            fprintf(pp, " 0=%d", dim);
+          const caffe::ContinuationIndicatorParameter &ci_param
+              = layer.continuation_indicator_param();
+          int time_step = ci_param.time_step();
+          int axis = ci_param.axis();
+          fprintf(pp, " 0=%d", time_step);
+          fprintf(pp, " 1=%d", axis);
         }
-        else if (layer.type() == "Convolution" || layer.type() == "ConvolutionDepthwise" || layer.type() == "DepthwiseConvolution")
+      else if (layer.type() == "Concat")
         {
-            const caffe::LayerParameter& binlayer = net.layer(netidx);
-            const caffe::BlobProto& weight_blob = binlayer.blobs(0);
-            const caffe::ConvolutionParameter& convolution_param = layer.convolution_param();
-            fprintf(pp, " 0=%d", convolution_param.num_output());
-            if (convolution_param.has_kernel_w() && convolution_param.has_kernel_h())
+          const caffe::ConcatParameter &concat_param = layer.concat_param();
+          int dim = concat_param.axis() - 1;
+          fprintf(pp, " 0=%d", dim);
+        }
+      else if (layer.type() == "Convolution"
+               || layer.type() == "ConvolutionDepthwise"
+               || layer.type() == "DepthwiseConvolution")
+        {
+          const caffe::LayerParameter &binlayer = net.layer(netidx);
+          const caffe::BlobProto &weight_blob = binlayer.blobs(0);
+          const caffe::ConvolutionParameter &convolution_param
+              = layer.convolution_param();
+          fprintf(pp, " 0=%d", convolution_param.num_output());
+          if (convolution_param.has_kernel_w()
+              && convolution_param.has_kernel_h())
             {
-                fprintf(pp, " 1=%d", convolution_param.kernel_w());
-                fprintf(pp, " 11=%d", convolution_param.kernel_h());
+              fprintf(pp, " 1=%d", convolution_param.kernel_w());
+              fprintf(pp, " 11=%d", convolution_param.kernel_h());
             }
-            else
+          else
             {
-                fprintf(pp, " 1=%d", convolution_param.kernel_size(0));
+              fprintf(pp, " 1=%d", convolution_param.kernel_size(0));
             }
-            fprintf(pp, " 2=%d", convolution_param.dilation_size() != 0 ? convolution_param.dilation(0) : 1);
-            if (convolution_param.has_stride_w() && convolution_param.has_stride_h())
+          fprintf(pp, " 2=%d",
+                  convolution_param.dilation_size() != 0
+                      ? convolution_param.dilation(0)
+                      : 1);
+          if (convolution_param.has_stride_w()
+              && convolution_param.has_stride_h())
             {
-                fprintf(pp, " 3=%d", convolution_param.stride_w());
-                fprintf(pp, " 13=%d", convolution_param.stride_h());
+              fprintf(pp, " 3=%d", convolution_param.stride_w());
+              fprintf(pp, " 13=%d", convolution_param.stride_h());
             }
-            else
+          else
             {
-                fprintf(pp, " 3=%d", convolution_param.stride_size() != 0 ? convolution_param.stride(0) : 1);
+              fprintf(pp, " 3=%d",
+                      convolution_param.stride_size() != 0
+                          ? convolution_param.stride(0)
+                          : 1);
             }
-            if (convolution_param.has_pad_w() && convolution_param.has_pad_h())
+          if (convolution_param.has_pad_w() && convolution_param.has_pad_h())
             {
-                fprintf(pp, " 4=%d", convolution_param.pad_w());
-                fprintf(pp, " 14=%d", convolution_param.pad_h());
+              fprintf(pp, " 4=%d", convolution_param.pad_w());
+              fprintf(pp, " 14=%d", convolution_param.pad_h());
             }
-            else
+          else
             {
-                fprintf(pp, " 4=%d", convolution_param.pad_size() != 0 ? convolution_param.pad(0) : 0);
+              fprintf(pp, " 4=%d",
+                      convolution_param.pad_size() != 0
+                          ? convolution_param.pad(0)
+                          : 0);
             }
-            fprintf(pp, " 5=%d", convolution_param.bias_term());
-            fprintf(pp, " 6=%d", weight_blob.data_size());
+          fprintf(pp, " 5=%d", convolution_param.bias_term());
+          fprintf(pp, " 6=%d", weight_blob.data_size());
 
-            int num_group = 1;
-            if (layer.type() == "ConvolutionDepthwise" || layer.type() == "DepthwiseConvolution")
+          int num_group = 1;
+          if (layer.type() == "ConvolutionDepthwise"
+              || layer.type() == "DepthwiseConvolution")
             {
-                num_group = convolution_param.num_output();
+              num_group = convolution_param.num_output();
             }
-            else
+          else
             {
-                num_group = convolution_param.group();
-            }
-
-            if (num_group != 1)
-            {
-                fprintf(pp, " 7=%d", num_group);
+              num_group = convolution_param.group();
             }
 
-            bool int8_scale_term = false;
-            std::vector<float> weight_int8scale;
-            std::vector<float> blob_int8scale;
-
-            if (int8scale_table_path)
+          if (num_group != 1)
             {
-                char key[256];
-                sprintf(key, "%s_param_0", layer.name().c_str());
-                if (weight_int8scale_table.find(std::string(key)) != weight_int8scale_table.end())
+              fprintf(pp, " 7=%d", num_group);
+            }
+
+          bool int8_scale_term = false;
+          std::vector<float> weight_int8scale;
+          std::vector<float> blob_int8scale;
+
+          if (int8scale_table_path)
+            {
+              char key[256];
+              sprintf(key, "%s_param_0", layer.name().c_str());
+              if (weight_int8scale_table.find(std::string(key))
+                  != weight_int8scale_table.end())
                 {
-                    weight_int8scale = weight_int8scale_table[std::string(key)];
+                  weight_int8scale = weight_int8scale_table[std::string(key)];
                 }
 
-                if (blob_int8scale_table.find(layer.name()) != blob_int8scale_table.end())
+              if (blob_int8scale_table.find(layer.name())
+                  != blob_int8scale_table.end())
                 {
-                    blob_int8scale = blob_int8scale_table[layer.name()];
+                  blob_int8scale = blob_int8scale_table[layer.name()];
                 }
 
-                int8_scale_term = !weight_int8scale.empty() && !blob_int8scale.empty();
+              int8_scale_term
+                  = !weight_int8scale.empty() && !blob_int8scale.empty();
 
-                if (int8_scale_term)
+              if (int8_scale_term)
                 {
-                    if ((int)weight_int8scale.size() == num_group)
+                  if ((int)weight_int8scale.size() == num_group)
                     {
-                        fprintf(pp, " 8=1");
+                      fprintf(pp, " 8=1");
                     }
-                    else
+                  else
                     {
-                        fprintf(pp, " 8=2");
+                      fprintf(pp, " 8=2");
                     }
                 }
             }
 
-            for (int j = 0; j < binlayer.blobs_size(); j++)
+          for (int j = 0; j < binlayer.blobs_size(); j++)
             {
-                int quantize_tag = 0;
-                const caffe::BlobProto& blob = binlayer.blobs(j);
+              int quantize_tag = 0;
+              const caffe::BlobProto &blob = binlayer.blobs(j);
 
-                std::vector<float> quantize_table;
-                std::vector<unsigned char> quantize_index;
+              std::vector<float> quantize_table;
+              std::vector<unsigned char> quantize_index;
 
-                std::vector<unsigned short> float16_weights;
-                std::vector<signed char> int8_weights;
+              std::vector<unsigned short> float16_weights;
+              std::vector<signed char> int8_weights;
 
-                // we will not quantize the bias values
-                if (j == 0)
+              // we will not quantize the bias values
+              if (j == 0)
                 {
-                    if (int8_scale_term)
+                  if (int8_scale_term)
                     {
-                        if (quantize_level == 0)
+                      if (quantize_level == 0)
                         {
-                            quantize_tag = 0x0002C056;
+                          quantize_tag = 0x0002C056;
                         }
-                        else if (quantize_level == 256)
+                      else if (quantize_level == 256)
                         {
-                            quantize_tag = quantize_weight((float *)blob.data().data(), blob.data_size(), weight_int8scale, int8_weights);
+                          quantize_tag = quantize_weight(
+                              (float *)blob.data().data(), blob.data_size(),
+                              weight_int8scale, int8_weights);
                         }
                     }
-                    else if (quantize_level == 256)
+                  else if (quantize_level == 256)
                     {
-                        quantize_tag = quantize_weight((float *)blob.data().data(), blob.data_size(), quantize_level, quantize_table, quantize_index);
+                      quantize_tag = quantize_weight(
+                          (float *)blob.data().data(), blob.data_size(),
+                          quantize_level, quantize_table, quantize_index);
                     }
-                    else if (quantize_level == 65536)
+                  else if (quantize_level == 65536)
                     {
-                        quantize_tag = quantize_weight((float *)blob.data().data(), blob.data_size(), float16_weights);
+                      quantize_tag
+                          = quantize_weight((float *)blob.data().data(),
+                                            blob.data_size(), float16_weights);
                     }
 
-                    // write quantize tag first
-                    fwrite(&quantize_tag, sizeof(int), 1, bp);
+                  // write quantize tag first
+                  fwrite(&quantize_tag, sizeof(int), 1, bp);
 
-                    if (quantize_tag)
+                  if (quantize_tag)
                     {
-                        int p0 = ftell(bp);
-                        if (int8_scale_term)
+                      int p0 = ftell(bp);
+                      if (int8_scale_term)
                         {
-                            if (quantize_level == 0)
+                          if (quantize_level == 0)
                             {
-                                // write original data and int8scale
-                                fwrite(blob.data().data(), sizeof(float), blob.data_size(), bp);
+                              // write original data and int8scale
+                              fwrite(blob.data().data(), sizeof(float),
+                                     blob.data_size(), bp);
                             }
-                            else if (quantize_level == 256)
+                          else if (quantize_level == 256)
                             {
-                                fwrite(int8_weights.data(), sizeof(signed char), int8_weights.size(), bp);
-                            }
-                        }
-                        else if (quantize_level == 256)
-                        {
-                            // write quantize table and index
-                            fwrite(quantize_table.data(), sizeof(float), quantize_table.size(), bp);
-                            fwrite(quantize_index.data(), sizeof(unsigned char), quantize_index.size(), bp);
-                        }
-                        else if (quantize_level == 65536)
-                        {
-                            fwrite(float16_weights.data(), sizeof(unsigned short), float16_weights.size(), bp);
-                        }
-
-                        // padding to 32bit align
-                        int nwrite = ftell(bp) - p0;
-                        int nalign = alignSize(nwrite, 4);
-                        unsigned char padding[4] = {0x00, 0x00, 0x00, 0x00};
-                        fwrite(padding, sizeof(unsigned char), nalign - nwrite, bp);
-                    }
-                    else
-                    {
-                        // write original data
-                        fwrite(blob.data().data(), sizeof(float), blob.data_size(), bp);
-                    }
-                }
-                else
-                {
-                    // write original data
-                    fwrite(blob.data().data(), sizeof(float), blob.data_size(), bp);
-                }
-            }
-
-            if (int8_scale_term)
-            {
-                // write int8_scale data
-                fwrite(weight_int8scale.data(), sizeof(float), weight_int8scale.size(), bp);
-                fwrite(blob_int8scale.data(), sizeof(float), blob_int8scale.size(), bp);
-            }
-        }
-        else if (layer.type() == "Crop")
-        {
-            const caffe::CropParameter& crop_param = layer.crop_param();
-            int num_offset = crop_param.offset_size();
-            if (num_offset == 1)
-            {
-                int offset = crop_param.offset(0);
-                int axis = crop_param.axis();
-                if (axis == 1)
-                {
-                    fprintf(pp, " 0=%d", offset);
-                    fprintf(pp, " 1=%d", offset);
-                    fprintf(pp, " 2=%d", offset);
-                }
-                else if (axis == 2)
-                {
-                    fprintf(pp, " 0=%d", offset);
-                    fprintf(pp, " 1=%d", offset);
-                }
-                else if (axis == 3)
-                {
-                    fprintf(pp, " 0=%d", offset);
-                }
-            }
-            else if (num_offset == 2)
-            {
-                int woffset = crop_param.offset(1);
-                int hoffset = crop_param.offset(0);
-                fprintf(pp, " 0=%d", woffset);
-                fprintf(pp, " 1=%d", hoffset);
-            }
-            else if (num_offset == 3)
-            {
-                int woffset = crop_param.offset(2);
-                int hoffset = crop_param.offset(1);
-                int coffset = crop_param.offset(0);
-                fprintf(pp, " 0=%d", woffset);
-                fprintf(pp, " 1=%d", hoffset);
-                fprintf(pp, " 2=%d", coffset);
-            }
-        }
-        else if (layer.type() == "Deconvolution")
-        {
-            const caffe::LayerParameter& binlayer = net.layer(netidx);
-
-            const caffe::BlobProto& weight_blob = binlayer.blobs(0);
-            const caffe::ConvolutionParameter& convolution_param = layer.convolution_param();
-            fprintf(pp, " 0=%d", convolution_param.num_output());
-            if (convolution_param.has_kernel_w() && convolution_param.has_kernel_h())
-            {
-                fprintf(pp, " 1=%d", convolution_param.kernel_w());
-                fprintf(pp, " 11=%d", convolution_param.kernel_h());
-            }
-            else
-            {
-                fprintf(pp, " 1=%d", convolution_param.kernel_size(0));
-            }
-            fprintf(pp, " 2=%d", convolution_param.dilation_size() != 0 ? convolution_param.dilation(0) : 1);
-            if (convolution_param.has_stride_w() && convolution_param.has_stride_h())
-            {
-                fprintf(pp, " 3=%d", convolution_param.stride_w());
-                fprintf(pp, " 13=%d", convolution_param.stride_h());
-            }
-            else
-            {
-                fprintf(pp, " 3=%d", convolution_param.stride_size() != 0 ? convolution_param.stride(0) : 1);
-            }
-            if (convolution_param.has_pad_w() && convolution_param.has_pad_h())
-            {
-                fprintf(pp, " 4=%d", convolution_param.pad_w());
-                fprintf(pp, " 14=%d", convolution_param.pad_h());
-            }
-            else
-            {
-                fprintf(pp, " 4=%d", convolution_param.pad_size() != 0 ? convolution_param.pad(0) : 0);
-            }
-            fprintf(pp, " 5=%d", convolution_param.bias_term());
-            fprintf(pp, " 6=%d", weight_blob.data_size());
-
-            int group = convolution_param.group();
-            if (group != 1)
-            {
-                fprintf(pp, " 7=%d", group);
-            }
-
-            int quantized_weight = 0;
-            fwrite(&quantized_weight, sizeof(int), 1, bp);
-
-            int maxk = 0;
-            if (convolution_param.has_kernel_w() && convolution_param.has_kernel_h())
-            {
-                maxk = convolution_param.kernel_w() * convolution_param.kernel_h();
-            }
-            else
-            {
-                maxk = convolution_param.kernel_size(0) * convolution_param.kernel_size(0);
-            }
-            for (int g=0; g<group; g++)
-            {
-            // reorder weight from inch-outch to outch-inch
-            int num_output = convolution_param.num_output() / group;
-            int num_input = weight_blob.data_size() / maxk / num_output / group;
-            const float* weight_data_ptr = weight_blob.data().data() + g * maxk * num_output * num_input;
-            for (int k=0; k<num_output; k++)
-            {
-                for (int j=0; j<num_input; j++)
-                {
-                    fwrite(weight_data_ptr + (j*num_output + k) * maxk, sizeof(float), maxk, bp);
-                }
-            }
-            }
-
-            for (int j=1; j<binlayer.blobs_size(); j++)
-            {
-                const caffe::BlobProto& blob = binlayer.blobs(j);
-                fwrite(blob.data().data(), sizeof(float), blob.data_size(), bp);
-            }
-        }
-        else if (layer.type() == "DetectionOutput")
-        {
-            const caffe::DetectionOutputParameter& detection_output_param = layer.detection_output_param();
-            const caffe::NonMaximumSuppressionParameter& nms_param = detection_output_param.nms_param();
-            fprintf(pp, " 0=%d", detection_output_param.num_classes());
-            fprintf(pp, " 1=%f", nms_param.nms_threshold());
-            fprintf(pp, " 2=%d", nms_param.top_k());
-            fprintf(pp, " 3=%d", detection_output_param.keep_top_k());
-            fprintf(pp, " 4=%f", detection_output_param.confidence_threshold());
-        }
-        else if (layer.type() == "Dropout")
-        {
-            const caffe::DropoutParameter& dropout_param = layer.dropout_param();
-            if (dropout_param.has_scale_train() && !dropout_param.scale_train())
-            {
-                float scale = 1.f - dropout_param.dropout_ratio();
-                fprintf(pp, " 0=%f", scale);
-            }
-        }
-        else if (layer.type() == "Eltwise")
-        {
-            const caffe::EltwiseParameter& eltwise_param = layer.eltwise_param();
-            int coeff_size = eltwise_param.coeff_size();
-            fprintf(pp, " 0=%d", (int)eltwise_param.operation());
-            fprintf(pp, " -23301=%d", coeff_size);
-            for (int j=0; j<coeff_size; j++)
-            {
-                fprintf(pp, ",%f", eltwise_param.coeff(j));
-            }
-        }
-        else if (layer.type() == "ELU")
-        {
-            const caffe::ELUParameter& elu_param = layer.elu_param();
-            fprintf(pp, " 0=%f", elu_param.alpha());
-        }
-        else if (layer.type() == "Embed")
-        {
-            const caffe::LayerParameter& binlayer = net.layer(netidx);
-
-            const caffe::BlobProto& weight_blob = binlayer.blobs(0);
-            const caffe::EmbedParameter& embed_param = layer.embed_param();
-            fprintf(pp, " 0=%d", embed_param.num_output());
-            fprintf(pp, " 1=%d", embed_param.input_dim());
-            fprintf(pp, " 2=%d", embed_param.bias_term());
-            fprintf(pp, " 3=%d", weight_blob.data_size());
-
-            for (int j=0; j<binlayer.blobs_size(); j++)
-            {
-                int quantize_tag = 0;
-                const caffe::BlobProto& blob = binlayer.blobs(j);
-
-                std::vector<float> quantize_table;
-                std::vector<unsigned char> quantize_index;
-
-                std::vector<unsigned short> float16_weights;
-
-                // we will not quantize the bias values
-                if (j == 0 && quantize_level != 0)
-                {
-                    if (quantize_level == 256)
-                    {
-                        quantize_tag = quantize_weight((float *)blob.data().data(), blob.data_size(), quantize_level, quantize_table, quantize_index);
-                    }
-                    else if (quantize_level == 65536)
-                    {
-                        quantize_tag = quantize_weight((float *)blob.data().data(), blob.data_size(), float16_weights);
-                    }
-                }
-
-                // write quantize tag first
-                if (j == 0)
-                    fwrite(&quantize_tag, sizeof(int), 1, bp);
-
-                if (quantize_tag)
-                {
-                    int p0 = ftell(bp);
-                    if (quantize_level == 256)
-                    {
-                        // write quantize table and index
-                        fwrite(quantize_table.data(), sizeof(float), quantize_table.size(), bp);
-                        fwrite(quantize_index.data(), sizeof(unsigned char), quantize_index.size(), bp);
-                    }
-                    else if (quantize_level == 65536)
-                    {
-                        fwrite(float16_weights.data(), sizeof(unsigned short), float16_weights.size(), bp);
-                    }
-                    // padding to 32bit align
-                    int nwrite = ftell(bp) - p0;
-                    int nalign = alignSize(nwrite, 4);
-                    unsigned char padding[4] = {0x00, 0x00, 0x00, 0x00};
-                    fwrite(padding, sizeof(unsigned char), nalign - nwrite, bp);
-                }
-                else
-                {
-                    // write original data
-                    fwrite(blob.data().data(), sizeof(float), blob.data_size(), bp);
-                }
-            }
-        }
-        else if (layer.type() == "InnerProduct")
-        {
-            const caffe::LayerParameter& binlayer = net.layer(netidx);
-
-            const caffe::BlobProto& weight_blob = binlayer.blobs(0);
-            const caffe::InnerProductParameter& inner_product_param = layer.inner_product_param();
-            fprintf(pp, " 0=%d", inner_product_param.num_output());
-            fprintf(pp, " 1=%d", inner_product_param.bias_term());
-            fprintf(pp, " 2=%d", weight_blob.data_size());
-            // in OCR case, we need to keep H dimensions in order to do H inner products
-            // custom inner product layer is needed for this
-            // same for timeserie :
-            const caffe::LayerParameter& layer_before = proto.layer(i-1);
-            bool lstm_before = (layer_before.type() == "LSTM");
-
-            if (ocr || lstm_before)
-                fprintf(pp, " 3=1");
-
-            bool int8_scale_term = false;
-            std::vector<float> weight_int8scale;
-            std::vector<float> blob_int8scale;
-
-            if (int8scale_table_path)
-            {
-                char key[256];
-                sprintf(key, "%s_param_0", layer.name().c_str());
-                if (weight_int8scale_table.find(std::string(key)) != weight_int8scale_table.end())
-                {
-                    weight_int8scale = weight_int8scale_table[std::string(key)];
-                }
-
-                if (blob_int8scale_table.find(layer.name()) != blob_int8scale_table.end())
-                {
-                    blob_int8scale = blob_int8scale_table[layer.name()];
-                }
-
-                int8_scale_term = !weight_int8scale.empty() && !blob_int8scale.empty();
-
-                if (int8_scale_term)
-                {
-                    fprintf(pp, " 8=1");
-                }
-            }
-
-            for (int j=0; j<binlayer.blobs_size(); j++)
-            {
-                int quantize_tag = 0;
-                const caffe::BlobProto& blob = binlayer.blobs(j);
-
-                std::vector<float> quantize_table;
-                std::vector<unsigned char> quantize_index;
-
-                std::vector<unsigned short> float16_weights;
-                std::vector<signed char> int8_weights;
-
-                // we will not quantize the bias values
-                if (j == 0)
-                {
-                    if (int8_scale_term)
-                    {
-                        if (quantize_level == 0)
-                        {
-                            quantize_tag = 0x0002C056;
-                        }
-                        else if (quantize_level == 256)
-                        {
-                            quantize_tag = quantize_weight((float *)blob.data().data(), blob.data_size(), weight_int8scale, int8_weights);
-                        }
-                    }
-                    else if (quantize_level == 256)
-                    {
-                        quantize_tag = quantize_weight((float *)blob.data().data(), blob.data_size(), quantize_level, quantize_table, quantize_index);
-                    }
-                    else if (quantize_level == 65536)
-                    {
-                        quantize_tag = quantize_weight((float *)blob.data().data(), blob.data_size(), float16_weights);
-                    }
-
-                    // write quantize tag first
-                    fwrite(&quantize_tag, sizeof(int), 1, bp);
-
-                    if (quantize_tag)
-                    {
-                        int p0 = ftell(bp);
-                        if (int8_scale_term)
-                        {
-                            if (quantize_level == 0)
-                            {
-                                // write original data and int8scale
-                                fwrite(blob.data().data(), sizeof(float), blob.data_size(), bp);
-                            }
-                            else if (quantize_level == 256)
-                            {
-                                fwrite(int8_weights.data(), sizeof(signed char), int8_weights.size(), bp);
+                              fwrite(int8_weights.data(), sizeof(signed char),
+                                     int8_weights.size(), bp);
                             }
                         }
-                        else if (quantize_level == 256)
+                      else if (quantize_level == 256)
                         {
-                            // write quantize table and index
-                            fwrite(quantize_table.data(), sizeof(float), quantize_table.size(), bp);
-                            fwrite(quantize_index.data(), sizeof(unsigned char), quantize_index.size(), bp);
+                          // write quantize table and index
+                          fwrite(quantize_table.data(), sizeof(float),
+                                 quantize_table.size(), bp);
+                          fwrite(quantize_index.data(), sizeof(unsigned char),
+                                 quantize_index.size(), bp);
                         }
-                        else if (quantize_level == 65536)
+                      else if (quantize_level == 65536)
                         {
-                            fwrite(float16_weights.data(), sizeof(unsigned short), float16_weights.size(), bp);
+                          fwrite(float16_weights.data(),
+                                 sizeof(unsigned short),
+                                 float16_weights.size(), bp);
                         }
 
-                        // padding to 32bit align
-                        int nwrite = ftell(bp) - p0;
-                        int nalign = alignSize(nwrite, 4);
-                        unsigned char padding[4] = {0x00, 0x00, 0x00, 0x00};
-                        fwrite(padding, sizeof(unsigned char), nalign - nwrite, bp);
+                      // padding to 32bit align
+                      int nwrite = ftell(bp) - p0;
+                      int nalign = alignSize(nwrite, 4);
+                      unsigned char padding[4] = { 0x00, 0x00, 0x00, 0x00 };
+                      fwrite(padding, sizeof(unsigned char), nalign - nwrite,
+                             bp);
                     }
-                    else
+                  else
                     {
-                        // write original data
-                        fwrite(blob.data().data(), sizeof(float), blob.data_size(), bp);
+                      // write original data
+                      fwrite(blob.data().data(), sizeof(float),
+                             blob.data_size(), bp);
                     }
                 }
-                else
+              else
                 {
-                    // write original data
-                    fwrite(blob.data().data(), sizeof(float), blob.data_size(), bp);
+                  // write original data
+                  fwrite(blob.data().data(), sizeof(float), blob.data_size(),
+                         bp);
                 }
             }
 
-            if (int8_scale_term)
+          if (int8_scale_term)
             {
-                // write int8_scale data
-                fwrite(weight_int8scale.data(), sizeof(float), weight_int8scale.size(), bp);
-                fwrite(blob_int8scale.data(), sizeof(float), blob_int8scale.size(), bp);
+              // write int8_scale data
+              fwrite(weight_int8scale.data(), sizeof(float),
+                     weight_int8scale.size(), bp);
+              fwrite(blob_int8scale.data(), sizeof(float),
+                     blob_int8scale.size(), bp);
             }
         }
-        else if (layer.type() == "Input")
+      else if (layer.type() == "Crop")
         {
-            const caffe::InputParameter& input_param = layer.input_param();
-            const caffe::BlobShape& bs = input_param.shape(0);
-            if (bs.dim_size() == 4)
+          const caffe::CropParameter &crop_param = layer.crop_param();
+          int num_offset = crop_param.offset_size();
+          if (num_offset == 1)
             {
-                fprintf(pp, " 0=%ld", bs.dim(3));
-                fprintf(pp, " 1=%ld", bs.dim(2));
-                fprintf(pp, " 2=%ld", bs.dim(1));
-            }
-            else if (bs.dim_size() == 3)
-            {
-                fprintf(pp, " 0=%ld", bs.dim(2));
-                fprintf(pp, " 1=%ld", bs.dim(1));
-                fprintf(pp, " 2=-233");
-            }
-            else if (bs.dim_size() == 2)
-            {
-                fprintf(pp, " 0=%ld", bs.dim(1));
-                fprintf(pp, " 1=-233");
-                fprintf(pp, " 2=-233");
-            }
-        }
-        else if (layer.type() == "Interp")
-        {
-            const caffe::InterpParameter& interp_param = layer.interp_param();
-            fprintf(pp, " 0=%d", 2);
-            fprintf(pp, " 1=%f", (float)interp_param.zoom_factor());
-            fprintf(pp, " 2=%f", (float)interp_param.zoom_factor());
-            fprintf(pp, " 3=%d", interp_param.height());
-            fprintf(pp, " 4=%d", interp_param.width());
-        }
-        else if (layer.type() == "LRN")
-        {
-            const caffe::LRNParameter& lrn_param = layer.lrn_param();
-            fprintf(pp, " 0=%d", lrn_param.norm_region());
-            fprintf(pp, " 1=%d", lrn_param.local_size());
-            fprintf(pp, " 2=%f", lrn_param.alpha());
-            fprintf(pp, " 3=%f", lrn_param.beta());
-        }
-        else if (layer.type() == "LSTM")
-        {
-            const caffe::LayerParameter& binlayer = net.layer(netidx);
-
-            const caffe::BlobProto& weight_blob = binlayer.blobs(0);
-            const caffe::RecurrentParameter& recurrent_param = layer.recurrent_param();
-            fprintf(pp, " 0=%d", recurrent_param.num_output());
-            fprintf(pp, " 1=%d", weight_blob.data_size());
-
-            for (int j=0; j<binlayer.blobs_size(); j++)
-            {
-                int quantize_tag = 0;
-                const caffe::BlobProto& blob = binlayer.blobs(j);
-
-                std::vector<float> quantize_table;
-                std::vector<unsigned char> quantize_index;
-
-                std::vector<unsigned short> float16_weights;
-
-                if (quantize_level != 0)
+              int offset = crop_param.offset(0);
+              int axis = crop_param.axis();
+              if (axis == 1)
                 {
-                    if (quantize_level == 256)
+                  fprintf(pp, " 0=%d", offset);
+                  fprintf(pp, " 1=%d", offset);
+                  fprintf(pp, " 2=%d", offset);
+                }
+              else if (axis == 2)
+                {
+                  fprintf(pp, " 0=%d", offset);
+                  fprintf(pp, " 1=%d", offset);
+                }
+              else if (axis == 3)
+                {
+                  fprintf(pp, " 0=%d", offset);
+                }
+            }
+          else if (num_offset == 2)
+            {
+              int woffset = crop_param.offset(1);
+              int hoffset = crop_param.offset(0);
+              fprintf(pp, " 0=%d", woffset);
+              fprintf(pp, " 1=%d", hoffset);
+            }
+          else if (num_offset == 3)
+            {
+              int woffset = crop_param.offset(2);
+              int hoffset = crop_param.offset(1);
+              int coffset = crop_param.offset(0);
+              fprintf(pp, " 0=%d", woffset);
+              fprintf(pp, " 1=%d", hoffset);
+              fprintf(pp, " 2=%d", coffset);
+            }
+        }
+      else if (layer.type() == "Deconvolution")
+        {
+          const caffe::LayerParameter &binlayer = net.layer(netidx);
+
+          const caffe::BlobProto &weight_blob = binlayer.blobs(0);
+          const caffe::ConvolutionParameter &convolution_param
+              = layer.convolution_param();
+          fprintf(pp, " 0=%d", convolution_param.num_output());
+          if (convolution_param.has_kernel_w()
+              && convolution_param.has_kernel_h())
+            {
+              fprintf(pp, " 1=%d", convolution_param.kernel_w());
+              fprintf(pp, " 11=%d", convolution_param.kernel_h());
+            }
+          else
+            {
+              fprintf(pp, " 1=%d", convolution_param.kernel_size(0));
+            }
+          fprintf(pp, " 2=%d",
+                  convolution_param.dilation_size() != 0
+                      ? convolution_param.dilation(0)
+                      : 1);
+          if (convolution_param.has_stride_w()
+              && convolution_param.has_stride_h())
+            {
+              fprintf(pp, " 3=%d", convolution_param.stride_w());
+              fprintf(pp, " 13=%d", convolution_param.stride_h());
+            }
+          else
+            {
+              fprintf(pp, " 3=%d",
+                      convolution_param.stride_size() != 0
+                          ? convolution_param.stride(0)
+                          : 1);
+            }
+          if (convolution_param.has_pad_w() && convolution_param.has_pad_h())
+            {
+              fprintf(pp, " 4=%d", convolution_param.pad_w());
+              fprintf(pp, " 14=%d", convolution_param.pad_h());
+            }
+          else
+            {
+              fprintf(pp, " 4=%d",
+                      convolution_param.pad_size() != 0
+                          ? convolution_param.pad(0)
+                          : 0);
+            }
+          fprintf(pp, " 5=%d", convolution_param.bias_term());
+          fprintf(pp, " 6=%d", weight_blob.data_size());
+
+          int group = convolution_param.group();
+          if (group != 1)
+            {
+              fprintf(pp, " 7=%d", group);
+            }
+
+          int quantized_weight = 0;
+          fwrite(&quantized_weight, sizeof(int), 1, bp);
+
+          int maxk = 0;
+          if (convolution_param.has_kernel_w()
+              && convolution_param.has_kernel_h())
+            {
+              maxk = convolution_param.kernel_w()
+                     * convolution_param.kernel_h();
+            }
+          else
+            {
+              maxk = convolution_param.kernel_size(0)
+                     * convolution_param.kernel_size(0);
+            }
+          for (int g = 0; g < group; g++)
+            {
+              // reorder weight from inch-outch to outch-inch
+              int num_output = convolution_param.num_output() / group;
+              int num_input
+                  = weight_blob.data_size() / maxk / num_output / group;
+              const float *weight_data_ptr
+                  = weight_blob.data().data()
+                    + g * maxk * num_output * num_input;
+              for (int k = 0; k < num_output; k++)
+                {
+                  for (int j = 0; j < num_input; j++)
                     {
-                        quantize_tag = quantize_weight((float *)blob.data().data(), blob.data_size(), quantize_level, quantize_table, quantize_index);
+                      fwrite(weight_data_ptr + (j * num_output + k) * maxk,
+                             sizeof(float), maxk, bp);
                     }
-                    else if (quantize_level == 65536)
+                }
+            }
+
+          for (int j = 1; j < binlayer.blobs_size(); j++)
+            {
+              const caffe::BlobProto &blob = binlayer.blobs(j);
+              fwrite(blob.data().data(), sizeof(float), blob.data_size(), bp);
+            }
+        }
+      else if (layer.type() == "DetectionOutput")
+        {
+          const caffe::DetectionOutputParameter &detection_output_param
+              = layer.detection_output_param();
+          const caffe::NonMaximumSuppressionParameter &nms_param
+              = detection_output_param.nms_param();
+          fprintf(pp, " 0=%d", detection_output_param.num_classes());
+          fprintf(pp, " 1=%f", nms_param.nms_threshold());
+          fprintf(pp, " 2=%d", nms_param.top_k());
+          fprintf(pp, " 3=%d", detection_output_param.keep_top_k());
+          fprintf(pp, " 4=%f", detection_output_param.confidence_threshold());
+        }
+      else if (layer.type() == "Dropout")
+        {
+          const caffe::DropoutParameter &dropout_param = layer.dropout_param();
+          if (dropout_param.has_scale_train() && !dropout_param.scale_train())
+            {
+              float scale = 1.f - dropout_param.dropout_ratio();
+              fprintf(pp, " 0=%f", scale);
+            }
+        }
+      else if (layer.type() == "Eltwise")
+        {
+          const caffe::EltwiseParameter &eltwise_param = layer.eltwise_param();
+          int coeff_size = eltwise_param.coeff_size();
+          fprintf(pp, " 0=%d", (int)eltwise_param.operation());
+          fprintf(pp, " -23301=%d", coeff_size);
+          for (int j = 0; j < coeff_size; j++)
+            {
+              fprintf(pp, ",%f", eltwise_param.coeff(j));
+            }
+        }
+      else if (layer.type() == "ELU")
+        {
+          const caffe::ELUParameter &elu_param = layer.elu_param();
+          fprintf(pp, " 0=%f", elu_param.alpha());
+        }
+      else if (layer.type() == "Embed")
+        {
+          const caffe::LayerParameter &binlayer = net.layer(netidx);
+
+          const caffe::BlobProto &weight_blob = binlayer.blobs(0);
+          const caffe::EmbedParameter &embed_param = layer.embed_param();
+          fprintf(pp, " 0=%d", embed_param.num_output());
+          fprintf(pp, " 1=%d", embed_param.input_dim());
+          fprintf(pp, " 2=%d", embed_param.bias_term());
+          fprintf(pp, " 3=%d", weight_blob.data_size());
+
+          for (int j = 0; j < binlayer.blobs_size(); j++)
+            {
+              int quantize_tag = 0;
+              const caffe::BlobProto &blob = binlayer.blobs(j);
+
+              std::vector<float> quantize_table;
+              std::vector<unsigned char> quantize_index;
+
+              std::vector<unsigned short> float16_weights;
+
+              // we will not quantize the bias values
+              if (j == 0 && quantize_level != 0)
+                {
+                  if (quantize_level == 256)
                     {
-                        quantize_tag = quantize_weight((float *)blob.data().data(), blob.data_size(), float16_weights);
+                      quantize_tag = quantize_weight(
+                          (float *)blob.data().data(), blob.data_size(),
+                          quantize_level, quantize_table, quantize_index);
+                    }
+                  else if (quantize_level == 65536)
+                    {
+                      quantize_tag
+                          = quantize_weight((float *)blob.data().data(),
+                                            blob.data_size(), float16_weights);
                     }
                 }
 
-                // write quantize tag first
+              // write quantize tag first
+              if (j == 0)
                 fwrite(&quantize_tag, sizeof(int), 1, bp);
 
-                if (quantize_tag)
+              if (quantize_tag)
                 {
-                    int p0 = ftell(bp);
-                    if (quantize_level == 256)
+                  int p0 = ftell(bp);
+                  if (quantize_level == 256)
                     {
-                        // write quantize table and index
-                        fwrite(quantize_table.data(), sizeof(float), quantize_table.size(), bp);
-                        fwrite(quantize_index.data(), sizeof(unsigned char), quantize_index.size(), bp);
+                      // write quantize table and index
+                      fwrite(quantize_table.data(), sizeof(float),
+                             quantize_table.size(), bp);
+                      fwrite(quantize_index.data(), sizeof(unsigned char),
+                             quantize_index.size(), bp);
                     }
-                    else if (quantize_level == 65536)
+                  else if (quantize_level == 65536)
                     {
-                        fwrite(float16_weights.data(), sizeof(unsigned short), float16_weights.size(), bp);
+                      fwrite(float16_weights.data(), sizeof(unsigned short),
+                             float16_weights.size(), bp);
                     }
-                    // padding to 32bit align
-                    int nwrite = ftell(bp) - p0;
-                    int nalign = alignSize(nwrite, 4);
-                    unsigned char padding[4] = {0x00, 0x00, 0x00, 0x00};
-                    fwrite(padding, sizeof(unsigned char), nalign - nwrite, bp);
+                  // padding to 32bit align
+                  int nwrite = ftell(bp) - p0;
+                  int nalign = alignSize(nwrite, 4);
+                  unsigned char padding[4] = { 0x00, 0x00, 0x00, 0x00 };
+                  fwrite(padding, sizeof(unsigned char), nalign - nwrite, bp);
                 }
-                else
+              else
                 {
-                    // write original data
-                    fwrite(blob.data().data(), sizeof(float), blob.data_size(), bp);
+                  // write original data
+                  fwrite(blob.data().data(), sizeof(float), blob.data_size(),
+                         bp);
                 }
             }
         }
-        else if (layer.type() == "MemoryData")
+      else if (layer.type() == "InnerProduct")
         {
-            const caffe::MemoryDataParameter& memory_data_param = layer.memory_data_param();
-            fprintf(pp, " 0=%d", memory_data_param.width());
-            fprintf(pp, " 1=%d", memory_data_param.height());
-            fprintf(pp, " 2=%d", memory_data_param.channels());
-        }
-        else if (layer.type() == "MVN")
-        {
-            const caffe::MVNParameter& mvn_param = layer.mvn_param();
-            fprintf(pp, " 0=%d", mvn_param.normalize_variance());
-            fprintf(pp, " 1=%d", mvn_param.across_channels());
-            fprintf(pp, " 2=%f", mvn_param.eps());
-        }
-        else if (layer.type() == "Normalize")
-        {
-            const caffe::LayerParameter& binlayer = net.layer(netidx);
-            const caffe::BlobProto& scale_blob = binlayer.blobs(0);
-            const caffe::NormalizeParameter& norm_param = layer.norm_param();
-            fprintf(pp, " 0=%d", norm_param.across_spatial());
-            fprintf(pp, " 1=%d", norm_param.channel_shared());
-            fprintf(pp, " 2=%f", norm_param.eps());
-            fprintf(pp, " 3=%d", scale_blob.data_size());
+          const caffe::LayerParameter &binlayer = net.layer(netidx);
 
-            fwrite(scale_blob.data().data(), sizeof(float), scale_blob.data_size(), bp);
-        }
-        else if (layer.type() == "Permute")
-        {
-            const caffe::PermuteParameter& permute_param = layer.permute_param();
-            int order_size = permute_param.order_size();
-            int order_type = 0;
-            if (order_size == 0)
-                order_type = 0;
-            if (order_size == 1)
+          const caffe::BlobProto &weight_blob = binlayer.blobs(0);
+          const caffe::InnerProductParameter &inner_product_param
+              = layer.inner_product_param();
+          fprintf(pp, " 0=%d", inner_product_param.num_output());
+          fprintf(pp, " 1=%d", inner_product_param.bias_term());
+          fprintf(pp, " 2=%d", weight_blob.data_size());
+          // in OCR case, we need to keep H dimensions in order to do H inner
+          // products custom inner product layer is needed for this same for
+          // timeserie :
+          const caffe::LayerParameter &layer_before = proto.layer(i - 1);
+          bool lstm_before = (layer_before.type() == "LSTM");
+
+          if (ocr || lstm_before)
+            fprintf(pp, " 3=1");
+
+          bool int8_scale_term = false;
+          std::vector<float> weight_int8scale;
+          std::vector<float> blob_int8scale;
+
+          if (int8scale_table_path)
             {
-                int order0 = permute_param.order(0);
-                if (order0 == 0)
-                    order_type = 0;
-                // permute with N not supported
-            }
-            if (order_size == 2)
-            {
-                int order0 = permute_param.order(0);
-                int order1 = permute_param.order(1);
-                if (order0 == 0)
+              char key[256];
+              sprintf(key, "%s_param_0", layer.name().c_str());
+              if (weight_int8scale_table.find(std::string(key))
+                  != weight_int8scale_table.end())
                 {
-                    if (order1 == 1) // 0 1 2 3
-                        order_type = 0;
-                    else if (order1 == 2) // 0 2 1 3
-                        order_type = 2;
-                    else if (order1 == 3) // 0 3 1 2
-                        order_type = 4;
+                  weight_int8scale = weight_int8scale_table[std::string(key)];
                 }
-                // permute with N not supported
-            }
-            if (order_size == 3 || order_size == 4)
-            {
-                int order0 = permute_param.order(0);
-                int order1 = permute_param.order(1);
-                int order2 = permute_param.order(2);
-                if (order0 == 0)
+
+              if (blob_int8scale_table.find(layer.name())
+                  != blob_int8scale_table.end())
                 {
-                    if (order1 == 1)
+                  blob_int8scale = blob_int8scale_table[layer.name()];
+                }
+
+              int8_scale_term
+                  = !weight_int8scale.empty() && !blob_int8scale.empty();
+
+              if (int8_scale_term)
+                {
+                  fprintf(pp, " 8=1");
+                }
+            }
+
+          for (int j = 0; j < binlayer.blobs_size(); j++)
+            {
+              int quantize_tag = 0;
+              const caffe::BlobProto &blob = binlayer.blobs(j);
+
+              std::vector<float> quantize_table;
+              std::vector<unsigned char> quantize_index;
+
+              std::vector<unsigned short> float16_weights;
+              std::vector<signed char> int8_weights;
+
+              // we will not quantize the bias values
+              if (j == 0)
+                {
+                  if (int8_scale_term)
                     {
-                        if (order2 == 2) // 0 1 2 3
-                            order_type = 0;
-                        if (order2 == 3) // 0 1 3 2
-                            order_type = 1;
-                    }
-                    else if (order1 == 2)
-                    {
-                        if (order2 == 1) // 0 2 1 3
-                            order_type = 2;
-                        if (order2 == 3) // 0 2 3 1
-                            order_type = 3;
-                    }
-                    else if (order1 == 3)
-                    {
-                        if (order2 == 1) // 0 3 1 2
-                            order_type = 4;
-                        if (order2 == 2) // 0 3 2 1
-                            order_type = 5;
-                    }
-                }
-                // permute with N not supported
-            }
-            if (ocr)
-                // in OCR case, only one permute juste before the LSTM to permute h and w
-                // computation above do not allow dimensions swaps as needed for LSTMs as
-                // LSTMS in caffe take T as first dim, second dim is 1 (batchsize forced to 1)
-                // and next dim is the data vector length. We thus hardcode it for now
-                fprintf(pp, " 0=1");
-            else
-                fprintf(pp, " 0=%d", order_type);
-        }
-        else if (layer.type() == "Pooling")
-        {
-            const caffe::PoolingParameter& pooling_param = layer.pooling_param();
-            fprintf(pp, " 0=%d", pooling_param.pool());
-            if (pooling_param.has_kernel_w() && pooling_param.has_kernel_h())
-            {
-                fprintf(pp, " 1=%d", pooling_param.kernel_w());
-                fprintf(pp, " 11=%d", pooling_param.kernel_h());
-            }
-            else
-            {
-                fprintf(pp, " 1=%d", pooling_param.kernel_size());
-            }
-            if (pooling_param.has_stride_w() && pooling_param.has_stride_h())
-            {
-                fprintf(pp, " 2=%d", pooling_param.stride_w());
-                fprintf(pp, " 12=%d", pooling_param.stride_h());
-            }
-            else
-            {
-                fprintf(pp, " 2=%d", pooling_param.stride());
-            }
-            if (pooling_param.has_pad_w() && pooling_param.has_pad_h())
-            {
-                fprintf(pp, " 3=%d", pooling_param.pad_w());
-                fprintf(pp, " 13=%d", pooling_param.pad_h());
-            }
-            else
-            {
-                fprintf(pp, " 3=%d", pooling_param.pad());
-            }
-            fprintf(pp, " 4=%d", pooling_param.has_global_pooling() ? pooling_param.global_pooling() : 0);
-        }
-        else if (layer.type() == "Power")
-        {
-            const caffe::PowerParameter& power_param = layer.power_param();
-            fprintf(pp, " 0=%f", power_param.power());
-            fprintf(pp, " 1=%f", power_param.scale());
-            fprintf(pp, " 2=%f", power_param.shift());
-        }
-        else if (layer.type() == "PReLU")
-        {
-            const caffe::LayerParameter& binlayer = net.layer(netidx);
-            const caffe::BlobProto& slope_blob = binlayer.blobs(0);
-            fprintf(pp, " 0=%d", slope_blob.data_size());
-            fwrite(slope_blob.data().data(), sizeof(float), slope_blob.data_size(), bp);
-        }
-        else if (layer.type() == "PriorBox")
-        {
-            const caffe::PriorBoxParameter& prior_box_param = layer.prior_box_param();
-
-            int num_aspect_ratio = prior_box_param.aspect_ratio_size();
-            for (int j=0; j<prior_box_param.aspect_ratio_size(); j++)
-            {
-                float ar = prior_box_param.aspect_ratio(j);
-                if (fabs(ar - 1.) < 1e-6) {
-                    num_aspect_ratio--;
-                }
-            }
-
-            float variances[4] = {0.1f, 0.1f, 0.1f, 0.1f};
-            if (prior_box_param.variance_size() == 4)
-            {
-                variances[0] = prior_box_param.variance(0);
-                variances[1] = prior_box_param.variance(1);
-                variances[2] = prior_box_param.variance(2);
-                variances[3] = prior_box_param.variance(3);
-            }
-            else if (prior_box_param.variance_size() == 1)
-            {
-                variances[0] = prior_box_param.variance(0);
-                variances[1] = prior_box_param.variance(0);
-                variances[2] = prior_box_param.variance(0);
-                variances[3] = prior_box_param.variance(0);
-            }
-
-            int flip = prior_box_param.has_flip() ? prior_box_param.flip() : 1;
-            int clip = prior_box_param.has_clip() ? prior_box_param.clip() : 0;
-            int image_width = -233;
-            int image_height = -233;
-            if (prior_box_param.has_img_size())
-            {
-                image_width = prior_box_param.img_size();
-                image_height = prior_box_param.img_size();
-            }
-            else if (prior_box_param.has_img_w() && prior_box_param.has_img_h())
-            {
-                image_width = prior_box_param.img_w();
-                image_height = prior_box_param.img_h();
-            }
-
-            float step_width = -233;
-            float step_height = -233;
-            if (prior_box_param.has_step())
-            {
-                step_width = prior_box_param.step();
-                step_height = prior_box_param.step();
-            }
-            else if (prior_box_param.has_step_w() && prior_box_param.has_step_h())
-            {
-                step_width = prior_box_param.step_w();
-                step_height = prior_box_param.step_h();
-            }
-
-            fprintf(pp, " -23300=%d", prior_box_param.min_size_size());
-            for (int j=0; j<prior_box_param.min_size_size(); j++)
-            {
-                fprintf(pp, ",%f", prior_box_param.min_size(j));
-            }
-            fprintf(pp, " -23301=%d", prior_box_param.max_size_size());
-            for (int j=0; j<prior_box_param.max_size_size(); j++)
-            {
-                fprintf(pp, ",%f", prior_box_param.max_size(j));
-            }
-            fprintf(pp, " -23302=%d", num_aspect_ratio);
-            for (int j=0; j<prior_box_param.aspect_ratio_size(); j++)
-            {
-                float ar = prior_box_param.aspect_ratio(j);
-                if (fabs(ar - 1.) < 1e-6) {
-                    continue;
-                }
-                fprintf(pp, ",%f", ar);
-            }
-            fprintf(pp, " 3=%f", variances[0]);
-            fprintf(pp, " 4=%f", variances[1]);
-            fprintf(pp, " 5=%f", variances[2]);
-            fprintf(pp, " 6=%f", variances[3]);
-            fprintf(pp, " 7=%d", flip);
-            fprintf(pp, " 8=%d", clip);
-            fprintf(pp, " 9=%d", image_width);
-            fprintf(pp, " 10=%d", image_height);
-            fprintf(pp, " 11=%f", step_width);
-            fprintf(pp, " 12=%f", step_height);
-            fprintf(pp, " 13=%f", prior_box_param.offset());
-        }
-        else if (layer.type() == "Python")
-        {
-            const caffe::PythonParameter& python_param = layer.python_param();
-            std::string python_layer_name = python_param.layer();
-            if (python_layer_name == "ProposalLayer")
-            {
-                int feat_stride = 16;
-                sscanf(python_param.param_str().c_str(), "'feat_stride': %d", &feat_stride);
-
-                int base_size = 16;
-//                 float ratio;
-//                 float scale;
-                int pre_nms_topN = 6000;
-                int after_nms_topN = 300;
-                float nms_thresh = 0.7;
-                int min_size = 16;
-                fprintf(pp, " 0=%d", feat_stride);
-                fprintf(pp, " 1=%d", base_size);
-                fprintf(pp, " 2=%d", pre_nms_topN);
-                fprintf(pp, " 3=%d", after_nms_topN);
-                fprintf(pp, " 4=%f", nms_thresh);
-                fprintf(pp, " 5=%d", min_size);
-            }
-        }
-        else if (layer.type() == "ReLU")
-        {
-            const caffe::ReLUParameter& relu_param = layer.relu_param();
-            if (relu_param.has_negative_slope())
-            {
-                fprintf(pp, " 0=%f", relu_param.negative_slope());
-            }
-        }
-        else if (layer.type() == "ReLU6")
-        {
-            float min = 0.f;
-            float max = 6.f;
-            fprintf(pp, " 0=%f", min);
-            fprintf(pp, " 1=%f", max);
-        }
-        else if (layer.type() == "Reshape")
-        {
-            const caffe::ReshapeParameter& reshape_param = layer.reshape_param();
-            const caffe::BlobShape& bs = reshape_param.shape();
-            if (bs.dim_size() == 1)
-            {
-                fprintf(pp, " 0=%ld 1=-233 2=-233", bs.dim(0));
-            }
-            else if (bs.dim_size() == 2)
-            {
-                fprintf(pp, " 0=%ld 1=-233 2=-233", bs.dim(1));
-            }
-            else if (bs.dim_size() == 3)
-            {
-	      if (ocr)
-		// in ocr case, c has no dimension (1), dim(1) is -1;
-		// ncnn badly interprets -1 and 0 in the same reshape
-		// params set, as a workaround in ocr case we force c dim to be 1, so
-		// h dim is correctly computed
-		fprintf(pp, " 0=%ld 1=%ld 2=%ld", bs.dim(2), bs.dim(1), 1L);
-	      else
-		fprintf(pp, " 0=%ld 1=%ld 2=-233", bs.dim(2), bs.dim(1));
-            }
-            else // bs.dim_size() == 4
-            {
-                fprintf(pp, " 0=%ld 1=%ld 2=%ld", bs.dim(3), bs.dim(2), bs.dim(1));
-            }
-            fprintf(pp, " 3=0");// permute
-        }
-        else if (layer.type() == "ROIPooling")
-        {
-            const caffe::ROIPoolingParameter& roi_pooling_param = layer.roi_pooling_param();
-            fprintf(pp, " 0=%d", roi_pooling_param.pooled_w());
-            fprintf(pp, " 1=%d", roi_pooling_param.pooled_h());
-            fprintf(pp, " 2=%f", roi_pooling_param.spatial_scale());
-        }
-        else if (layer.type() == "Scale")
-        {
-            const caffe::LayerParameter& binlayer = net.layer(netidx);
-
-            const caffe::ScaleParameter& scale_param = layer.scale_param();
-            bool scale_weight = scale_param.bias_term() ? (binlayer.blobs_size() == 2) : (binlayer.blobs_size() == 1);
-            if (scale_weight)
-            {
-                const caffe::BlobProto& weight_blob = binlayer.blobs(0);
-                fprintf(pp, " 0=%d", (int)weight_blob.data_size());
-            }
-            else
-            {
-                fprintf(pp, " 0=-233");
-            }
-
-            fprintf(pp, " 1=%d", scale_param.bias_term());
-
-            for (int j=0; j<binlayer.blobs_size(); j++)
-            {
-                const caffe::BlobProto& blob = binlayer.blobs(j);
-                fwrite(blob.data().data(), sizeof(float), blob.data_size(), bp);
-            }
-        }
-        else if (layer.type() == "ShuffleChannel")
-        {
-            const caffe::ShuffleChannelParameter& shuffle_channel_param = layer.shuffle_channel_param();
-            fprintf(pp, " 0=%d", shuffle_channel_param.group());
-        }
-        else if (layer.type() == "Slice")
-        {
-            const caffe::SliceParameter& slice_param = layer.slice_param();
-            if (slice_param.slice_point_size() == 0)
-            {
-                int num_slice = layer.top_size();
-                fprintf(pp, " -23300=%d", num_slice);
-                for (int j=0; j<num_slice; j++)
-                {
-                    fprintf(pp, ",-233");
-                }
-            }
-            else
-            {
-                int num_slice = slice_param.slice_point_size() + 1;
-                fprintf(pp, " -23300=%d", num_slice);
-                int prev_offset = 0;
-                for (int j=0; j<slice_param.slice_point_size(); j++)
-                {
-                    int offset = slice_param.slice_point(j);
-                    fprintf(pp, ",%d", offset - prev_offset);
-                    prev_offset = offset;
-                }
-                fprintf(pp, ",-233");
-            }
-            int dim = slice_param.axis() - 1;
-            fprintf(pp, " 1=%d", dim);
-        }
-        else if (layer.type() == "Softmax")
-        {
-            const caffe::SoftmaxParameter& softmax_param = layer.softmax_param();
-            int dim = softmax_param.axis() - 1;
-            fprintf(pp, " 0=%d", dim);
-            fprintf(pp, " 1=1");
-        }
-        else if (layer.type() == "Threshold")
-        {
-            const caffe::ThresholdParameter& threshold_param = layer.threshold_param();
-            fprintf(pp, " 0=%f", threshold_param.threshold());
-        }
-        fprintf(pp, "\n");
-
-        // add split layer if top reference larger than one
-        if (layer.bottom_size() == 1 && layer.top_size() == 1 && layer.bottom(0) == layer.top(0))
-        {
-            std::string blob_name = blob_name_decorated[layer.top(0)];
-            if (bottom_reference.find(blob_name) != bottom_reference.end())
-            {
-                int refcount = bottom_reference[blob_name];
-                if (refcount > 1)
-                {
-                    char splitname[256];
-                    sprintf(splitname, "splitncnn_%d", internal_split);
-                    fprintf(pp, "%-16s %-16s %d %d", "Split", splitname, 1, refcount);
-                    fprintf(pp, " %s", blob_name.c_str());
-
-                    for (int j=0; j<refcount; j++)
-                    {
-                        fprintf(pp, " %s_splitncnn_%d", blob_name.c_str(), j);
-                    }
-                    fprintf(pp, "\n");
-
-                    internal_split++;
-                }
-            }
-        }
-        else
-        {
-            for (int j=0; j<layer.top_size(); j++)
-            {
-                std::string blob_name = layer.top(j);
-                if (bottom_reference.find(blob_name) != bottom_reference.end())
-                {
-                    int refcount = bottom_reference[blob_name];
-                    if (refcount > 1)
-                    {
-                        char splitname[256];
-                        sprintf(splitname, "splitncnn_%d", internal_split);
-                        fprintf(pp, "%-16s %-16s %d %d", "Split", splitname, 1, refcount);
-                        fprintf(pp, " %s", blob_name.c_str());
-
-                        for (int j=0; j<refcount; j++)
+                      if (quantize_level == 0)
                         {
-                            fprintf(pp, " %s_splitncnn_%d", blob_name.c_str(), j);
+                          quantize_tag = 0x0002C056;
                         }
-                        fprintf(pp, "\n");
+                      else if (quantize_level == 256)
+                        {
+                          quantize_tag = quantize_weight(
+                              (float *)blob.data().data(), blob.data_size(),
+                              weight_int8scale, int8_weights);
+                        }
+                    }
+                  else if (quantize_level == 256)
+                    {
+                      quantize_tag = quantize_weight(
+                          (float *)blob.data().data(), blob.data_size(),
+                          quantize_level, quantize_table, quantize_index);
+                    }
+                  else if (quantize_level == 65536)
+                    {
+                      quantize_tag
+                          = quantize_weight((float *)blob.data().data(),
+                                            blob.data_size(), float16_weights);
+                    }
 
-                        internal_split++;
+                  // write quantize tag first
+                  fwrite(&quantize_tag, sizeof(int), 1, bp);
+
+                  if (quantize_tag)
+                    {
+                      int p0 = ftell(bp);
+                      if (int8_scale_term)
+                        {
+                          if (quantize_level == 0)
+                            {
+                              // write original data and int8scale
+                              fwrite(blob.data().data(), sizeof(float),
+                                     blob.data_size(), bp);
+                            }
+                          else if (quantize_level == 256)
+                            {
+                              fwrite(int8_weights.data(), sizeof(signed char),
+                                     int8_weights.size(), bp);
+                            }
+                        }
+                      else if (quantize_level == 256)
+                        {
+                          // write quantize table and index
+                          fwrite(quantize_table.data(), sizeof(float),
+                                 quantize_table.size(), bp);
+                          fwrite(quantize_index.data(), sizeof(unsigned char),
+                                 quantize_index.size(), bp);
+                        }
+                      else if (quantize_level == 65536)
+                        {
+                          fwrite(float16_weights.data(),
+                                 sizeof(unsigned short),
+                                 float16_weights.size(), bp);
+                        }
+
+                      // padding to 32bit align
+                      int nwrite = ftell(bp) - p0;
+                      int nalign = alignSize(nwrite, 4);
+                      unsigned char padding[4] = { 0x00, 0x00, 0x00, 0x00 };
+                      fwrite(padding, sizeof(unsigned char), nalign - nwrite,
+                             bp);
+                    }
+                  else
+                    {
+                      // write original data
+                      fwrite(blob.data().data(), sizeof(float),
+                             blob.data_size(), bp);
+                    }
+                }
+              else
+                {
+                  // write original data
+                  fwrite(blob.data().data(), sizeof(float), blob.data_size(),
+                         bp);
+                }
+            }
+
+          if (int8_scale_term)
+            {
+              // write int8_scale data
+              fwrite(weight_int8scale.data(), sizeof(float),
+                     weight_int8scale.size(), bp);
+              fwrite(blob_int8scale.data(), sizeof(float),
+                     blob_int8scale.size(), bp);
+            }
+        }
+      else if (layer.type() == "Input")
+        {
+          const caffe::InputParameter &input_param = layer.input_param();
+          const caffe::BlobShape &bs = input_param.shape(0);
+          if (bs.dim_size() == 4)
+            {
+              fprintf(pp, " 0=%ld", bs.dim(3));
+              fprintf(pp, " 1=%ld", bs.dim(2));
+              fprintf(pp, " 2=%ld", bs.dim(1));
+            }
+          else if (bs.dim_size() == 3)
+            {
+              fprintf(pp, " 0=%ld", bs.dim(2));
+              fprintf(pp, " 1=%ld", bs.dim(1));
+              fprintf(pp, " 2=-233");
+            }
+          else if (bs.dim_size() == 2)
+            {
+              fprintf(pp, " 0=%ld", bs.dim(1));
+              fprintf(pp, " 1=-233");
+              fprintf(pp, " 2=-233");
+            }
+        }
+      else if (layer.type() == "Interp")
+        {
+          const caffe::InterpParameter &interp_param = layer.interp_param();
+          fprintf(pp, " 0=%d", 2);
+          fprintf(pp, " 1=%f", (float)interp_param.zoom_factor());
+          fprintf(pp, " 2=%f", (float)interp_param.zoom_factor());
+          fprintf(pp, " 3=%d", interp_param.height());
+          fprintf(pp, " 4=%d", interp_param.width());
+        }
+      else if (layer.type() == "LRN")
+        {
+          const caffe::LRNParameter &lrn_param = layer.lrn_param();
+          fprintf(pp, " 0=%d", lrn_param.norm_region());
+          fprintf(pp, " 1=%d", lrn_param.local_size());
+          fprintf(pp, " 2=%f", lrn_param.alpha());
+          fprintf(pp, " 3=%f", lrn_param.beta());
+        }
+      else if (layer.type() == "LSTM")
+        {
+          const caffe::LayerParameter &binlayer = net.layer(netidx);
+
+          const caffe::BlobProto &weight_blob = binlayer.blobs(0);
+          const caffe::RecurrentParameter &recurrent_param
+              = layer.recurrent_param();
+          fprintf(pp, " 0=%d", recurrent_param.num_output());
+          fprintf(pp, " 1=%d", weight_blob.data_size());
+
+          for (int j = 0; j < binlayer.blobs_size(); j++)
+            {
+              int quantize_tag = 0;
+              const caffe::BlobProto &blob = binlayer.blobs(j);
+
+              std::vector<float> quantize_table;
+              std::vector<unsigned char> quantize_index;
+
+              std::vector<unsigned short> float16_weights;
+
+              if (quantize_level != 0)
+                {
+                  if (quantize_level == 256)
+                    {
+                      quantize_tag = quantize_weight(
+                          (float *)blob.data().data(), blob.data_size(),
+                          quantize_level, quantize_table, quantize_index);
+                    }
+                  else if (quantize_level == 65536)
+                    {
+                      quantize_tag
+                          = quantize_weight((float *)blob.data().data(),
+                                            blob.data_size(), float16_weights);
+                    }
+                }
+
+              // write quantize tag first
+              fwrite(&quantize_tag, sizeof(int), 1, bp);
+
+              if (quantize_tag)
+                {
+                  int p0 = ftell(bp);
+                  if (quantize_level == 256)
+                    {
+                      // write quantize table and index
+                      fwrite(quantize_table.data(), sizeof(float),
+                             quantize_table.size(), bp);
+                      fwrite(quantize_index.data(), sizeof(unsigned char),
+                             quantize_index.size(), bp);
+                    }
+                  else if (quantize_level == 65536)
+                    {
+                      fwrite(float16_weights.data(), sizeof(unsigned short),
+                             float16_weights.size(), bp);
+                    }
+                  // padding to 32bit align
+                  int nwrite = ftell(bp) - p0;
+                  int nalign = alignSize(nwrite, 4);
+                  unsigned char padding[4] = { 0x00, 0x00, 0x00, 0x00 };
+                  fwrite(padding, sizeof(unsigned char), nalign - nwrite, bp);
+                }
+              else
+                {
+                  // write original data
+                  fwrite(blob.data().data(), sizeof(float), blob.data_size(),
+                         bp);
+                }
+            }
+        }
+      else if (layer.type() == "MemoryData")
+        {
+          const caffe::MemoryDataParameter &memory_data_param
+              = layer.memory_data_param();
+          fprintf(pp, " 0=%d", memory_data_param.width());
+          fprintf(pp, " 1=%d", memory_data_param.height());
+          fprintf(pp, " 2=%d", memory_data_param.channels());
+        }
+      else if (layer.type() == "MVN")
+        {
+          const caffe::MVNParameter &mvn_param = layer.mvn_param();
+          fprintf(pp, " 0=%d", mvn_param.normalize_variance());
+          fprintf(pp, " 1=%d", mvn_param.across_channels());
+          fprintf(pp, " 2=%f", mvn_param.eps());
+        }
+      else if (layer.type() == "Normalize")
+        {
+          const caffe::LayerParameter &binlayer = net.layer(netidx);
+          const caffe::BlobProto &scale_blob = binlayer.blobs(0);
+          const caffe::NormalizeParameter &norm_param = layer.norm_param();
+          fprintf(pp, " 0=%d", norm_param.across_spatial());
+          fprintf(pp, " 1=%d", norm_param.channel_shared());
+          fprintf(pp, " 2=%f", norm_param.eps());
+          fprintf(pp, " 3=%d", scale_blob.data_size());
+
+          fwrite(scale_blob.data().data(), sizeof(float),
+                 scale_blob.data_size(), bp);
+        }
+      else if (layer.type() == "Permute")
+        {
+          const caffe::PermuteParameter &permute_param = layer.permute_param();
+          int order_size = permute_param.order_size();
+          int order_type = 0;
+          if (order_size == 0)
+            order_type = 0;
+          if (order_size == 1)
+            {
+              int order0 = permute_param.order(0);
+              if (order0 == 0)
+                order_type = 0;
+              // permute with N not supported
+            }
+          if (order_size == 2)
+            {
+              int order0 = permute_param.order(0);
+              int order1 = permute_param.order(1);
+              if (order0 == 0)
+                {
+                  if (order1 == 1) // 0 1 2 3
+                    order_type = 0;
+                  else if (order1 == 2) // 0 2 1 3
+                    order_type = 2;
+                  else if (order1 == 3) // 0 3 1 2
+                    order_type = 4;
+                }
+              // permute with N not supported
+            }
+          if (order_size == 3 || order_size == 4)
+            {
+              int order0 = permute_param.order(0);
+              int order1 = permute_param.order(1);
+              int order2 = permute_param.order(2);
+              if (order0 == 0)
+                {
+                  if (order1 == 1)
+                    {
+                      if (order2 == 2) // 0 1 2 3
+                        order_type = 0;
+                      if (order2 == 3) // 0 1 3 2
+                        order_type = 1;
+                    }
+                  else if (order1 == 2)
+                    {
+                      if (order2 == 1) // 0 2 1 3
+                        order_type = 2;
+                      if (order2 == 3) // 0 2 3 1
+                        order_type = 3;
+                    }
+                  else if (order1 == 3)
+                    {
+                      if (order2 == 1) // 0 3 1 2
+                        order_type = 4;
+                      if (order2 == 2) // 0 3 2 1
+                        order_type = 5;
+                    }
+                }
+              // permute with N not supported
+            }
+          if (ocr)
+            // in OCR case, only one permute juste before the LSTM to permute h
+            // and w computation above do not allow dimensions swaps as needed
+            // for LSTMs as LSTMS in caffe take T as first dim, second dim is 1
+            // (batchsize forced to 1) and next dim is the data vector length.
+            // We thus hardcode it for now
+            fprintf(pp, " 0=1");
+          else
+            fprintf(pp, " 0=%d", order_type);
+        }
+      else if (layer.type() == "Pooling")
+        {
+          const caffe::PoolingParameter &pooling_param = layer.pooling_param();
+          fprintf(pp, " 0=%d", pooling_param.pool());
+          if (pooling_param.has_kernel_w() && pooling_param.has_kernel_h())
+            {
+              fprintf(pp, " 1=%d", pooling_param.kernel_w());
+              fprintf(pp, " 11=%d", pooling_param.kernel_h());
+            }
+          else
+            {
+              fprintf(pp, " 1=%d", pooling_param.kernel_size());
+            }
+          if (pooling_param.has_stride_w() && pooling_param.has_stride_h())
+            {
+              fprintf(pp, " 2=%d", pooling_param.stride_w());
+              fprintf(pp, " 12=%d", pooling_param.stride_h());
+            }
+          else
+            {
+              fprintf(pp, " 2=%d", pooling_param.stride());
+            }
+          if (pooling_param.has_pad_w() && pooling_param.has_pad_h())
+            {
+              fprintf(pp, " 3=%d", pooling_param.pad_w());
+              fprintf(pp, " 13=%d", pooling_param.pad_h());
+            }
+          else
+            {
+              fprintf(pp, " 3=%d", pooling_param.pad());
+            }
+          fprintf(pp, " 4=%d",
+                  pooling_param.has_global_pooling()
+                      ? pooling_param.global_pooling()
+                      : 0);
+        }
+      else if (layer.type() == "Power")
+        {
+          const caffe::PowerParameter &power_param = layer.power_param();
+          fprintf(pp, " 0=%f", power_param.power());
+          fprintf(pp, " 1=%f", power_param.scale());
+          fprintf(pp, " 2=%f", power_param.shift());
+        }
+      else if (layer.type() == "PReLU")
+        {
+          const caffe::LayerParameter &binlayer = net.layer(netidx);
+          const caffe::BlobProto &slope_blob = binlayer.blobs(0);
+          fprintf(pp, " 0=%d", slope_blob.data_size());
+          fwrite(slope_blob.data().data(), sizeof(float),
+                 slope_blob.data_size(), bp);
+        }
+      else if (layer.type() == "PriorBox")
+        {
+          const caffe::PriorBoxParameter &prior_box_param
+              = layer.prior_box_param();
+
+          int num_aspect_ratio = prior_box_param.aspect_ratio_size();
+          for (int j = 0; j < prior_box_param.aspect_ratio_size(); j++)
+            {
+              float ar = prior_box_param.aspect_ratio(j);
+              if (fabs(ar - 1.) < 1e-6)
+                {
+                  num_aspect_ratio--;
+                }
+            }
+
+          float variances[4] = { 0.1f, 0.1f, 0.1f, 0.1f };
+          if (prior_box_param.variance_size() == 4)
+            {
+              variances[0] = prior_box_param.variance(0);
+              variances[1] = prior_box_param.variance(1);
+              variances[2] = prior_box_param.variance(2);
+              variances[3] = prior_box_param.variance(3);
+            }
+          else if (prior_box_param.variance_size() == 1)
+            {
+              variances[0] = prior_box_param.variance(0);
+              variances[1] = prior_box_param.variance(0);
+              variances[2] = prior_box_param.variance(0);
+              variances[3] = prior_box_param.variance(0);
+            }
+
+          int flip = prior_box_param.has_flip() ? prior_box_param.flip() : 1;
+          int clip = prior_box_param.has_clip() ? prior_box_param.clip() : 0;
+          int image_width = -233;
+          int image_height = -233;
+          if (prior_box_param.has_img_size())
+            {
+              image_width = prior_box_param.img_size();
+              image_height = prior_box_param.img_size();
+            }
+          else if (prior_box_param.has_img_w() && prior_box_param.has_img_h())
+            {
+              image_width = prior_box_param.img_w();
+              image_height = prior_box_param.img_h();
+            }
+
+          float step_width = -233;
+          float step_height = -233;
+          if (prior_box_param.has_step())
+            {
+              step_width = prior_box_param.step();
+              step_height = prior_box_param.step();
+            }
+          else if (prior_box_param.has_step_w()
+                   && prior_box_param.has_step_h())
+            {
+              step_width = prior_box_param.step_w();
+              step_height = prior_box_param.step_h();
+            }
+
+          fprintf(pp, " -23300=%d", prior_box_param.min_size_size());
+          for (int j = 0; j < prior_box_param.min_size_size(); j++)
+            {
+              fprintf(pp, ",%f", prior_box_param.min_size(j));
+            }
+          fprintf(pp, " -23301=%d", prior_box_param.max_size_size());
+          for (int j = 0; j < prior_box_param.max_size_size(); j++)
+            {
+              fprintf(pp, ",%f", prior_box_param.max_size(j));
+            }
+          fprintf(pp, " -23302=%d", num_aspect_ratio);
+          for (int j = 0; j < prior_box_param.aspect_ratio_size(); j++)
+            {
+              float ar = prior_box_param.aspect_ratio(j);
+              if (fabs(ar - 1.) < 1e-6)
+                {
+                  continue;
+                }
+              fprintf(pp, ",%f", ar);
+            }
+          fprintf(pp, " 3=%f", variances[0]);
+          fprintf(pp, " 4=%f", variances[1]);
+          fprintf(pp, " 5=%f", variances[2]);
+          fprintf(pp, " 6=%f", variances[3]);
+          fprintf(pp, " 7=%d", flip);
+          fprintf(pp, " 8=%d", clip);
+          fprintf(pp, " 9=%d", image_width);
+          fprintf(pp, " 10=%d", image_height);
+          fprintf(pp, " 11=%f", step_width);
+          fprintf(pp, " 12=%f", step_height);
+          fprintf(pp, " 13=%f", prior_box_param.offset());
+        }
+      else if (layer.type() == "Python")
+        {
+          const caffe::PythonParameter &python_param = layer.python_param();
+          std::string python_layer_name = python_param.layer();
+          if (python_layer_name == "ProposalLayer")
+            {
+              int feat_stride = 16;
+              sscanf(python_param.param_str().c_str(), "'feat_stride': %d",
+                     &feat_stride);
+
+              int base_size = 16;
+              //                 float ratio;
+              //                 float scale;
+              int pre_nms_topN = 6000;
+              int after_nms_topN = 300;
+              float nms_thresh = 0.7;
+              int min_size = 16;
+              fprintf(pp, " 0=%d", feat_stride);
+              fprintf(pp, " 1=%d", base_size);
+              fprintf(pp, " 2=%d", pre_nms_topN);
+              fprintf(pp, " 3=%d", after_nms_topN);
+              fprintf(pp, " 4=%f", nms_thresh);
+              fprintf(pp, " 5=%d", min_size);
+            }
+        }
+      else if (layer.type() == "ReLU")
+        {
+          const caffe::ReLUParameter &relu_param = layer.relu_param();
+          if (relu_param.has_negative_slope())
+            {
+              fprintf(pp, " 0=%f", relu_param.negative_slope());
+            }
+        }
+      else if (layer.type() == "ReLU6")
+        {
+          float min = 0.f;
+          float max = 6.f;
+          fprintf(pp, " 0=%f", min);
+          fprintf(pp, " 1=%f", max);
+        }
+      else if (layer.type() == "Reshape")
+        {
+          const caffe::ReshapeParameter &reshape_param = layer.reshape_param();
+          const caffe::BlobShape &bs = reshape_param.shape();
+          if (bs.dim_size() == 1)
+            {
+              fprintf(pp, " 0=%ld 1=-233 2=-233", bs.dim(0));
+            }
+          else if (bs.dim_size() == 2)
+            {
+              fprintf(pp, " 0=%ld 1=-233 2=-233", bs.dim(1));
+            }
+          else if (bs.dim_size() == 3)
+            {
+              if (ocr)
+                // in ocr case, c has no dimension (1), dim(1) is -1;
+                // ncnn badly interprets -1 and 0 in the same reshape
+                // params set, as a workaround in ocr case we force c dim to be
+                // 1, so h dim is correctly computed
+                fprintf(pp, " 0=%ld 1=%ld 2=%ld", bs.dim(2), bs.dim(1), 1L);
+              else
+                fprintf(pp, " 0=%ld 1=%ld 2=-233", bs.dim(2), bs.dim(1));
+            }
+          else // bs.dim_size() == 4
+            {
+              fprintf(pp, " 0=%ld 1=%ld 2=%ld", bs.dim(3), bs.dim(2),
+                      bs.dim(1));
+            }
+          fprintf(pp, " 3=0"); // permute
+        }
+      else if (layer.type() == "ROIPooling")
+        {
+          const caffe::ROIPoolingParameter &roi_pooling_param
+              = layer.roi_pooling_param();
+          fprintf(pp, " 0=%d", roi_pooling_param.pooled_w());
+          fprintf(pp, " 1=%d", roi_pooling_param.pooled_h());
+          fprintf(pp, " 2=%f", roi_pooling_param.spatial_scale());
+        }
+      else if (layer.type() == "Scale")
+        {
+          const caffe::LayerParameter &binlayer = net.layer(netidx);
+
+          const caffe::ScaleParameter &scale_param = layer.scale_param();
+          bool scale_weight = scale_param.bias_term()
+                                  ? (binlayer.blobs_size() == 2)
+                                  : (binlayer.blobs_size() == 1);
+          if (scale_weight)
+            {
+              const caffe::BlobProto &weight_blob = binlayer.blobs(0);
+              fprintf(pp, " 0=%d", (int)weight_blob.data_size());
+            }
+          else
+            {
+              fprintf(pp, " 0=-233");
+            }
+
+          fprintf(pp, " 1=%d", scale_param.bias_term());
+
+          for (int j = 0; j < binlayer.blobs_size(); j++)
+            {
+              const caffe::BlobProto &blob = binlayer.blobs(j);
+              fwrite(blob.data().data(), sizeof(float), blob.data_size(), bp);
+            }
+        }
+      else if (layer.type() == "ShuffleChannel")
+        {
+          const caffe::ShuffleChannelParameter &shuffle_channel_param
+              = layer.shuffle_channel_param();
+          fprintf(pp, " 0=%d", shuffle_channel_param.group());
+        }
+      else if (layer.type() == "Slice")
+        {
+          const caffe::SliceParameter &slice_param = layer.slice_param();
+          if (slice_param.slice_point_size() == 0)
+            {
+              int num_slice = layer.top_size();
+              fprintf(pp, " -23300=%d", num_slice);
+              for (int j = 0; j < num_slice; j++)
+                {
+                  fprintf(pp, ",-233");
+                }
+            }
+          else
+            {
+              int num_slice = slice_param.slice_point_size() + 1;
+              fprintf(pp, " -23300=%d", num_slice);
+              int prev_offset = 0;
+              for (int j = 0; j < slice_param.slice_point_size(); j++)
+                {
+                  int offset = slice_param.slice_point(j);
+                  fprintf(pp, ",%d", offset - prev_offset);
+                  prev_offset = offset;
+                }
+              fprintf(pp, ",-233");
+            }
+          int dim = slice_param.axis() - 1;
+          fprintf(pp, " 1=%d", dim);
+        }
+      else if (layer.type() == "Softmax")
+        {
+          const caffe::SoftmaxParameter &softmax_param = layer.softmax_param();
+          int dim = softmax_param.axis() - 1;
+          fprintf(pp, " 0=%d", dim);
+          fprintf(pp, " 1=1");
+        }
+      else if (layer.type() == "Threshold")
+        {
+          const caffe::ThresholdParameter &threshold_param
+              = layer.threshold_param();
+          fprintf(pp, " 0=%f", threshold_param.threshold());
+        }
+      fprintf(pp, "\n");
+
+      // add split layer if top reference larger than one
+      if (layer.bottom_size() == 1 && layer.top_size() == 1
+          && layer.bottom(0) == layer.top(0))
+        {
+          std::string blob_name = blob_name_decorated[layer.top(0)];
+          if (bottom_reference.find(blob_name) != bottom_reference.end())
+            {
+              int refcount = bottom_reference[blob_name];
+              if (refcount > 1)
+                {
+                  char splitname[256];
+                  sprintf(splitname, "splitncnn_%d", internal_split);
+                  fprintf(pp, "%-16s %-16s %d %d", "Split", splitname, 1,
+                          refcount);
+                  fprintf(pp, " %s", blob_name.c_str());
+
+                  for (int j = 0; j < refcount; j++)
+                    {
+                      fprintf(pp, " %s_splitncnn_%d", blob_name.c_str(), j);
+                    }
+                  fprintf(pp, "\n");
+
+                  internal_split++;
+                }
+            }
+        }
+      else
+        {
+          for (int j = 0; j < layer.top_size(); j++)
+            {
+              std::string blob_name = layer.top(j);
+              if (bottom_reference.find(blob_name) != bottom_reference.end())
+                {
+                  int refcount = bottom_reference[blob_name];
+                  if (refcount > 1)
+                    {
+                      char splitname[256];
+                      sprintf(splitname, "splitncnn_%d", internal_split);
+                      fprintf(pp, "%-16s %-16s %d %d", "Split", splitname, 1,
+                              refcount);
+                      fprintf(pp, " %s", blob_name.c_str());
+
+                      for (int j = 0; j < refcount; j++)
+                        {
+                          fprintf(pp, " %s_splitncnn_%d", blob_name.c_str(),
+                                  j);
+                        }
+                      fprintf(pp, "\n");
+
+                      internal_split++;
                     }
                 }
             }
         }
-
     }
 
-    fclose(pp);
-    fclose(bp);
+  fclose(pp);
+  fclose(bp);
 
-    return 0;
+  return 0;
 }

--- a/src/backends/ncnn/caffe2ncnn.h
+++ b/src/backends/ncnn/caffe2ncnn.h
@@ -1,9 +1,9 @@
 #ifndef CAFFE2NCNN_H
 #define CAFFE2NCNN_H
 
-int convert_caffe_to_ncnn(bool ocr, const char* caffeproto, const char* caffemodel,
-            const char* ncnn_prototxt, const char* ncnn_modelbin,
-            int quantize_level, const char* int8scale_table_path);
-
+int convert_caffe_to_ncnn(bool ocr, const char *caffeproto,
+                          const char *caffemodel, const char *ncnn_prototxt,
+                          const char *ncnn_modelbin, int quantize_level,
+                          const char *int8scale_table_path);
 
 #endif

--- a/src/backends/ncnn/ncnninputconns.h
+++ b/src/backends/ncnn/ncnninputconns.h
@@ -30,190 +30,209 @@
 
 namespace dd
 {
-    class NCNNInputInterface
+  class NCNNInputInterface
+  {
+  public:
+    NCNNInputInterface()
     {
-    public:
-      NCNNInputInterface() {}
-      NCNNInputInterface(const NCNNInputInterface &i)
-      {
-        _timeseries_lengths = i._timeseries_lengths;
-        _continuation = i._continuation;
-        _ntargets = i._ntargets;
-      }
-
-      ~NCNNInputInterface() {}
-
-      double unscale_res(double res, int nout);
-
-      std::vector<int> _timeseries_lengths;
-      bool _continuation = false;
-      int _ntargets;
-    };
-
-    class ImgNCNNInputFileConn : public ImgInputFileConn, public NCNNInputInterface
+    }
+    NCNNInputInterface(const NCNNInputInterface &i)
     {
-    public:
-        ImgNCNNInputFileConn()
-            :ImgInputFileConn() {}
-        ImgNCNNInputFileConn(const ImgNCNNInputFileConn &i)
-            :ImgInputFileConn(i),NCNNInputInterface(i) {}
-        ~ImgNCNNInputFileConn() {}
+      _timeseries_lengths = i._timeseries_lengths;
+      _continuation = i._continuation;
+      _ntargets = i._ntargets;
+    }
 
-        // for API info only
-        int width() const
-        {
-            return _width;
-        }
-
-        // for API info only
-        int height() const
-        {
-            return _height;
-        }
-
-        void init(const APIData &ad)
-        {
-            ImgInputFileConn::init(ad);
-        }
-        
-        void transform(const APIData &ad)
-        {
-            try
-            {
-                ImgInputFileConn::transform(ad);
-            }
-            catch(const std::exception& e)
-            {
-                throw;
-            }
-            cv::Mat bgr = this->_images.at(0);
-            _height = bgr.rows;
-            _width = bgr.cols;
-
-            _in = ncnn::Mat::from_pixels(bgr.data, ncnn::Mat::PIXEL_BGR, bgr.cols, bgr.rows);
-            if (_has_mean_scalar)
-              _in.substract_mean_normalize(&_mean[0], 0);
-	    _ids.push_back(this->_uris.at(0));
-        }
-
-      double unscale_res(double res, int nout) {return 0 * res * nout;}
-
-    public:
-      ncnn::Mat _in;
-      ncnn::Mat _out;
-      std::vector<std::string> _ids; /**< input ids (e.g. image ids) */
-    };
-
-    class CSVTSNCNNInputFileConn : public CSVTSInputFileConn, public NCNNInputInterface
+    ~NCNNInputInterface()
     {
-    public:
-        CSVTSNCNNInputFileConn()
-            :CSVTSInputFileConn() {}
-        CSVTSNCNNInputFileConn(const CSVTSNCNNInputFileConn &i)
-            :CSVTSInputFileConn(i),NCNNInputInterface(i) {}
-        ~CSVTSNCNNInputFileConn() {}
+    }
 
-        // for API info only
-        int width() const
+    double unscale_res(double res, int nout);
+
+    std::vector<int> _timeseries_lengths;
+    bool _continuation = false;
+    int _ntargets;
+  };
+
+  class ImgNCNNInputFileConn : public ImgInputFileConn,
+                               public NCNNInputInterface
+  {
+  public:
+    ImgNCNNInputFileConn() : ImgInputFileConn()
+    {
+    }
+    ImgNCNNInputFileConn(const ImgNCNNInputFileConn &i)
+        : ImgInputFileConn(i), NCNNInputInterface(i)
+    {
+    }
+    ~ImgNCNNInputFileConn()
+    {
+    }
+
+    // for API info only
+    int width() const
+    {
+      return _width;
+    }
+
+    // for API info only
+    int height() const
+    {
+      return _height;
+    }
+
+    void init(const APIData &ad)
+    {
+      ImgInputFileConn::init(ad);
+    }
+
+    void transform(const APIData &ad)
+    {
+      try
         {
-            return _width;
+          ImgInputFileConn::transform(ad);
+        }
+      catch (const std::exception &e)
+        {
+          throw;
+        }
+      cv::Mat bgr = this->_images.at(0);
+      _height = bgr.rows;
+      _width = bgr.cols;
+
+      _in = ncnn::Mat::from_pixels(bgr.data, ncnn::Mat::PIXEL_BGR, bgr.cols,
+                                   bgr.rows);
+      if (_has_mean_scalar)
+        _in.substract_mean_normalize(&_mean[0], 0);
+      _ids.push_back(this->_uris.at(0));
+    }
+
+    double unscale_res(double res, int nout)
+    {
+      return 0 * res * nout;
+    }
+
+  public:
+    ncnn::Mat _in;
+    ncnn::Mat _out;
+    std::vector<std::string> _ids; /**< input ids (e.g. image ids) */
+  };
+
+  class CSVTSNCNNInputFileConn : public CSVTSInputFileConn,
+                                 public NCNNInputInterface
+  {
+  public:
+    CSVTSNCNNInputFileConn() : CSVTSInputFileConn()
+    {
+    }
+    CSVTSNCNNInputFileConn(const CSVTSNCNNInputFileConn &i)
+        : CSVTSInputFileConn(i), NCNNInputInterface(i)
+    {
+    }
+    ~CSVTSNCNNInputFileConn()
+    {
+    }
+
+    // for API info only
+    int width() const
+    {
+      return _width;
+    }
+
+    // for API info only
+    int height() const
+    {
+      return _height;
+    }
+
+    void init(const APIData &ad)
+    {
+      CSVTSInputFileConn::init(ad);
+      if (ad.has("continuation"))
+        _continuation = ad.get("continuation").get<bool>();
+    }
+
+    void transform(const APIData &ad)
+    {
+      try
+        {
+          CSVTSInputFileConn::transform(ad);
+        }
+      catch (const std::exception &e)
+        {
+          throw;
         }
 
-        // for API info only
-        int height() const
-        {
-            return _height;
-        }
+      APIData ad_input = ad.getobj("parameters").getobj("input");
+      if (ad_input.has("continuation"))
+        _continuation = ad_input.get("continuation").get<bool>();
 
-        void init(const APIData &ad)
-        {
-            CSVTSInputFileConn::init(ad);
-            if (ad.has("continuation"))
-              _continuation= ad.get("continuation").get<bool>();
-        }
+      //  data should be is in this->_csvtsdata
+      int nseries = this->_csvtsdata.size();
+      _height = 0;
+      _width = this->_csvtsdata[0][0]._v.size() + 1;
 
-        void transform(const APIData &ad)
+      for (int i = 0; i < nseries; ++i)
         {
-            try
+          int l = this->_csvtsdata[i].size();
+          _timeseries_lengths.push_back(l);
+          _height += l;
+        }
+      // Mat(w,h)
+      _in.create(_width, _height);
+
+      int mati = 0;
+
+      // only inputs are put into _in
+      _ntargets = this->_label_pos.size();
+      std::vector<int> input_pos;
+      for (int i = 0; i < _width - 1; ++i)
+        if (std::find(this->_label_pos.begin(), this->_label_pos.end(), i)
+            == this->_label_pos.end())
+          input_pos.push_back(i);
+
+      for (unsigned int si = 0; si < this->_csvtsdata.size(); ++si)
+        {
+          if (_continuation)
+            _in[mati++] = 1;
+          else
+            _in[mati++] = 0;
+          for (int di = 0; di < _ntargets; ++di)
+            _in[mati++] = 0;
+          for (unsigned int di : input_pos)
+            _in[mati++] = this->_csvtsdata[si][0]._v[di];
+          for (unsigned int ti = 1; ti < this->_csvtsdata[si].size(); ++ti)
             {
-                CSVTSInputFileConn::transform(ad);
+              _in[mati++] = 1;
+              for (int di = 0; di < _ntargets; ++di)
+                _in[mati++] = 0;
+              for (unsigned int di : input_pos)
+                _in[mati++] = this->_csvtsdata[si][ti]._v[di];
             }
-            catch(const std::exception& e)
-            {
-                throw;
-            }
-
-            APIData ad_input = ad.getobj("parameters").getobj("input");
-            if (ad_input.has("continuation"))
-              _continuation= ad_input.get("continuation").get<bool>();
-
-            //  data should be is in this->_csvtsdata
-            int nseries = this->_csvtsdata.size();
-            _height = 0;
-            _width = this->_csvtsdata[0][0]._v.size() + 1;
-
-            for (int i =0; i< nseries; ++i)
-              {
-                int l = this->_csvtsdata[i].size();
-                _timeseries_lengths.push_back(l);
-                _height += l;
-              }
-            // Mat(w,h)
-            _in.create(_width,_height);
-
-            int mati = 0;
-
-            //only inputs are put into _in
-            _ntargets = this->_label_pos.size();
-            std::vector<int> input_pos;
-            for (int i =0; i<_width-1; ++i)
-              if (std::find(this->_label_pos.begin(),this->_label_pos.end(),i)
-                  == this->_label_pos.end())
-                input_pos.push_back(i);
-
-            for (unsigned int si = 0; si<this->_csvtsdata.size(); ++si)
-              {
-                if (_continuation)
-                  _in[mati++] = 1;
-                else
-                  _in[mati++] = 0;
-                for (int di = 0; di < _ntargets; ++di)
-                  _in[mati++] = 0;
-                for (unsigned int di : input_pos)
-                  _in[mati++] = this->_csvtsdata[si][0]._v[di];
-                for (unsigned int ti=1; ti < this->_csvtsdata[si].size(); ++ti)
-                  {
-                    _in[mati++] = 1;
-                    for (int di = 0; di < _ntargets; ++di)
-                      _in[mati++] = 0;
-                    for (unsigned int di : input_pos)
-                      _in[mati++] = this->_csvtsdata[si][ti]._v[di];
-                  }
-              }
-            _ids.push_back(this->_uris.at(0));
         }
+      _ids.push_back(this->_uris.at(0));
+    }
 
-      double unscale_res(double res, int k)
-      {
-        if (_dont_scale_labels)
-          return res;
-        if (_min_vals.empty() || _max_vals.empty())
-          return res;
-        double min = _min_vals[_label_pos[k]];
-        if (_scale_between_minus1_and_1)
-          return (res+0.5) * (_max_vals[_label_pos[k]]- min) + min;
-        else
-          return res * (_max_vals[_label_pos[k]]- min) + min;
-      }
+    double unscale_res(double res, int k)
+    {
+      if (_dont_scale_labels)
+        return res;
+      if (_min_vals.empty() || _max_vals.empty())
+        return res;
+      double min = _min_vals[_label_pos[k]];
+      if (_scale_between_minus1_and_1)
+        return (res + 0.5) * (_max_vals[_label_pos[k]] - min) + min;
+      else
+        return res * (_max_vals[_label_pos[k]] - min) + min;
+    }
 
-
-    public:
-      ncnn::Mat _in;
-      ncnn::Mat _out;
-      int _height;
-      int _width;
-      std::vector<std::string> _ids; /**< input ids (e.g. image ids) */
-    };
+  public:
+    ncnn::Mat _in;
+    ncnn::Mat _out;
+    int _height;
+    int _width;
+    std::vector<std::string> _ids; /**< input ids (e.g. image ids) */
+  };
 
 }
 

--- a/src/backends/ncnn/ncnnlib.cc
+++ b/src/backends/ncnn/ncnnlib.cc
@@ -33,354 +33,392 @@
 
 namespace dd
 {
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-    ncnn::UnlockedPoolAllocator NCNNLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::_blob_pool_allocator
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  ncnn::UnlockedPoolAllocator
+      NCNNLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+              TMLModel>::_blob_pool_allocator
       = ncnn::UnlockedPoolAllocator();
-    template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-    ncnn::PoolAllocator NCNNLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::_workspace_pool_allocator
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  ncnn::PoolAllocator
+      NCNNLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+              TMLModel>::_workspace_pool_allocator
       = ncnn::PoolAllocator();
-  
-    template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-    NCNNLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::NCNNLib(const NCNNModel &cmodel)
-        :MLLib<TInputConnectorStrategy,TOutputConnectorStrategy,NCNNModel>(cmodel)
-    {
-        this->_libname = "ncnn";
-        _net = new ncnn::Net();
-        _net->opt.lightmode = true;
-        _net->opt.num_threads = _threads;
-        _net->opt.blob_allocator = &_blob_pool_allocator;
-        _net->opt.workspace_allocator = &_workspace_pool_allocator;
+
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  NCNNLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+          TMLModel>::NCNNLib(const NCNNModel &cmodel)
+      : MLLib<TInputConnectorStrategy, TOutputConnectorStrategy, NCNNModel>(
+          cmodel)
+  {
+    this->_libname = "ncnn";
+    _net = new ncnn::Net();
+    _net->opt.lightmode = true;
+    _net->opt.num_threads = _threads;
+    _net->opt.blob_allocator = &_blob_pool_allocator;
+    _net->opt.workspace_allocator = &_workspace_pool_allocator;
+    _net->opt.lightmode = _lightmode;
+  }
+
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  NCNNLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+          TMLModel>::NCNNLib(NCNNLib &&tl) noexcept
+      : MLLib<TInputConnectorStrategy, TOutputConnectorStrategy, NCNNModel>(
+          std::move(tl))
+  {
+    this->_libname = "ncnn";
+    _net = tl._net;
+    tl._net = nullptr;
+    _nclasses = tl._nclasses;
+    _threads = tl._threads;
+    _timeserie = tl._timeserie;
+    _old_height = tl._old_height;
+    _inputBlob = tl._inputBlob;
+    _outputBlob = tl._outputBlob;
+  }
+
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  NCNNLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+          TMLModel>::~NCNNLib()
+  {
+    delete _net;
+    _net = nullptr;
+  }
+
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void NCNNLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+               TMLModel>::init_mllib(const APIData &ad)
+  {
+    int res = _net->load_param(this->_mlmodel._params.c_str());
+    if (res != 0)
+      {
+        this->_logger->error(
+            "problem while loading ncnn params {} from repo {}",
+            this->_mlmodel._params, this->_mlmodel._repo);
+        throw MLLibBadParamException("could not load ncnn params ["
+                                     + this->_mlmodel._params + "] from repo ["
+                                     + this->_mlmodel._repo + "]");
+      }
+    res = _net->load_model(this->_mlmodel._weights.c_str());
+    if (res != 0)
+      {
+        this->_logger->error(
+            "problem while loading ncnn weigths {} from repo {}",
+            this->_mlmodel._weights, this->_mlmodel._repo);
+        throw MLLibBadParamException(
+            "could not load ncnn weights [" + this->_mlmodel._weights
+            + "] from repo [" + this->_mlmodel._repo + "]");
+      }
+    _old_height = this->_inputc.height();
+    _net->set_input_h(_old_height);
+
+    if (ad.has("nclasses"))
+      _nclasses = ad.get("nclasses").get<int>();
+
+    if (ad.has("threads"))
+      _threads = ad.get("threads").get<int>();
+    else
+      _threads = dd_utils::my_hardware_concurrency();
+
+    _timeserie = this->_inputc._timeserie;
+    if (_timeserie)
+      this->_mltype = "timeserie";
+
+    if (ad.has("lightmode"))
+      {
+        _lightmode = ad.get("lightmode").get<bool>();
         _net->opt.lightmode = _lightmode;
-    }
+      }
 
-    template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-    NCNNLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::NCNNLib(NCNNLib &&tl) noexcept
-        :MLLib<TInputConnectorStrategy,TOutputConnectorStrategy,NCNNModel>(std::move(tl))
-    {
-        this->_libname = "ncnn";
-	_net = tl._net;
-	tl._net = nullptr;
-	_nclasses = tl._nclasses;
-       _threads = tl._threads;
-       _timeserie = tl._timeserie;
-       _old_height = tl._old_height;
-       _inputBlob = tl._inputBlob;
-       _outputBlob = tl._outputBlob;
-    }
+    // setting the value of Input Layer
+    if (ad.has("inputblob"))
+      {
+        _inputBlob = ad.get("inputblob").get<std::string>();
+      }
+    // setting the final Output Layer
+    if (ad.has("outputblob"))
+      {
+        _outputBlob = ad.get("outputblob").get<std::string>();
+      }
 
-    template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-    NCNNLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::~NCNNLib()
-    {
-      delete _net;
-      _net = nullptr;
-    }
+    _blob_pool_allocator.set_size_compare_ratio(0.0f);
+    _workspace_pool_allocator.set_size_compare_ratio(0.5f);
+    model_type(this->_mlmodel._params, this->_mltype);
+  }
 
-    template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-    void NCNNLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::init_mllib(const APIData &ad)
-    {
-      int res = _net->load_param(this->_mlmodel._params.c_str());
-      if (res != 0)
-        {
-          this->_logger->error("problem while loading ncnn params {} from repo {}",
-                               this->_mlmodel._params, this->_mlmodel._repo);
-	      throw MLLibBadParamException("could not load ncnn params [" +
-                                       this->_mlmodel._params+"] from repo ["+
-                                       this->_mlmodel._repo+"]");
-        }
-      res =  _net->load_model(this->_mlmodel._weights.c_str());
-      if (res != 0)
-        {
-          this->_logger->error("problem while loading ncnn weigths {} from repo {}",
-                               this->_mlmodel._weights, this->_mlmodel._repo);
-	      throw MLLibBadParamException("could not load ncnn weights [" +
-                                       this->_mlmodel._weights+"] from repo ["+
-                                       this->_mlmodel._repo+"]");
-        }
-        _old_height = this->_inputc.height();
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void NCNNLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+               TMLModel>::clear_mllib(const APIData &ad)
+  {
+    (void)ad;
+  }
+
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  int NCNNLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+              TMLModel>::train(const APIData &ad, APIData &out)
+  {
+    (void)ad;
+    (void)out;
+    return 0;
+  }
+
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  int NCNNLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+              TMLModel>::predict(const APIData &ad, APIData &out)
+  {
+
+    TInputConnectorStrategy inputc(this->_inputc);
+    TOutputConnectorStrategy tout(this->_outputc);
+    try
+      {
+        inputc.transform(ad);
+      }
+    catch (...)
+      {
+        throw;
+      }
+
+    // if height (timestep) changes we need to clear net before recreating an
+    // extractor with new height, and to reload params and models after clear()
+    if (_old_height != -1 && _old_height != inputc.height())
+      {
+        // in case of new prediction with different timesteps value, clear old
+        // net
+        _net->clear();
+        _net->load_param(this->_mlmodel._params.c_str());
+        _net->load_model(this->_mlmodel._weights.c_str());
+        _old_height = inputc.height();
         _net->set_input_h(_old_height);
+      }
 
-        if (ad.has("nclasses"))
-	        _nclasses = ad.get("nclasses").get<int>();
+    ncnn::Extractor ex = _net->create_extractor();
 
-        if (ad.has("threads"))
-            _threads = ad.get("threads").get<int>();
+    ex.set_num_threads(_threads);
+    ex.input(_inputBlob.c_str(), inputc._in);
+
+    APIData ad_output = ad.getobj("parameters").getobj("output");
+
+    // Get bbox
+    bool bbox = false;
+    if (ad_output.has("bbox"))
+      bbox = ad_output.get("bbox").get<bool>();
+
+    // Ctc model
+    bool ctc = false;
+    int blank_label = -1;
+    if (ad_output.has("ctc"))
+      {
+        ctc = ad_output.get("ctc").get<bool>();
+        if (ctc)
+          {
+            if (ad_output.has("blank_label"))
+              blank_label = ad_output.get("blank_label").get<int>();
+          }
+      }
+
+    // Extract detection or classification
+    int ret = 0;
+    std::string out_blob = _outputBlob;
+    if (out_blob.empty())
+      {
+        if (bbox == true)
+          out_blob = "detection_out";
+        else if (ctc == true)
+          out_blob = "probs";
+        else if (_timeserie)
+          out_blob = "rnn_pred";
         else
-            _threads = dd_utils::my_hardware_concurrency();
+          out_blob = "prob";
+      }
+    ret = ex.extract(out_blob.c_str(), inputc._out);
+    if (ret == -1)
+      {
+        throw MLLibInternalException("NCNN internal error");
+      }
 
-        _timeserie = this->_inputc._timeserie;
-        if (_timeserie)
-          this->_mltype = "timeserie";
+    std::vector<APIData> vrad;
+    std::vector<double> probs;
+    std::vector<std::string> cats;
+    std::vector<APIData> bboxes;
+    std::vector<APIData> series;
+    APIData rad;
 
-        if(ad.has("lightmode"))
+    // Get confidence_threshold
+    float confidence_threshold = 0.0;
+    if (ad_output.has("confidence_threshold"))
+      {
+        apitools::get_float(ad_output, "confidence_threshold",
+                            confidence_threshold);
+      }
+
+    // Get best
+    int best = 1;
+    if (ad_output.has("best"))
+      {
+        best = ad_output.get("best").get<int>();
+      }
+
+    if (bbox == true)
+      {
+        for (int i = 0; i < inputc._out.h; i++)
           {
-            _lightmode = ad.get("lightmode").get<bool>();
-            _net->opt.lightmode = _lightmode;
+            const float *values = inputc._out.row(i);
+            if (values[1] < confidence_threshold)
+              continue;
+
+            cats.push_back(this->_mlmodel.get_hcorresp(values[0]));
+            probs.push_back(values[1]);
+
+            APIData ad_bbox;
+            ad_bbox.add("xmin",
+                        static_cast<double>(values[2] * inputc.width()));
+            ad_bbox.add("ymin",
+                        static_cast<double>(values[3] * inputc.height()));
+            ad_bbox.add("xmax",
+                        static_cast<double>(values[4] * inputc.width()));
+            ad_bbox.add("ymax",
+                        static_cast<double>(values[5] * inputc.height()));
+            bboxes.push_back(ad_bbox);
+          }
+      }
+    else if (ctc == true)
+      {
+        int alphabet = inputc._out.w;
+        int time_step = inputc._out.h;
+        std::vector<int> pred_label_seq_with_blank(time_step);
+        for (int t = 0; t < time_step; ++t)
+          {
+            const float *values = inputc._out.row(t);
+            pred_label_seq_with_blank[t] = std::distance(
+                values, std::max_element(values, values + alphabet));
           }
 
-        // setting the value of Input Layer
-        if (ad.has("inputblob"))
+        std::vector<int> pred_label_seq;
+        int prev = blank_label;
+        for (int t = 0; t < time_step; ++t)
           {
-            _inputBlob = ad.get("inputblob").get<std::string>();
+            int cur = pred_label_seq_with_blank[t];
+            if (cur != prev && cur != blank_label)
+              pred_label_seq.push_back(cur);
+            prev = cur;
           }
-        // setting the final Output Layer
-        if (ad.has("outputblob"))
+        std::string outstr;
+        std::ostringstream oss;
+        for (auto l : pred_label_seq)
+          outstr += char(std::atoi(this->_mlmodel.get_hcorresp(l).c_str()));
+        cats.push_back(outstr);
+        probs.push_back(1.0);
+      }
+    else if (_timeserie)
+      {
+        std::vector<int> tsl = inputc._timeseries_lengths;
+        for (unsigned int tsi = 0; tsi < tsl.size(); ++tsi)
           {
-            _outputBlob = ad.get("outputblob").get<std::string>();
+            for (int ti = 0; ti < tsl[tsi]; ++ti)
+              {
+                std::vector<double> predictions;
+                for (int k = 0; k < inputc._ntargets; ++k)
+                  {
+                    double res = inputc._out.row(ti)[k];
+                    predictions.push_back(inputc.unscale_res(res, k));
+                  }
+                APIData ts;
+                ts.add("out", predictions);
+                series.push_back(ts);
+              }
           }
+      }
+    else
+      {
+        std::vector<float> cls_scores;
 
-        _blob_pool_allocator.set_size_compare_ratio(0.0f);
-        _workspace_pool_allocator.set_size_compare_ratio(0.5f);
-        model_type(this->_mlmodel._params,this->_mltype);
-    }
-
-    template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-    void NCNNLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::clear_mllib(const APIData &ad)
-    {
-        (void)ad;
-    }
-
-    template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-    int NCNNLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::train(const APIData &ad,
-                                        APIData &out)
-    {
-      (void)ad;
-      (void)out;
-      return 0;
-    }
-
-    template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-    int NCNNLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::predict(const APIData &ad,
-										APIData &out)
-    {
-
-        TInputConnectorStrategy inputc(this->_inputc);
-        TOutputConnectorStrategy tout(this->_outputc);
-        try {
-            inputc.transform(ad);
-        } catch (...) {
-            throw;
-        }
-
-
-        // if height (timestep) changes we need to clear net before recreating an extractor with new
-        // height,
-        // and to reload params and models after clear()
-        if (_old_height != -1 && _old_height != inputc.height())
+        cls_scores.resize(inputc._out.w);
+        for (int j = 0; j < inputc._out.w; j++)
           {
-            // in case of new prediction with different timesteps value, clear old net
-            _net->clear();
-            _net->load_param(this->_mlmodel._params.c_str());
-            _net->load_model(this->_mlmodel._weights.c_str());
-            _old_height = inputc.height();
-            _net->set_input_h(_old_height);
+            cls_scores[j] = inputc._out[j];
+          }
+        int size = cls_scores.size();
+        std::vector<std::pair<float, int>> vec;
+        vec.resize(size);
+        for (int i = 0; i < size; i++)
+          {
+            vec[i] = std::make_pair(cls_scores[i], i);
           }
 
-        ncnn::Extractor ex = _net->create_extractor();
+        std::partial_sort(vec.begin(), vec.begin() + best, vec.end(),
+                          std::greater<std::pair<float, int>>());
 
-        ex.set_num_threads(_threads);
-        ex.input(_inputBlob.c_str(), inputc._in);
-
-        APIData ad_output = ad.getobj("parameters").getobj("output");
-
-        // Get bbox
-        bool bbox = false;
-        if (ad_output.has("bbox"))
-	  bbox = ad_output.get("bbox").get<bool>();
-
-	// Ctc model
-	bool ctc = false;
-	int blank_label = -1;
-	if (ad_output.has("ctc"))
-	  {
-	    ctc = ad_output.get("ctc").get<bool>();
-	    if (ctc)
-	      {
-		if (ad_output.has("blank_label"))
-		  blank_label = ad_output.get("blank_label").get<int>();
-	      }
-	  }
-
-        // Extract detection or classification
-        int ret = 0;
-        std::string out_blob = _outputBlob;
-        if (out_blob.empty())
+        for (int i = 0; i < best; i++)
           {
-            if (bbox == true)
-              out_blob = "detection_out";
-            else if (ctc == true)
-              out_blob = "probs";
-            else if (_timeserie)
-              out_blob = "rnn_pred";
-            else
-              out_blob = "prob";
+            if (vec[i].first < confidence_threshold)
+              continue;
+            cats.push_back(this->_mlmodel.get_hcorresp(vec[i].second));
+            probs.push_back(vec[i].first);
           }
-        ret = ex.extract(out_blob.c_str(),inputc._out);
-        if (ret == -1) {
-            throw MLLibInternalException("NCNN internal error");
-        }
+      }
 
-        std::vector<APIData> vrad;
-        std::vector<double> probs;
-        std::vector<std::string> cats;
-        std::vector<APIData> bboxes;
-        std::vector<APIData> series;
-        APIData rad;
-	
-        // Get confidence_threshold
-        float confidence_threshold = 0.0;
-        if (ad_output.has("confidence_threshold")) {
-            apitools::get_float(ad_output, "confidence_threshold", confidence_threshold);
-        }
+    rad.add("uri", inputc._ids.at(0));
+    rad.add("loss", 0.0);
+    rad.add("cats", cats);
+    if (bbox == true)
+      rad.add("bboxes", bboxes);
+    if (_timeserie)
+      {
+        rad.add("series", series);
+        rad.add("probs", std::vector<double>(series.size(), 1.0));
+      }
+    else
+      rad.add("probs", probs);
 
-        // Get best
-        int best = 1;
-        if (ad_output.has("best")) {
-            best = ad_output.get("best").get<int>();
-        }
+    if (_timeserie)
+      out.add("timeseries", true);
 
-        if (bbox == true)
-	  {
-            for (int i = 0; i < inputc._out.h; i++) {
-                const float* values = inputc._out.row(i);
-                if (values[1] < confidence_threshold)
-                    continue;
+    vrad.push_back(rad);
+    tout.add_results(vrad);
+    out.add("nclasses", this->_nclasses);
+    if (bbox == true)
+      out.add("bbox", true);
+    out.add("roi", false);
+    out.add("multibox_rois", false);
+    tout.finalize(ad.getobj("parameters").getobj("output"), out,
+                  static_cast<MLModel *>(&this->_mlmodel));
+    out.add("status", 0);
+    return 0;
+  }
 
-                cats.push_back(this->_mlmodel.get_hcorresp(values[0]));
-                probs.push_back(values[1]);
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void NCNNLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+               TMLModel>::model_type(const std::string &param_file,
+                                     std::string &mltype)
+  {
+    std::ifstream paramf(param_file);
+    std::stringstream content;
+    content << paramf.rdbuf();
 
-                APIData ad_bbox;
-                ad_bbox.add("xmin",static_cast<double>(values[2] * inputc.width()));
-                ad_bbox.add("ymin",static_cast<double>(values[3] * inputc.height()));
-                ad_bbox.add("xmax",static_cast<double>(values[4] * inputc.width()));
-                ad_bbox.add("ymax",static_cast<double>(values[5] * inputc.height()));
-                bboxes.push_back(ad_bbox);
-            }
-        }
-	else if (ctc == true)
-	  {
-	    int alphabet = inputc._out.w;
-	    int time_step = inputc._out.h;
-	    std::vector<int> pred_label_seq_with_blank(time_step);
-	    for (int t=0;t<time_step;++t)
-	      {
-		const float *values = inputc._out.row(t);
-		pred_label_seq_with_blank[t] = std::distance(values,std::max_element(values,values+alphabet));
-	      }
+    std::size_t found_detection = content.str().find("DetectionOutput");
+    if (found_detection != std::string::npos)
+      {
+        mltype = "detection";
+        return;
+      }
+    std::size_t found_ocr = content.str().find("ContinuationIndicator");
+    if (found_ocr != std::string::npos)
+      {
+        mltype = "ctc";
+        return;
+      }
+    mltype = "classification";
+  }
 
-	    std::vector<int> pred_label_seq;
-	    int prev = blank_label;
-	    for (int t=0;t<time_step;++t)
-	      {
-		int cur = pred_label_seq_with_blank[t];
-		if (cur != prev && cur != blank_label)
-		  pred_label_seq.push_back(cur);
-		prev = cur;
-	      }
-	    std::string outstr;
-	    std::ostringstream oss;
-	    for (auto l: pred_label_seq)
-	      outstr += char(std::atoi(this->_mlmodel.get_hcorresp(l).c_str()));
-	    cats.push_back(outstr);
-	    probs.push_back(1.0);
-	  }
-	else if (_timeserie)
-         {
-           std::vector<int> tsl = inputc._timeseries_lengths;
-           for (unsigned int tsi = 0; tsi< tsl.size(); ++tsi)
-             {
-               for (int ti = 0; ti<tsl[tsi]; ++ti)
-                 {
-                   std::vector<double> predictions;
-                   for (int k =0; k< inputc._ntargets; ++k)
-                     {
-                       double res = inputc._out.row(ti)[k];
-                       predictions.push_back(inputc.unscale_res(res,k));
-                     }
-                   APIData ts;
-                   ts.add("out", predictions);
-                   series.push_back(ts);
-                 }
-             }
-         }
-       else
-         {
-            std::vector<float> cls_scores;
-
-            cls_scores.resize(inputc._out.w);
-            for (int j = 0; j < inputc._out.w; j++) {
-                cls_scores[j] = inputc._out[j];
-            }
-            int size = cls_scores.size();
-            std::vector< std::pair<float, int> > vec;
-            vec.resize(size);
-            for (int i = 0; i < size; i++) {
-                vec[i] = std::make_pair(cls_scores[i], i);
-            }
-        
-            std::partial_sort(vec.begin(), vec.begin() + best, vec.end(),
-                              std::greater< std::pair<float, int> >());
-        
-            for (int i = 0; i < best; i++)
-            {
-                if (vec[i].first < confidence_threshold)
-                    continue;
-                cats.push_back(this->_mlmodel.get_hcorresp(vec[i].second));
-                probs.push_back(vec[i].first);
-            }
-        }
-
-        rad.add("uri",inputc._ids.at(0));
-        rad.add("loss", 0.0);
-        rad.add("cats", cats);
-        if (bbox == true)
-            rad.add("bboxes", bboxes);
-        if (_timeserie)
-          {
-            rad.add("series", series);
-            rad.add("probs",std::vector<double>(series.size(),1.0));
-          }
-        else
-          rad.add("probs", probs);
-
-        if (_timeserie)
-          out.add("timeseries",true);
-
-
-        vrad.push_back(rad);
-        tout.add_results(vrad);
-        out.add("nclasses", this->_nclasses);
-        if (bbox == true)
-          out.add("bbox", true);
-        out.add("roi", false);
-        out.add("multibox_rois", false);
-	tout.finalize(ad.getobj("parameters").getobj("output"),out,static_cast<MLModel*>(&this->_mlmodel));
-        out.add("status", 0);
-	return 0;
-    }
-
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void NCNNLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::model_type(const std::string &param_file,
-										     std::string &mltype)
-    {
-      std::ifstream paramf(param_file);
-      std::stringstream content;
-      content << paramf.rdbuf();
-      
-      std::size_t found_detection = content.str().find("DetectionOutput");
-      if (found_detection != std::string::npos)
-	{
-	  mltype = "detection";
-	  return;
-	}
-      std::size_t found_ocr = content.str().find("ContinuationIndicator");
-      if (found_ocr != std::string::npos)
-	{
-	  mltype = "ctc";
-	  return;
-	}
-      mltype = "classification";
-    }
-  
-    template class NCNNLib<ImgNCNNInputFileConn,SupervisedOutput,NCNNModel>;
-  template class NCNNLib<CSVTSNCNNInputFileConn,SupervisedOutput,NCNNModel>;
+  template class NCNNLib<ImgNCNNInputFileConn, SupervisedOutput, NCNNModel>;
+  template class NCNNLib<CSVTSNCNNInputFileConn, SupervisedOutput, NCNNModel>;
 }

--- a/src/backends/ncnn/ncnnlib.h
+++ b/src/backends/ncnn/ncnnlib.h
@@ -30,40 +30,43 @@
 
 namespace dd
 {
-    template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel=NCNNModel>
-    class NCNNLib : public MLLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>
-    {
-    public:
-        NCNNLib(const NCNNModel &tmodel);
-        NCNNLib(NCNNLib &&tl) noexcept;
-        ~NCNNLib();
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel = NCNNModel>
+  class NCNNLib : public MLLib<TInputConnectorStrategy,
+                               TOutputConnectorStrategy, TMLModel>
+  {
+  public:
+    NCNNLib(const NCNNModel &tmodel);
+    NCNNLib(NCNNLib &&tl) noexcept;
+    ~NCNNLib();
 
-        /*- from mllib -*/
-        void init_mllib(const APIData &ad);
+    /*- from mllib -*/
+    void init_mllib(const APIData &ad);
 
-        void clear_mllib(const APIData &ad);
+    void clear_mllib(const APIData &ad);
 
-        int train(const APIData &ad, APIData &out);
+    int train(const APIData &ad, APIData &out);
 
-        int predict(const APIData &ad, APIData &out);
+    int predict(const APIData &ad, APIData &out);
 
-        void model_type(const std::string &param_file,
-			std::string &mltype);
-    
-    public:
-        ncnn::Net *_net = nullptr;
-        int _nclasses = 0;
-        bool _timeserie =  false;
-        bool _lightmode = true;
-    private:
-        static ncnn::UnlockedPoolAllocator _blob_pool_allocator;
-        static ncnn::PoolAllocator _workspace_pool_allocator;
-    protected:
-        int _threads = 1;
+    void model_type(const std::string &param_file, std::string &mltype);
+
+  public:
+    ncnn::Net *_net = nullptr;
+    int _nclasses = 0;
+    bool _timeserie = false;
+    bool _lightmode = true;
+
+  private:
+    static ncnn::UnlockedPoolAllocator _blob_pool_allocator;
+    static ncnn::PoolAllocator _workspace_pool_allocator;
+
+  protected:
+    int _threads = 1;
     int _old_height = -1;
     std::string _inputBlob = "data";
     std::string _outputBlob;
-    };
+  };
 }
 
 #endif

--- a/src/backends/ncnn/ncnnmodel.cc
+++ b/src/backends/ncnn/ncnnmodel.cc
@@ -24,97 +24,112 @@
 
 namespace dd
 {
-    int NCNNModel::read_from_repository(const std::shared_ptr<spdlog::logger> &logger)
-    {
-        static std::string params = ".param";
-        static std::string caffe_params = "deploy.prototxt";
-        static std::string weights = ".bin";
-        static std::string caffe_weights = ".caffemodel";
-        static std::string corresp = "corresp";
-        std::unordered_set<std::string> lfiles;
-        int e = fileops::list_directory(_repo,true,false,false,lfiles);
-        if (e != 0) {
-            logger->error("error reading or listing NCNN models in repository {}",_repo);
-            return 1;
-        }
-        std::string paramsf,weightsf,correspf;
-        std::string caffe_paramsf, caffe_weightsf;
-        int weight_t = -1;
-        int caffe_weight_t = -1;
-        int params_t = -1;
-        int caffe_params_t = -1;
+  int NCNNModel::read_from_repository(
+      const std::shared_ptr<spdlog::logger> &logger)
+  {
+    static std::string params = ".param";
+    static std::string caffe_params = "deploy.prototxt";
+    static std::string weights = ".bin";
+    static std::string caffe_weights = ".caffemodel";
+    static std::string corresp = "corresp";
+    std::unordered_set<std::string> lfiles;
+    int e = fileops::list_directory(_repo, true, false, false, lfiles);
+    if (e != 0)
+      {
+        logger->error("error reading or listing NCNN models in repository {}",
+                      _repo);
+        return 1;
+      }
+    std::string paramsf, weightsf, correspf;
+    std::string caffe_paramsf, caffe_weightsf;
+    int weight_t = -1;
+    int caffe_weight_t = -1;
+    int params_t = -1;
+    int caffe_params_t = -1;
 
-        auto hit = lfiles.begin();
-        while (hit != lfiles.end()) {
-            if ((*hit).find(params) != std::string::npos) {
-                // stat file to pick the latest one
-                long int pm = fileops::file_last_modif((*hit));
-                if (pm > params_t) {
-                    paramsf = (*hit);
-                    params_t = pm;
-                }
-            } else if ((*hit).find(weights) != std::string::npos) {
-                // stat file to pick the latest one
-                long int wt = fileops::file_last_modif((*hit));
-                if (wt > weight_t) {
-        	        weightsf = (*hit);
-        	        weight_t = wt;
-                }
-            } else if ((*hit).find(caffe_params) != std::string::npos) {
-              // stat file to pick the latest one
-              long int pm = fileops::file_last_modif((*hit));
-              if (pm > caffe_params_t) {
+    auto hit = lfiles.begin();
+    while (hit != lfiles.end())
+      {
+        if ((*hit).find(params) != std::string::npos)
+          {
+            // stat file to pick the latest one
+            long int pm = fileops::file_last_modif((*hit));
+            if (pm > params_t)
+              {
+                paramsf = (*hit);
+                params_t = pm;
+              }
+          }
+        else if ((*hit).find(weights) != std::string::npos)
+          {
+            // stat file to pick the latest one
+            long int wt = fileops::file_last_modif((*hit));
+            if (wt > weight_t)
+              {
+                weightsf = (*hit);
+                weight_t = wt;
+              }
+          }
+        else if ((*hit).find(caffe_params) != std::string::npos)
+          {
+            // stat file to pick the latest one
+            long int pm = fileops::file_last_modif((*hit));
+            if (pm > caffe_params_t)
+              {
                 caffe_paramsf = (*hit);
                 caffe_params_t = pm;
               }
-            } else if ((*hit).find(caffe_weights) != std::string::npos) {
-              // stat file to pick the latest one
-              long int wt = fileops::file_last_modif((*hit));
-              if (wt > caffe_weight_t) {
+          }
+        else if ((*hit).find(caffe_weights) != std::string::npos)
+          {
+            // stat file to pick the latest one
+            long int wt = fileops::file_last_modif((*hit));
+            if (wt > caffe_weight_t)
+              {
                 caffe_weightsf = (*hit);
                 caffe_weight_t = wt;
               }
-
-            } else if ((*hit).find(corresp) != std::string::npos) {
-                correspf = (*hit);
-            }
-            ++hit;
-
-
-
-        }
-
-        if (paramsf.empty() || weightsf.empty())
-          {
-            if (caffe_params.empty() || caffe_weights.empty())
-              {
-                logger->error("could not find neither ncnn model nor caffe model in repository {}",
-                              _repo);
-                return 1;
-              }
-            else
-              {
-                logger->info("could not find  ncnn model, converting caffe model in repository {}",
-                              _repo);
-              }
-            // try to generate ncnn files from caffe files
-            bool ocr = false;
-            std::ifstream paramf(caffe_paramsf);
-            std::stringstream content;
-            content << paramf.rdbuf();
-            std::size_t found_ocr = content.str().find("ContinuationIndicator");
-            if (found_ocr != std::string::npos)
-              ocr = true;
-            paramsf = _repo+"/ncnn.param";
-            weightsf = _repo+"/ncnn.bin";
-            convert_caffe_to_ncnn(ocr, caffe_paramsf.c_str(), caffe_weightsf.c_str(),
-                                  paramsf.c_str(),weightsf.c_str(), 0, NULL);
           }
+        else if ((*hit).find(corresp) != std::string::npos)
+          {
+            correspf = (*hit);
+          }
+        ++hit;
+      }
 
+    if (paramsf.empty() || weightsf.empty())
+      {
+        if (caffe_params.empty() || caffe_weights.empty())
+          {
+            logger->error("could not find neither ncnn model nor caffe model "
+                          "in repository {}",
+                          _repo);
+            return 1;
+          }
+        else
+          {
+            logger->info("could not find  ncnn model, converting caffe model "
+                         "in repository {}",
+                         _repo);
+          }
+        // try to generate ncnn files from caffe files
+        bool ocr = false;
+        std::ifstream paramf(caffe_paramsf);
+        std::stringstream content;
+        content << paramf.rdbuf();
+        std::size_t found_ocr = content.str().find("ContinuationIndicator");
+        if (found_ocr != std::string::npos)
+          ocr = true;
+        paramsf = _repo + "/ncnn.param";
+        weightsf = _repo + "/ncnn.bin";
+        convert_caffe_to_ncnn(ocr, caffe_paramsf.c_str(),
+                              caffe_weightsf.c_str(), paramsf.c_str(),
+                              weightsf.c_str(), 0, NULL);
+      }
 
-        _params = paramsf;
-        _weights = weightsf;
-        _corresp = correspf;
-        return 0;
-    }
+    _params = paramsf;
+    _weights = weightsf;
+    _corresp = correspf;
+    return 0;
+  }
 }

--- a/src/backends/ncnn/ncnnmodel.h
+++ b/src/backends/ncnn/ncnnmodel.h
@@ -28,28 +28,34 @@
 
 namespace dd
 {
-    class NCNNModel : public MLModel
+  class NCNNModel : public MLModel
+  {
+  public:
+    NCNNModel() : MLModel()
     {
-    public:
-        NCNNModel():MLModel() {}
-        NCNNModel(const APIData &ad, APIData &adg,
-		  const std::shared_ptr<spdlog::logger> &logger)
-	   :MLModel(ad,adg,logger) {
-            if (ad.has("repository"))
-	            this->_repo = ad.get("repository").get<std::string>();
-	        read_from_repository(spdlog::get("api"));
-            read_corresp_file();
-        }
-        NCNNModel(const std::string &repo)
-            :MLModel(repo) {}
-        ~NCNNModel() {}
+    }
+    NCNNModel(const APIData &ad, APIData &adg,
+              const std::shared_ptr<spdlog::logger> &logger)
+        : MLModel(ad, adg, logger)
+    {
+      if (ad.has("repository"))
+        this->_repo = ad.get("repository").get<std::string>();
+      read_from_repository(spdlog::get("api"));
+      read_corresp_file();
+    }
+    NCNNModel(const std::string &repo) : MLModel(repo)
+    {
+    }
+    ~NCNNModel()
+    {
+    }
 
-        int read_from_repository(const std::shared_ptr<spdlog::logger> &logger);
+    int read_from_repository(const std::shared_ptr<spdlog::logger> &logger);
 
-    public:
-        std::string _weights;
-        std::string _params;
-    };
+  public:
+    std::string _weights;
+    std::string _params;
+  };
 }
 
 #endif

--- a/src/backends/ncnn/upgrade_proto.cpp
+++ b/src/backends/ncnn/upgrade_proto.cpp
@@ -8,910 +8,1277 @@
 #include "src/caffe.pb.h"
 #include "upgrade_proto.hpp"
 
-
-
-bool NetNeedsUpgrade(const caffe::NetParameter& net_param) {
+bool NetNeedsUpgrade(const caffe::NetParameter &net_param)
+{
   return NetNeedsV0ToV1Upgrade(net_param) || NetNeedsV1ToV2Upgrade(net_param)
-      || NetNeedsDataUpgrade(net_param) || NetNeedsInputUpgrade(net_param)
-      || NetNeedsBatchNormUpgrade(net_param);
+         || NetNeedsDataUpgrade(net_param) || NetNeedsInputUpgrade(net_param)
+         || NetNeedsBatchNormUpgrade(net_param);
 }
 
-bool UpgradeNetAsNeeded(caffe::NetParameter* param) {
+bool UpgradeNetAsNeeded(caffe::NetParameter *param)
+{
   bool success = true;
-  if (NetNeedsV0ToV1Upgrade(*param)) {
-    caffe::NetParameter original_param(*param);
-    if (!UpgradeV0Net(original_param, param)) {
-      success = false;
+  if (NetNeedsV0ToV1Upgrade(*param))
+    {
+      caffe::NetParameter original_param(*param);
+      if (!UpgradeV0Net(original_param, param))
+        {
+          success = false;
+        }
     }
-  }
   // NetParameter uses old style data transformation fields; try to upgrade it.
-  if (NetNeedsDataUpgrade(*param)) {
-    UpgradeNetDataTransformation(param);
-  }
-  if (NetNeedsV1ToV2Upgrade(*param)) {
-    caffe::NetParameter original_param(*param);
-    if (!UpgradeV1Net(original_param, param)) {
-      success = false;
+  if (NetNeedsDataUpgrade(*param))
+    {
+      UpgradeNetDataTransformation(param);
     }
-  }
+  if (NetNeedsV1ToV2Upgrade(*param))
+    {
+      caffe::NetParameter original_param(*param);
+      if (!UpgradeV1Net(original_param, param))
+        {
+          success = false;
+        }
+    }
   // NetParameter uses old style input fields; try to upgrade it.
-  if (NetNeedsInputUpgrade(*param)) {
-    UpgradeNetInput(param);
-  }
+  if (NetNeedsInputUpgrade(*param))
+    {
+      UpgradeNetInput(param);
+    }
   // NetParameter uses old style batch norm layers; try to upgrade it.
-  if (NetNeedsBatchNormUpgrade(*param)) {
-    UpgradeNetBatchNorm(param);
-  }
+  if (NetNeedsBatchNormUpgrade(*param))
+    {
+      UpgradeNetBatchNorm(param);
+    }
   return success;
 }
 
-
-
-bool NetNeedsV0ToV1Upgrade(const caffe::NetParameter& net_param) {
-  for (int i = 0; i < net_param.layers_size(); ++i) {
-    if (net_param.layers(i).has_layer()) {
-      return true;
+bool NetNeedsV0ToV1Upgrade(const caffe::NetParameter &net_param)
+{
+  for (int i = 0; i < net_param.layers_size(); ++i)
+    {
+      if (net_param.layers(i).has_layer())
+        {
+          return true;
+        }
     }
-  }
   return false;
 }
 
-bool NetNeedsV1ToV2Upgrade(const caffe::NetParameter& net_param) {
+bool NetNeedsV1ToV2Upgrade(const caffe::NetParameter &net_param)
+{
   return net_param.layers_size() > 0;
 }
 
-bool UpgradeV0Net(const caffe::NetParameter& v0_net_param_padding_layers,
-                  caffe::NetParameter* net_param) {
+bool UpgradeV0Net(const caffe::NetParameter &v0_net_param_padding_layers,
+                  caffe::NetParameter *net_param)
+{
   // First upgrade padding layers to padded conv layers.
   caffe::NetParameter v0_net_param;
   UpgradeV0PaddingLayers(v0_net_param_padding_layers, &v0_net_param);
   // Now upgrade layer parameters.
   bool is_fully_compatible = true;
   net_param->Clear();
-  if (v0_net_param.has_name()) {
-    net_param->set_name(v0_net_param.name());
-  }
-  for (int i = 0; i < v0_net_param.layers_size(); ++i) {
-    is_fully_compatible &= UpgradeV0LayerParameter(v0_net_param.layers(i),
-                                                   net_param->add_layers());
-  }
-  for (int i = 0; i < v0_net_param.input_size(); ++i) {
-    net_param->add_input(v0_net_param.input(i));
-  }
-  for (int i = 0; i < v0_net_param.input_dim_size(); ++i) {
-    net_param->add_input_dim(v0_net_param.input_dim(i));
-  }
-  if (v0_net_param.has_force_backward()) {
-    net_param->set_force_backward(v0_net_param.force_backward());
-  }
+  if (v0_net_param.has_name())
+    {
+      net_param->set_name(v0_net_param.name());
+    }
+  for (int i = 0; i < v0_net_param.layers_size(); ++i)
+    {
+      is_fully_compatible &= UpgradeV0LayerParameter(v0_net_param.layers(i),
+                                                     net_param->add_layers());
+    }
+  for (int i = 0; i < v0_net_param.input_size(); ++i)
+    {
+      net_param->add_input(v0_net_param.input(i));
+    }
+  for (int i = 0; i < v0_net_param.input_dim_size(); ++i)
+    {
+      net_param->add_input_dim(v0_net_param.input_dim(i));
+    }
+  if (v0_net_param.has_force_backward())
+    {
+      net_param->set_force_backward(v0_net_param.force_backward());
+    }
   return is_fully_compatible;
 }
 
-void UpgradeV0PaddingLayers(const caffe::NetParameter& param,
-                            caffe::NetParameter* param_upgraded_pad) {
+void UpgradeV0PaddingLayers(const caffe::NetParameter &param,
+                            caffe::NetParameter *param_upgraded_pad)
+{
   // Copy everything other than the layers from the original param.
   param_upgraded_pad->Clear();
   param_upgraded_pad->CopyFrom(param);
   param_upgraded_pad->clear_layers();
   // Figure out which layer each bottom blob comes from.
   std::map<std::string, int> blob_name_to_last_top_idx;
-  for (int i = 0; i < param.input_size(); ++i) {
-    const std::string& blob_name = param.input(i);
-    blob_name_to_last_top_idx[blob_name] = -1;
-  }
-  for (int i = 0; i < param.layers_size(); ++i) {
-    const caffe::V1LayerParameter& layer_connection = param.layers(i);
-    const caffe::V0LayerParameter& layer_param = layer_connection.layer();
-    // Add the layer to the new net, unless it's a padding layer.
-    if (layer_param.type() != "padding") {
-      param_upgraded_pad->add_layers()->CopyFrom(layer_connection);
+  for (int i = 0; i < param.input_size(); ++i)
+    {
+      const std::string &blob_name = param.input(i);
+      blob_name_to_last_top_idx[blob_name] = -1;
     }
-    for (int j = 0; j < layer_connection.bottom_size(); ++j) {
-      const std::string& blob_name = layer_connection.bottom(j);
-      if (blob_name_to_last_top_idx.find(blob_name) ==
-          blob_name_to_last_top_idx.end()) {
-        return;
-      }
-      const int top_idx = blob_name_to_last_top_idx[blob_name];
-      if (top_idx == -1) {
-        continue;
-      }
-      const caffe::V1LayerParameter& source_layer = param.layers(top_idx);
-      if (source_layer.layer().type() == "padding") {
-        int layer_index = param_upgraded_pad->layers_size() - 1;
-        param_upgraded_pad->mutable_layers(layer_index)->mutable_layer()
-            ->set_pad(source_layer.layer().pad());
-        param_upgraded_pad->mutable_layers(layer_index)
-            ->set_bottom(j, source_layer.bottom(0));
-      }
+  for (int i = 0; i < param.layers_size(); ++i)
+    {
+      const caffe::V1LayerParameter &layer_connection = param.layers(i);
+      const caffe::V0LayerParameter &layer_param = layer_connection.layer();
+      // Add the layer to the new net, unless it's a padding layer.
+      if (layer_param.type() != "padding")
+        {
+          param_upgraded_pad->add_layers()->CopyFrom(layer_connection);
+        }
+      for (int j = 0; j < layer_connection.bottom_size(); ++j)
+        {
+          const std::string &blob_name = layer_connection.bottom(j);
+          if (blob_name_to_last_top_idx.find(blob_name)
+              == blob_name_to_last_top_idx.end())
+            {
+              return;
+            }
+          const int top_idx = blob_name_to_last_top_idx[blob_name];
+          if (top_idx == -1)
+            {
+              continue;
+            }
+          const caffe::V1LayerParameter &source_layer = param.layers(top_idx);
+          if (source_layer.layer().type() == "padding")
+            {
+              int layer_index = param_upgraded_pad->layers_size() - 1;
+              param_upgraded_pad->mutable_layers(layer_index)
+                  ->mutable_layer()
+                  ->set_pad(source_layer.layer().pad());
+              param_upgraded_pad->mutable_layers(layer_index)
+                  ->set_bottom(j, source_layer.bottom(0));
+            }
+        }
+      for (int j = 0; j < layer_connection.top_size(); ++j)
+        {
+          const std::string &blob_name = layer_connection.top(j);
+          blob_name_to_last_top_idx[blob_name] = i;
+        }
     }
-    for (int j = 0; j < layer_connection.top_size(); ++j) {
-      const std::string& blob_name = layer_connection.top(j);
-      blob_name_to_last_top_idx[blob_name] = i;
-    }
-  }
 }
 
-bool UpgradeV0LayerParameter(const caffe::V1LayerParameter& v0_layer_connection,
-                             caffe::V1LayerParameter* layer_param) {
+bool UpgradeV0LayerParameter(
+    const caffe::V1LayerParameter &v0_layer_connection,
+    caffe::V1LayerParameter *layer_param)
+{
   bool is_fully_compatible = true;
   layer_param->Clear();
-  for (int i = 0; i < v0_layer_connection.bottom_size(); ++i) {
-    layer_param->add_bottom(v0_layer_connection.bottom(i));
-  }
-  for (int i = 0; i < v0_layer_connection.top_size(); ++i) {
-    layer_param->add_top(v0_layer_connection.top(i));
-  }
-  if (v0_layer_connection.has_layer()) {
-    const caffe::V0LayerParameter& v0_layer_param = v0_layer_connection.layer();
-    if (v0_layer_param.has_name()) {
-      layer_param->set_name(v0_layer_param.name());
+  for (int i = 0; i < v0_layer_connection.bottom_size(); ++i)
+    {
+      layer_param->add_bottom(v0_layer_connection.bottom(i));
     }
-    const std::string& type = v0_layer_param.type();
-    if (v0_layer_param.has_type()) {
-      layer_param->set_type(UpgradeV0LayerType(type));
+  for (int i = 0; i < v0_layer_connection.top_size(); ++i)
+    {
+      layer_param->add_top(v0_layer_connection.top(i));
     }
-    for (int i = 0; i < v0_layer_param.blobs_size(); ++i) {
-      layer_param->add_blobs()->CopyFrom(v0_layer_param.blobs(i));
-    }
-    for (int i = 0; i < v0_layer_param.blobs_lr_size(); ++i) {
-      layer_param->add_blobs_lr(v0_layer_param.blobs_lr(i));
-    }
-    for (int i = 0; i < v0_layer_param.weight_decay_size(); ++i) {
-      layer_param->add_weight_decay(v0_layer_param.weight_decay(i));
-    }
-    if (v0_layer_param.has_num_output()) {
-      if (type == "conv") {
-        layer_param->mutable_convolution_param()->set_num_output(
-            v0_layer_param.num_output());
-      } else if (type == "innerproduct") {
-        layer_param->mutable_inner_product_param()->set_num_output(
-            v0_layer_param.num_output());
-      } else {
-        is_fully_compatible = false;
-      }
-    }
-    if (v0_layer_param.has_biasterm()) {
-      if (type == "conv") {
-        layer_param->mutable_convolution_param()->set_bias_term(
-            v0_layer_param.biasterm());
-      } else if (type == "innerproduct") {
-        layer_param->mutable_inner_product_param()->set_bias_term(
-            v0_layer_param.biasterm());
-      } else {
-        is_fully_compatible = false;
-      }
-    }
-    if (v0_layer_param.has_weight_filler()) {
-      if (type == "conv") {
-        layer_param->mutable_convolution_param()->
-            mutable_weight_filler()->CopyFrom(v0_layer_param.weight_filler());
-      } else if (type == "innerproduct") {
-        layer_param->mutable_inner_product_param()->
-            mutable_weight_filler()->CopyFrom(v0_layer_param.weight_filler());
-      } else {
-        is_fully_compatible = false;
-      }
-    }
-    if (v0_layer_param.has_bias_filler()) {
-      if (type == "conv") {
-        layer_param->mutable_convolution_param()->
-            mutable_bias_filler()->CopyFrom(v0_layer_param.bias_filler());
-      } else if (type == "innerproduct") {
-        layer_param->mutable_inner_product_param()->
-            mutable_bias_filler()->CopyFrom(v0_layer_param.bias_filler());
-      } else {
-        is_fully_compatible = false;
-      }
-    }
-    if (v0_layer_param.has_pad()) {
-      if (type == "conv") {
-        layer_param->mutable_convolution_param()->add_pad(v0_layer_param.pad());
-      } else if (type == "pool") {
-        layer_param->mutable_pooling_param()->set_pad(v0_layer_param.pad());
-      } else {
-        is_fully_compatible = false;
-      }
-    }
-    if (v0_layer_param.has_kernelsize()) {
-      if (type == "conv") {
-        layer_param->mutable_convolution_param()->add_kernel_size(
-            v0_layer_param.kernelsize());
-      } else if (type == "pool") {
-        layer_param->mutable_pooling_param()->set_kernel_size(
-            v0_layer_param.kernelsize());
-      } else {
-        is_fully_compatible = false;
-      }
-    }
-    if (v0_layer_param.has_group()) {
-      if (type == "conv") {
-        layer_param->mutable_convolution_param()->set_group(
-            v0_layer_param.group());
-      } else {
-        is_fully_compatible = false;
-      }
-    }
-    if (v0_layer_param.has_stride()) {
-      if (type == "conv") {
-        layer_param->mutable_convolution_param()->add_stride(
-            v0_layer_param.stride());
-      } else if (type == "pool") {
-        layer_param->mutable_pooling_param()->set_stride(
-            v0_layer_param.stride());
-      } else {
-        is_fully_compatible = false;
-      }
-    }
-    if (v0_layer_param.has_pool()) {
-      if (type == "pool") {
-        caffe::V0LayerParameter_PoolMethod pool = v0_layer_param.pool();
-        switch (pool) {
-        case caffe::V0LayerParameter_PoolMethod_MAX:
-          layer_param->mutable_pooling_param()->set_pool(
-                                                         caffe::PoolingParameter_PoolMethod_MAX);
-          break;
-        case caffe::V0LayerParameter_PoolMethod_AVE:
-          layer_param->mutable_pooling_param()->set_pool(
-                                                         caffe::PoolingParameter_PoolMethod_AVE);
-          break;
-        case caffe::V0LayerParameter_PoolMethod_STOCHASTIC:
-          layer_param->mutable_pooling_param()->set_pool(
-                                                         caffe::PoolingParameter_PoolMethod_STOCHASTIC);
-          break;
-        default:
-          is_fully_compatible = false;
+  if (v0_layer_connection.has_layer())
+    {
+      const caffe::V0LayerParameter &v0_layer_param
+          = v0_layer_connection.layer();
+      if (v0_layer_param.has_name())
+        {
+          layer_param->set_name(v0_layer_param.name());
         }
-      } else {
-        is_fully_compatible = false;
-      }
+      const std::string &type = v0_layer_param.type();
+      if (v0_layer_param.has_type())
+        {
+          layer_param->set_type(UpgradeV0LayerType(type));
+        }
+      for (int i = 0; i < v0_layer_param.blobs_size(); ++i)
+        {
+          layer_param->add_blobs()->CopyFrom(v0_layer_param.blobs(i));
+        }
+      for (int i = 0; i < v0_layer_param.blobs_lr_size(); ++i)
+        {
+          layer_param->add_blobs_lr(v0_layer_param.blobs_lr(i));
+        }
+      for (int i = 0; i < v0_layer_param.weight_decay_size(); ++i)
+        {
+          layer_param->add_weight_decay(v0_layer_param.weight_decay(i));
+        }
+      if (v0_layer_param.has_num_output())
+        {
+          if (type == "conv")
+            {
+              layer_param->mutable_convolution_param()->set_num_output(
+                  v0_layer_param.num_output());
+            }
+          else if (type == "innerproduct")
+            {
+              layer_param->mutable_inner_product_param()->set_num_output(
+                  v0_layer_param.num_output());
+            }
+          else
+            {
+              is_fully_compatible = false;
+            }
+        }
+      if (v0_layer_param.has_biasterm())
+        {
+          if (type == "conv")
+            {
+              layer_param->mutable_convolution_param()->set_bias_term(
+                  v0_layer_param.biasterm());
+            }
+          else if (type == "innerproduct")
+            {
+              layer_param->mutable_inner_product_param()->set_bias_term(
+                  v0_layer_param.biasterm());
+            }
+          else
+            {
+              is_fully_compatible = false;
+            }
+        }
+      if (v0_layer_param.has_weight_filler())
+        {
+          if (type == "conv")
+            {
+              layer_param->mutable_convolution_param()
+                  ->mutable_weight_filler()
+                  ->CopyFrom(v0_layer_param.weight_filler());
+            }
+          else if (type == "innerproduct")
+            {
+              layer_param->mutable_inner_product_param()
+                  ->mutable_weight_filler()
+                  ->CopyFrom(v0_layer_param.weight_filler());
+            }
+          else
+            {
+              is_fully_compatible = false;
+            }
+        }
+      if (v0_layer_param.has_bias_filler())
+        {
+          if (type == "conv")
+            {
+              layer_param->mutable_convolution_param()
+                  ->mutable_bias_filler()
+                  ->CopyFrom(v0_layer_param.bias_filler());
+            }
+          else if (type == "innerproduct")
+            {
+              layer_param->mutable_inner_product_param()
+                  ->mutable_bias_filler()
+                  ->CopyFrom(v0_layer_param.bias_filler());
+            }
+          else
+            {
+              is_fully_compatible = false;
+            }
+        }
+      if (v0_layer_param.has_pad())
+        {
+          if (type == "conv")
+            {
+              layer_param->mutable_convolution_param()->add_pad(
+                  v0_layer_param.pad());
+            }
+          else if (type == "pool")
+            {
+              layer_param->mutable_pooling_param()->set_pad(
+                  v0_layer_param.pad());
+            }
+          else
+            {
+              is_fully_compatible = false;
+            }
+        }
+      if (v0_layer_param.has_kernelsize())
+        {
+          if (type == "conv")
+            {
+              layer_param->mutable_convolution_param()->add_kernel_size(
+                  v0_layer_param.kernelsize());
+            }
+          else if (type == "pool")
+            {
+              layer_param->mutable_pooling_param()->set_kernel_size(
+                  v0_layer_param.kernelsize());
+            }
+          else
+            {
+              is_fully_compatible = false;
+            }
+        }
+      if (v0_layer_param.has_group())
+        {
+          if (type == "conv")
+            {
+              layer_param->mutable_convolution_param()->set_group(
+                  v0_layer_param.group());
+            }
+          else
+            {
+              is_fully_compatible = false;
+            }
+        }
+      if (v0_layer_param.has_stride())
+        {
+          if (type == "conv")
+            {
+              layer_param->mutable_convolution_param()->add_stride(
+                  v0_layer_param.stride());
+            }
+          else if (type == "pool")
+            {
+              layer_param->mutable_pooling_param()->set_stride(
+                  v0_layer_param.stride());
+            }
+          else
+            {
+              is_fully_compatible = false;
+            }
+        }
+      if (v0_layer_param.has_pool())
+        {
+          if (type == "pool")
+            {
+              caffe::V0LayerParameter_PoolMethod pool = v0_layer_param.pool();
+              switch (pool)
+                {
+                case caffe::V0LayerParameter_PoolMethod_MAX:
+                  layer_param->mutable_pooling_param()->set_pool(
+                      caffe::PoolingParameter_PoolMethod_MAX);
+                  break;
+                case caffe::V0LayerParameter_PoolMethod_AVE:
+                  layer_param->mutable_pooling_param()->set_pool(
+                      caffe::PoolingParameter_PoolMethod_AVE);
+                  break;
+                case caffe::V0LayerParameter_PoolMethod_STOCHASTIC:
+                  layer_param->mutable_pooling_param()->set_pool(
+                      caffe::PoolingParameter_PoolMethod_STOCHASTIC);
+                  break;
+                default:
+                  is_fully_compatible = false;
+                }
+            }
+          else
+            {
+              is_fully_compatible = false;
+            }
+        }
+      if (v0_layer_param.has_dropout_ratio())
+        {
+          if (type == "dropout")
+            {
+              layer_param->mutable_dropout_param()->set_dropout_ratio(
+                  v0_layer_param.dropout_ratio());
+            }
+          else
+            {
+              is_fully_compatible = false;
+            }
+        }
+      if (v0_layer_param.has_local_size())
+        {
+          if (type == "lrn")
+            {
+              layer_param->mutable_lrn_param()->set_local_size(
+                  v0_layer_param.local_size());
+            }
+          else
+            {
+              is_fully_compatible = false;
+            }
+        }
+      if (v0_layer_param.has_alpha())
+        {
+          if (type == "lrn")
+            {
+              layer_param->mutable_lrn_param()->set_alpha(
+                  v0_layer_param.alpha());
+            }
+          else
+            {
+              is_fully_compatible = false;
+            }
+        }
+      if (v0_layer_param.has_beta())
+        {
+          if (type == "lrn")
+            {
+              layer_param->mutable_lrn_param()->set_beta(
+                  v0_layer_param.beta());
+            }
+          else
+            {
+              is_fully_compatible = false;
+            }
+        }
+      if (v0_layer_param.has_k())
+        {
+          if (type == "lrn")
+            {
+              layer_param->mutable_lrn_param()->set_k(v0_layer_param.k());
+            }
+          else
+            {
+              is_fully_compatible = false;
+            }
+        }
+      if (v0_layer_param.has_source())
+        {
+          if (type == "data")
+            {
+              layer_param->mutable_data_param()->set_source(
+                  v0_layer_param.source());
+            }
+          else if (type == "hdf5_data")
+            {
+              layer_param->mutable_hdf5_data_param()->set_source(
+                  v0_layer_param.source());
+            }
+          else if (type == "images")
+            {
+              layer_param->mutable_image_data_param()->set_source(
+                  v0_layer_param.source());
+            }
+          else if (type == "window_data")
+            {
+              layer_param->mutable_window_data_param()->set_source(
+                  v0_layer_param.source());
+            }
+          else if (type == "infogain_loss")
+            {
+              layer_param->mutable_infogain_loss_param()->set_source(
+                  v0_layer_param.source());
+            }
+          else
+            {
+              is_fully_compatible = false;
+            }
+        }
+      if (v0_layer_param.has_scale())
+        {
+          layer_param->mutable_transform_param()->set_scale(
+              v0_layer_param.scale());
+        }
+      if (v0_layer_param.has_meanfile())
+        {
+          layer_param->mutable_transform_param()->set_mean_file(
+              v0_layer_param.meanfile());
+        }
+      if (v0_layer_param.has_batchsize())
+        {
+          if (type == "data")
+            {
+              layer_param->mutable_data_param()->set_batch_size(
+                  v0_layer_param.batchsize());
+            }
+          else if (type == "hdf5_data")
+            {
+              layer_param->mutable_hdf5_data_param()->set_batch_size(
+                  v0_layer_param.batchsize());
+            }
+          else if (type == "images")
+            {
+              layer_param->mutable_image_data_param()->set_batch_size(
+                  v0_layer_param.batchsize());
+            }
+          else if (type == "window_data")
+            {
+              layer_param->mutable_window_data_param()->set_batch_size(
+                  v0_layer_param.batchsize());
+            }
+          else
+            {
+              is_fully_compatible = false;
+            }
+        }
+      if (v0_layer_param.has_cropsize())
+        {
+          layer_param->mutable_transform_param()->set_crop_size(
+              v0_layer_param.cropsize());
+        }
+      if (v0_layer_param.has_mirror())
+        {
+          layer_param->mutable_transform_param()->set_mirror(
+              v0_layer_param.mirror());
+        }
+      if (v0_layer_param.has_rand_skip())
+        {
+          if (type == "data")
+            {
+              layer_param->mutable_data_param()->set_rand_skip(
+                  v0_layer_param.rand_skip());
+            }
+          else if (type == "images")
+            {
+              layer_param->mutable_image_data_param()->set_rand_skip(
+                  v0_layer_param.rand_skip());
+            }
+          else
+            {
+              is_fully_compatible = false;
+            }
+        }
+      if (v0_layer_param.has_shuffle_images())
+        {
+          if (type == "images")
+            {
+              layer_param->mutable_image_data_param()->set_shuffle(
+                  v0_layer_param.shuffle_images());
+            }
+          else
+            {
+              is_fully_compatible = false;
+            }
+        }
+      if (v0_layer_param.has_new_height())
+        {
+          if (type == "images")
+            {
+              layer_param->mutable_image_data_param()->set_new_height(
+                  v0_layer_param.new_height());
+            }
+          else
+            {
+              is_fully_compatible = false;
+            }
+        }
+      if (v0_layer_param.has_new_width())
+        {
+          if (type == "images")
+            {
+              layer_param->mutable_image_data_param()->set_new_width(
+                  v0_layer_param.new_width());
+            }
+          else
+            {
+              is_fully_compatible = false;
+            }
+        }
+      if (v0_layer_param.has_concat_dim())
+        {
+          if (type == "concat")
+            {
+              layer_param->mutable_concat_param()->set_concat_dim(
+                  v0_layer_param.concat_dim());
+            }
+          else
+            {
+              is_fully_compatible = false;
+            }
+        }
+      if (v0_layer_param.has_det_fg_threshold())
+        {
+          if (type == "window_data")
+            {
+              layer_param->mutable_window_data_param()->set_fg_threshold(
+                  v0_layer_param.det_fg_threshold());
+            }
+          else
+            {
+              is_fully_compatible = false;
+            }
+        }
+      if (v0_layer_param.has_det_bg_threshold())
+        {
+          if (type == "window_data")
+            {
+              layer_param->mutable_window_data_param()->set_bg_threshold(
+                  v0_layer_param.det_bg_threshold());
+            }
+          else
+            {
+              is_fully_compatible = false;
+            }
+        }
+      if (v0_layer_param.has_det_fg_fraction())
+        {
+          if (type == "window_data")
+            {
+              layer_param->mutable_window_data_param()->set_fg_fraction(
+                  v0_layer_param.det_fg_fraction());
+            }
+          else
+            {
+              is_fully_compatible = false;
+            }
+        }
+      if (v0_layer_param.has_det_context_pad())
+        {
+          if (type == "window_data")
+            {
+              layer_param->mutable_window_data_param()->set_context_pad(
+                  v0_layer_param.det_context_pad());
+            }
+          else
+            {
+              is_fully_compatible = false;
+            }
+        }
+      if (v0_layer_param.has_det_crop_mode())
+        {
+          if (type == "window_data")
+            {
+              layer_param->mutable_window_data_param()->set_crop_mode(
+                  v0_layer_param.det_crop_mode());
+            }
+          else
+            {
+              is_fully_compatible = false;
+            }
+        }
+      if (v0_layer_param.has_hdf5_output_param())
+        {
+          if (type == "hdf5_output")
+            {
+              layer_param->mutable_hdf5_output_param()->CopyFrom(
+                  v0_layer_param.hdf5_output_param());
+            }
+          else
+            {
+              is_fully_compatible = false;
+            }
+        }
     }
-    if (v0_layer_param.has_dropout_ratio()) {
-      if (type == "dropout") {
-        layer_param->mutable_dropout_param()->set_dropout_ratio(
-            v0_layer_param.dropout_ratio());
-      } else {
-        is_fully_compatible = false;
-      }
-    }
-    if (v0_layer_param.has_local_size()) {
-      if (type == "lrn") {
-        layer_param->mutable_lrn_param()->set_local_size(
-            v0_layer_param.local_size());
-      } else {
-        is_fully_compatible = false;
-      }
-    }
-    if (v0_layer_param.has_alpha()) {
-      if (type == "lrn") {
-        layer_param->mutable_lrn_param()->set_alpha(v0_layer_param.alpha());
-      } else {
-        is_fully_compatible = false;
-      }
-    }
-    if (v0_layer_param.has_beta()) {
-      if (type == "lrn") {
-        layer_param->mutable_lrn_param()->set_beta(v0_layer_param.beta());
-      } else {
-        is_fully_compatible = false;
-      }
-    }
-    if (v0_layer_param.has_k()) {
-      if (type == "lrn") {
-        layer_param->mutable_lrn_param()->set_k(v0_layer_param.k());
-      } else {
-        is_fully_compatible = false;
-      }
-    }
-    if (v0_layer_param.has_source()) {
-      if (type == "data") {
-        layer_param->mutable_data_param()->set_source(v0_layer_param.source());
-      } else if (type == "hdf5_data") {
-        layer_param->mutable_hdf5_data_param()->set_source(
-            v0_layer_param.source());
-      } else if (type == "images") {
-        layer_param->mutable_image_data_param()->set_source(
-            v0_layer_param.source());
-      } else if (type == "window_data") {
-        layer_param->mutable_window_data_param()->set_source(
-            v0_layer_param.source());
-      } else if (type == "infogain_loss") {
-        layer_param->mutable_infogain_loss_param()->set_source(
-            v0_layer_param.source());
-      } else {
-        is_fully_compatible = false;
-      }
-    }
-    if (v0_layer_param.has_scale()) {
-      layer_param->mutable_transform_param()->
-          set_scale(v0_layer_param.scale());
-    }
-    if (v0_layer_param.has_meanfile()) {
-      layer_param->mutable_transform_param()->
-          set_mean_file(v0_layer_param.meanfile());
-    }
-    if (v0_layer_param.has_batchsize()) {
-      if (type == "data") {
-        layer_param->mutable_data_param()->set_batch_size(
-            v0_layer_param.batchsize());
-      } else if (type == "hdf5_data") {
-        layer_param->mutable_hdf5_data_param()->set_batch_size(
-            v0_layer_param.batchsize());
-      } else if (type == "images") {
-        layer_param->mutable_image_data_param()->set_batch_size(
-            v0_layer_param.batchsize());
-      } else if (type == "window_data") {
-        layer_param->mutable_window_data_param()->set_batch_size(
-            v0_layer_param.batchsize());
-      } else {
-        is_fully_compatible = false;
-      }
-    }
-    if (v0_layer_param.has_cropsize()) {
-      layer_param->mutable_transform_param()->
-          set_crop_size(v0_layer_param.cropsize());
-    }
-    if (v0_layer_param.has_mirror()) {
-      layer_param->mutable_transform_param()->
-          set_mirror(v0_layer_param.mirror());
-    }
-    if (v0_layer_param.has_rand_skip()) {
-      if (type == "data") {
-        layer_param->mutable_data_param()->set_rand_skip(
-            v0_layer_param.rand_skip());
-      } else if (type == "images") {
-        layer_param->mutable_image_data_param()->set_rand_skip(
-            v0_layer_param.rand_skip());
-      } else {
-        is_fully_compatible = false;
-      }
-    }
-    if (v0_layer_param.has_shuffle_images()) {
-      if (type == "images") {
-        layer_param->mutable_image_data_param()->set_shuffle(
-            v0_layer_param.shuffle_images());
-      } else {
-        is_fully_compatible = false;
-      }
-    }
-    if (v0_layer_param.has_new_height()) {
-      if (type == "images") {
-        layer_param->mutable_image_data_param()->set_new_height(
-            v0_layer_param.new_height());
-      } else {
-        is_fully_compatible = false;
-      }
-    }
-    if (v0_layer_param.has_new_width()) {
-      if (type == "images") {
-        layer_param->mutable_image_data_param()->set_new_width(
-            v0_layer_param.new_width());
-      } else {
-        is_fully_compatible = false;
-      }
-    }
-    if (v0_layer_param.has_concat_dim()) {
-      if (type == "concat") {
-        layer_param->mutable_concat_param()->set_concat_dim(
-            v0_layer_param.concat_dim());
-      } else {
-        is_fully_compatible = false;
-      }
-    }
-    if (v0_layer_param.has_det_fg_threshold()) {
-      if (type == "window_data") {
-        layer_param->mutable_window_data_param()->set_fg_threshold(
-            v0_layer_param.det_fg_threshold());
-      } else {
-        is_fully_compatible = false;
-      }
-    }
-    if (v0_layer_param.has_det_bg_threshold()) {
-      if (type == "window_data") {
-        layer_param->mutable_window_data_param()->set_bg_threshold(
-            v0_layer_param.det_bg_threshold());
-      } else {
-        is_fully_compatible = false;
-      }
-    }
-    if (v0_layer_param.has_det_fg_fraction()) {
-      if (type == "window_data") {
-        layer_param->mutable_window_data_param()->set_fg_fraction(
-            v0_layer_param.det_fg_fraction());
-      } else {
-        is_fully_compatible = false;
-      }
-    }
-    if (v0_layer_param.has_det_context_pad()) {
-      if (type == "window_data") {
-        layer_param->mutable_window_data_param()->set_context_pad(
-            v0_layer_param.det_context_pad());
-      } else {
-        is_fully_compatible = false;
-      }
-    }
-    if (v0_layer_param.has_det_crop_mode()) {
-      if (type == "window_data") {
-        layer_param->mutable_window_data_param()->set_crop_mode(
-            v0_layer_param.det_crop_mode());
-      } else {
-        is_fully_compatible = false;
-      }
-    }
-    if (v0_layer_param.has_hdf5_output_param()) {
-      if (type == "hdf5_output") {
-        layer_param->mutable_hdf5_output_param()->CopyFrom(
-            v0_layer_param.hdf5_output_param());
-      } else {
-        is_fully_compatible = false;
-      }
-    }
-  }
   return is_fully_compatible;
 }
 
-caffe::V1LayerParameter_LayerType UpgradeV0LayerType(const std::string& type) {
-  if (type == "accuracy") {
-    return caffe::V1LayerParameter_LayerType_ACCURACY;
-  } else if (type == "bnll") {
-    return caffe::V1LayerParameter_LayerType_BNLL;
-  } else if (type == "concat") {
-    return caffe::V1LayerParameter_LayerType_CONCAT;
-  } else if (type == "conv") {
-    return caffe::V1LayerParameter_LayerType_CONVOLUTION;
-  } else if (type == "data") {
-    return caffe::V1LayerParameter_LayerType_DATA;
-  } else if (type == "dropout") {
-    return caffe::V1LayerParameter_LayerType_DROPOUT;
-  } else if (type == "euclidean_loss") {
-    return caffe::V1LayerParameter_LayerType_EUCLIDEAN_LOSS;
-  } else if (type == "flatten") {
-    return caffe::V1LayerParameter_LayerType_FLATTEN;
-  } else if (type == "hdf5_data") {
-    return caffe::V1LayerParameter_LayerType_HDF5_DATA;
-  } else if (type == "hdf5_output") {
-    return caffe::V1LayerParameter_LayerType_HDF5_OUTPUT;
-  } else if (type == "im2col") {
-    return caffe::V1LayerParameter_LayerType_IM2COL;
-  } else if (type == "images") {
-    return caffe::V1LayerParameter_LayerType_IMAGE_DATA;
-  } else if (type == "infogain_loss") {
-    return caffe::V1LayerParameter_LayerType_INFOGAIN_LOSS;
-  } else if (type == "innerproduct") {
-    return caffe::V1LayerParameter_LayerType_INNER_PRODUCT;
-  } else if (type == "lrn") {
-    return caffe::V1LayerParameter_LayerType_LRN;
-  } else if (type == "multinomial_logistic_loss") {
-    return caffe::V1LayerParameter_LayerType_MULTINOMIAL_LOGISTIC_LOSS;
-  } else if (type == "pool") {
-    return caffe::V1LayerParameter_LayerType_POOLING;
-  } else if (type == "relu") {
-    return caffe::V1LayerParameter_LayerType_RELU;
-  } else if (type == "sigmoid") {
-    return caffe::V1LayerParameter_LayerType_SIGMOID;
-  } else if (type == "softmax") {
-    return caffe::V1LayerParameter_LayerType_SOFTMAX;
-  } else if (type == "softmax_loss") {
-    return caffe::V1LayerParameter_LayerType_SOFTMAX_LOSS;
-  } else if (type == "split") {
-    return caffe::V1LayerParameter_LayerType_SPLIT;
-  } else if (type == "tanh") {
-    return caffe::V1LayerParameter_LayerType_TANH;
-  } else if (type == "window_data") {
-    return caffe::V1LayerParameter_LayerType_WINDOW_DATA;
-  } else {
-    return caffe::V1LayerParameter_LayerType_NONE;
-  }
+caffe::V1LayerParameter_LayerType UpgradeV0LayerType(const std::string &type)
+{
+  if (type == "accuracy")
+    {
+      return caffe::V1LayerParameter_LayerType_ACCURACY;
+    }
+  else if (type == "bnll")
+    {
+      return caffe::V1LayerParameter_LayerType_BNLL;
+    }
+  else if (type == "concat")
+    {
+      return caffe::V1LayerParameter_LayerType_CONCAT;
+    }
+  else if (type == "conv")
+    {
+      return caffe::V1LayerParameter_LayerType_CONVOLUTION;
+    }
+  else if (type == "data")
+    {
+      return caffe::V1LayerParameter_LayerType_DATA;
+    }
+  else if (type == "dropout")
+    {
+      return caffe::V1LayerParameter_LayerType_DROPOUT;
+    }
+  else if (type == "euclidean_loss")
+    {
+      return caffe::V1LayerParameter_LayerType_EUCLIDEAN_LOSS;
+    }
+  else if (type == "flatten")
+    {
+      return caffe::V1LayerParameter_LayerType_FLATTEN;
+    }
+  else if (type == "hdf5_data")
+    {
+      return caffe::V1LayerParameter_LayerType_HDF5_DATA;
+    }
+  else if (type == "hdf5_output")
+    {
+      return caffe::V1LayerParameter_LayerType_HDF5_OUTPUT;
+    }
+  else if (type == "im2col")
+    {
+      return caffe::V1LayerParameter_LayerType_IM2COL;
+    }
+  else if (type == "images")
+    {
+      return caffe::V1LayerParameter_LayerType_IMAGE_DATA;
+    }
+  else if (type == "infogain_loss")
+    {
+      return caffe::V1LayerParameter_LayerType_INFOGAIN_LOSS;
+    }
+  else if (type == "innerproduct")
+    {
+      return caffe::V1LayerParameter_LayerType_INNER_PRODUCT;
+    }
+  else if (type == "lrn")
+    {
+      return caffe::V1LayerParameter_LayerType_LRN;
+    }
+  else if (type == "multinomial_logistic_loss")
+    {
+      return caffe::V1LayerParameter_LayerType_MULTINOMIAL_LOGISTIC_LOSS;
+    }
+  else if (type == "pool")
+    {
+      return caffe::V1LayerParameter_LayerType_POOLING;
+    }
+  else if (type == "relu")
+    {
+      return caffe::V1LayerParameter_LayerType_RELU;
+    }
+  else if (type == "sigmoid")
+    {
+      return caffe::V1LayerParameter_LayerType_SIGMOID;
+    }
+  else if (type == "softmax")
+    {
+      return caffe::V1LayerParameter_LayerType_SOFTMAX;
+    }
+  else if (type == "softmax_loss")
+    {
+      return caffe::V1LayerParameter_LayerType_SOFTMAX_LOSS;
+    }
+  else if (type == "split")
+    {
+      return caffe::V1LayerParameter_LayerType_SPLIT;
+    }
+  else if (type == "tanh")
+    {
+      return caffe::V1LayerParameter_LayerType_TANH;
+    }
+  else if (type == "window_data")
+    {
+      return caffe::V1LayerParameter_LayerType_WINDOW_DATA;
+    }
+  else
+    {
+      return caffe::V1LayerParameter_LayerType_NONE;
+    }
 }
 
-bool NetNeedsDataUpgrade(const caffe::NetParameter& net_param) {
-  for (int i = 0; i < net_param.layers_size(); ++i) {
-    if (net_param.layers(i).type() == caffe::V1LayerParameter_LayerType_DATA) {
-      caffe::DataParameter layer_param = net_param.layers(i).data_param();
-      if (layer_param.has_scale()) { return true; }
-      if (layer_param.has_mean_file()) { return true; }
-      if (layer_param.has_crop_size()) { return true; }
-      if (layer_param.has_mirror()) { return true; }
+bool NetNeedsDataUpgrade(const caffe::NetParameter &net_param)
+{
+  for (int i = 0; i < net_param.layers_size(); ++i)
+    {
+      if (net_param.layers(i).type() == caffe::V1LayerParameter_LayerType_DATA)
+        {
+          caffe::DataParameter layer_param = net_param.layers(i).data_param();
+          if (layer_param.has_scale())
+            {
+              return true;
+            }
+          if (layer_param.has_mean_file())
+            {
+              return true;
+            }
+          if (layer_param.has_crop_size())
+            {
+              return true;
+            }
+          if (layer_param.has_mirror())
+            {
+              return true;
+            }
+        }
+      if (net_param.layers(i).type()
+          == caffe::V1LayerParameter_LayerType_IMAGE_DATA)
+        {
+          caffe::ImageDataParameter layer_param
+              = net_param.layers(i).image_data_param();
+          if (layer_param.has_scale())
+            {
+              return true;
+            }
+          if (layer_param.has_mean_file())
+            {
+              return true;
+            }
+          if (layer_param.has_crop_size())
+            {
+              return true;
+            }
+          if (layer_param.has_mirror())
+            {
+              return true;
+            }
+        }
+      if (net_param.layers(i).type()
+          == caffe::V1LayerParameter_LayerType_WINDOW_DATA)
+        {
+          caffe::WindowDataParameter layer_param
+              = net_param.layers(i).window_data_param();
+          if (layer_param.has_scale())
+            {
+              return true;
+            }
+          if (layer_param.has_mean_file())
+            {
+              return true;
+            }
+          if (layer_param.has_crop_size())
+            {
+              return true;
+            }
+          if (layer_param.has_mirror())
+            {
+              return true;
+            }
+        }
     }
-    if (net_param.layers(i).type() == caffe::V1LayerParameter_LayerType_IMAGE_DATA) {
-      caffe::ImageDataParameter layer_param = net_param.layers(i).image_data_param();
-      if (layer_param.has_scale()) { return true; }
-      if (layer_param.has_mean_file()) { return true; }
-      if (layer_param.has_crop_size()) { return true; }
-      if (layer_param.has_mirror()) { return true; }
-    }
-    if (net_param.layers(i).type() == caffe::V1LayerParameter_LayerType_WINDOW_DATA) {
-      caffe::WindowDataParameter layer_param = net_param.layers(i).window_data_param();
-      if (layer_param.has_scale()) { return true; }
-      if (layer_param.has_mean_file()) { return true; }
-      if (layer_param.has_crop_size()) { return true; }
-      if (layer_param.has_mirror()) { return true; }
-    }
-  }
   return false;
 }
 
-#define CONVERT_LAYER_TRANSFORM_PARAM(TYPE, Name, param_name) \
-  do { \
-    if (net_param->layers(i).type() == caffe::V1LayerParameter_LayerType_##TYPE) { \
-      Name##Parameter* layer_param = \
-          net_param->mutable_layers(i)->mutable_##param_name##_param(); \
-      caffe::TransformationParameter* transform_param =                 \
-          net_param->mutable_layers(i)->mutable_transform_param(); \
-      if (layer_param->has_scale()) { \
-        transform_param->set_scale(layer_param->scale()); \
-        layer_param->clear_scale(); \
-      } \
-      if (layer_param->has_mean_file()) { \
-        transform_param->set_mean_file(layer_param->mean_file()); \
-        layer_param->clear_mean_file(); \
-      } \
-      if (layer_param->has_crop_size()) { \
-        transform_param->set_crop_size(layer_param->crop_size()); \
-        layer_param->clear_crop_size(); \
-      } \
-      if (layer_param->has_mirror()) { \
-        transform_param->set_mirror(layer_param->mirror()); \
-        layer_param->clear_mirror(); \
-      } \
-    } \
-  } while (0)
+#define CONVERT_LAYER_TRANSFORM_PARAM(TYPE, Name, param_name)                 \
+  do                                                                          \
+    {                                                                         \
+      if (net_param->layers(i).type()                                         \
+          == caffe::V1LayerParameter_LayerType_##TYPE)                        \
+        {                                                                     \
+          Name##Parameter *layer_param                                        \
+              = net_param->mutable_layers(i)->mutable_##param_name##_param(); \
+          caffe::TransformationParameter *transform_param                     \
+              = net_param->mutable_layers(i)->mutable_transform_param();      \
+          if (layer_param->has_scale())                                       \
+            {                                                                 \
+              transform_param->set_scale(layer_param->scale());               \
+              layer_param->clear_scale();                                     \
+            }                                                                 \
+          if (layer_param->has_mean_file())                                   \
+            {                                                                 \
+              transform_param->set_mean_file(layer_param->mean_file());       \
+              layer_param->clear_mean_file();                                 \
+            }                                                                 \
+          if (layer_param->has_crop_size())                                   \
+            {                                                                 \
+              transform_param->set_crop_size(layer_param->crop_size());       \
+              layer_param->clear_crop_size();                                 \
+            }                                                                 \
+          if (layer_param->has_mirror())                                      \
+            {                                                                 \
+              transform_param->set_mirror(layer_param->mirror());             \
+              layer_param->clear_mirror();                                    \
+            }                                                                 \
+        }                                                                     \
+    }                                                                         \
+  while (0)
 
-void UpgradeNetDataTransformation(caffe::NetParameter* net_param) {
-  for (int i = 0; i < net_param->layers_size(); ++i) {
-    CONVERT_LAYER_TRANSFORM_PARAM(DATA, caffe::Data, data);
-    CONVERT_LAYER_TRANSFORM_PARAM(IMAGE_DATA, caffe::ImageData, image_data);
-    CONVERT_LAYER_TRANSFORM_PARAM(WINDOW_DATA, caffe::WindowData, window_data);
-  }
+void UpgradeNetDataTransformation(caffe::NetParameter *net_param)
+{
+  for (int i = 0; i < net_param->layers_size(); ++i)
+    {
+      CONVERT_LAYER_TRANSFORM_PARAM(DATA, caffe::Data, data);
+      CONVERT_LAYER_TRANSFORM_PARAM(IMAGE_DATA, caffe::ImageData, image_data);
+      CONVERT_LAYER_TRANSFORM_PARAM(WINDOW_DATA, caffe::WindowData,
+                                    window_data);
+    }
 }
 
-bool UpgradeV1Net(const caffe::NetParameter& v1_net_param, caffe::NetParameter* net_param) {
-  if (v1_net_param.layer_size() > 0) {
-    return false;
-  }
+bool UpgradeV1Net(const caffe::NetParameter &v1_net_param,
+                  caffe::NetParameter *net_param)
+{
+  if (v1_net_param.layer_size() > 0)
+    {
+      return false;
+    }
   bool is_fully_compatible = true;
   net_param->CopyFrom(v1_net_param);
   net_param->clear_layers();
   net_param->clear_layer();
-  for (int i = 0; i < v1_net_param.layers_size(); ++i) {
-    if (!UpgradeV1LayerParameter(v1_net_param.layers(i),
-                                 net_param->add_layer())) {
-      is_fully_compatible = false;
+  for (int i = 0; i < v1_net_param.layers_size(); ++i)
+    {
+      if (!UpgradeV1LayerParameter(v1_net_param.layers(i),
+                                   net_param->add_layer()))
+        {
+          is_fully_compatible = false;
+        }
     }
-  }
   return is_fully_compatible;
 }
 
-bool UpgradeV1LayerParameter(const caffe::V1LayerParameter& v1_layer_param,
-                             caffe::LayerParameter* layer_param) {
+bool UpgradeV1LayerParameter(const caffe::V1LayerParameter &v1_layer_param,
+                             caffe::LayerParameter *layer_param)
+{
   layer_param->Clear();
   bool is_fully_compatible = true;
-  for (int i = 0; i < v1_layer_param.bottom_size(); ++i) {
-    layer_param->add_bottom(v1_layer_param.bottom(i));
-  }
-  for (int i = 0; i < v1_layer_param.top_size(); ++i) {
-    layer_param->add_top(v1_layer_param.top(i));
-  }
-  if (v1_layer_param.has_name()) {
-    layer_param->set_name(v1_layer_param.name());
-  }
-  for (int i = 0; i < v1_layer_param.include_size(); ++i) {
-    layer_param->add_include()->CopyFrom(v1_layer_param.include(i));
-  }
-  for (int i = 0; i < v1_layer_param.exclude_size(); ++i) {
-    layer_param->add_exclude()->CopyFrom(v1_layer_param.exclude(i));
-  }
-  if (v1_layer_param.has_type()) {
-    layer_param->set_type(UpgradeV1LayerType(v1_layer_param.type()));
-  }
-  for (int i = 0; i < v1_layer_param.blobs_size(); ++i) {
-    layer_param->add_blobs()->CopyFrom(v1_layer_param.blobs(i));
-  }
-  for (int i = 0; i < v1_layer_param.param_size(); ++i) {
-    while (layer_param->param_size() <= i) { layer_param->add_param(); }
-    layer_param->mutable_param(i)->set_name(v1_layer_param.param(i));
-  }
-  caffe::ParamSpec_DimCheckMode mode;
-  for (int i = 0; i < v1_layer_param.blob_share_mode_size(); ++i) {
-    while (layer_param->param_size() <= i) { layer_param->add_param(); }
-    switch (v1_layer_param.blob_share_mode(i)) {
-    case caffe::V1LayerParameter_DimCheckMode_STRICT:
-      mode = caffe::ParamSpec_DimCheckMode_STRICT;
-      break;
-    case caffe::V1LayerParameter_DimCheckMode_PERMISSIVE:
-      mode = caffe::ParamSpec_DimCheckMode_PERMISSIVE;
-      break;
-    default:
-      break;
+  for (int i = 0; i < v1_layer_param.bottom_size(); ++i)
+    {
+      layer_param->add_bottom(v1_layer_param.bottom(i));
     }
-    layer_param->mutable_param(i)->set_share_mode(mode);
-  }
-  for (int i = 0; i < v1_layer_param.blobs_lr_size(); ++i) {
-    while (layer_param->param_size() <= i) { layer_param->add_param(); }
-    layer_param->mutable_param(i)->set_lr_mult(v1_layer_param.blobs_lr(i));
-  }
-  for (int i = 0; i < v1_layer_param.weight_decay_size(); ++i) {
-    while (layer_param->param_size() <= i) { layer_param->add_param(); }
-    layer_param->mutable_param(i)->set_decay_mult(
-        v1_layer_param.weight_decay(i));
-  }
-  for (int i = 0; i < v1_layer_param.loss_weight_size(); ++i) {
-    layer_param->add_loss_weight(v1_layer_param.loss_weight(i));
-  }
-  if (v1_layer_param.has_accuracy_param()) {
-    layer_param->mutable_accuracy_param()->CopyFrom(
-        v1_layer_param.accuracy_param());
-  }
-  if (v1_layer_param.has_argmax_param()) {
-    layer_param->mutable_argmax_param()->CopyFrom(
-        v1_layer_param.argmax_param());
-  }
-  if (v1_layer_param.has_concat_param()) {
-    layer_param->mutable_concat_param()->CopyFrom(
-        v1_layer_param.concat_param());
-  }
-  if (v1_layer_param.has_contrastive_loss_param()) {
-    layer_param->mutable_contrastive_loss_param()->CopyFrom(
-        v1_layer_param.contrastive_loss_param());
-  }
-  if (v1_layer_param.has_convolution_param()) {
-    layer_param->mutable_convolution_param()->CopyFrom(
-        v1_layer_param.convolution_param());
-  }
-  if (v1_layer_param.has_data_param()) {
-    layer_param->mutable_data_param()->CopyFrom(
-        v1_layer_param.data_param());
-  }
-  if (v1_layer_param.has_dropout_param()) {
-    layer_param->mutable_dropout_param()->CopyFrom(
-        v1_layer_param.dropout_param());
-  }
-  if (v1_layer_param.has_dummy_data_param()) {
-    layer_param->mutable_dummy_data_param()->CopyFrom(
-        v1_layer_param.dummy_data_param());
-  }
-  if (v1_layer_param.has_eltwise_param()) {
-    layer_param->mutable_eltwise_param()->CopyFrom(
-        v1_layer_param.eltwise_param());
-  }
-  if (v1_layer_param.has_exp_param()) {
-    layer_param->mutable_exp_param()->CopyFrom(
-        v1_layer_param.exp_param());
-  }
-  if (v1_layer_param.has_hdf5_data_param()) {
-    layer_param->mutable_hdf5_data_param()->CopyFrom(
-        v1_layer_param.hdf5_data_param());
-  }
-  if (v1_layer_param.has_hdf5_output_param()) {
-    layer_param->mutable_hdf5_output_param()->CopyFrom(
-        v1_layer_param.hdf5_output_param());
-  }
-  if (v1_layer_param.has_hinge_loss_param()) {
-    layer_param->mutable_hinge_loss_param()->CopyFrom(
-        v1_layer_param.hinge_loss_param());
-  }
-  if (v1_layer_param.has_image_data_param()) {
-    layer_param->mutable_image_data_param()->CopyFrom(
-        v1_layer_param.image_data_param());
-  }
-  if (v1_layer_param.has_infogain_loss_param()) {
-    layer_param->mutable_infogain_loss_param()->CopyFrom(
-        v1_layer_param.infogain_loss_param());
-  }
-  if (v1_layer_param.has_inner_product_param()) {
-    layer_param->mutable_inner_product_param()->CopyFrom(
-        v1_layer_param.inner_product_param());
-  }
-  if (v1_layer_param.has_lrn_param()) {
-    layer_param->mutable_lrn_param()->CopyFrom(
-        v1_layer_param.lrn_param());
-  }
-  if (v1_layer_param.has_memory_data_param()) {
-    layer_param->mutable_memory_data_param()->CopyFrom(
-        v1_layer_param.memory_data_param());
-  }
-  if (v1_layer_param.has_mvn_param()) {
-    layer_param->mutable_mvn_param()->CopyFrom(
-        v1_layer_param.mvn_param());
-  }
-  if (v1_layer_param.has_pooling_param()) {
-    layer_param->mutable_pooling_param()->CopyFrom(
-        v1_layer_param.pooling_param());
-  }
-  if (v1_layer_param.has_power_param()) {
-    layer_param->mutable_power_param()->CopyFrom(
-        v1_layer_param.power_param());
-  }
-  if (v1_layer_param.has_relu_param()) {
-    layer_param->mutable_relu_param()->CopyFrom(
-        v1_layer_param.relu_param());
-  }
-  if (v1_layer_param.has_sigmoid_param()) {
-    layer_param->mutable_sigmoid_param()->CopyFrom(
-        v1_layer_param.sigmoid_param());
-  }
-  if (v1_layer_param.has_softmax_param()) {
-    layer_param->mutable_softmax_param()->CopyFrom(
-        v1_layer_param.softmax_param());
-  }
-  if (v1_layer_param.has_slice_param()) {
-    layer_param->mutable_slice_param()->CopyFrom(
-        v1_layer_param.slice_param());
-  }
-  if (v1_layer_param.has_tanh_param()) {
-    layer_param->mutable_tanh_param()->CopyFrom(
-        v1_layer_param.tanh_param());
-  }
-  if (v1_layer_param.has_threshold_param()) {
-    layer_param->mutable_threshold_param()->CopyFrom(
-        v1_layer_param.threshold_param());
-  }
-  if (v1_layer_param.has_window_data_param()) {
-    layer_param->mutable_window_data_param()->CopyFrom(
-        v1_layer_param.window_data_param());
-  }
-  if (v1_layer_param.has_transform_param()) {
-    layer_param->mutable_transform_param()->CopyFrom(
-        v1_layer_param.transform_param());
-  }
-  if (v1_layer_param.has_loss_param()) {
-    layer_param->mutable_loss_param()->CopyFrom(
-        v1_layer_param.loss_param());
-  }
-  if (v1_layer_param.has_layer()) {
-    is_fully_compatible = false;
-  }
+  for (int i = 0; i < v1_layer_param.top_size(); ++i)
+    {
+      layer_param->add_top(v1_layer_param.top(i));
+    }
+  if (v1_layer_param.has_name())
+    {
+      layer_param->set_name(v1_layer_param.name());
+    }
+  for (int i = 0; i < v1_layer_param.include_size(); ++i)
+    {
+      layer_param->add_include()->CopyFrom(v1_layer_param.include(i));
+    }
+  for (int i = 0; i < v1_layer_param.exclude_size(); ++i)
+    {
+      layer_param->add_exclude()->CopyFrom(v1_layer_param.exclude(i));
+    }
+  if (v1_layer_param.has_type())
+    {
+      layer_param->set_type(UpgradeV1LayerType(v1_layer_param.type()));
+    }
+  for (int i = 0; i < v1_layer_param.blobs_size(); ++i)
+    {
+      layer_param->add_blobs()->CopyFrom(v1_layer_param.blobs(i));
+    }
+  for (int i = 0; i < v1_layer_param.param_size(); ++i)
+    {
+      while (layer_param->param_size() <= i)
+        {
+          layer_param->add_param();
+        }
+      layer_param->mutable_param(i)->set_name(v1_layer_param.param(i));
+    }
+  caffe::ParamSpec_DimCheckMode mode;
+  for (int i = 0; i < v1_layer_param.blob_share_mode_size(); ++i)
+    {
+      while (layer_param->param_size() <= i)
+        {
+          layer_param->add_param();
+        }
+      switch (v1_layer_param.blob_share_mode(i))
+        {
+        case caffe::V1LayerParameter_DimCheckMode_STRICT:
+          mode = caffe::ParamSpec_DimCheckMode_STRICT;
+          break;
+        case caffe::V1LayerParameter_DimCheckMode_PERMISSIVE:
+          mode = caffe::ParamSpec_DimCheckMode_PERMISSIVE;
+          break;
+        default:
+          break;
+        }
+      layer_param->mutable_param(i)->set_share_mode(mode);
+    }
+  for (int i = 0; i < v1_layer_param.blobs_lr_size(); ++i)
+    {
+      while (layer_param->param_size() <= i)
+        {
+          layer_param->add_param();
+        }
+      layer_param->mutable_param(i)->set_lr_mult(v1_layer_param.blobs_lr(i));
+    }
+  for (int i = 0; i < v1_layer_param.weight_decay_size(); ++i)
+    {
+      while (layer_param->param_size() <= i)
+        {
+          layer_param->add_param();
+        }
+      layer_param->mutable_param(i)->set_decay_mult(
+          v1_layer_param.weight_decay(i));
+    }
+  for (int i = 0; i < v1_layer_param.loss_weight_size(); ++i)
+    {
+      layer_param->add_loss_weight(v1_layer_param.loss_weight(i));
+    }
+  if (v1_layer_param.has_accuracy_param())
+    {
+      layer_param->mutable_accuracy_param()->CopyFrom(
+          v1_layer_param.accuracy_param());
+    }
+  if (v1_layer_param.has_argmax_param())
+    {
+      layer_param->mutable_argmax_param()->CopyFrom(
+          v1_layer_param.argmax_param());
+    }
+  if (v1_layer_param.has_concat_param())
+    {
+      layer_param->mutable_concat_param()->CopyFrom(
+          v1_layer_param.concat_param());
+    }
+  if (v1_layer_param.has_contrastive_loss_param())
+    {
+      layer_param->mutable_contrastive_loss_param()->CopyFrom(
+          v1_layer_param.contrastive_loss_param());
+    }
+  if (v1_layer_param.has_convolution_param())
+    {
+      layer_param->mutable_convolution_param()->CopyFrom(
+          v1_layer_param.convolution_param());
+    }
+  if (v1_layer_param.has_data_param())
+    {
+      layer_param->mutable_data_param()->CopyFrom(v1_layer_param.data_param());
+    }
+  if (v1_layer_param.has_dropout_param())
+    {
+      layer_param->mutable_dropout_param()->CopyFrom(
+          v1_layer_param.dropout_param());
+    }
+  if (v1_layer_param.has_dummy_data_param())
+    {
+      layer_param->mutable_dummy_data_param()->CopyFrom(
+          v1_layer_param.dummy_data_param());
+    }
+  if (v1_layer_param.has_eltwise_param())
+    {
+      layer_param->mutable_eltwise_param()->CopyFrom(
+          v1_layer_param.eltwise_param());
+    }
+  if (v1_layer_param.has_exp_param())
+    {
+      layer_param->mutable_exp_param()->CopyFrom(v1_layer_param.exp_param());
+    }
+  if (v1_layer_param.has_hdf5_data_param())
+    {
+      layer_param->mutable_hdf5_data_param()->CopyFrom(
+          v1_layer_param.hdf5_data_param());
+    }
+  if (v1_layer_param.has_hdf5_output_param())
+    {
+      layer_param->mutable_hdf5_output_param()->CopyFrom(
+          v1_layer_param.hdf5_output_param());
+    }
+  if (v1_layer_param.has_hinge_loss_param())
+    {
+      layer_param->mutable_hinge_loss_param()->CopyFrom(
+          v1_layer_param.hinge_loss_param());
+    }
+  if (v1_layer_param.has_image_data_param())
+    {
+      layer_param->mutable_image_data_param()->CopyFrom(
+          v1_layer_param.image_data_param());
+    }
+  if (v1_layer_param.has_infogain_loss_param())
+    {
+      layer_param->mutable_infogain_loss_param()->CopyFrom(
+          v1_layer_param.infogain_loss_param());
+    }
+  if (v1_layer_param.has_inner_product_param())
+    {
+      layer_param->mutable_inner_product_param()->CopyFrom(
+          v1_layer_param.inner_product_param());
+    }
+  if (v1_layer_param.has_lrn_param())
+    {
+      layer_param->mutable_lrn_param()->CopyFrom(v1_layer_param.lrn_param());
+    }
+  if (v1_layer_param.has_memory_data_param())
+    {
+      layer_param->mutable_memory_data_param()->CopyFrom(
+          v1_layer_param.memory_data_param());
+    }
+  if (v1_layer_param.has_mvn_param())
+    {
+      layer_param->mutable_mvn_param()->CopyFrom(v1_layer_param.mvn_param());
+    }
+  if (v1_layer_param.has_pooling_param())
+    {
+      layer_param->mutable_pooling_param()->CopyFrom(
+          v1_layer_param.pooling_param());
+    }
+  if (v1_layer_param.has_power_param())
+    {
+      layer_param->mutable_power_param()->CopyFrom(
+          v1_layer_param.power_param());
+    }
+  if (v1_layer_param.has_relu_param())
+    {
+      layer_param->mutable_relu_param()->CopyFrom(v1_layer_param.relu_param());
+    }
+  if (v1_layer_param.has_sigmoid_param())
+    {
+      layer_param->mutable_sigmoid_param()->CopyFrom(
+          v1_layer_param.sigmoid_param());
+    }
+  if (v1_layer_param.has_softmax_param())
+    {
+      layer_param->mutable_softmax_param()->CopyFrom(
+          v1_layer_param.softmax_param());
+    }
+  if (v1_layer_param.has_slice_param())
+    {
+      layer_param->mutable_slice_param()->CopyFrom(
+          v1_layer_param.slice_param());
+    }
+  if (v1_layer_param.has_tanh_param())
+    {
+      layer_param->mutable_tanh_param()->CopyFrom(v1_layer_param.tanh_param());
+    }
+  if (v1_layer_param.has_threshold_param())
+    {
+      layer_param->mutable_threshold_param()->CopyFrom(
+          v1_layer_param.threshold_param());
+    }
+  if (v1_layer_param.has_window_data_param())
+    {
+      layer_param->mutable_window_data_param()->CopyFrom(
+          v1_layer_param.window_data_param());
+    }
+  if (v1_layer_param.has_transform_param())
+    {
+      layer_param->mutable_transform_param()->CopyFrom(
+          v1_layer_param.transform_param());
+    }
+  if (v1_layer_param.has_loss_param())
+    {
+      layer_param->mutable_loss_param()->CopyFrom(v1_layer_param.loss_param());
+    }
+  if (v1_layer_param.has_layer())
+    {
+      is_fully_compatible = false;
+    }
   return is_fully_compatible;
 }
 
-const char* UpgradeV1LayerType(const caffe::V1LayerParameter_LayerType type) {
-  switch (type) {
-  case caffe::V1LayerParameter_LayerType_NONE:
-    return "";
-  case caffe::V1LayerParameter_LayerType_ABSVAL:
-    return "AbsVal";
-  case caffe::V1LayerParameter_LayerType_ACCURACY:
-    return "Accuracy";
-  case caffe::V1LayerParameter_LayerType_ARGMAX:
-    return "ArgMax";
-  case caffe::V1LayerParameter_LayerType_BNLL:
-    return "BNLL";
-  case caffe::V1LayerParameter_LayerType_CONCAT:
-    return "Concat";
-  case caffe::V1LayerParameter_LayerType_CONTRASTIVE_LOSS:
-    return "ContrastiveLoss";
-  case caffe::V1LayerParameter_LayerType_CONVOLUTION:
-    return "Convolution";
-  case caffe::V1LayerParameter_LayerType_DECONVOLUTION:
-    return "Deconvolution";
-  case caffe::V1LayerParameter_LayerType_DATA:
-    return "Data";
-  case caffe::V1LayerParameter_LayerType_DROPOUT:
-    return "Dropout";
-  case caffe::V1LayerParameter_LayerType_DUMMY_DATA:
-    return "DummyData";
-  case caffe::V1LayerParameter_LayerType_EUCLIDEAN_LOSS:
-    return "EuclideanLoss";
-  case caffe::V1LayerParameter_LayerType_ELTWISE:
-    return "Eltwise";
-  case caffe::V1LayerParameter_LayerType_EXP:
-    return "Exp";
-  case caffe::V1LayerParameter_LayerType_FLATTEN:
-    return "Flatten";
-  case caffe::V1LayerParameter_LayerType_HDF5_DATA:
-    return "HDF5Data";
-  case caffe::V1LayerParameter_LayerType_HDF5_OUTPUT:
-    return "HDF5Output";
-  case caffe::V1LayerParameter_LayerType_HINGE_LOSS:
-    return "HingeLoss";
-  case caffe::V1LayerParameter_LayerType_IM2COL:
-    return "Im2col";
-  case caffe::V1LayerParameter_LayerType_IMAGE_DATA:
-    return "ImageData";
-  case caffe::V1LayerParameter_LayerType_INFOGAIN_LOSS:
-    return "InfogainLoss";
-  case caffe::V1LayerParameter_LayerType_INNER_PRODUCT:
-    return "InnerProduct";
-  case caffe::V1LayerParameter_LayerType_LRN:
-    return "LRN";
-  case caffe::V1LayerParameter_LayerType_MEMORY_DATA:
-    return "MemoryData";
-  case caffe::V1LayerParameter_LayerType_MULTINOMIAL_LOGISTIC_LOSS:
-    return "MultinomialLogisticLoss";
-  case caffe::V1LayerParameter_LayerType_MVN:
-    return "MVN";
-  case caffe::V1LayerParameter_LayerType_POOLING:
-    return "Pooling";
-  case caffe::V1LayerParameter_LayerType_POWER:
-    return "Power";
-  case caffe::V1LayerParameter_LayerType_RELU:
-    return "ReLU";
-  case caffe::V1LayerParameter_LayerType_SIGMOID:
-    return "Sigmoid";
-  case caffe::V1LayerParameter_LayerType_SIGMOID_CROSS_ENTROPY_LOSS:
-    return "SigmoidCrossEntropyLoss";
-  case caffe::V1LayerParameter_LayerType_SILENCE:
-    return "Silence";
-  case caffe::V1LayerParameter_LayerType_SOFTMAX:
-    return "Softmax";
-  case caffe::V1LayerParameter_LayerType_SOFTMAX_LOSS:
-    return "SoftmaxWithLoss";
-  case caffe::V1LayerParameter_LayerType_SPLIT:
-    return "Split";
-  case caffe::V1LayerParameter_LayerType_SLICE:
-    return "Slice";
-  case caffe::V1LayerParameter_LayerType_TANH:
-    return "TanH";
-  case caffe::V1LayerParameter_LayerType_WINDOW_DATA:
-    return "WindowData";
-  case caffe::V1LayerParameter_LayerType_THRESHOLD:
-    return "Threshold";
-  default:
-    return "";
-  }
+const char *UpgradeV1LayerType(const caffe::V1LayerParameter_LayerType type)
+{
+  switch (type)
+    {
+    case caffe::V1LayerParameter_LayerType_NONE:
+      return "";
+    case caffe::V1LayerParameter_LayerType_ABSVAL:
+      return "AbsVal";
+    case caffe::V1LayerParameter_LayerType_ACCURACY:
+      return "Accuracy";
+    case caffe::V1LayerParameter_LayerType_ARGMAX:
+      return "ArgMax";
+    case caffe::V1LayerParameter_LayerType_BNLL:
+      return "BNLL";
+    case caffe::V1LayerParameter_LayerType_CONCAT:
+      return "Concat";
+    case caffe::V1LayerParameter_LayerType_CONTRASTIVE_LOSS:
+      return "ContrastiveLoss";
+    case caffe::V1LayerParameter_LayerType_CONVOLUTION:
+      return "Convolution";
+    case caffe::V1LayerParameter_LayerType_DECONVOLUTION:
+      return "Deconvolution";
+    case caffe::V1LayerParameter_LayerType_DATA:
+      return "Data";
+    case caffe::V1LayerParameter_LayerType_DROPOUT:
+      return "Dropout";
+    case caffe::V1LayerParameter_LayerType_DUMMY_DATA:
+      return "DummyData";
+    case caffe::V1LayerParameter_LayerType_EUCLIDEAN_LOSS:
+      return "EuclideanLoss";
+    case caffe::V1LayerParameter_LayerType_ELTWISE:
+      return "Eltwise";
+    case caffe::V1LayerParameter_LayerType_EXP:
+      return "Exp";
+    case caffe::V1LayerParameter_LayerType_FLATTEN:
+      return "Flatten";
+    case caffe::V1LayerParameter_LayerType_HDF5_DATA:
+      return "HDF5Data";
+    case caffe::V1LayerParameter_LayerType_HDF5_OUTPUT:
+      return "HDF5Output";
+    case caffe::V1LayerParameter_LayerType_HINGE_LOSS:
+      return "HingeLoss";
+    case caffe::V1LayerParameter_LayerType_IM2COL:
+      return "Im2col";
+    case caffe::V1LayerParameter_LayerType_IMAGE_DATA:
+      return "ImageData";
+    case caffe::V1LayerParameter_LayerType_INFOGAIN_LOSS:
+      return "InfogainLoss";
+    case caffe::V1LayerParameter_LayerType_INNER_PRODUCT:
+      return "InnerProduct";
+    case caffe::V1LayerParameter_LayerType_LRN:
+      return "LRN";
+    case caffe::V1LayerParameter_LayerType_MEMORY_DATA:
+      return "MemoryData";
+    case caffe::V1LayerParameter_LayerType_MULTINOMIAL_LOGISTIC_LOSS:
+      return "MultinomialLogisticLoss";
+    case caffe::V1LayerParameter_LayerType_MVN:
+      return "MVN";
+    case caffe::V1LayerParameter_LayerType_POOLING:
+      return "Pooling";
+    case caffe::V1LayerParameter_LayerType_POWER:
+      return "Power";
+    case caffe::V1LayerParameter_LayerType_RELU:
+      return "ReLU";
+    case caffe::V1LayerParameter_LayerType_SIGMOID:
+      return "Sigmoid";
+    case caffe::V1LayerParameter_LayerType_SIGMOID_CROSS_ENTROPY_LOSS:
+      return "SigmoidCrossEntropyLoss";
+    case caffe::V1LayerParameter_LayerType_SILENCE:
+      return "Silence";
+    case caffe::V1LayerParameter_LayerType_SOFTMAX:
+      return "Softmax";
+    case caffe::V1LayerParameter_LayerType_SOFTMAX_LOSS:
+      return "SoftmaxWithLoss";
+    case caffe::V1LayerParameter_LayerType_SPLIT:
+      return "Split";
+    case caffe::V1LayerParameter_LayerType_SLICE:
+      return "Slice";
+    case caffe::V1LayerParameter_LayerType_TANH:
+      return "TanH";
+    case caffe::V1LayerParameter_LayerType_WINDOW_DATA:
+      return "WindowData";
+    case caffe::V1LayerParameter_LayerType_THRESHOLD:
+      return "Threshold";
+    default:
+      return "";
+    }
 }
 
-bool NetNeedsInputUpgrade(const caffe::NetParameter& net_param) {
+bool NetNeedsInputUpgrade(const caffe::NetParameter &net_param)
+{
   (void)net_param;
-  return false; // beniz: deactivated, as breaking existing net -> net_param.input_size() > 0;
+  return false; // beniz: deactivated, as breaking existing net ->
+                // net_param.input_size() > 0;
 }
 
-void UpgradeNetInput(caffe::NetParameter* net_param) {
+void UpgradeNetInput(caffe::NetParameter *net_param)
+{
   // Collect inputs and convert to Input layer definitions.
   // If the NetParameter holds an input alone, without shape/dim, then
   // it's a legacy caffemodel and simply stripping the input field is enough.
   bool has_shape = net_param->input_shape_size() > 0;
   bool has_dim = net_param->input_dim_size() > 0;
-  if (has_shape || has_dim) {
-    caffe::LayerParameter* layer_param = net_param->add_layer();
-    layer_param->set_name("input");
-    layer_param->set_type("Input");
-    caffe::InputParameter* input_param = layer_param->mutable_input_param();
-    // Convert input fields into a layer.
-    for (int i = 0; i < net_param->input_size(); ++i) {
-      layer_param->add_top(net_param->input(i));
-      if (has_shape) {
-        input_param->add_shape()->CopyFrom(net_param->input_shape(i));
-      } else {
-        // Turn legacy input dimensions into shape.
-        caffe::BlobShape* shape = input_param->add_shape();
-        int first_dim = i*4;
-        int last_dim = first_dim + 4;
-        for (int j = first_dim; j < last_dim; j++) {
-          shape->add_dim(net_param->input_dim(j));
+  if (has_shape || has_dim)
+    {
+      caffe::LayerParameter *layer_param = net_param->add_layer();
+      layer_param->set_name("input");
+      layer_param->set_type("Input");
+      caffe::InputParameter *input_param = layer_param->mutable_input_param();
+      // Convert input fields into a layer.
+      for (int i = 0; i < net_param->input_size(); ++i)
+        {
+          layer_param->add_top(net_param->input(i));
+          if (has_shape)
+            {
+              input_param->add_shape()->CopyFrom(net_param->input_shape(i));
+            }
+          else
+            {
+              // Turn legacy input dimensions into shape.
+              caffe::BlobShape *shape = input_param->add_shape();
+              int first_dim = i * 4;
+              int last_dim = first_dim + 4;
+              for (int j = first_dim; j < last_dim; j++)
+                {
+                  shape->add_dim(net_param->input_dim(j));
+                }
+            }
         }
-      }
+      // Swap input layer to beginning of net to satisfy layer dependencies.
+      for (int i = net_param->layer_size() - 1; i > 0; --i)
+        {
+          net_param->mutable_layer(i - 1)->Swap(net_param->mutable_layer(i));
+        }
     }
-    // Swap input layer to beginning of net to satisfy layer dependencies.
-    for (int i = net_param->layer_size() - 1; i > 0; --i) {
-      net_param->mutable_layer(i-1)->Swap(net_param->mutable_layer(i));
-    }
-  }
   // Clear inputs.
   net_param->clear_input();
   net_param->clear_input_shape();
   net_param->clear_input_dim();
 }
 
-bool NetNeedsBatchNormUpgrade(const caffe::NetParameter& net_param) {
-  for (int i = 0; i < net_param.layer_size(); ++i) {
-    // Check if BatchNorm layers declare three parameters, as required by
-    // the previous BatchNorm layer definition.
-    if (net_param.layer(i).type() == "BatchNorm"
-        && net_param.layer(i).param_size() == 3) {
-      return true;
+bool NetNeedsBatchNormUpgrade(const caffe::NetParameter &net_param)
+{
+  for (int i = 0; i < net_param.layer_size(); ++i)
+    {
+      // Check if BatchNorm layers declare three parameters, as required by
+      // the previous BatchNorm layer definition.
+      if (net_param.layer(i).type() == "BatchNorm"
+          && net_param.layer(i).param_size() == 3)
+        {
+          return true;
+        }
     }
-  }
   return false;
 }
 
-void UpgradeNetBatchNorm(caffe::NetParameter* net_param) {
-  for (int i = 0; i < net_param->layer_size(); ++i) {
-    // Check if BatchNorm layers declare three parameters, as required by
-    // the previous BatchNorm layer definition.
-    if (net_param->layer(i).type() == "BatchNorm"
-        && net_param->layer(i).param_size() == 3) {
-      net_param->mutable_layer(i)->clear_param();
+void UpgradeNetBatchNorm(caffe::NetParameter *net_param)
+{
+  for (int i = 0; i < net_param->layer_size(); ++i)
+    {
+      // Check if BatchNorm layers declare three parameters, as required by
+      // the previous BatchNorm layer definition.
+      if (net_param->layer(i).type() == "BatchNorm"
+          && net_param->layer(i).param_size() == 3)
+        {
+          net_param->mutable_layer(i)->clear_param();
+        }
     }
-  }
 }

--- a/src/backends/ncnn/upgrade_proto.hpp
+++ b/src/backends/ncnn/upgrade_proto.hpp
@@ -5,65 +5,66 @@
 
 #include "src/caffe.pb.h"
 
-
 // Return true iff the net is not the current version.
-bool NetNeedsUpgrade(const caffe::NetParameter& net_param);
+bool NetNeedsUpgrade(const caffe::NetParameter &net_param);
 
 // Check for deprecations and upgrade the NetParameter as needed.
-bool UpgradeNetAsNeeded(caffe::NetParameter* param);
+bool UpgradeNetAsNeeded(caffe::NetParameter *param);
 
 // Return true iff any layer contains parameters specified using
 // deprecated V0LayerParameter.
-bool NetNeedsV0ToV1Upgrade(const caffe::NetParameter& net_param);
+bool NetNeedsV0ToV1Upgrade(const caffe::NetParameter &net_param);
 
 // Perform all necessary transformations to upgrade a V0NetParameter into a
 // NetParameter (including upgrading padding layers and LayerParameters).
-bool UpgradeV0Net(const caffe::NetParameter& v0_net_param, caffe::NetParameter* net_param);
+bool UpgradeV0Net(const caffe::NetParameter &v0_net_param,
+                  caffe::NetParameter *net_param);
 
 // Upgrade NetParameter with padding layers to pad-aware conv layers.
 // For any padding layer, remove it and put its pad parameter in any layers
 // taking its top blob as input.
 // Error if any of these above layers are not-conv layers.
-void UpgradeV0PaddingLayers(const caffe::NetParameter& param,
-                            caffe::NetParameter* param_upgraded_pad);
+void UpgradeV0PaddingLayers(const caffe::NetParameter &param,
+                            caffe::NetParameter *param_upgraded_pad);
 
 // Upgrade a single V0LayerConnection to the V1LayerParameter format.
-bool UpgradeV0LayerParameter(const caffe::V1LayerParameter& v0_layer_connection,
-                             caffe::V1LayerParameter* layer_param);
+bool UpgradeV0LayerParameter(
+    const caffe::V1LayerParameter &v0_layer_connection,
+    caffe::V1LayerParameter *layer_param);
 
-caffe::V1LayerParameter_LayerType UpgradeV0LayerType(const std::string& type);
+caffe::V1LayerParameter_LayerType UpgradeV0LayerType(const std::string &type);
 
-// Return true iff any layer contains deprecated data transformation parameters.
-bool NetNeedsDataUpgrade(const caffe::NetParameter& net_param);
+// Return true iff any layer contains deprecated data transformation
+// parameters.
+bool NetNeedsDataUpgrade(const caffe::NetParameter &net_param);
 
 // Perform all necessary transformations to upgrade old transformation fields
 // into a TransformationParameter.
-void UpgradeNetDataTransformation(caffe::NetParameter* net_param);
+void UpgradeNetDataTransformation(caffe::NetParameter *net_param);
 
 // Return true iff the Net contains any layers specified as V1LayerParameters.
-bool NetNeedsV1ToV2Upgrade(const caffe::NetParameter& net_param);
+bool NetNeedsV1ToV2Upgrade(const caffe::NetParameter &net_param);
 
 // Perform all necessary transformations to upgrade a NetParameter with
 // deprecated V1LayerParameters.
-bool UpgradeV1Net(const caffe::NetParameter& v1_net_param, caffe::NetParameter* net_param);
+bool UpgradeV1Net(const caffe::NetParameter &v1_net_param,
+                  caffe::NetParameter *net_param);
 
-bool UpgradeV1LayerParameter(const caffe::V1LayerParameter& v1_layer_param,
-                             caffe::LayerParameter* layer_param);
+bool UpgradeV1LayerParameter(const caffe::V1LayerParameter &v1_layer_param,
+                             caffe::LayerParameter *layer_param);
 
-const char* UpgradeV1LayerType(const caffe::V1LayerParameter_LayerType type);
+const char *UpgradeV1LayerType(const caffe::V1LayerParameter_LayerType type);
 
 // Return true iff the Net contains input fields.
-bool NetNeedsInputUpgrade(const caffe::NetParameter& net_param);
+bool NetNeedsInputUpgrade(const caffe::NetParameter &net_param);
 
 // Perform all necessary transformations to upgrade input fields into layers.
-void UpgradeNetInput(caffe::NetParameter* net_param);
+void UpgradeNetInput(caffe::NetParameter *net_param);
 
 // Return true iff the Net contains batch norm layers with manual local LRs.
-bool NetNeedsBatchNormUpgrade(const caffe::NetParameter& net_param);
+bool NetNeedsBatchNormUpgrade(const caffe::NetParameter &net_param);
 
 // Perform all necessary transformations to upgrade batch norm layers.
-void UpgradeNetBatchNorm(caffe::NetParameter* net_param);
+void UpgradeNetBatchNorm(caffe::NetParameter *net_param);
 
-
-
-#endif   // CAFFE_UTIL_UPGRADE_PROTO_H_
+#endif // CAFFE_UTIL_UPGRADE_PROTO_H_

--- a/src/backends/tensorrt/half.hpp
+++ b/src/backends/tensorrt/half.hpp
@@ -2,17 +2,23 @@
 //
 // Copyright (c) 2012-2017 Christian Rau <rauy@users.sourceforge.net>
 //
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation 
-// files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, 
-// modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the 
-// Software is furnished to do so, subject to the following conditions:
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
 //
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
 //
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE 
-// WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR 
-// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, 
-// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
 
 // Version 1.12.0
 
@@ -23,157 +29,159 @@
 #define HALF_HALF_HPP
 
 /// Combined gcc version number.
-#define HALF_GNUC_VERSION (__GNUC__*100+__GNUC_MINOR__)
+#define HALF_GNUC_VERSION (__GNUC__ * 100 + __GNUC_MINOR__)
 
-//check C++11 language features
-#if defined(__clang__)										//clang
-	#if __has_feature(cxx_static_assert) && !defined(HALF_ENABLE_CPP11_STATIC_ASSERT)
-		#define HALF_ENABLE_CPP11_STATIC_ASSERT 1
-	#endif
-	#if __has_feature(cxx_constexpr) && !defined(HALF_ENABLE_CPP11_CONSTEXPR)
-		#define HALF_ENABLE_CPP11_CONSTEXPR 1
-	#endif
-	#if __has_feature(cxx_noexcept) && !defined(HALF_ENABLE_CPP11_NOEXCEPT)
-		#define HALF_ENABLE_CPP11_NOEXCEPT 1
-	#endif
-	#if __has_feature(cxx_user_literals) && !defined(HALF_ENABLE_CPP11_USER_LITERALS)
-		#define HALF_ENABLE_CPP11_USER_LITERALS 1
-	#endif
-	#if (defined(__GXX_EXPERIMENTAL_CXX0X__) || __cplusplus >= 201103L) && !defined(HALF_ENABLE_CPP11_LONG_LONG)
-		#define HALF_ENABLE_CPP11_LONG_LONG 1
-	#endif
-/*#elif defined(__INTEL_COMPILER)								//Intel C++
-	#if __INTEL_COMPILER >= 1100 && !defined(HALF_ENABLE_CPP11_STATIC_ASSERT)		????????
-		#define HALF_ENABLE_CPP11_STATIC_ASSERT 1
-	#endif
-	#if __INTEL_COMPILER >= 1300 && !defined(HALF_ENABLE_CPP11_CONSTEXPR)			????????
-		#define HALF_ENABLE_CPP11_CONSTEXPR 1
-	#endif
-	#if __INTEL_COMPILER >= 1300 && !defined(HALF_ENABLE_CPP11_NOEXCEPT)			????????
-		#define HALF_ENABLE_CPP11_NOEXCEPT 1
-	#endif
-	#if __INTEL_COMPILER >= 1100 && !defined(HALF_ENABLE_CPP11_LONG_LONG)			????????
-		#define HALF_ENABLE_CPP11_LONG_LONG 1
-	#endif*/
-#elif defined(__GNUC__)										//gcc
-	#if defined(__GXX_EXPERIMENTAL_CXX0X__) || __cplusplus >= 201103L
-		#if HALF_GNUC_VERSION >= 403 && !defined(HALF_ENABLE_CPP11_STATIC_ASSERT)
-			#define HALF_ENABLE_CPP11_STATIC_ASSERT 1
-		#endif
-		#if HALF_GNUC_VERSION >= 406 && !defined(HALF_ENABLE_CPP11_CONSTEXPR)
-			#define HALF_ENABLE_CPP11_CONSTEXPR 1
-		#endif
-		#if HALF_GNUC_VERSION >= 406 && !defined(HALF_ENABLE_CPP11_NOEXCEPT)
-			#define HALF_ENABLE_CPP11_NOEXCEPT 1
-		#endif
-		#if HALF_GNUC_VERSION >= 407 && !defined(HALF_ENABLE_CPP11_USER_LITERALS)
-			#define HALF_ENABLE_CPP11_USER_LITERALS 1
-		#endif
-		#if !defined(HALF_ENABLE_CPP11_LONG_LONG)
-			#define HALF_ENABLE_CPP11_LONG_LONG 1
-		#endif
-	#endif
-#elif defined(_MSC_VER)										//Visual C++
-	#if _MSC_VER >= 1900 && !defined(HALF_ENABLE_CPP11_CONSTEXPR)
-		#define HALF_ENABLE_CPP11_CONSTEXPR 1
-	#endif
-	#if _MSC_VER >= 1900 && !defined(HALF_ENABLE_CPP11_NOEXCEPT)
-		#define HALF_ENABLE_CPP11_NOEXCEPT 1
-	#endif
-	#if _MSC_VER >= 1900 && !defined(HALF_ENABLE_CPP11_USER_LITERALS)
-		#define HALF_ENABLE_CPP11_USER_LITERALS 1
-	#endif
-	#if _MSC_VER >= 1600 && !defined(HALF_ENABLE_CPP11_STATIC_ASSERT)
-		#define HALF_ENABLE_CPP11_STATIC_ASSERT 1
-	#endif
-	#if _MSC_VER >= 1310 && !defined(HALF_ENABLE_CPP11_LONG_LONG)
-		#define HALF_ENABLE_CPP11_LONG_LONG 1
-	#endif
-	#define HALF_POP_WARNINGS 1
-	#pragma warning(push)
-	#pragma warning(disable : 4099 4127 4146)	//struct vs class, constant in if, negative unsigned
+// check C++11 language features
+#if defined(__clang__) // clang
+#if __has_feature(cxx_static_assert)                                          \
+    && !defined(HALF_ENABLE_CPP11_STATIC_ASSERT)
+#define HALF_ENABLE_CPP11_STATIC_ASSERT 1
+#endif
+#if __has_feature(cxx_constexpr) && !defined(HALF_ENABLE_CPP11_CONSTEXPR)
+#define HALF_ENABLE_CPP11_CONSTEXPR 1
+#endif
+#if __has_feature(cxx_noexcept) && !defined(HALF_ENABLE_CPP11_NOEXCEPT)
+#define HALF_ENABLE_CPP11_NOEXCEPT 1
+#endif
+#if __has_feature(cxx_user_literals)                                          \
+    && !defined(HALF_ENABLE_CPP11_USER_LITERALS)
+#define HALF_ENABLE_CPP11_USER_LITERALS 1
+#endif
+#if (defined(__GXX_EXPERIMENTAL_CXX0X__) || __cplusplus >= 201103L)           \
+    && !defined(HALF_ENABLE_CPP11_LONG_LONG)
+#define HALF_ENABLE_CPP11_LONG_LONG 1
+#endif
+/*#elif defined(__INTEL_COMPILER)
+   //Intel C++ #if __INTEL_COMPILER >= 1100 &&
+   !defined(HALF_ENABLE_CPP11_STATIC_ASSERT)		???????? #define
+   HALF_ENABLE_CPP11_STATIC_ASSERT 1 #endif #if __INTEL_COMPILER >= 1300 &&
+   !defined(HALF_ENABLE_CPP11_CONSTEXPR)			????????
+                #define HALF_ENABLE_CPP11_CONSTEXPR 1
+        #endif
+        #if __INTEL_COMPILER >= 1300 && !defined(HALF_ENABLE_CPP11_NOEXCEPT)
+   ???????? #define HALF_ENABLE_CPP11_NOEXCEPT 1 #endif #if __INTEL_COMPILER >=
+   1100 && !defined(HALF_ENABLE_CPP11_LONG_LONG) ???????? #define
+   HALF_ENABLE_CPP11_LONG_LONG 1 #endif*/
+#elif defined(__GNUC__) // gcc
+#if defined(__GXX_EXPERIMENTAL_CXX0X__) || __cplusplus >= 201103L
+#if HALF_GNUC_VERSION >= 403 && !defined(HALF_ENABLE_CPP11_STATIC_ASSERT)
+#define HALF_ENABLE_CPP11_STATIC_ASSERT 1
+#endif
+#if HALF_GNUC_VERSION >= 406 && !defined(HALF_ENABLE_CPP11_CONSTEXPR)
+#define HALF_ENABLE_CPP11_CONSTEXPR 1
+#endif
+#if HALF_GNUC_VERSION >= 406 && !defined(HALF_ENABLE_CPP11_NOEXCEPT)
+#define HALF_ENABLE_CPP11_NOEXCEPT 1
+#endif
+#if HALF_GNUC_VERSION >= 407 && !defined(HALF_ENABLE_CPP11_USER_LITERALS)
+#define HALF_ENABLE_CPP11_USER_LITERALS 1
+#endif
+#if !defined(HALF_ENABLE_CPP11_LONG_LONG)
+#define HALF_ENABLE_CPP11_LONG_LONG 1
+#endif
+#endif
+#elif defined(_MSC_VER) // Visual C++
+#if _MSC_VER >= 1900 && !defined(HALF_ENABLE_CPP11_CONSTEXPR)
+#define HALF_ENABLE_CPP11_CONSTEXPR 1
+#endif
+#if _MSC_VER >= 1900 && !defined(HALF_ENABLE_CPP11_NOEXCEPT)
+#define HALF_ENABLE_CPP11_NOEXCEPT 1
+#endif
+#if _MSC_VER >= 1900 && !defined(HALF_ENABLE_CPP11_USER_LITERALS)
+#define HALF_ENABLE_CPP11_USER_LITERALS 1
+#endif
+#if _MSC_VER >= 1600 && !defined(HALF_ENABLE_CPP11_STATIC_ASSERT)
+#define HALF_ENABLE_CPP11_STATIC_ASSERT 1
+#endif
+#if _MSC_VER >= 1310 && !defined(HALF_ENABLE_CPP11_LONG_LONG)
+#define HALF_ENABLE_CPP11_LONG_LONG 1
+#endif
+#define HALF_POP_WARNINGS 1
+#pragma warning(push)
+#pragma warning(disable : 4099 4127 4146) // struct vs class, constant in if,
+                                          // negative unsigned
 #endif
 
-//check C++11 library features
+// check C++11 library features
 #include <utility>
-#if defined(_LIBCPP_VERSION)								//libc++
-	#if defined(__GXX_EXPERIMENTAL_CXX0X__) || __cplusplus >= 201103
-		#ifndef HALF_ENABLE_CPP11_TYPE_TRAITS
-			#define HALF_ENABLE_CPP11_TYPE_TRAITS 1
-		#endif
-		#ifndef HALF_ENABLE_CPP11_CSTDINT
-			#define HALF_ENABLE_CPP11_CSTDINT 1
-		#endif
-		#ifndef HALF_ENABLE_CPP11_CMATH
-			#define HALF_ENABLE_CPP11_CMATH 1
-		#endif
-		#ifndef HALF_ENABLE_CPP11_HASH
-			#define HALF_ENABLE_CPP11_HASH 1
-		#endif
-	#endif
-#elif defined(__GLIBCXX__)									//libstdc++
-	#if defined(__GXX_EXPERIMENTAL_CXX0X__) || __cplusplus >= 201103
-		#ifdef __clang__
-			#if __GLIBCXX__ >= 20080606 && !defined(HALF_ENABLE_CPP11_TYPE_TRAITS)
-				#define HALF_ENABLE_CPP11_TYPE_TRAITS 1
-			#endif
-			#if __GLIBCXX__ >= 20080606 && !defined(HALF_ENABLE_CPP11_CSTDINT)
-				#define HALF_ENABLE_CPP11_CSTDINT 1
-			#endif
-			#if __GLIBCXX__ >= 20080606 && !defined(HALF_ENABLE_CPP11_CMATH)
-				#define HALF_ENABLE_CPP11_CMATH 1
-			#endif
-			#if __GLIBCXX__ >= 20080606 && !defined(HALF_ENABLE_CPP11_HASH)
-				#define HALF_ENABLE_CPP11_HASH 1
-			#endif
-		#else
-			#if HALF_GNUC_VERSION >= 403 && !defined(HALF_ENABLE_CPP11_CSTDINT)
-				#define HALF_ENABLE_CPP11_CSTDINT 1
-			#endif
-			#if HALF_GNUC_VERSION >= 403 && !defined(HALF_ENABLE_CPP11_CMATH)
-				#define HALF_ENABLE_CPP11_CMATH 1
-			#endif
-			#if HALF_GNUC_VERSION >= 403 && !defined(HALF_ENABLE_CPP11_HASH)
-				#define HALF_ENABLE_CPP11_HASH 1
-			#endif
-		#endif
-	#endif
-#elif defined(_CPPLIB_VER)									//Dinkumware/Visual C++
-	#if _CPPLIB_VER >= 520
-		#ifndef HALF_ENABLE_CPP11_TYPE_TRAITS
-			#define HALF_ENABLE_CPP11_TYPE_TRAITS 1
-		#endif
-		#ifndef HALF_ENABLE_CPP11_CSTDINT
-			#define HALF_ENABLE_CPP11_CSTDINT 1
-		#endif
-		#ifndef HALF_ENABLE_CPP11_HASH
-			#define HALF_ENABLE_CPP11_HASH 1
-		#endif
-	#endif
-	#if _CPPLIB_VER >= 610
-		#ifndef HALF_ENABLE_CPP11_CMATH
-			#define HALF_ENABLE_CPP11_CMATH 1
-		#endif
-	#endif
+#if defined(_LIBCPP_VERSION) // libc++
+#if defined(__GXX_EXPERIMENTAL_CXX0X__) || __cplusplus >= 201103
+#ifndef HALF_ENABLE_CPP11_TYPE_TRAITS
+#define HALF_ENABLE_CPP11_TYPE_TRAITS 1
+#endif
+#ifndef HALF_ENABLE_CPP11_CSTDINT
+#define HALF_ENABLE_CPP11_CSTDINT 1
+#endif
+#ifndef HALF_ENABLE_CPP11_CMATH
+#define HALF_ENABLE_CPP11_CMATH 1
+#endif
+#ifndef HALF_ENABLE_CPP11_HASH
+#define HALF_ENABLE_CPP11_HASH 1
+#endif
+#endif
+#elif defined(__GLIBCXX__) // libstdc++
+#if defined(__GXX_EXPERIMENTAL_CXX0X__) || __cplusplus >= 201103
+#ifdef __clang__
+#if __GLIBCXX__ >= 20080606 && !defined(HALF_ENABLE_CPP11_TYPE_TRAITS)
+#define HALF_ENABLE_CPP11_TYPE_TRAITS 1
+#endif
+#if __GLIBCXX__ >= 20080606 && !defined(HALF_ENABLE_CPP11_CSTDINT)
+#define HALF_ENABLE_CPP11_CSTDINT 1
+#endif
+#if __GLIBCXX__ >= 20080606 && !defined(HALF_ENABLE_CPP11_CMATH)
+#define HALF_ENABLE_CPP11_CMATH 1
+#endif
+#if __GLIBCXX__ >= 20080606 && !defined(HALF_ENABLE_CPP11_HASH)
+#define HALF_ENABLE_CPP11_HASH 1
+#endif
+#else
+#if HALF_GNUC_VERSION >= 403 && !defined(HALF_ENABLE_CPP11_CSTDINT)
+#define HALF_ENABLE_CPP11_CSTDINT 1
+#endif
+#if HALF_GNUC_VERSION >= 403 && !defined(HALF_ENABLE_CPP11_CMATH)
+#define HALF_ENABLE_CPP11_CMATH 1
+#endif
+#if HALF_GNUC_VERSION >= 403 && !defined(HALF_ENABLE_CPP11_HASH)
+#define HALF_ENABLE_CPP11_HASH 1
+#endif
+#endif
+#endif
+#elif defined(_CPPLIB_VER) // Dinkumware/Visual C++
+#if _CPPLIB_VER >= 520
+#ifndef HALF_ENABLE_CPP11_TYPE_TRAITS
+#define HALF_ENABLE_CPP11_TYPE_TRAITS 1
+#endif
+#ifndef HALF_ENABLE_CPP11_CSTDINT
+#define HALF_ENABLE_CPP11_CSTDINT 1
+#endif
+#ifndef HALF_ENABLE_CPP11_HASH
+#define HALF_ENABLE_CPP11_HASH 1
+#endif
+#endif
+#if _CPPLIB_VER >= 610
+#ifndef HALF_ENABLE_CPP11_CMATH
+#define HALF_ENABLE_CPP11_CMATH 1
+#endif
+#endif
 #endif
 #undef HALF_GNUC_VERSION
 
-//support constexpr
+// support constexpr
 #if HALF_ENABLE_CPP11_CONSTEXPR
-	#define HALF_CONSTEXPR			constexpr
-	#define HALF_CONSTEXPR_CONST	constexpr
+#define HALF_CONSTEXPR constexpr
+#define HALF_CONSTEXPR_CONST constexpr
 #else
-	#define HALF_CONSTEXPR
-	#define HALF_CONSTEXPR_CONST	const
+#define HALF_CONSTEXPR
+#define HALF_CONSTEXPR_CONST const
 #endif
 
-//support noexcept
+// support noexcept
 #if HALF_ENABLE_CPP11_NOEXCEPT
-	#define HALF_NOEXCEPT	noexcept
-	#define HALF_NOTHROW	noexcept
+#define HALF_NOEXCEPT noexcept
+#define HALF_NOTHROW noexcept
 #else
-	#define HALF_NOEXCEPT
-	#define HALF_NOTHROW	throw()
+#define HALF_NOEXCEPT
+#define HALF_NOTHROW throw()
 #endif
 
 #include <algorithm>
@@ -183,20 +191,21 @@
 #include <cmath>
 #include <cstring>
 #if HALF_ENABLE_CPP11_TYPE_TRAITS
-	#include <type_traits>
+#include <type_traits>
 #endif
 #if HALF_ENABLE_CPP11_CSTDINT
-	#include <cstdint>
+#include <cstdint>
 #endif
 #if HALF_ENABLE_CPP11_HASH
-	#include <functional>
+#include <functional>
 #endif
 
-
 /// Default rounding mode.
-/// This specifies the rounding mode used for all conversions between [half](\ref half_float::half)s and `float`s as well as 
-/// for the half_cast() if not specifying a rounding mode explicitly. It can be redefined (before including half.hpp) to one 
-/// of the standard rounding modes using their respective constants or the equivalent values of `std::float_round_style`:
+/// This specifies the rounding mode used for all conversions between
+/// [half](\ref half_float::half)s and `float`s as well as for the half_cast()
+/// if not specifying a rounding mode explicitly. It can be redefined (before
+/// including half.hpp) to one of the standard rounding modes using their
+/// respective constants or the equivalent values of `std::float_round_style`:
 ///
 /// `std::float_round_style`         | value | rounding
 /// ---------------------------------|-------|-------------------------
@@ -206,2862 +215,4387 @@
 /// `std::round_toward_infinity`     | 2     | toward positive infinity
 /// `std::round_toward_neg_infinity` | 3     | toward negative infinity
 ///
-/// By default this is set to `-1` (`std::round_indeterminate`), which uses truncation (round toward zero, but with overflows 
-/// set to infinity) and is the fastest rounding mode possible. It can even be set to `std::numeric_limits<float>::round_style` 
-/// to synchronize the rounding mode with that of the underlying single-precision implementation.
+/// By default this is set to `-1` (`std::round_indeterminate`), which uses
+/// truncation (round toward zero, but with overflows set to infinity) and is
+/// the fastest rounding mode possible. It can even be set to
+/// `std::numeric_limits<float>::round_style` to synchronize the rounding mode
+/// with that of the underlying single-precision implementation.
 #ifndef HALF_ROUND_STYLE
-	#define HALF_ROUND_STYLE	-1			// = std::round_indeterminate
+#define HALF_ROUND_STYLE -1 // = std::round_indeterminate
 #endif
 
 /// Tie-breaking behaviour for round to nearest.
-/// This specifies if ties in round to nearest should be resolved by rounding to the nearest even value. By default this is 
-/// defined to `0` resulting in the faster but slightly more biased behaviour of rounding away from zero in half-way cases (and 
-/// thus equal to the round() function), but can be redefined to `1` (before including half.hpp) if more IEEE-conformant 
+/// This specifies if ties in round to nearest should be resolved by rounding
+/// to the nearest even value. By default this is defined to `0` resulting in
+/// the faster but slightly more biased behaviour of rounding away from zero in
+/// half-way cases (and thus equal to the round() function), but can be
+/// redefined to `1` (before including half.hpp) if more IEEE-conformant
 /// behaviour is needed.
 #ifndef HALF_ROUND_TIES_TO_EVEN
-	#define HALF_ROUND_TIES_TO_EVEN	0		// ties away from zero
+#define HALF_ROUND_TIES_TO_EVEN 0 // ties away from zero
 #endif
 
 /// Value signaling overflow.
-/// In correspondence with `HUGE_VAL[F|L]` from `<cmath>` this symbol expands to a positive value signaling the overflow of an 
-/// operation, in particular it just evaluates to positive infinity.
-#define HUGE_VALH	std::numeric_limits<half_float::half>::infinity()
+/// In correspondence with `HUGE_VAL[F|L]` from `<cmath>` this symbol expands
+/// to a positive value signaling the overflow of an operation, in particular
+/// it just evaluates to positive infinity.
+#define HUGE_VALH std::numeric_limits<half_float::half>::infinity()
 
 /// Fast half-precision fma function.
-/// This symbol is only defined if the fma() function generally executes as fast as, or faster than, a separate 
-/// half-precision multiplication followed by an addition. Due to the internal single-precision implementation of all 
+/// This symbol is only defined if the fma() function generally executes as
+/// fast as, or faster than, a separate half-precision multiplication followed
+/// by an addition. Due to the internal single-precision implementation of all
 /// arithmetic operations, this is in fact always the case.
-#define FP_FAST_FMAH	1
+#define FP_FAST_FMAH 1
 
 #ifndef FP_ILOGB0
-	#define FP_ILOGB0		INT_MIN
+#define FP_ILOGB0 INT_MIN
 #endif
 #ifndef FP_ILOGBNAN
-	#define FP_ILOGBNAN		INT_MAX
+#define FP_ILOGBNAN INT_MAX
 #endif
 #ifndef FP_SUBNORMAL
-	#define FP_SUBNORMAL	0
+#define FP_SUBNORMAL 0
 #endif
 #ifndef FP_ZERO
-	#define FP_ZERO			1
+#define FP_ZERO 1
 #endif
 #ifndef FP_NAN
-	#define FP_NAN			2
+#define FP_NAN 2
 #endif
 #ifndef FP_INFINITE
-	#define FP_INFINITE		3
+#define FP_INFINITE 3
 #endif
 #ifndef FP_NORMAL
-	#define FP_NORMAL		4
+#define FP_NORMAL 4
 #endif
-
 
 /// Main namespace for half precision functionality.
 /// This namespace contains all the functionality provided by the library.
 namespace half_float
 {
-	class half;
+  class half;
 
 #if HALF_ENABLE_CPP11_USER_LITERALS
-	/// Library-defined half-precision literals.
-	/// Import this namespace to enable half-precision floating point literals:
-	/// ~~~~{.cpp}
-	/// using namespace half_float::literal;
-	/// half_float::half = 4.2_h;
-	/// ~~~~
-	namespace literal
-	{
-		half operator""_h(long double);
-	}
+  /// Library-defined half-precision literals.
+  /// Import this namespace to enable half-precision floating point literals:
+  /// ~~~~{.cpp}
+  /// using namespace half_float::literal;
+  /// half_float::half = 4.2_h;
+  /// ~~~~
+  namespace literal
+  {
+    half operator""_h(long double);
+  }
 #endif
 
-	/// \internal
-	/// \brief Implementation details.
-	namespace detail
-	{
-	#if HALF_ENABLE_CPP11_TYPE_TRAITS
-		/// Conditional type.
-		template<bool B,typename T,typename F> struct conditional : std::conditional<B,T,F> {};
+  /// \internal
+  /// \brief Implementation details.
+  namespace detail
+  {
+#if HALF_ENABLE_CPP11_TYPE_TRAITS
+    /// Conditional type.
+    template <bool B, typename T, typename F>
+    struct conditional : std::conditional<B, T, F>
+    {
+    };
 
-		/// Helper for tag dispatching.
-		template<bool B> struct bool_type : std::integral_constant<bool,B> {};
-		using std::true_type;
-		using std::false_type;
+    /// Helper for tag dispatching.
+    template <bool B> struct bool_type : std::integral_constant<bool, B>
+    {
+    };
+    using std::false_type;
+    using std::true_type;
 
-		/// Type traits for floating point types.
-		template<typename T> struct is_float : std::is_floating_point<T> {};
-	#else
-		/// Conditional type.
-		template<bool,typename T,typename> struct conditional { typedef T type; };
-		template<typename T,typename F> struct conditional<false,T,F> { typedef F type; };
+    /// Type traits for floating point types.
+    template <typename T> struct is_float : std::is_floating_point<T>
+    {
+    };
+#else
+    /// Conditional type.
+    template <bool, typename T, typename> struct conditional
+    {
+      typedef T type;
+    };
+    template <typename T, typename F> struct conditional<false, T, F>
+    {
+      typedef F type;
+    };
 
-		/// Helper for tag dispatching.
-		template<bool> struct bool_type {};
-		typedef bool_type<true> true_type;
-		typedef bool_type<false> false_type;
+    /// Helper for tag dispatching.
+    template <bool> struct bool_type
+    {
+    };
+    typedef bool_type<true> true_type;
+    typedef bool_type<false> false_type;
 
-		/// Type traits for floating point types.
-		template<typename> struct is_float : false_type {};
-		template<typename T> struct is_float<const T> : is_float<T> {};
-		template<typename T> struct is_float<volatile T> : is_float<T> {};
-		template<typename T> struct is_float<const volatile T> : is_float<T> {};
-		template<> struct is_float<float> : true_type {};
-		template<> struct is_float<double> : true_type {};
-		template<> struct is_float<long double> : true_type {};
-	#endif
-
-		/// Type traits for floating point bits.
-		template<typename T> struct bits { typedef unsigned char type; };
-		template<typename T> struct bits<const T> : bits<T> {};
-		template<typename T> struct bits<volatile T> : bits<T> {};
-		template<typename T> struct bits<const volatile T> : bits<T> {};
-
-	#if HALF_ENABLE_CPP11_CSTDINT
-		/// Unsigned integer of (at least) 16 bits width.
-		typedef std::uint_least16_t uint16;
-
-		/// Unsigned integer of (at least) 32 bits width.
-		template<> struct bits<float> { typedef std::uint_least32_t type; };
-
-		/// Unsigned integer of (at least) 64 bits width.
-		template<> struct bits<double> { typedef std::uint_least64_t type; };
-	#else
-		/// Unsigned integer of (at least) 16 bits width.
-		typedef unsigned short uint16;
-
-		/// Unsigned integer of (at least) 32 bits width.
-		template<> struct bits<float> : conditional<std::numeric_limits<unsigned int>::digits>=32,unsigned int,unsigned long> {};
-
-		#if HALF_ENABLE_CPP11_LONG_LONG
-			/// Unsigned integer of (at least) 64 bits width.
-			template<> struct bits<double> : conditional<std::numeric_limits<unsigned long>::digits>=64,unsigned long,unsigned long long> {};
-		#else
-			/// Unsigned integer of (at least) 64 bits width.
-			template<> struct bits<double> { typedef unsigned long type; };
-		#endif
-	#endif
-
-		/// Tag type for binary construction.
-		struct binary_t {};
-
-		/// Tag for binary construction.
-		HALF_CONSTEXPR_CONST binary_t binary = binary_t();
-
-		/// Temporary half-precision expression.
-		/// This class represents a half-precision expression which just stores a single-precision value internally.
-		struct expr
-		{
-			/// Conversion constructor.
-			/// \param f single-precision value to convert
-			explicit HALF_CONSTEXPR expr(float f) HALF_NOEXCEPT : value_(f) {}
-
-			/// Conversion to single-precision.
-			/// \return single precision value representing expression value
-			HALF_CONSTEXPR operator float() const HALF_NOEXCEPT { return value_; }
-
-		private:
-			/// Internal expression value stored in single-precision.
-			float value_;
-		};
-
-		/// SFINAE helper for generic half-precision functions.
-		/// This class template has to be specialized for each valid combination of argument types to provide a corresponding 
-		/// `type` member equivalent to \a T.
-		/// \tparam T type to return
-		template<typename T,typename,typename=void,typename=void> struct enable {};
-		template<typename T> struct enable<T,half,void,void> { typedef T type; };
-		template<typename T> struct enable<T,expr,void,void> { typedef T type; };
-		template<typename T> struct enable<T,half,half,void> { typedef T type; };
-		template<typename T> struct enable<T,half,expr,void> { typedef T type; };
-		template<typename T> struct enable<T,expr,half,void> { typedef T type; };
-		template<typename T> struct enable<T,expr,expr,void> { typedef T type; };
-		template<typename T> struct enable<T,half,half,half> { typedef T type; };
-		template<typename T> struct enable<T,half,half,expr> { typedef T type; };
-		template<typename T> struct enable<T,half,expr,half> { typedef T type; };
-		template<typename T> struct enable<T,half,expr,expr> { typedef T type; };
-		template<typename T> struct enable<T,expr,half,half> { typedef T type; };
-		template<typename T> struct enable<T,expr,half,expr> { typedef T type; };
-		template<typename T> struct enable<T,expr,expr,half> { typedef T type; };
-		template<typename T> struct enable<T,expr,expr,expr> { typedef T type; };
-
-		/// Return type for specialized generic 2-argument half-precision functions.
-		/// This class template has to be specialized for each valid combination of argument types to provide a corresponding 
-		/// `type` member denoting the appropriate return type.
-		/// \tparam T first argument type
-		/// \tparam U first argument type
-		template<typename T,typename U> struct result : enable<expr,T,U> {};
-		template<> struct result<half,half> { typedef half type; };
-
-		/// \name Classification helpers
-		/// \{
-
-		/// Check for infinity.
-		/// \tparam T argument type (builtin floating point type)
-		/// \param arg value to query
-		/// \retval true if infinity
-		/// \retval false else
-		template<typename T> bool builtin_isinf(T arg)
-		{
-		#if HALF_ENABLE_CPP11_CMATH
-			return std::isinf(arg);
-		#elif defined(_MSC_VER)
-			return !::_finite(static_cast<double>(arg)) && !::_isnan(static_cast<double>(arg));
-		#else
-			return arg == std::numeric_limits<T>::infinity() || arg == -std::numeric_limits<T>::infinity();
-		#endif
-		}
-
-		/// Check for NaN.
-		/// \tparam T argument type (builtin floating point type)
-		/// \param arg value to query
-		/// \retval true if not a number
-		/// \retval false else
-		template<typename T> bool builtin_isnan(T arg)
-		{
-		#if HALF_ENABLE_CPP11_CMATH
-			return std::isnan(arg);
-		#elif defined(_MSC_VER)
-			return ::_isnan(static_cast<double>(arg)) != 0;
-		#else
-			return arg != arg;
-		#endif
-		}
-
-		/// Check sign.
-		/// \tparam T argument type (builtin floating point type)
-		/// \param arg value to query
-		/// \retval true if signbit set
-		/// \retval false else
-		template<typename T> bool builtin_signbit(T arg)
-		{
-		#if HALF_ENABLE_CPP11_CMATH
-			return std::signbit(arg);
-		#else
-			return arg < T() || (arg == T() && T(1)/arg < T());
-		#endif
-		}
-
-		/// \}
-		/// \name Conversion
-		/// \{
-
-		/// Convert IEEE single-precision to half-precision.
-		/// Credit for this goes to [Jeroen van der Zijp](ftp://ftp.fox-toolkit.org/pub/fasthalffloatconversion.pdf).
-		/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest rounding
-		/// \param value single-precision value
-		/// \return binary representation of half-precision value
-		template<std::float_round_style R> uint16 float2half_impl(float value, true_type)
-		{
-			typedef bits<float>::type uint32;
-			uint32 bits;// = *reinterpret_cast<uint32*>(&value);		//violating strict aliasing!
-			std::memcpy(&bits, &value, sizeof(float));
-/*			uint16 hbits = (bits>>16) & 0x8000;
-			bits &= 0x7FFFFFFF;
-			int exp = bits >> 23;
-			if(exp == 255)
-				return hbits | 0x7C00 | (0x3FF&-static_cast<unsigned>((bits&0x7FFFFF)!=0));
-			if(exp > 142)
-			{
-				if(R == std::round_toward_infinity)
-					return hbits | 0x7C00 - (hbits>>15);
-				if(R == std::round_toward_neg_infinity)
-					return hbits | 0x7BFF + (hbits>>15);
-				return hbits | 0x7BFF + (R!=std::round_toward_zero);
-			}
-			int g, s;
-			if(exp > 112)
-			{
-				g = (bits>>12) & 1;
-				s = (bits&0xFFF) != 0;
-				hbits |= ((exp-112)<<10) | ((bits>>13)&0x3FF);
-			}
-			else if(exp > 101)
-			{
-				int i = 125 - exp;
-				bits = (bits&0x7FFFFF) | 0x800000;
-				g = (bits>>i) & 1;
-				s = (bits&((1L<<i)-1)) != 0;
-				hbits |= bits >> (i+1);
-			}
-			else
-			{
-				g = 0;
-				s = bits != 0;
-			}
-			if(R == std::round_to_nearest)
-				#if HALF_ROUND_TIES_TO_EVEN
-					hbits += g & (s|hbits);
-				#else
-					hbits += g;
-				#endif
-			else if(R == std::round_toward_infinity)
-				hbits += ~(hbits>>15) & (s|g);
-			else if(R == std::round_toward_neg_infinity)
-				hbits += (hbits>>15) & (g|s);
-*/			static const uint16 base_table[512] = { 
-				0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 
-				0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 
-				0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 
-				0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 
-				0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 
-				0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 
-				0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0001, 0x0002, 0x0004, 0x0008, 0x0010, 0x0020, 0x0040, 0x0080, 0x0100, 
-				0x0200, 0x0400, 0x0800, 0x0C00, 0x1000, 0x1400, 0x1800, 0x1C00, 0x2000, 0x2400, 0x2800, 0x2C00, 0x3000, 0x3400, 0x3800, 0x3C00, 
-				0x4000, 0x4400, 0x4800, 0x4C00, 0x5000, 0x5400, 0x5800, 0x5C00, 0x6000, 0x6400, 0x6800, 0x6C00, 0x7000, 0x7400, 0x7800, 0x7C00, 
-				0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 
-				0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 
-				0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 
-				0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 
-				0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 
-				0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 
-				0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 
-				0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 
-				0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 
-				0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 
-				0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 
-				0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 
-				0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 
-				0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8001, 0x8002, 0x8004, 0x8008, 0x8010, 0x8020, 0x8040, 0x8080, 0x8100, 
-				0x8200, 0x8400, 0x8800, 0x8C00, 0x9000, 0x9400, 0x9800, 0x9C00, 0xA000, 0xA400, 0xA800, 0xAC00, 0xB000, 0xB400, 0xB800, 0xBC00, 
-				0xC000, 0xC400, 0xC800, 0xCC00, 0xD000, 0xD400, 0xD800, 0xDC00, 0xE000, 0xE400, 0xE800, 0xEC00, 0xF000, 0xF400, 0xF800, 0xFC00, 
-				0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 
-				0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 
-				0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 
-				0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 
-				0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 
-				0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 
-				0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00 };
-			static const unsigned char shift_table[512] = { 
-				24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 
-				24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 
-				24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 
-				24, 24, 24, 24, 24, 24, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 
-				13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 
-				24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 
-				24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 
-				24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 13, 
-				24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 
-				24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 
-				24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 
-				24, 24, 24, 24, 24, 24, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 
-				13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 
-				24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 
-				24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 
-				24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 13 };
-			uint16 hbits = base_table[bits>>23] + static_cast<uint16>((bits&0x7FFFFF)>>shift_table[bits>>23]);
-			if(R == std::round_to_nearest)
-				hbits += (((bits&0x7FFFFF)>>(shift_table[bits>>23]-1))|(((bits>>23)&0xFF)==102)) & ((hbits&0x7C00)!=0x7C00)
-				#if HALF_ROUND_TIES_TO_EVEN
-					& (((((static_cast<uint32>(1)<<(shift_table[bits>>23]-1))-1)&bits)!=0)|hbits)
-				#endif
-				;
-			else if(R == std::round_toward_zero)
-				hbits -= ((hbits&0x7FFF)==0x7C00) & ~shift_table[bits>>23];
-			else if(R == std::round_toward_infinity)
-				hbits += ((((bits&0x7FFFFF&((static_cast<uint32>(1)<<(shift_table[bits>>23]))-1))!=0)|(((bits>>23)<=102)&
-					((bits>>23)!=0)))&(hbits<0x7C00)) - ((hbits==0xFC00)&((bits>>23)!=511));
-			else if(R == std::round_toward_neg_infinity)
-				hbits += ((((bits&0x7FFFFF&((static_cast<uint32>(1)<<(shift_table[bits>>23]))-1))!=0)|(((bits>>23)<=358)&
-					((bits>>23)!=256)))&(hbits<0xFC00)&(hbits>>15)) - ((hbits==0x7C00)&((bits>>23)!=255));
-			return hbits;
-		}
-
-		/// Convert IEEE double-precision to half-precision.
-		/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest rounding
-		/// \param value double-precision value
-		/// \return binary representation of half-precision value
-		template<std::float_round_style R> uint16 float2half_impl(double value, true_type)
-		{
-			typedef bits<float>::type uint32;
-			typedef bits<double>::type uint64;
-			uint64 bits;// = *reinterpret_cast<uint64*>(&value);		//violating strict aliasing!
-			std::memcpy(&bits, &value, sizeof(double));
-			uint32 hi = bits >> 32, lo = bits & 0xFFFFFFFF;
-			uint16 hbits = (hi>>16) & 0x8000;
-			hi &= 0x7FFFFFFF;
-			int exp = hi >> 20;
-			if(exp == 2047)
-				return hbits | 0x7C00 | (0x3FF&-static_cast<unsigned>((bits&0xFFFFFFFFFFFFF)!=0));
-			if(exp > 1038)
-			{
-				if(R == std::round_toward_infinity)
-					return hbits | 0x7C00 - (hbits>>15);
-				if(R == std::round_toward_neg_infinity)
-					return hbits | 0x7BFF + (hbits>>15);
-				return hbits | 0x7BFF + (R!=std::round_toward_zero);
-			}
-			int g, s = lo != 0;
-			if(exp > 1008)
-			{
-				g = (hi>>9) & 1;
-				s |= (hi&0x1FF) != 0;
-				hbits |= ((exp-1008)<<10) | ((hi>>10)&0x3FF);
-			}
-			else if(exp > 997)
-			{
-				int i = 1018 - exp;
-				hi = (hi&0xFFFFF) | 0x100000;
-				g = (hi>>i) & 1;
-				s |= (hi&((1L<<i)-1)) != 0;
-				hbits |= hi >> (i+1);
-			}
-			else
-			{
-				g = 0;
-				s |= hi != 0;
-			}
-			if(R == std::round_to_nearest)
-				#if HALF_ROUND_TIES_TO_EVEN
-					hbits += g & (s|hbits);
-				#else
-					hbits += g;
-				#endif
-			else if(R == std::round_toward_infinity)
-				hbits += ~(hbits>>15) & (s|g);
-			else if(R == std::round_toward_neg_infinity)
-				hbits += (hbits>>15) & (g|s);
-			return hbits;
-		}
-
-		/// Convert non-IEEE floating point to half-precision.
-		/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest rounding
-		/// \tparam T source type (builtin floating point type)
-		/// \param value floating point value
-		/// \return binary representation of half-precision value
-		template<std::float_round_style R,typename T> uint16 float2half_impl(T value, ...)
-		{
-			uint16 hbits = static_cast<unsigned>(builtin_signbit(value)) << 15;
-			if(value == T())
-				return hbits;
-			if(builtin_isnan(value))
-				return hbits | 0x7FFF;
-			if(builtin_isinf(value))
-				return hbits | 0x7C00;
-			int exp;
-			std::frexp(value, &exp);
-			if(exp > 16)
-			{
-				if(R == std::round_toward_infinity)
-					return (hbits | 0x7C00) - (hbits>>15);
-				else if(R == std::round_toward_neg_infinity)
-					return (hbits | 0x7BFF) + (hbits>>15);
-				return (hbits | 0x7BFF) + (R!=std::round_toward_zero);
-			}
-			if(exp < -13)
-				value = std::ldexp(value, 24);
-			else
-			{
-				value = std::ldexp(value, 11-exp);
-				hbits |= ((exp+13)<<10);
-			}
-			T ival, frac = std::modf(value, &ival);
-			hbits += static_cast<uint16>(std::abs(static_cast<int>(ival)));
-			if(R == std::round_to_nearest)
-			{
-				frac = std::abs(frac);
-				#if HALF_ROUND_TIES_TO_EVEN
-					hbits += (frac>T(0.5)) | ((frac==T(0.5))&hbits);
-				#else
-					hbits += frac >= T(0.5);
-				#endif
-			}
-			else if(R == std::round_toward_infinity)
-				hbits += frac > T();
-			else if(R == std::round_toward_neg_infinity)
-				hbits += frac < T();
-			return hbits;
-		}
-
-		/// Convert floating point to half-precision.
-		/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest rounding
-		/// \tparam T source type (builtin floating point type)
-		/// \param value floating point value
-		/// \return binary representation of half-precision value
-		template<std::float_round_style R,typename T> uint16 float2half(T value)
-		{
-			return float2half_impl<R>(value, bool_type<std::numeric_limits<T>::is_iec559&&sizeof(typename bits<T>::type)==sizeof(T)>());
-		}
-
-		/// Convert integer to half-precision floating point.
-		/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest rounding
-		/// \tparam S `true` if value negative, `false` else
-		/// \tparam T type to convert (builtin integer type)
-		/// \param value non-negative integral value
-		/// \return binary representation of half-precision value
-		template<std::float_round_style R,bool S,typename T> uint16 int2half_impl(T value)
-		{
-		#if HALF_ENABLE_CPP11_STATIC_ASSERT && HALF_ENABLE_CPP11_TYPE_TRAITS
-			static_assert(std::is_integral<T>::value, "int to half conversion only supports builtin integer types");
-		#endif
-			if(S)
-				value = -value;
-			uint16 bits = S << 15;
-			if(value > 0xFFFF)
-			{
-				if(R == std::round_toward_infinity)
-					bits |= 0x7C00 - S;
-				else if(R == std::round_toward_neg_infinity)
-					bits |= 0x7BFF + S;
-				else
-					bits |= 0x7BFF + (R!=std::round_toward_zero);
-			}
-			else if(value)
-			{
-				unsigned int m = value, exp = 24;
-				for(; m<0x400; m<<=1,--exp) ;
-				for(; m>0x7FF; m>>=1,++exp) ;
-				bits |= (exp<<10) + m;
-				if(exp > 24)
-				{
-					if(R == std::round_to_nearest)
-						bits += (value>>(exp-25)) & 1
-						#if HALF_ROUND_TIES_TO_EVEN
-							& (((((1<<(exp-25))-1)&value)!=0)|bits)
-						#endif
-						;
-					else if(R == std::round_toward_infinity)
-						bits += ((value&((1<<(exp-24))-1))!=0) & !S;
-					else if(R == std::round_toward_neg_infinity)
-						bits += ((value&((1<<(exp-24))-1))!=0) & S;
-				}
-			}
-			return bits;
-		}
-
-		/// Convert integer to half-precision floating point.
-		/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest rounding
-		/// \tparam T type to convert (builtin integer type)
-		/// \param value integral value
-		/// \return binary representation of half-precision value
-		template<std::float_round_style R,typename T> uint16 int2half(T value)
-		{
-			return (value<0) ? int2half_impl<R,true>(value) : int2half_impl<R,false>(value);
-		}
-
-		/// Convert half-precision to IEEE single-precision.
-		/// Credit for this goes to [Jeroen van der Zijp](ftp://ftp.fox-toolkit.org/pub/fasthalffloatconversion.pdf).
-		/// \param value binary representation of half-precision value
-		/// \return single-precision value
-		inline float half2float_impl(uint16 value, float, true_type)
-		{
-			typedef bits<float>::type uint32;
-/*			uint32 bits = static_cast<uint32>(value&0x8000) << 16;
-			int abs = value & 0x7FFF;
-			if(abs)
-			{
-				bits |= 0x38000000 << static_cast<unsigned>(abs>=0x7C00);
-				for(; abs<0x400; abs<<=1,bits-=0x800000) ;
-				bits += static_cast<uint32>(abs) << 13;
-			}
-*/			static const uint32 mantissa_table[2048] = { 
-				0x00000000, 0x33800000, 0x34000000, 0x34400000, 0x34800000, 0x34A00000, 0x34C00000, 0x34E00000, 0x35000000, 0x35100000, 0x35200000, 0x35300000, 0x35400000, 0x35500000, 0x35600000, 0x35700000, 
-				0x35800000, 0x35880000, 0x35900000, 0x35980000, 0x35A00000, 0x35A80000, 0x35B00000, 0x35B80000, 0x35C00000, 0x35C80000, 0x35D00000, 0x35D80000, 0x35E00000, 0x35E80000, 0x35F00000, 0x35F80000, 
-				0x36000000, 0x36040000, 0x36080000, 0x360C0000, 0x36100000, 0x36140000, 0x36180000, 0x361C0000, 0x36200000, 0x36240000, 0x36280000, 0x362C0000, 0x36300000, 0x36340000, 0x36380000, 0x363C0000, 
-				0x36400000, 0x36440000, 0x36480000, 0x364C0000, 0x36500000, 0x36540000, 0x36580000, 0x365C0000, 0x36600000, 0x36640000, 0x36680000, 0x366C0000, 0x36700000, 0x36740000, 0x36780000, 0x367C0000, 
-				0x36800000, 0x36820000, 0x36840000, 0x36860000, 0x36880000, 0x368A0000, 0x368C0000, 0x368E0000, 0x36900000, 0x36920000, 0x36940000, 0x36960000, 0x36980000, 0x369A0000, 0x369C0000, 0x369E0000, 
-				0x36A00000, 0x36A20000, 0x36A40000, 0x36A60000, 0x36A80000, 0x36AA0000, 0x36AC0000, 0x36AE0000, 0x36B00000, 0x36B20000, 0x36B40000, 0x36B60000, 0x36B80000, 0x36BA0000, 0x36BC0000, 0x36BE0000, 
-				0x36C00000, 0x36C20000, 0x36C40000, 0x36C60000, 0x36C80000, 0x36CA0000, 0x36CC0000, 0x36CE0000, 0x36D00000, 0x36D20000, 0x36D40000, 0x36D60000, 0x36D80000, 0x36DA0000, 0x36DC0000, 0x36DE0000, 
-				0x36E00000, 0x36E20000, 0x36E40000, 0x36E60000, 0x36E80000, 0x36EA0000, 0x36EC0000, 0x36EE0000, 0x36F00000, 0x36F20000, 0x36F40000, 0x36F60000, 0x36F80000, 0x36FA0000, 0x36FC0000, 0x36FE0000, 
-				0x37000000, 0x37010000, 0x37020000, 0x37030000, 0x37040000, 0x37050000, 0x37060000, 0x37070000, 0x37080000, 0x37090000, 0x370A0000, 0x370B0000, 0x370C0000, 0x370D0000, 0x370E0000, 0x370F0000, 
-				0x37100000, 0x37110000, 0x37120000, 0x37130000, 0x37140000, 0x37150000, 0x37160000, 0x37170000, 0x37180000, 0x37190000, 0x371A0000, 0x371B0000, 0x371C0000, 0x371D0000, 0x371E0000, 0x371F0000, 
-				0x37200000, 0x37210000, 0x37220000, 0x37230000, 0x37240000, 0x37250000, 0x37260000, 0x37270000, 0x37280000, 0x37290000, 0x372A0000, 0x372B0000, 0x372C0000, 0x372D0000, 0x372E0000, 0x372F0000, 
-				0x37300000, 0x37310000, 0x37320000, 0x37330000, 0x37340000, 0x37350000, 0x37360000, 0x37370000, 0x37380000, 0x37390000, 0x373A0000, 0x373B0000, 0x373C0000, 0x373D0000, 0x373E0000, 0x373F0000, 
-				0x37400000, 0x37410000, 0x37420000, 0x37430000, 0x37440000, 0x37450000, 0x37460000, 0x37470000, 0x37480000, 0x37490000, 0x374A0000, 0x374B0000, 0x374C0000, 0x374D0000, 0x374E0000, 0x374F0000, 
-				0x37500000, 0x37510000, 0x37520000, 0x37530000, 0x37540000, 0x37550000, 0x37560000, 0x37570000, 0x37580000, 0x37590000, 0x375A0000, 0x375B0000, 0x375C0000, 0x375D0000, 0x375E0000, 0x375F0000, 
-				0x37600000, 0x37610000, 0x37620000, 0x37630000, 0x37640000, 0x37650000, 0x37660000, 0x37670000, 0x37680000, 0x37690000, 0x376A0000, 0x376B0000, 0x376C0000, 0x376D0000, 0x376E0000, 0x376F0000, 
-				0x37700000, 0x37710000, 0x37720000, 0x37730000, 0x37740000, 0x37750000, 0x37760000, 0x37770000, 0x37780000, 0x37790000, 0x377A0000, 0x377B0000, 0x377C0000, 0x377D0000, 0x377E0000, 0x377F0000, 
-				0x37800000, 0x37808000, 0x37810000, 0x37818000, 0x37820000, 0x37828000, 0x37830000, 0x37838000, 0x37840000, 0x37848000, 0x37850000, 0x37858000, 0x37860000, 0x37868000, 0x37870000, 0x37878000, 
-				0x37880000, 0x37888000, 0x37890000, 0x37898000, 0x378A0000, 0x378A8000, 0x378B0000, 0x378B8000, 0x378C0000, 0x378C8000, 0x378D0000, 0x378D8000, 0x378E0000, 0x378E8000, 0x378F0000, 0x378F8000, 
-				0x37900000, 0x37908000, 0x37910000, 0x37918000, 0x37920000, 0x37928000, 0x37930000, 0x37938000, 0x37940000, 0x37948000, 0x37950000, 0x37958000, 0x37960000, 0x37968000, 0x37970000, 0x37978000, 
-				0x37980000, 0x37988000, 0x37990000, 0x37998000, 0x379A0000, 0x379A8000, 0x379B0000, 0x379B8000, 0x379C0000, 0x379C8000, 0x379D0000, 0x379D8000, 0x379E0000, 0x379E8000, 0x379F0000, 0x379F8000, 
-				0x37A00000, 0x37A08000, 0x37A10000, 0x37A18000, 0x37A20000, 0x37A28000, 0x37A30000, 0x37A38000, 0x37A40000, 0x37A48000, 0x37A50000, 0x37A58000, 0x37A60000, 0x37A68000, 0x37A70000, 0x37A78000, 
-				0x37A80000, 0x37A88000, 0x37A90000, 0x37A98000, 0x37AA0000, 0x37AA8000, 0x37AB0000, 0x37AB8000, 0x37AC0000, 0x37AC8000, 0x37AD0000, 0x37AD8000, 0x37AE0000, 0x37AE8000, 0x37AF0000, 0x37AF8000, 
-				0x37B00000, 0x37B08000, 0x37B10000, 0x37B18000, 0x37B20000, 0x37B28000, 0x37B30000, 0x37B38000, 0x37B40000, 0x37B48000, 0x37B50000, 0x37B58000, 0x37B60000, 0x37B68000, 0x37B70000, 0x37B78000, 
-				0x37B80000, 0x37B88000, 0x37B90000, 0x37B98000, 0x37BA0000, 0x37BA8000, 0x37BB0000, 0x37BB8000, 0x37BC0000, 0x37BC8000, 0x37BD0000, 0x37BD8000, 0x37BE0000, 0x37BE8000, 0x37BF0000, 0x37BF8000, 
-				0x37C00000, 0x37C08000, 0x37C10000, 0x37C18000, 0x37C20000, 0x37C28000, 0x37C30000, 0x37C38000, 0x37C40000, 0x37C48000, 0x37C50000, 0x37C58000, 0x37C60000, 0x37C68000, 0x37C70000, 0x37C78000, 
-				0x37C80000, 0x37C88000, 0x37C90000, 0x37C98000, 0x37CA0000, 0x37CA8000, 0x37CB0000, 0x37CB8000, 0x37CC0000, 0x37CC8000, 0x37CD0000, 0x37CD8000, 0x37CE0000, 0x37CE8000, 0x37CF0000, 0x37CF8000, 
-				0x37D00000, 0x37D08000, 0x37D10000, 0x37D18000, 0x37D20000, 0x37D28000, 0x37D30000, 0x37D38000, 0x37D40000, 0x37D48000, 0x37D50000, 0x37D58000, 0x37D60000, 0x37D68000, 0x37D70000, 0x37D78000, 
-				0x37D80000, 0x37D88000, 0x37D90000, 0x37D98000, 0x37DA0000, 0x37DA8000, 0x37DB0000, 0x37DB8000, 0x37DC0000, 0x37DC8000, 0x37DD0000, 0x37DD8000, 0x37DE0000, 0x37DE8000, 0x37DF0000, 0x37DF8000, 
-				0x37E00000, 0x37E08000, 0x37E10000, 0x37E18000, 0x37E20000, 0x37E28000, 0x37E30000, 0x37E38000, 0x37E40000, 0x37E48000, 0x37E50000, 0x37E58000, 0x37E60000, 0x37E68000, 0x37E70000, 0x37E78000, 
-				0x37E80000, 0x37E88000, 0x37E90000, 0x37E98000, 0x37EA0000, 0x37EA8000, 0x37EB0000, 0x37EB8000, 0x37EC0000, 0x37EC8000, 0x37ED0000, 0x37ED8000, 0x37EE0000, 0x37EE8000, 0x37EF0000, 0x37EF8000, 
-				0x37F00000, 0x37F08000, 0x37F10000, 0x37F18000, 0x37F20000, 0x37F28000, 0x37F30000, 0x37F38000, 0x37F40000, 0x37F48000, 0x37F50000, 0x37F58000, 0x37F60000, 0x37F68000, 0x37F70000, 0x37F78000, 
-				0x37F80000, 0x37F88000, 0x37F90000, 0x37F98000, 0x37FA0000, 0x37FA8000, 0x37FB0000, 0x37FB8000, 0x37FC0000, 0x37FC8000, 0x37FD0000, 0x37FD8000, 0x37FE0000, 0x37FE8000, 0x37FF0000, 0x37FF8000, 
-				0x38000000, 0x38004000, 0x38008000, 0x3800C000, 0x38010000, 0x38014000, 0x38018000, 0x3801C000, 0x38020000, 0x38024000, 0x38028000, 0x3802C000, 0x38030000, 0x38034000, 0x38038000, 0x3803C000, 
-				0x38040000, 0x38044000, 0x38048000, 0x3804C000, 0x38050000, 0x38054000, 0x38058000, 0x3805C000, 0x38060000, 0x38064000, 0x38068000, 0x3806C000, 0x38070000, 0x38074000, 0x38078000, 0x3807C000, 
-				0x38080000, 0x38084000, 0x38088000, 0x3808C000, 0x38090000, 0x38094000, 0x38098000, 0x3809C000, 0x380A0000, 0x380A4000, 0x380A8000, 0x380AC000, 0x380B0000, 0x380B4000, 0x380B8000, 0x380BC000, 
-				0x380C0000, 0x380C4000, 0x380C8000, 0x380CC000, 0x380D0000, 0x380D4000, 0x380D8000, 0x380DC000, 0x380E0000, 0x380E4000, 0x380E8000, 0x380EC000, 0x380F0000, 0x380F4000, 0x380F8000, 0x380FC000, 
-				0x38100000, 0x38104000, 0x38108000, 0x3810C000, 0x38110000, 0x38114000, 0x38118000, 0x3811C000, 0x38120000, 0x38124000, 0x38128000, 0x3812C000, 0x38130000, 0x38134000, 0x38138000, 0x3813C000, 
-				0x38140000, 0x38144000, 0x38148000, 0x3814C000, 0x38150000, 0x38154000, 0x38158000, 0x3815C000, 0x38160000, 0x38164000, 0x38168000, 0x3816C000, 0x38170000, 0x38174000, 0x38178000, 0x3817C000, 
-				0x38180000, 0x38184000, 0x38188000, 0x3818C000, 0x38190000, 0x38194000, 0x38198000, 0x3819C000, 0x381A0000, 0x381A4000, 0x381A8000, 0x381AC000, 0x381B0000, 0x381B4000, 0x381B8000, 0x381BC000, 
-				0x381C0000, 0x381C4000, 0x381C8000, 0x381CC000, 0x381D0000, 0x381D4000, 0x381D8000, 0x381DC000, 0x381E0000, 0x381E4000, 0x381E8000, 0x381EC000, 0x381F0000, 0x381F4000, 0x381F8000, 0x381FC000, 
-				0x38200000, 0x38204000, 0x38208000, 0x3820C000, 0x38210000, 0x38214000, 0x38218000, 0x3821C000, 0x38220000, 0x38224000, 0x38228000, 0x3822C000, 0x38230000, 0x38234000, 0x38238000, 0x3823C000, 
-				0x38240000, 0x38244000, 0x38248000, 0x3824C000, 0x38250000, 0x38254000, 0x38258000, 0x3825C000, 0x38260000, 0x38264000, 0x38268000, 0x3826C000, 0x38270000, 0x38274000, 0x38278000, 0x3827C000, 
-				0x38280000, 0x38284000, 0x38288000, 0x3828C000, 0x38290000, 0x38294000, 0x38298000, 0x3829C000, 0x382A0000, 0x382A4000, 0x382A8000, 0x382AC000, 0x382B0000, 0x382B4000, 0x382B8000, 0x382BC000, 
-				0x382C0000, 0x382C4000, 0x382C8000, 0x382CC000, 0x382D0000, 0x382D4000, 0x382D8000, 0x382DC000, 0x382E0000, 0x382E4000, 0x382E8000, 0x382EC000, 0x382F0000, 0x382F4000, 0x382F8000, 0x382FC000, 
-				0x38300000, 0x38304000, 0x38308000, 0x3830C000, 0x38310000, 0x38314000, 0x38318000, 0x3831C000, 0x38320000, 0x38324000, 0x38328000, 0x3832C000, 0x38330000, 0x38334000, 0x38338000, 0x3833C000, 
-				0x38340000, 0x38344000, 0x38348000, 0x3834C000, 0x38350000, 0x38354000, 0x38358000, 0x3835C000, 0x38360000, 0x38364000, 0x38368000, 0x3836C000, 0x38370000, 0x38374000, 0x38378000, 0x3837C000, 
-				0x38380000, 0x38384000, 0x38388000, 0x3838C000, 0x38390000, 0x38394000, 0x38398000, 0x3839C000, 0x383A0000, 0x383A4000, 0x383A8000, 0x383AC000, 0x383B0000, 0x383B4000, 0x383B8000, 0x383BC000, 
-				0x383C0000, 0x383C4000, 0x383C8000, 0x383CC000, 0x383D0000, 0x383D4000, 0x383D8000, 0x383DC000, 0x383E0000, 0x383E4000, 0x383E8000, 0x383EC000, 0x383F0000, 0x383F4000, 0x383F8000, 0x383FC000, 
-				0x38400000, 0x38404000, 0x38408000, 0x3840C000, 0x38410000, 0x38414000, 0x38418000, 0x3841C000, 0x38420000, 0x38424000, 0x38428000, 0x3842C000, 0x38430000, 0x38434000, 0x38438000, 0x3843C000, 
-				0x38440000, 0x38444000, 0x38448000, 0x3844C000, 0x38450000, 0x38454000, 0x38458000, 0x3845C000, 0x38460000, 0x38464000, 0x38468000, 0x3846C000, 0x38470000, 0x38474000, 0x38478000, 0x3847C000, 
-				0x38480000, 0x38484000, 0x38488000, 0x3848C000, 0x38490000, 0x38494000, 0x38498000, 0x3849C000, 0x384A0000, 0x384A4000, 0x384A8000, 0x384AC000, 0x384B0000, 0x384B4000, 0x384B8000, 0x384BC000, 
-				0x384C0000, 0x384C4000, 0x384C8000, 0x384CC000, 0x384D0000, 0x384D4000, 0x384D8000, 0x384DC000, 0x384E0000, 0x384E4000, 0x384E8000, 0x384EC000, 0x384F0000, 0x384F4000, 0x384F8000, 0x384FC000, 
-				0x38500000, 0x38504000, 0x38508000, 0x3850C000, 0x38510000, 0x38514000, 0x38518000, 0x3851C000, 0x38520000, 0x38524000, 0x38528000, 0x3852C000, 0x38530000, 0x38534000, 0x38538000, 0x3853C000, 
-				0x38540000, 0x38544000, 0x38548000, 0x3854C000, 0x38550000, 0x38554000, 0x38558000, 0x3855C000, 0x38560000, 0x38564000, 0x38568000, 0x3856C000, 0x38570000, 0x38574000, 0x38578000, 0x3857C000, 
-				0x38580000, 0x38584000, 0x38588000, 0x3858C000, 0x38590000, 0x38594000, 0x38598000, 0x3859C000, 0x385A0000, 0x385A4000, 0x385A8000, 0x385AC000, 0x385B0000, 0x385B4000, 0x385B8000, 0x385BC000, 
-				0x385C0000, 0x385C4000, 0x385C8000, 0x385CC000, 0x385D0000, 0x385D4000, 0x385D8000, 0x385DC000, 0x385E0000, 0x385E4000, 0x385E8000, 0x385EC000, 0x385F0000, 0x385F4000, 0x385F8000, 0x385FC000, 
-				0x38600000, 0x38604000, 0x38608000, 0x3860C000, 0x38610000, 0x38614000, 0x38618000, 0x3861C000, 0x38620000, 0x38624000, 0x38628000, 0x3862C000, 0x38630000, 0x38634000, 0x38638000, 0x3863C000, 
-				0x38640000, 0x38644000, 0x38648000, 0x3864C000, 0x38650000, 0x38654000, 0x38658000, 0x3865C000, 0x38660000, 0x38664000, 0x38668000, 0x3866C000, 0x38670000, 0x38674000, 0x38678000, 0x3867C000, 
-				0x38680000, 0x38684000, 0x38688000, 0x3868C000, 0x38690000, 0x38694000, 0x38698000, 0x3869C000, 0x386A0000, 0x386A4000, 0x386A8000, 0x386AC000, 0x386B0000, 0x386B4000, 0x386B8000, 0x386BC000, 
-				0x386C0000, 0x386C4000, 0x386C8000, 0x386CC000, 0x386D0000, 0x386D4000, 0x386D8000, 0x386DC000, 0x386E0000, 0x386E4000, 0x386E8000, 0x386EC000, 0x386F0000, 0x386F4000, 0x386F8000, 0x386FC000, 
-				0x38700000, 0x38704000, 0x38708000, 0x3870C000, 0x38710000, 0x38714000, 0x38718000, 0x3871C000, 0x38720000, 0x38724000, 0x38728000, 0x3872C000, 0x38730000, 0x38734000, 0x38738000, 0x3873C000, 
-				0x38740000, 0x38744000, 0x38748000, 0x3874C000, 0x38750000, 0x38754000, 0x38758000, 0x3875C000, 0x38760000, 0x38764000, 0x38768000, 0x3876C000, 0x38770000, 0x38774000, 0x38778000, 0x3877C000, 
-				0x38780000, 0x38784000, 0x38788000, 0x3878C000, 0x38790000, 0x38794000, 0x38798000, 0x3879C000, 0x387A0000, 0x387A4000, 0x387A8000, 0x387AC000, 0x387B0000, 0x387B4000, 0x387B8000, 0x387BC000, 
-				0x387C0000, 0x387C4000, 0x387C8000, 0x387CC000, 0x387D0000, 0x387D4000, 0x387D8000, 0x387DC000, 0x387E0000, 0x387E4000, 0x387E8000, 0x387EC000, 0x387F0000, 0x387F4000, 0x387F8000, 0x387FC000, 
-				0x38000000, 0x38002000, 0x38004000, 0x38006000, 0x38008000, 0x3800A000, 0x3800C000, 0x3800E000, 0x38010000, 0x38012000, 0x38014000, 0x38016000, 0x38018000, 0x3801A000, 0x3801C000, 0x3801E000, 
-				0x38020000, 0x38022000, 0x38024000, 0x38026000, 0x38028000, 0x3802A000, 0x3802C000, 0x3802E000, 0x38030000, 0x38032000, 0x38034000, 0x38036000, 0x38038000, 0x3803A000, 0x3803C000, 0x3803E000, 
-				0x38040000, 0x38042000, 0x38044000, 0x38046000, 0x38048000, 0x3804A000, 0x3804C000, 0x3804E000, 0x38050000, 0x38052000, 0x38054000, 0x38056000, 0x38058000, 0x3805A000, 0x3805C000, 0x3805E000, 
-				0x38060000, 0x38062000, 0x38064000, 0x38066000, 0x38068000, 0x3806A000, 0x3806C000, 0x3806E000, 0x38070000, 0x38072000, 0x38074000, 0x38076000, 0x38078000, 0x3807A000, 0x3807C000, 0x3807E000, 
-				0x38080000, 0x38082000, 0x38084000, 0x38086000, 0x38088000, 0x3808A000, 0x3808C000, 0x3808E000, 0x38090000, 0x38092000, 0x38094000, 0x38096000, 0x38098000, 0x3809A000, 0x3809C000, 0x3809E000, 
-				0x380A0000, 0x380A2000, 0x380A4000, 0x380A6000, 0x380A8000, 0x380AA000, 0x380AC000, 0x380AE000, 0x380B0000, 0x380B2000, 0x380B4000, 0x380B6000, 0x380B8000, 0x380BA000, 0x380BC000, 0x380BE000, 
-				0x380C0000, 0x380C2000, 0x380C4000, 0x380C6000, 0x380C8000, 0x380CA000, 0x380CC000, 0x380CE000, 0x380D0000, 0x380D2000, 0x380D4000, 0x380D6000, 0x380D8000, 0x380DA000, 0x380DC000, 0x380DE000, 
-				0x380E0000, 0x380E2000, 0x380E4000, 0x380E6000, 0x380E8000, 0x380EA000, 0x380EC000, 0x380EE000, 0x380F0000, 0x380F2000, 0x380F4000, 0x380F6000, 0x380F8000, 0x380FA000, 0x380FC000, 0x380FE000, 
-				0x38100000, 0x38102000, 0x38104000, 0x38106000, 0x38108000, 0x3810A000, 0x3810C000, 0x3810E000, 0x38110000, 0x38112000, 0x38114000, 0x38116000, 0x38118000, 0x3811A000, 0x3811C000, 0x3811E000, 
-				0x38120000, 0x38122000, 0x38124000, 0x38126000, 0x38128000, 0x3812A000, 0x3812C000, 0x3812E000, 0x38130000, 0x38132000, 0x38134000, 0x38136000, 0x38138000, 0x3813A000, 0x3813C000, 0x3813E000, 
-				0x38140000, 0x38142000, 0x38144000, 0x38146000, 0x38148000, 0x3814A000, 0x3814C000, 0x3814E000, 0x38150000, 0x38152000, 0x38154000, 0x38156000, 0x38158000, 0x3815A000, 0x3815C000, 0x3815E000, 
-				0x38160000, 0x38162000, 0x38164000, 0x38166000, 0x38168000, 0x3816A000, 0x3816C000, 0x3816E000, 0x38170000, 0x38172000, 0x38174000, 0x38176000, 0x38178000, 0x3817A000, 0x3817C000, 0x3817E000, 
-				0x38180000, 0x38182000, 0x38184000, 0x38186000, 0x38188000, 0x3818A000, 0x3818C000, 0x3818E000, 0x38190000, 0x38192000, 0x38194000, 0x38196000, 0x38198000, 0x3819A000, 0x3819C000, 0x3819E000, 
-				0x381A0000, 0x381A2000, 0x381A4000, 0x381A6000, 0x381A8000, 0x381AA000, 0x381AC000, 0x381AE000, 0x381B0000, 0x381B2000, 0x381B4000, 0x381B6000, 0x381B8000, 0x381BA000, 0x381BC000, 0x381BE000, 
-				0x381C0000, 0x381C2000, 0x381C4000, 0x381C6000, 0x381C8000, 0x381CA000, 0x381CC000, 0x381CE000, 0x381D0000, 0x381D2000, 0x381D4000, 0x381D6000, 0x381D8000, 0x381DA000, 0x381DC000, 0x381DE000, 
-				0x381E0000, 0x381E2000, 0x381E4000, 0x381E6000, 0x381E8000, 0x381EA000, 0x381EC000, 0x381EE000, 0x381F0000, 0x381F2000, 0x381F4000, 0x381F6000, 0x381F8000, 0x381FA000, 0x381FC000, 0x381FE000, 
-				0x38200000, 0x38202000, 0x38204000, 0x38206000, 0x38208000, 0x3820A000, 0x3820C000, 0x3820E000, 0x38210000, 0x38212000, 0x38214000, 0x38216000, 0x38218000, 0x3821A000, 0x3821C000, 0x3821E000, 
-				0x38220000, 0x38222000, 0x38224000, 0x38226000, 0x38228000, 0x3822A000, 0x3822C000, 0x3822E000, 0x38230000, 0x38232000, 0x38234000, 0x38236000, 0x38238000, 0x3823A000, 0x3823C000, 0x3823E000, 
-				0x38240000, 0x38242000, 0x38244000, 0x38246000, 0x38248000, 0x3824A000, 0x3824C000, 0x3824E000, 0x38250000, 0x38252000, 0x38254000, 0x38256000, 0x38258000, 0x3825A000, 0x3825C000, 0x3825E000, 
-				0x38260000, 0x38262000, 0x38264000, 0x38266000, 0x38268000, 0x3826A000, 0x3826C000, 0x3826E000, 0x38270000, 0x38272000, 0x38274000, 0x38276000, 0x38278000, 0x3827A000, 0x3827C000, 0x3827E000, 
-				0x38280000, 0x38282000, 0x38284000, 0x38286000, 0x38288000, 0x3828A000, 0x3828C000, 0x3828E000, 0x38290000, 0x38292000, 0x38294000, 0x38296000, 0x38298000, 0x3829A000, 0x3829C000, 0x3829E000, 
-				0x382A0000, 0x382A2000, 0x382A4000, 0x382A6000, 0x382A8000, 0x382AA000, 0x382AC000, 0x382AE000, 0x382B0000, 0x382B2000, 0x382B4000, 0x382B6000, 0x382B8000, 0x382BA000, 0x382BC000, 0x382BE000, 
-				0x382C0000, 0x382C2000, 0x382C4000, 0x382C6000, 0x382C8000, 0x382CA000, 0x382CC000, 0x382CE000, 0x382D0000, 0x382D2000, 0x382D4000, 0x382D6000, 0x382D8000, 0x382DA000, 0x382DC000, 0x382DE000, 
-				0x382E0000, 0x382E2000, 0x382E4000, 0x382E6000, 0x382E8000, 0x382EA000, 0x382EC000, 0x382EE000, 0x382F0000, 0x382F2000, 0x382F4000, 0x382F6000, 0x382F8000, 0x382FA000, 0x382FC000, 0x382FE000, 
-				0x38300000, 0x38302000, 0x38304000, 0x38306000, 0x38308000, 0x3830A000, 0x3830C000, 0x3830E000, 0x38310000, 0x38312000, 0x38314000, 0x38316000, 0x38318000, 0x3831A000, 0x3831C000, 0x3831E000, 
-				0x38320000, 0x38322000, 0x38324000, 0x38326000, 0x38328000, 0x3832A000, 0x3832C000, 0x3832E000, 0x38330000, 0x38332000, 0x38334000, 0x38336000, 0x38338000, 0x3833A000, 0x3833C000, 0x3833E000, 
-				0x38340000, 0x38342000, 0x38344000, 0x38346000, 0x38348000, 0x3834A000, 0x3834C000, 0x3834E000, 0x38350000, 0x38352000, 0x38354000, 0x38356000, 0x38358000, 0x3835A000, 0x3835C000, 0x3835E000, 
-				0x38360000, 0x38362000, 0x38364000, 0x38366000, 0x38368000, 0x3836A000, 0x3836C000, 0x3836E000, 0x38370000, 0x38372000, 0x38374000, 0x38376000, 0x38378000, 0x3837A000, 0x3837C000, 0x3837E000, 
-				0x38380000, 0x38382000, 0x38384000, 0x38386000, 0x38388000, 0x3838A000, 0x3838C000, 0x3838E000, 0x38390000, 0x38392000, 0x38394000, 0x38396000, 0x38398000, 0x3839A000, 0x3839C000, 0x3839E000, 
-				0x383A0000, 0x383A2000, 0x383A4000, 0x383A6000, 0x383A8000, 0x383AA000, 0x383AC000, 0x383AE000, 0x383B0000, 0x383B2000, 0x383B4000, 0x383B6000, 0x383B8000, 0x383BA000, 0x383BC000, 0x383BE000, 
-				0x383C0000, 0x383C2000, 0x383C4000, 0x383C6000, 0x383C8000, 0x383CA000, 0x383CC000, 0x383CE000, 0x383D0000, 0x383D2000, 0x383D4000, 0x383D6000, 0x383D8000, 0x383DA000, 0x383DC000, 0x383DE000, 
-				0x383E0000, 0x383E2000, 0x383E4000, 0x383E6000, 0x383E8000, 0x383EA000, 0x383EC000, 0x383EE000, 0x383F0000, 0x383F2000, 0x383F4000, 0x383F6000, 0x383F8000, 0x383FA000, 0x383FC000, 0x383FE000, 
-				0x38400000, 0x38402000, 0x38404000, 0x38406000, 0x38408000, 0x3840A000, 0x3840C000, 0x3840E000, 0x38410000, 0x38412000, 0x38414000, 0x38416000, 0x38418000, 0x3841A000, 0x3841C000, 0x3841E000, 
-				0x38420000, 0x38422000, 0x38424000, 0x38426000, 0x38428000, 0x3842A000, 0x3842C000, 0x3842E000, 0x38430000, 0x38432000, 0x38434000, 0x38436000, 0x38438000, 0x3843A000, 0x3843C000, 0x3843E000, 
-				0x38440000, 0x38442000, 0x38444000, 0x38446000, 0x38448000, 0x3844A000, 0x3844C000, 0x3844E000, 0x38450000, 0x38452000, 0x38454000, 0x38456000, 0x38458000, 0x3845A000, 0x3845C000, 0x3845E000, 
-				0x38460000, 0x38462000, 0x38464000, 0x38466000, 0x38468000, 0x3846A000, 0x3846C000, 0x3846E000, 0x38470000, 0x38472000, 0x38474000, 0x38476000, 0x38478000, 0x3847A000, 0x3847C000, 0x3847E000, 
-				0x38480000, 0x38482000, 0x38484000, 0x38486000, 0x38488000, 0x3848A000, 0x3848C000, 0x3848E000, 0x38490000, 0x38492000, 0x38494000, 0x38496000, 0x38498000, 0x3849A000, 0x3849C000, 0x3849E000, 
-				0x384A0000, 0x384A2000, 0x384A4000, 0x384A6000, 0x384A8000, 0x384AA000, 0x384AC000, 0x384AE000, 0x384B0000, 0x384B2000, 0x384B4000, 0x384B6000, 0x384B8000, 0x384BA000, 0x384BC000, 0x384BE000, 
-				0x384C0000, 0x384C2000, 0x384C4000, 0x384C6000, 0x384C8000, 0x384CA000, 0x384CC000, 0x384CE000, 0x384D0000, 0x384D2000, 0x384D4000, 0x384D6000, 0x384D8000, 0x384DA000, 0x384DC000, 0x384DE000, 
-				0x384E0000, 0x384E2000, 0x384E4000, 0x384E6000, 0x384E8000, 0x384EA000, 0x384EC000, 0x384EE000, 0x384F0000, 0x384F2000, 0x384F4000, 0x384F6000, 0x384F8000, 0x384FA000, 0x384FC000, 0x384FE000, 
-				0x38500000, 0x38502000, 0x38504000, 0x38506000, 0x38508000, 0x3850A000, 0x3850C000, 0x3850E000, 0x38510000, 0x38512000, 0x38514000, 0x38516000, 0x38518000, 0x3851A000, 0x3851C000, 0x3851E000, 
-				0x38520000, 0x38522000, 0x38524000, 0x38526000, 0x38528000, 0x3852A000, 0x3852C000, 0x3852E000, 0x38530000, 0x38532000, 0x38534000, 0x38536000, 0x38538000, 0x3853A000, 0x3853C000, 0x3853E000, 
-				0x38540000, 0x38542000, 0x38544000, 0x38546000, 0x38548000, 0x3854A000, 0x3854C000, 0x3854E000, 0x38550000, 0x38552000, 0x38554000, 0x38556000, 0x38558000, 0x3855A000, 0x3855C000, 0x3855E000, 
-				0x38560000, 0x38562000, 0x38564000, 0x38566000, 0x38568000, 0x3856A000, 0x3856C000, 0x3856E000, 0x38570000, 0x38572000, 0x38574000, 0x38576000, 0x38578000, 0x3857A000, 0x3857C000, 0x3857E000, 
-				0x38580000, 0x38582000, 0x38584000, 0x38586000, 0x38588000, 0x3858A000, 0x3858C000, 0x3858E000, 0x38590000, 0x38592000, 0x38594000, 0x38596000, 0x38598000, 0x3859A000, 0x3859C000, 0x3859E000, 
-				0x385A0000, 0x385A2000, 0x385A4000, 0x385A6000, 0x385A8000, 0x385AA000, 0x385AC000, 0x385AE000, 0x385B0000, 0x385B2000, 0x385B4000, 0x385B6000, 0x385B8000, 0x385BA000, 0x385BC000, 0x385BE000, 
-				0x385C0000, 0x385C2000, 0x385C4000, 0x385C6000, 0x385C8000, 0x385CA000, 0x385CC000, 0x385CE000, 0x385D0000, 0x385D2000, 0x385D4000, 0x385D6000, 0x385D8000, 0x385DA000, 0x385DC000, 0x385DE000, 
-				0x385E0000, 0x385E2000, 0x385E4000, 0x385E6000, 0x385E8000, 0x385EA000, 0x385EC000, 0x385EE000, 0x385F0000, 0x385F2000, 0x385F4000, 0x385F6000, 0x385F8000, 0x385FA000, 0x385FC000, 0x385FE000, 
-				0x38600000, 0x38602000, 0x38604000, 0x38606000, 0x38608000, 0x3860A000, 0x3860C000, 0x3860E000, 0x38610000, 0x38612000, 0x38614000, 0x38616000, 0x38618000, 0x3861A000, 0x3861C000, 0x3861E000, 
-				0x38620000, 0x38622000, 0x38624000, 0x38626000, 0x38628000, 0x3862A000, 0x3862C000, 0x3862E000, 0x38630000, 0x38632000, 0x38634000, 0x38636000, 0x38638000, 0x3863A000, 0x3863C000, 0x3863E000, 
-				0x38640000, 0x38642000, 0x38644000, 0x38646000, 0x38648000, 0x3864A000, 0x3864C000, 0x3864E000, 0x38650000, 0x38652000, 0x38654000, 0x38656000, 0x38658000, 0x3865A000, 0x3865C000, 0x3865E000, 
-				0x38660000, 0x38662000, 0x38664000, 0x38666000, 0x38668000, 0x3866A000, 0x3866C000, 0x3866E000, 0x38670000, 0x38672000, 0x38674000, 0x38676000, 0x38678000, 0x3867A000, 0x3867C000, 0x3867E000, 
-				0x38680000, 0x38682000, 0x38684000, 0x38686000, 0x38688000, 0x3868A000, 0x3868C000, 0x3868E000, 0x38690000, 0x38692000, 0x38694000, 0x38696000, 0x38698000, 0x3869A000, 0x3869C000, 0x3869E000, 
-				0x386A0000, 0x386A2000, 0x386A4000, 0x386A6000, 0x386A8000, 0x386AA000, 0x386AC000, 0x386AE000, 0x386B0000, 0x386B2000, 0x386B4000, 0x386B6000, 0x386B8000, 0x386BA000, 0x386BC000, 0x386BE000, 
-				0x386C0000, 0x386C2000, 0x386C4000, 0x386C6000, 0x386C8000, 0x386CA000, 0x386CC000, 0x386CE000, 0x386D0000, 0x386D2000, 0x386D4000, 0x386D6000, 0x386D8000, 0x386DA000, 0x386DC000, 0x386DE000, 
-				0x386E0000, 0x386E2000, 0x386E4000, 0x386E6000, 0x386E8000, 0x386EA000, 0x386EC000, 0x386EE000, 0x386F0000, 0x386F2000, 0x386F4000, 0x386F6000, 0x386F8000, 0x386FA000, 0x386FC000, 0x386FE000, 
-				0x38700000, 0x38702000, 0x38704000, 0x38706000, 0x38708000, 0x3870A000, 0x3870C000, 0x3870E000, 0x38710000, 0x38712000, 0x38714000, 0x38716000, 0x38718000, 0x3871A000, 0x3871C000, 0x3871E000, 
-				0x38720000, 0x38722000, 0x38724000, 0x38726000, 0x38728000, 0x3872A000, 0x3872C000, 0x3872E000, 0x38730000, 0x38732000, 0x38734000, 0x38736000, 0x38738000, 0x3873A000, 0x3873C000, 0x3873E000, 
-				0x38740000, 0x38742000, 0x38744000, 0x38746000, 0x38748000, 0x3874A000, 0x3874C000, 0x3874E000, 0x38750000, 0x38752000, 0x38754000, 0x38756000, 0x38758000, 0x3875A000, 0x3875C000, 0x3875E000, 
-				0x38760000, 0x38762000, 0x38764000, 0x38766000, 0x38768000, 0x3876A000, 0x3876C000, 0x3876E000, 0x38770000, 0x38772000, 0x38774000, 0x38776000, 0x38778000, 0x3877A000, 0x3877C000, 0x3877E000, 
-				0x38780000, 0x38782000, 0x38784000, 0x38786000, 0x38788000, 0x3878A000, 0x3878C000, 0x3878E000, 0x38790000, 0x38792000, 0x38794000, 0x38796000, 0x38798000, 0x3879A000, 0x3879C000, 0x3879E000, 
-				0x387A0000, 0x387A2000, 0x387A4000, 0x387A6000, 0x387A8000, 0x387AA000, 0x387AC000, 0x387AE000, 0x387B0000, 0x387B2000, 0x387B4000, 0x387B6000, 0x387B8000, 0x387BA000, 0x387BC000, 0x387BE000, 
-				0x387C0000, 0x387C2000, 0x387C4000, 0x387C6000, 0x387C8000, 0x387CA000, 0x387CC000, 0x387CE000, 0x387D0000, 0x387D2000, 0x387D4000, 0x387D6000, 0x387D8000, 0x387DA000, 0x387DC000, 0x387DE000, 
-				0x387E0000, 0x387E2000, 0x387E4000, 0x387E6000, 0x387E8000, 0x387EA000, 0x387EC000, 0x387EE000, 0x387F0000, 0x387F2000, 0x387F4000, 0x387F6000, 0x387F8000, 0x387FA000, 0x387FC000, 0x387FE000 };
-			static const uint32 exponent_table[64] = { 
-				0x00000000, 0x00800000, 0x01000000, 0x01800000, 0x02000000, 0x02800000, 0x03000000, 0x03800000, 0x04000000, 0x04800000, 0x05000000, 0x05800000, 0x06000000, 0x06800000, 0x07000000, 0x07800000, 
-				0x08000000, 0x08800000, 0x09000000, 0x09800000, 0x0A000000, 0x0A800000, 0x0B000000, 0x0B800000, 0x0C000000, 0x0C800000, 0x0D000000, 0x0D800000, 0x0E000000, 0x0E800000, 0x0F000000, 0x47800000, 
-				0x80000000, 0x80800000, 0x81000000, 0x81800000, 0x82000000, 0x82800000, 0x83000000, 0x83800000, 0x84000000, 0x84800000, 0x85000000, 0x85800000, 0x86000000, 0x86800000, 0x87000000, 0x87800000, 
-				0x88000000, 0x88800000, 0x89000000, 0x89800000, 0x8A000000, 0x8A800000, 0x8B000000, 0x8B800000, 0x8C000000, 0x8C800000, 0x8D000000, 0x8D800000, 0x8E000000, 0x8E800000, 0x8F000000, 0xC7800000 };
-			static const unsigned short offset_table[64] = { 
-				   0, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 
-				   0, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024 };
-			uint32 bits = mantissa_table[offset_table[value>>10]+(value&0x3FF)] + exponent_table[value>>10];
-//			return *reinterpret_cast<float*>(&bits);			//violating strict aliasing!
-			float out;
-			std::memcpy(&out, &bits, sizeof(float));
-			return out;
-		}
-
-		/// Convert half-precision to IEEE double-precision.
-		/// \param value binary representation of half-precision value
-		/// \return double-precision value
-		inline double half2float_impl(uint16 value, double, true_type)
-		{
-			typedef bits<float>::type uint32;
-			typedef bits<double>::type uint64;
-			uint32 hi = static_cast<uint32>(value&0x8000) << 16;
-			int abs = value & 0x7FFF;
-			if(abs)
-			{
-				hi |= 0x3F000000 << static_cast<unsigned>(abs>=0x7C00);
-				for(; abs<0x400; abs<<=1,hi-=0x100000) ;
-				hi += static_cast<uint32>(abs) << 10;
-			}
-			uint64 bits = static_cast<uint64>(hi) << 32;
-//			return *reinterpret_cast<double*>(&bits);			//violating strict aliasing!
-			double out;
-			std::memcpy(&out, &bits, sizeof(double));
-			return out;
-		}
-
-		/// Convert half-precision to non-IEEE floating point.
-		/// \tparam T type to convert to (builtin integer type)
-		/// \param value binary representation of half-precision value
-		/// \return floating point value
-		template<typename T> T half2float_impl(uint16 value, T, ...)
-		{
-			T out;
-			int abs = value & 0x7FFF;
-			if(abs > 0x7C00)
-				out = std::numeric_limits<T>::has_quiet_NaN ? std::numeric_limits<T>::quiet_NaN() : T();
-			else if(abs == 0x7C00)
-				out = std::numeric_limits<T>::has_infinity ? std::numeric_limits<T>::infinity() : std::numeric_limits<T>::max();
-			else if(abs > 0x3FF)
-				out = std::ldexp(static_cast<T>((abs&0x3FF)|0x400), (abs>>10)-25);
-			else
-				out = std::ldexp(static_cast<T>(abs), -24);
-			return (value&0x8000) ? -out : out;
-		}
-
-		/// Convert half-precision to floating point.
-		/// \tparam T type to convert to (builtin integer type)
-		/// \param value binary representation of half-precision value
-		/// \return floating point value
-		template<typename T> T half2float(uint16 value)
-		{
-			return half2float_impl(value, T(), bool_type<std::numeric_limits<T>::is_iec559&&sizeof(typename bits<T>::type)==sizeof(T)>());
-		}
-
-		/// Convert half-precision floating point to integer.
-		/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest rounding
-		/// \tparam E `true` for round to even, `false` for round away from zero
-		/// \tparam T type to convert to (buitlin integer type with at least 16 bits precision, excluding any implicit sign bits)
-		/// \param value binary representation of half-precision value
-		/// \return integral value
-		template<std::float_round_style R,bool E,typename T> T half2int_impl(uint16 value)
-		{
-		#if HALF_ENABLE_CPP11_STATIC_ASSERT && HALF_ENABLE_CPP11_TYPE_TRAITS
-			static_assert(std::is_integral<T>::value, "half to int conversion only supports builtin integer types");
-		#endif
-			unsigned int e = value & 0x7FFF;
-			if(e >= 0x7C00)
-				return (value&0x8000) ? std::numeric_limits<T>::min() : std::numeric_limits<T>::max();
-			if(e < 0x3800)
-			{
-				if(R == std::round_toward_infinity)
-					return T(~(value>>15)&(e!=0));
-				else if(R == std::round_toward_neg_infinity)
-					return -T(value>0x8000);
-				return T();
-			}
-			unsigned int m = (value&0x3FF) | 0x400;
-			e >>= 10;
-			if(e < 25)
-			{
-				if(R == std::round_to_nearest)
-					m += (1<<(24-e)) - (~(m>>(25-e))&E);
-				else if(R == std::round_toward_infinity)
-					m += ((value>>15)-1) & ((1<<(25-e))-1U);
-				else if(R == std::round_toward_neg_infinity)
-					m += -(value>>15) & ((1<<(25-e))-1U);
-				m >>= 25 - e;
-			}
-			else
-				m <<= e - 25;
-			return (value&0x8000) ? -static_cast<T>(m) : static_cast<T>(m);
-		}
-
-		/// Convert half-precision floating point to integer.
-		/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest rounding
-		/// \tparam T type to convert to (buitlin integer type with at least 16 bits precision, excluding any implicit sign bits)
-		/// \param value binary representation of half-precision value
-		/// \return integral value
-		template<std::float_round_style R,typename T> T half2int(uint16 value) { return half2int_impl<R,HALF_ROUND_TIES_TO_EVEN,T>(value); }
-
-		/// Convert half-precision floating point to integer using round-to-nearest-away-from-zero.
-		/// \tparam T type to convert to (buitlin integer type with at least 16 bits precision, excluding any implicit sign bits)
-		/// \param value binary representation of half-precision value
-		/// \return integral value
-		template<typename T> T half2int_up(uint16 value) { return half2int_impl<std::round_to_nearest,0,T>(value); }
-
-		/// Round half-precision number to nearest integer value.
-		/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest rounding
-		/// \tparam E `true` for round to even, `false` for round away from zero
-		/// \param value binary representation of half-precision value
-		/// \return half-precision bits for nearest integral value
-		template<std::float_round_style R,bool E> uint16 round_half_impl(uint16 value)
-		{
-			unsigned int e = value & 0x7FFF;
-			uint16 result = value;
-			if(e < 0x3C00)
-			{
-				result &= 0x8000;
-				if(R == std::round_to_nearest)
-					result |= 0x3C00U & -(e>=(0x3800+E));
-				else if(R == std::round_toward_infinity)
-					result |= 0x3C00U & -(~(value>>15)&(e!=0));
-				else if(R == std::round_toward_neg_infinity)
-					result |= 0x3C00U & -(value>0x8000);
-			}
-			else if(e < 0x6400)
-			{
-				e = 25 - (e>>10);
-				unsigned int mask = (1<<e) - 1;
-				if(R == std::round_to_nearest)
-					result += (1<<(e-1)) - (~(result>>e)&E);
-				else if(R == std::round_toward_infinity)
-					result += mask & ((value>>15)-1);
-				else if(R == std::round_toward_neg_infinity)
-					result += mask & -(value>>15);
-				result &= ~mask;
-			}
-			return result;
-		}
-
-		/// Round half-precision number to nearest integer value.
-		/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest rounding
-		/// \param value binary representation of half-precision value
-		/// \return half-precision bits for nearest integral value
-		template<std::float_round_style R> uint16 round_half(uint16 value) { return round_half_impl<R,HALF_ROUND_TIES_TO_EVEN>(value); }
-
-		/// Round half-precision number to nearest integer value using round-to-nearest-away-from-zero.
-		/// \param value binary representation of half-precision value
-		/// \return half-precision bits for nearest integral value
-		inline uint16 round_half_up(uint16 value) { return round_half_impl<std::round_to_nearest,0>(value); }
-		/// \}
-
-		struct functions;
-		template<typename> struct unary_specialized;
-		template<typename,typename> struct binary_specialized;
-		template<typename,typename,std::float_round_style> struct half_caster;
-	}
-
-	/// Half-precision floating point type.
-	/// This class implements an IEEE-conformant half-precision floating point type with the usual arithmetic operators and 
-	/// conversions. It is implicitly convertible to single-precision floating point, which makes artihmetic expressions and 
-	/// functions with mixed-type operands to be of the most precise operand type. Additionally all arithmetic operations 
-	/// (and many mathematical functions) are carried out in single-precision internally. All conversions from single- to 
-	/// half-precision are done using the library's default rounding mode, but temporary results inside chained arithmetic 
-	/// expressions are kept in single-precision as long as possible (while of course still maintaining a strong half-precision type).
-	///
-	/// According to the C++98/03 definition, the half type is not a POD type. But according to C++11's less strict and 
-	/// extended definitions it is both a standard layout type and a trivially copyable type (even if not a POD type), which 
-	/// means it can be standard-conformantly copied using raw binary copies. But in this context some more words about the 
-	/// actual size of the type. Although the half is representing an IEEE 16-bit type, it does not neccessarily have to be of 
-	/// exactly 16-bits size. But on any reasonable implementation the actual binary representation of this type will most 
-	/// probably not ivolve any additional "magic" or padding beyond the simple binary representation of the underlying 16-bit 
-	/// IEEE number, even if not strictly guaranteed by the standard. But even then it only has an actual size of 16 bits if 
-	/// your C++ implementation supports an unsigned integer type of exactly 16 bits width. But this should be the case on 
-	/// nearly any reasonable platform.
-	///
-	/// So if your C++ implementation is not totally exotic or imposes special alignment requirements, it is a reasonable 
-	/// assumption that the data of a half is just comprised of the 2 bytes of the underlying IEEE representation.
-	class half
-	{
-		friend struct detail::functions;
-		friend struct detail::unary_specialized<half>;
-		friend struct detail::binary_specialized<half,half>;
-		template<typename,typename,std::float_round_style> friend struct detail::half_caster;
-		friend class std::numeric_limits<half>;
-	#if HALF_ENABLE_CPP11_HASH
-		friend struct std::hash<half>;
-	#endif
-	#if HALF_ENABLE_CPP11_USER_LITERALS
-		friend half literal::operator""_h(long double);
-	#endif
-
-	public:
-		/// Default constructor.
-		/// This initializes the half to 0. Although this does not match the builtin types' default-initialization semantics 
-		/// and may be less efficient than no initialization, it is needed to provide proper value-initialization semantics.
-		HALF_CONSTEXPR half() HALF_NOEXCEPT : data_() {}
-
-		/// Copy constructor.
-		/// \tparam T type of concrete half expression
-		/// \param rhs half expression to copy from
-		half(detail::expr rhs) : data_(detail::float2half<round_style>(static_cast<float>(rhs))) {}
-
-		/// Conversion constructor.
-		/// \param rhs float to convert
-		explicit half(float rhs) : data_(detail::float2half<round_style>(rhs)) {}
-	
-		/// Conversion to single-precision.
-		/// \return single precision value representing expression value
-		operator float() const { return detail::half2float<float>(data_); }
-
-		/// Assignment operator.
-		/// \tparam T type of concrete half expression
-		/// \param rhs half expression to copy from
-		/// \return reference to this half
-		half& operator=(detail::expr rhs) { return *this = static_cast<float>(rhs); }
-
-		/// Arithmetic assignment.
-		/// \tparam T type of concrete half expression
-		/// \param rhs half expression to add
-		/// \return reference to this half
-		template<typename T> typename detail::enable<half&,T>::type operator+=(T rhs) { return *this += static_cast<float>(rhs); }
-
-		/// Arithmetic assignment.
-		/// \tparam T type of concrete half expression
-		/// \param rhs half expression to subtract
-		/// \return reference to this half
-		template<typename T> typename detail::enable<half&,T>::type operator-=(T rhs) { return *this -= static_cast<float>(rhs); }
-
-		/// Arithmetic assignment.
-		/// \tparam T type of concrete half expression
-		/// \param rhs half expression to multiply with
-		/// \return reference to this half
-		template<typename T> typename detail::enable<half&,T>::type operator*=(T rhs) { return *this *= static_cast<float>(rhs); }
-
-		/// Arithmetic assignment.
-		/// \tparam T type of concrete half expression
-		/// \param rhs half expression to divide by
-		/// \return reference to this half
-		template<typename T> typename detail::enable<half&,T>::type operator/=(T rhs) { return *this /= static_cast<float>(rhs); }
-
-		/// Assignment operator.
-		/// \param rhs single-precision value to copy from
-		/// \return reference to this half
-		half& operator=(float rhs) { data_ = detail::float2half<round_style>(rhs); return *this; }
-
-		/// Arithmetic assignment.
-		/// \param rhs single-precision value to add
-		/// \return reference to this half
-		half& operator+=(float rhs) { data_ = detail::float2half<round_style>(detail::half2float<float>(data_)+rhs); return *this; }
-
-		/// Arithmetic assignment.
-		/// \param rhs single-precision value to subtract
-		/// \return reference to this half
-		half& operator-=(float rhs) { data_ = detail::float2half<round_style>(detail::half2float<float>(data_)-rhs); return *this; }
-
-		/// Arithmetic assignment.
-		/// \param rhs single-precision value to multiply with
-		/// \return reference to this half
-		half& operator*=(float rhs) { data_ = detail::float2half<round_style>(detail::half2float<float>(data_)*rhs); return *this; }
-
-		/// Arithmetic assignment.
-		/// \param rhs single-precision value to divide by
-		/// \return reference to this half
-		half& operator/=(float rhs) { data_ = detail::float2half<round_style>(detail::half2float<float>(data_)/rhs); return *this; }
-
-		/// Prefix increment.
-		/// \return incremented half value
-		half& operator++() { return *this += 1.0f; }
-
-		/// Prefix decrement.
-		/// \return decremented half value
-		half& operator--() { return *this -= 1.0f; }
-
-		/// Postfix increment.
-		/// \return non-incremented half value
-		half operator++(int) { half out(*this); ++*this; return out; }
-
-		/// Postfix decrement.
-		/// \return non-decremented half value
-		half operator--(int) { half out(*this); --*this; return out; }
-	
-	private:
-		/// Rounding mode to use
-		static const std::float_round_style round_style = (std::float_round_style)(HALF_ROUND_STYLE);
-
-		/// Constructor.
-		/// \param bits binary representation to set half to
-		HALF_CONSTEXPR half(detail::binary_t, detail::uint16 bits) HALF_NOEXCEPT : data_(bits) {}
-
-		/// Internal binary representation
-		detail::uint16 data_;
-	};
-
-#if HALF_ENABLE_CPP11_USER_LITERALS
-	namespace literal
-	{
-		/// Half literal.
-		/// While this returns an actual half-precision value, half literals can unfortunately not be constant expressions due 
-		/// to rather involved conversions.
-		/// \param value literal value
-		/// \return half with given value (if representable)
-		inline half operator""_h(long double value) { return half(detail::binary, detail::float2half<half::round_style>(value)); }
-	}
+    /// Type traits for floating point types.
+    template <typename> struct is_float : false_type
+    {
+    };
+    template <typename T> struct is_float<const T> : is_float<T>
+    {
+    };
+    template <typename T> struct is_float<volatile T> : is_float<T>
+    {
+    };
+    template <typename T> struct is_float<const volatile T> : is_float<T>
+    {
+    };
+    template <> struct is_float<float> : true_type
+    {
+    };
+    template <> struct is_float<double> : true_type
+    {
+    };
+    template <> struct is_float<long double> : true_type
+    {
+    };
 #endif
 
-	namespace detail
-	{
-		/// Wrapper implementing unspecialized half-precision functions.
-		struct functions
-		{
-			/// Addition implementation.
-			/// \param x first operand
-			/// \param y second operand
-			/// \return Half-precision sum stored in single-precision
-			static expr plus(float x, float y) { return expr(x+y); }
+    /// Type traits for floating point bits.
+    template <typename T> struct bits
+    {
+      typedef unsigned char type;
+    };
+    template <typename T> struct bits<const T> : bits<T>
+    {
+    };
+    template <typename T> struct bits<volatile T> : bits<T>
+    {
+    };
+    template <typename T> struct bits<const volatile T> : bits<T>
+    {
+    };
+
+#if HALF_ENABLE_CPP11_CSTDINT
+    /// Unsigned integer of (at least) 16 bits width.
+    typedef std::uint_least16_t uint16;
+
+    /// Unsigned integer of (at least) 32 bits width.
+    template <> struct bits<float>
+    {
+      typedef std::uint_least32_t type;
+    };
+
+    /// Unsigned integer of (at least) 64 bits width.
+    template <> struct bits<double>
+    {
+      typedef std::uint_least64_t type;
+    };
+#else
+    /// Unsigned integer of (at least) 16 bits width.
+    typedef unsigned short uint16;
+
+    /// Unsigned integer of (at least) 32 bits width.
+    template <>
+    struct bits<float>
+        : conditional<std::numeric_limits<unsigned int>::digits >= 32,
+                      unsigned int, unsigned long>
+    {
+    };
 
-			/// Subtraction implementation.
-			/// \param x first operand
-			/// \param y second operand
-			/// \return Half-precision difference stored in single-precision
-			static expr minus(float x, float y) { return expr(x-y); }
-
-			/// Multiplication implementation.
-			/// \param x first operand
-			/// \param y second operand
-			/// \return Half-precision product stored in single-precision
-			static expr multiplies(float x, float y) { return expr(x*y); }
-
-			/// Division implementation.
-			/// \param x first operand
-			/// \param y second operand
-			/// \return Half-precision quotient stored in single-precision
-			static expr divides(float x, float y) { return expr(x/y); }
-
-			/// Output implementation.
-			/// \param out stream to write to
-			/// \param arg value to write
-			/// \return reference to stream
-			template<typename charT,typename traits> static std::basic_ostream<charT,traits>& write(std::basic_ostream<charT,traits> &out, float arg) { return out << arg; }
-
-			/// Input implementation.
-			/// \param in stream to read from
-			/// \param arg half to read into
-			/// \return reference to stream
-			template<typename charT,typename traits> static std::basic_istream<charT,traits>& read(std::basic_istream<charT,traits> &in, half &arg)
-			{
-				float f;
-				if(in >> f)
-					arg = f;
-				return in;
-			}
-
-			/// Modulo implementation.
-			/// \param x first operand
-			/// \param y second operand
-			/// \return Half-precision division remainder stored in single-precision
-			static expr fmod(float x, float y) { return expr(std::fmod(x, y)); }
-
-			/// Remainder implementation.
-			/// \param x first operand
-			/// \param y second operand
-			/// \return Half-precision division remainder stored in single-precision
-			static expr remainder(float x, float y)
-			{
-			#if HALF_ENABLE_CPP11_CMATH
-				return expr(std::remainder(x, y));
-			#else
-				if(builtin_isnan(x) || builtin_isnan(y))
-					return expr(std::numeric_limits<float>::quiet_NaN());
-				float ax = std::fabs(x), ay = std::fabs(y);
-				if(ax >= 65536.0f || ay < std::ldexp(1.0f, -24))
-					return expr(std::numeric_limits<float>::quiet_NaN());
-				if(ay >= 65536.0f)
-					return expr(x);
-				if(ax == ay)
-					return expr(builtin_signbit(x) ? -0.0f : 0.0f);
-				ax = std::fmod(ax, ay+ay);
-				float y2 = 0.5f * ay;
-				if(ax > y2)
-				{
-					ax -= ay;
-					if(ax >= y2)
-						ax -= ay;
-				}
-				return expr(builtin_signbit(x) ? -ax : ax);
-			#endif
-			}
-
-			/// Remainder implementation.
-			/// \param x first operand
-			/// \param y second operand
-			/// \param quo address to store quotient bits at
-			/// \return Half-precision division remainder stored in single-precision
-			static expr remquo(float x, float y, int *quo)
-			{
-			#if HALF_ENABLE_CPP11_CMATH
-				return expr(std::remquo(x, y, quo));
-			#else
-				if(builtin_isnan(x) || builtin_isnan(y))
-					return expr(std::numeric_limits<float>::quiet_NaN());
-				bool sign = builtin_signbit(x), qsign = static_cast<bool>(sign^builtin_signbit(y));
-				float ax = std::fabs(x), ay = std::fabs(y);
-				if(ax >= 65536.0f || ay < std::ldexp(1.0f, -24))
-					return expr(std::numeric_limits<float>::quiet_NaN());
-				if(ay >= 65536.0f)
-					return expr(x);
-				if(ax == ay)
-					return *quo = qsign ? -1 : 1, expr(sign ? -0.0f : 0.0f);
-				ax = std::fmod(ax, 8.0f*ay);
-				int cquo = 0;
-				if(ax >= 4.0f * ay)
-				{
-					ax -= 4.0f * ay;
-					cquo += 4;
-				}
-				if(ax >= 2.0f * ay)
-				{
-					ax -= 2.0f * ay;
-					cquo += 2;
-				}
-				float y2 = 0.5f * ay;
-				if(ax > y2)
-				{
-					ax -= ay;
-					++cquo;
-					if(ax >= y2)
-					{
-						ax -= ay;
-						++cquo;
-					}
-				}
-				return *quo = qsign ? -cquo : cquo, expr(sign ? -ax : ax);
-			#endif
-			}
-
-			/// Positive difference implementation.
-			/// \param x first operand
-			/// \param y second operand
-			/// \return Positive difference stored in single-precision
-			static expr fdim(float x, float y)
-			{
-			#if HALF_ENABLE_CPP11_CMATH
-				return expr(std::fdim(x, y));
-			#else
-				return expr((x<=y) ? 0.0f : (x-y));
-			#endif
-			}
-
-			/// Fused multiply-add implementation.
-			/// \param x first operand
-			/// \param y second operand
-			/// \param z third operand
-			/// \return \a x * \a y + \a z stored in single-precision
-			static expr fma(float x, float y, float z)
-			{
-			#if HALF_ENABLE_CPP11_CMATH && defined(FP_FAST_FMAF)
-				return expr(std::fma(x, y, z));
-			#else
-				return expr(x*y+z);
-			#endif
-			}
-
-			/// Get NaN.
-			/// \return Half-precision quiet NaN
-			static half nanh() { return half(binary, 0x7FFF); }
-
-			/// Exponential implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr exp(float arg) { return expr(std::exp(arg)); }
-
-			/// Exponential implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr expm1(float arg)
-			{
-			#if HALF_ENABLE_CPP11_CMATH
-				return expr(std::expm1(arg));
-			#else
-				return expr(static_cast<float>(std::exp(static_cast<double>(arg))-1.0));
-			#endif
-			}
-
-			/// Binary exponential implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr exp2(float arg)
-			{
-			#if HALF_ENABLE_CPP11_CMATH
-				return expr(std::exp2(arg));
-			#else
-				return expr(static_cast<float>(std::exp(arg*0.69314718055994530941723212145818)));
-			#endif
-			}
-
-			/// Logarithm implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr log(float arg) { return expr(std::log(arg)); }
-
-			/// Common logarithm implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr log10(float arg) { return expr(std::log10(arg)); }
-
-			/// Logarithm implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr log1p(float arg)
-			{
-			#if HALF_ENABLE_CPP11_CMATH
-				return expr(std::log1p(arg));
-			#else
-				return expr(static_cast<float>(std::log(1.0+arg)));
-			#endif
-			}
-
-			/// Binary logarithm implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr log2(float arg)
-			{
-			#if HALF_ENABLE_CPP11_CMATH
-				return expr(std::log2(arg));
-			#else
-				return expr(static_cast<float>(std::log(static_cast<double>(arg))*1.4426950408889634073599246810019));
-			#endif
-			}
-
-			/// Square root implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr sqrt(float arg) { return expr(std::sqrt(arg)); }
-
-			/// Cubic root implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr cbrt(float arg)
-			{
-			#if HALF_ENABLE_CPP11_CMATH
-				return expr(std::cbrt(arg));
-			#else
-				if(builtin_isnan(arg) || builtin_isinf(arg))
-					return expr(arg);
-				return expr(builtin_signbit(arg) ? -static_cast<float>(std::pow(-static_cast<double>(arg), 1.0/3.0)) : 
-					static_cast<float>(std::pow(static_cast<double>(arg), 1.0/3.0)));
-			#endif
-			}
-
-			/// Hypotenuse implementation.
-			/// \param x first argument
-			/// \param y second argument
-			/// \return function value stored in single-preicision
-			static expr hypot(float x, float y)
-			{
-			#if HALF_ENABLE_CPP11_CMATH
-				return expr(std::hypot(x, y));
-			#else
-				return expr((builtin_isinf(x) || builtin_isinf(y)) ? std::numeric_limits<float>::infinity() : 
-					static_cast<float>(std::sqrt(static_cast<double>(x)*x+static_cast<double>(y)*y)));
-			#endif
-			}
-
-			/// Power implementation.
-			/// \param base value to exponentiate
-			/// \param exp power to expontiate to
-			/// \return function value stored in single-preicision
-			static expr pow(float base, float exp) { return expr(std::pow(base, exp)); }
-
-			/// Sine implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr sin(float arg) { return expr(std::sin(arg)); }
-
-			/// Cosine implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr cos(float arg) { return expr(std::cos(arg)); }
-
-			/// Tan implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr tan(float arg) { return expr(std::tan(arg)); }
-
-			/// Arc sine implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr asin(float arg) { return expr(std::asin(arg)); }
-
-			/// Arc cosine implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr acos(float arg) { return expr(std::acos(arg)); }
-
-			/// Arc tangent implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr atan(float arg) { return expr(std::atan(arg)); }
-
-			/// Arc tangent implementation.
-			/// \param x first argument
-			/// \param y second argument
-			/// \return function value stored in single-preicision
-			static expr atan2(float x, float y) { return expr(std::atan2(x, y)); }
-
-			/// Hyperbolic sine implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr sinh(float arg) { return expr(std::sinh(arg)); }
-
-			/// Hyperbolic cosine implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr cosh(float arg) { return expr(std::cosh(arg)); }
-
-			/// Hyperbolic tangent implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr tanh(float arg) { return expr(std::tanh(arg)); }
-
-			/// Hyperbolic area sine implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr asinh(float arg)
-			{
-			#if HALF_ENABLE_CPP11_CMATH
-				return expr(std::asinh(arg));
-			#else
-				return expr((arg==-std::numeric_limits<float>::infinity()) ? arg : static_cast<float>(std::log(arg+std::sqrt(arg*arg+1.0))));
-			#endif
-			}
-
-			/// Hyperbolic area cosine implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr acosh(float arg)
-			{
-			#if HALF_ENABLE_CPP11_CMATH
-				return expr(std::acosh(arg));
-			#else
-				return expr((arg<-1.0f) ? std::numeric_limits<float>::quiet_NaN() : static_cast<float>(std::log(arg+std::sqrt(arg*arg-1.0))));
-			#endif
-			}
-
-			/// Hyperbolic area tangent implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr atanh(float arg)
-			{
-			#if HALF_ENABLE_CPP11_CMATH
-				return expr(std::atanh(arg));
-			#else
-				return expr(static_cast<float>(0.5*std::log((1.0+arg)/(1.0-arg))));
-			#endif
-			}
-
-			/// Error function implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr erf(float arg)
-			{
-			#if HALF_ENABLE_CPP11_CMATH
-				return expr(std::erf(arg));
-			#else
-				return expr(static_cast<float>(erf(static_cast<double>(arg))));
-			#endif
-			}
-
-			/// Complementary implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr erfc(float arg)
-			{
-			#if HALF_ENABLE_CPP11_CMATH
-				return expr(std::erfc(arg));
-			#else
-				return expr(static_cast<float>(1.0-erf(static_cast<double>(arg))));
-			#endif
-			}
-
-			/// Gamma logarithm implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr lgamma(float arg)
-			{
-			#if HALF_ENABLE_CPP11_CMATH
-				return expr(std::lgamma(arg));
-			#else
-				if(builtin_isinf(arg))
-					return expr(std::numeric_limits<float>::infinity());
-				if(arg < 0.0f)
-				{
-					float i, f = std::modf(-arg, &i);
-					if(f == 0.0f)
-						return expr(std::numeric_limits<float>::infinity());
-					return expr(static_cast<float>(1.1447298858494001741434273513531-
-						std::log(std::abs(std::sin(3.1415926535897932384626433832795*f)))-lgamma(1.0-arg)));
-				}
-				return expr(static_cast<float>(lgamma(static_cast<double>(arg))));
-			#endif
-			}
-
-			/// Gamma implementation.
-			/// \param arg function argument
-			/// \return function value stored in single-preicision
-			static expr tgamma(float arg)
-			{
-			#if HALF_ENABLE_CPP11_CMATH
-				return expr(std::tgamma(arg));
-			#else
-				if(arg == 0.0f)
-					return builtin_signbit(arg) ? expr(-std::numeric_limits<float>::infinity()) : expr(std::numeric_limits<float>::infinity());
-				if(arg < 0.0f)
-				{
-					float i, f = std::modf(-arg, &i);
-					if(f == 0.0f)
-						return expr(std::numeric_limits<float>::quiet_NaN());
-					double value = 3.1415926535897932384626433832795 / (std::sin(3.1415926535897932384626433832795*f)*std::exp(lgamma(1.0-arg)));
-					return expr(static_cast<float>((std::fmod(i, 2.0f)==0.0f) ? -value : value));
-				}
-				if(builtin_isinf(arg))
-					return expr(arg);
-				return expr(static_cast<float>(std::exp(lgamma(static_cast<double>(arg)))));
-			#endif
-			}
-
-			/// Floor implementation.
-			/// \param arg value to round
-			/// \return rounded value
-			static half floor(half arg) { return half(binary, round_half<std::round_toward_neg_infinity>(arg.data_)); }
-
-			/// Ceiling implementation.
-			/// \param arg value to round
-			/// \return rounded value
-			static half ceil(half arg) { return half(binary, round_half<std::round_toward_infinity>(arg.data_)); }
-
-			/// Truncation implementation.
-			/// \param arg value to round
-			/// \return rounded value
-			static half trunc(half arg) { return half(binary, round_half<std::round_toward_zero>(arg.data_)); }
-
-			/// Nearest integer implementation.
-			/// \param arg value to round
-			/// \return rounded value
-			static half round(half arg) { return half(binary, round_half_up(arg.data_)); }
-
-			/// Nearest integer implementation.
-			/// \param arg value to round
-			/// \return rounded value
-			static long lround(half arg) { return detail::half2int_up<long>(arg.data_); }
-
-			/// Nearest integer implementation.
-			/// \param arg value to round
-			/// \return rounded value
-			static half rint(half arg) { return half(binary, round_half<half::round_style>(arg.data_)); }
-
-			/// Nearest integer implementation.
-			/// \param arg value to round
-			/// \return rounded value
-			static long lrint(half arg) { return detail::half2int<half::round_style,long>(arg.data_); }
-
-		#if HALF_ENABLE_CPP11_LONG_LONG
-			/// Nearest integer implementation.
-			/// \param arg value to round
-			/// \return rounded value
-			static long long llround(half arg) { return detail::half2int_up<long long>(arg.data_); }
-
-			/// Nearest integer implementation.
-			/// \param arg value to round
-			/// \return rounded value
-			static long long llrint(half arg) { return detail::half2int<half::round_style,long long>(arg.data_); }
-		#endif
-
-			/// Decompression implementation.
-			/// \param arg number to decompress
-			/// \param exp address to store exponent at
-			/// \return normalized significant
-			static half frexp(half arg, int *exp)
-			{
-				int m = arg.data_ & 0x7FFF, e = -14;
-				if(m >= 0x7C00 || !m)
-					return *exp = 0, arg;
-				for(; m<0x400; m<<=1,--e) ;
-				return *exp = e+(m>>10), half(binary, (arg.data_&0x8000)|0x3800|(m&0x3FF));
-			}
-
-			/// Decompression implementation.
-			/// \param arg number to decompress
-			/// \param iptr address to store integer part at
-			/// \return fractional part
-			static half modf(half arg, half *iptr)
-			{
-				unsigned int e = arg.data_ & 0x7FFF;
-				if(e >= 0x6400)
-					return *iptr = arg, half(binary, arg.data_&(0x8000U|-(e>0x7C00)));
-				if(e < 0x3C00)
-					return iptr->data_ = arg.data_ & 0x8000, arg;
-				e >>= 10;
-				unsigned int mask = (1<<(25-e)) - 1, m = arg.data_ & mask;
-				iptr->data_ = arg.data_ & ~mask;
-				if(!m)
-					return half(binary, arg.data_&0x8000);
-				for(; m<0x400; m<<=1,--e) ;
-				return half(binary, static_cast<uint16>((arg.data_&0x8000)|(e<<10)|(m&0x3FF)));
-			}
-
-			/// Scaling implementation.
-			/// \param arg number to scale
-			/// \param exp power of two to scale by
-			/// \return scaled number
-			static half scalbln(half arg, long exp)
-			{
-				unsigned int m = arg.data_ & 0x7FFF;
-				if(m >= 0x7C00 || !m)
-					return arg;
-				for(; m<0x400; m<<=1,--exp) ;
-				exp += m >> 10;
-				uint16 value = arg.data_ & 0x8000;
-				if(exp > 30)
-				{
-					if(half::round_style == std::round_toward_zero)
-						value |= 0x7BFF;
-					else if(half::round_style == std::round_toward_infinity)
-						value |= 0x7C00 - (value>>15);
-					else if(half::round_style == std::round_toward_neg_infinity)
-						value |= 0x7BFF + (value>>15);
-					else
-						value |= 0x7C00;
-				}
-				else if(exp > 0)
-					value |= (exp<<10) | (m&0x3FF);
-				else if(exp > -11)
-				{
-					m = (m&0x3FF) | 0x400;
-					if(half::round_style == std::round_to_nearest)
-					{
-						m += 1 << -exp;
-					#if HALF_ROUND_TIES_TO_EVEN
-						m -= (m>>(1-exp)) & 1;
-					#endif
-					}
-					else if(half::round_style == std::round_toward_infinity)
-						m += ((value>>15)-1) & ((1<<(1-exp))-1U);
-					else if(half::round_style == std::round_toward_neg_infinity)
-						m += -(value>>15) & ((1<<(1-exp))-1U);
-					value |= m >> (1-exp);
-				}
-				else if(half::round_style == std::round_toward_infinity)
-					value -= (value>>15) - 1;
-				else if(half::round_style == std::round_toward_neg_infinity)
-					value += value >> 15;
-				return half(binary, value);
-			}
-
-			/// Exponent implementation.
-			/// \param arg number to query
-			/// \return floating point exponent
-			static int ilogb(half arg)
-			{
-				int abs = arg.data_ & 0x7FFF;
-				if(!abs)
-					return FP_ILOGB0;
-				if(abs < 0x7C00)
-				{
-					int exp = (abs>>10) - 15;
-					if(abs < 0x400)
-						for(; abs<0x200; abs<<=1,--exp) ;
-					return exp;
-				}
-				if(abs > 0x7C00)
-					return FP_ILOGBNAN;
-				return INT_MAX;
-			}
-
-			/// Exponent implementation.
-			/// \param arg number to query
-			/// \return floating point exponent
-			static half logb(half arg)
-			{
-				int abs = arg.data_ & 0x7FFF;
-				if(!abs)
-					return half(binary, 0xFC00);
-				if(abs < 0x7C00)
-				{
-					int exp = (abs>>10) - 15;
-					if(abs < 0x400)
-						for(; abs<0x200; abs<<=1,--exp) ;
-					uint16 bits = (exp<0) << 15;
-					if(exp)
-					{
-						unsigned int m = std::abs(exp) << 6, e = 18;
-						for(; m<0x400; m<<=1,--e) ;
-						bits |= (e<<10) + m;
-					}
-					return half(binary, bits);
-				}
-				if(abs > 0x7C00)
-					return arg;
-				return half(binary, 0x7C00);
-			}
-
-			/// Enumeration implementation.
-			/// \param from number to increase/decrease
-			/// \param to direction to enumerate into
-			/// \return next representable number
-			static half nextafter(half from, half to)
-			{
-				uint16 fabs = from.data_ & 0x7FFF, tabs = to.data_ & 0x7FFF;
-				if(fabs > 0x7C00)
-					return from;
-				if(tabs > 0x7C00 || from.data_ == to.data_ || !(fabs|tabs))
-					return to;
-				if(!fabs)
-					return half(binary, (to.data_&0x8000)+1);
-				bool lt = ((fabs==from.data_) ? static_cast<int>(fabs) : -static_cast<int>(fabs)) < 
-					((tabs==to.data_) ? static_cast<int>(tabs) : -static_cast<int>(tabs));
-				return half(binary, from.data_+(((from.data_>>15)^static_cast<unsigned>(lt))<<1)-1);
-			}
-
-			/// Enumeration implementation.
-			/// \param from number to increase/decrease
-			/// \param to direction to enumerate into
-			/// \return next representable number
-			static half nexttoward(half from, long double to)
-			{
-				if(isnan(from))
-					return from;
-				long double lfrom = static_cast<long double>(from);
-				if(builtin_isnan(to) || lfrom == to)
-					return half(static_cast<float>(to));
-				if(!(from.data_&0x7FFF))
-					return half(binary, (static_cast<detail::uint16>(builtin_signbit(to))<<15)+1);
-				return half(binary, from.data_+(((from.data_>>15)^static_cast<unsigned>(lfrom<to))<<1)-1);
-			}
-
-			/// Sign implementation
-			/// \param x first operand
-			/// \param y second operand
-			/// \return composed value
-			static half copysign(half x, half y) { return half(binary, x.data_^((x.data_^y.data_)&0x8000)); }
-
-			/// Classification implementation.
-			/// \param arg value to classify
-			/// \retval true if infinite number
-			/// \retval false else
-			static int fpclassify(half arg)
-			{
-				unsigned int abs = arg.data_ & 0x7FFF;
-				return abs ? ((abs>0x3FF) ? ((abs>=0x7C00) ? ((abs>0x7C00) ? FP_NAN : FP_INFINITE) : FP_NORMAL) :FP_SUBNORMAL) : FP_ZERO;
-			}
-
-			/// Classification implementation.
-			/// \param arg value to classify
-			/// \retval true if finite number
-			/// \retval false else
-			static bool isfinite(half arg) { return (arg.data_&0x7C00) != 0x7C00; }
-
-			/// Classification implementation.
-			/// \param arg value to classify
-			/// \retval true if infinite number
-			/// \retval false else
-			static bool isinf(half arg) { return (arg.data_&0x7FFF) == 0x7C00; }
-
-			/// Classification implementation.
-			/// \param arg value to classify
-			/// \retval true if not a number
-			/// \retval false else
-			static bool isnan(half arg) { return (arg.data_&0x7FFF) > 0x7C00; }
-
-			/// Classification implementation.
-			/// \param arg value to classify
-			/// \retval true if normal number
-			/// \retval false else
-			static bool isnormal(half arg) { return ((arg.data_&0x7C00)!=0) & ((arg.data_&0x7C00)!=0x7C00); }
-
-			/// Sign bit implementation.
-			/// \param arg value to check
-			/// \retval true if signed
-			/// \retval false if unsigned
-			static bool signbit(half arg) { return (arg.data_&0x8000) != 0; }
-
-			/// Comparison implementation.
-			/// \param x first operand
-			/// \param y second operand
-			/// \retval true if operands equal
-			/// \retval false else
-			static bool isequal(half x, half y) { return (x.data_==y.data_ || !((x.data_|y.data_)&0x7FFF)) && !isnan(x); }
-
-			/// Comparison implementation.
-			/// \param x first operand
-			/// \param y second operand
-			/// \retval true if operands not equal
-			/// \retval false else
-			static bool isnotequal(half x, half y) { return (x.data_!=y.data_ && ((x.data_|y.data_)&0x7FFF)) || isnan(x); }
-
-			/// Comparison implementation.
-			/// \param x first operand
-			/// \param y second operand
-			/// \retval true if \a x > \a y
-			/// \retval false else
-			static bool isgreater(half x, half y)
-			{
-				int xabs = x.data_ & 0x7FFF, yabs = y.data_ & 0x7FFF;
-				return xabs<=0x7C00 && yabs<=0x7C00 && (((xabs==x.data_) ? xabs : -xabs) > ((yabs==y.data_) ? yabs : -yabs));
-			}
-
-			/// Comparison implementation.
-			/// \param x first operand
-			/// \param y second operand
-			/// \retval true if \a x >= \a y
-			/// \retval false else
-			static bool isgreaterequal(half x, half y)
-			{
-				int xabs = x.data_ & 0x7FFF, yabs = y.data_ & 0x7FFF;
-				return xabs<=0x7C00 && yabs<=0x7C00 && (((xabs==x.data_) ? xabs : -xabs) >= ((yabs==y.data_) ? yabs : -yabs));
-			}
-
-			/// Comparison implementation.
-			/// \param x first operand
-			/// \param y second operand
-			/// \retval true if \a x < \a y
-			/// \retval false else
-			static bool isless(half x, half y)
-			{
-				int xabs = x.data_ & 0x7FFF, yabs = y.data_ & 0x7FFF;
-				return xabs<=0x7C00 && yabs<=0x7C00 && (((xabs==x.data_) ? xabs : -xabs) < ((yabs==y.data_) ? yabs : -yabs));
-			}
-
-			/// Comparison implementation.
-			/// \param x first operand
-			/// \param y second operand
-			/// \retval true if \a x <= \a y
-			/// \retval false else
-			static bool islessequal(half x, half y)
-			{
-				int xabs = x.data_ & 0x7FFF, yabs = y.data_ & 0x7FFF;
-				return xabs<=0x7C00 && yabs<=0x7C00 && (((xabs==x.data_) ? xabs : -xabs) <= ((yabs==y.data_) ? yabs : -yabs));
-			}
-
-			/// Comparison implementation.
-			/// \param x first operand
-			/// \param y second operand
-			/// \retval true if either \a x > \a y nor \a x < \a y
-			/// \retval false else
-			static bool islessgreater(half x, half y)
-			{
-				int xabs = x.data_ & 0x7FFF, yabs = y.data_ & 0x7FFF;
-				if(xabs > 0x7C00 || yabs > 0x7C00)
-					return false;
-				int a = (xabs==x.data_) ? xabs : -xabs, b = (yabs==y.data_) ? yabs : -yabs;
-				return a < b || a > b;
-			}
-
-			/// Comparison implementation.
-			/// \param x first operand
-			/// \param y second operand
-			/// \retval true if operand unordered
-			/// \retval false else
-			static bool isunordered(half x, half y) { return isnan(x) || isnan(y); }
-
-		private:
-			static double erf(double arg)
-			{
-				if(builtin_isinf(arg))
-					return (arg<0.0) ? -1.0 : 1.0;
-				double x2 = arg * arg, ax2 = 0.147 * x2, value = std::sqrt(1.0-std::exp(-x2*(1.2732395447351626861510701069801+ax2)/(1.0+ax2)));
-				return builtin_signbit(arg) ? -value : value;
-			}
-
-			static double lgamma(double arg)
-			{
-				double v = 1.0;
-				for(; arg<8.0; ++arg) v *= arg;
-				double w = 1.0 / (arg*arg);
-				return (((((((-0.02955065359477124183006535947712*w+0.00641025641025641025641025641026)*w+
-					-0.00191752691752691752691752691753)*w+8.4175084175084175084175084175084e-4)*w+
-					-5.952380952380952380952380952381e-4)*w+7.9365079365079365079365079365079e-4)*w+
-					-0.00277777777777777777777777777778)*w+0.08333333333333333333333333333333)/arg + 
-					0.91893853320467274178032973640562 - std::log(v) - arg + (arg-0.5) * std::log(arg);
-			}
-		};
-
-		/// Wrapper for unary half-precision functions needing specialization for individual argument types.
-		/// \tparam T argument type
-		template<typename T> struct unary_specialized
-		{
-			/// Negation implementation.
-			/// \param arg value to negate
-			/// \return negated value
-			static HALF_CONSTEXPR half negate(half arg) { return half(binary, arg.data_^0x8000); }
-
-			/// Absolute value implementation.
-			/// \param arg function argument
-			/// \return absolute value
-			static half fabs(half arg) { return half(binary, arg.data_&0x7FFF); }
-		};
-		template<> struct unary_specialized<expr>
-		{
-			static HALF_CONSTEXPR expr negate(float arg) { return expr(-arg); }
-			static expr fabs(float arg) { return expr(std::fabs(arg)); }
-		};
-
-		/// Wrapper for binary half-precision functions needing specialization for individual argument types.
-		/// \tparam T first argument type
-		/// \tparam U first argument type
-		template<typename T,typename U> struct binary_specialized
-		{
-			/// Minimum implementation.
-			/// \param x first operand
-			/// \param y second operand
-			/// \return minimum value
-			static expr fmin(float x, float y)
-			{
-			#if HALF_ENABLE_CPP11_CMATH
-				return expr(std::fmin(x, y));
-			#else
-				if(builtin_isnan(x))
-					return expr(y);
-				if(builtin_isnan(y))
-					return expr(x);
-				return expr(std::min(x, y));
-			#endif
-			}
-
-			/// Maximum implementation.
-			/// \param x first operand
-			/// \param y second operand
-			/// \return maximum value
-			static expr fmax(float x, float y)
-			{
-			#if HALF_ENABLE_CPP11_CMATH
-				return expr(std::fmax(x, y));
-			#else
-				if(builtin_isnan(x))
-					return expr(y);
-				if(builtin_isnan(y))
-					return expr(x);
-				return expr(std::max(x, y));
-			#endif
-			}
-		};
-		template<> struct binary_specialized<half,half>
-		{
-			static half fmin(half x, half y)
-			{
-				int xabs = x.data_ & 0x7FFF, yabs = y.data_ & 0x7FFF;
-				if(xabs > 0x7C00)
-					return y;
-				if(yabs > 0x7C00)
-					return x;
-				return (((xabs==x.data_) ? xabs : -xabs) > ((yabs==y.data_) ? yabs : -yabs)) ? y : x;
-			}
-			static half fmax(half x, half y)
-			{
-				int xabs = x.data_ & 0x7FFF, yabs = y.data_ & 0x7FFF;
-				if(xabs > 0x7C00)
-					return y;
-				if(yabs > 0x7C00)
-					return x;
-				return (((xabs==x.data_) ? xabs : -xabs) < ((yabs==y.data_) ? yabs : -yabs)) ? y : x;
-			}
-		};
-
-		/// Helper class for half casts.
-		/// This class template has to be specialized for all valid cast argument to define an appropriate static `cast` member 
-		/// function and a corresponding `type` member denoting its return type.
-		/// \tparam T destination type
-		/// \tparam U source type
-		/// \tparam R rounding mode to use
-		template<typename T,typename U,std::float_round_style R=(std::float_round_style)(HALF_ROUND_STYLE)> struct half_caster {};
-		template<typename U,std::float_round_style R> struct half_caster<half,U,R>
-		{
-		#if HALF_ENABLE_CPP11_STATIC_ASSERT && HALF_ENABLE_CPP11_TYPE_TRAITS
-			static_assert(std::is_arithmetic<U>::value, "half_cast from non-arithmetic type unsupported");
-		#endif
-
-			static half cast(U arg) { return cast_impl(arg, is_float<U>()); };
-
-		private:
-			static half cast_impl(U arg, true_type) { return half(binary, float2half<R>(arg)); }
-			static half cast_impl(U arg, false_type) { return half(binary, int2half<R>(arg)); }
-		};
-		template<typename T,std::float_round_style R> struct half_caster<T,half,R>
-		{
-		#if HALF_ENABLE_CPP11_STATIC_ASSERT && HALF_ENABLE_CPP11_TYPE_TRAITS
-			static_assert(std::is_arithmetic<T>::value, "half_cast to non-arithmetic type unsupported");
-		#endif
-
-			static T cast(half arg) { return cast_impl(arg, is_float<T>()); }
-
-		private:
-			static T cast_impl(half arg, true_type) { return half2float<T>(arg.data_); }
-			static T cast_impl(half arg, false_type) { return half2int<R,T>(arg.data_); }
-		};
-		template<typename T,std::float_round_style R> struct half_caster<T,expr,R>
-		{
-		#if HALF_ENABLE_CPP11_STATIC_ASSERT && HALF_ENABLE_CPP11_TYPE_TRAITS
-			static_assert(std::is_arithmetic<T>::value, "half_cast to non-arithmetic type unsupported");
-		#endif
-
-			static T cast(expr arg) { return cast_impl(arg, is_float<T>()); }
-
-		private:
-			static T cast_impl(float arg, true_type) { return static_cast<T>(arg); }
-			static T cast_impl(half arg, false_type) { return half2int<R,T>(arg.data_); }
-		};
-		template<std::float_round_style R> struct half_caster<half,half,R>
-		{
-			static half cast(half arg) { return arg; }
-		};
-		template<std::float_round_style R> struct half_caster<half,expr,R> : half_caster<half,half,R> {};
-
-		/// \name Comparison operators
-		/// \{
-
-		/// Comparison for equality.
-		/// \param x first operand
-		/// \param y second operand
-		/// \retval true if operands equal
-		/// \retval false else
-		template<typename T,typename U> typename enable<bool,T,U>::type operator==(T x, U y) { return functions::isequal(x, y); }
-
-		/// Comparison for inequality.
-		/// \param x first operand
-		/// \param y second operand
-		/// \retval true if operands not equal
-		/// \retval false else
-		template<typename T,typename U> typename enable<bool,T,U>::type operator!=(T x, U y) { return functions::isnotequal(x, y); }
-
-		/// Comparison for less than.
-		/// \param x first operand
-		/// \param y second operand
-		/// \retval true if \a x less than \a y
-		/// \retval false else
-		template<typename T,typename U> typename enable<bool,T,U>::type operator<(T x, U y) { return functions::isless(x, y); }
-
-		/// Comparison for greater than.
-		/// \param x first operand
-		/// \param y second operand
-		/// \retval true if \a x greater than \a y
-		/// \retval false else
-		template<typename T,typename U> typename enable<bool,T,U>::type operator>(T x, U y) { return functions::isgreater(x, y); }
-
-		/// Comparison for less equal.
-		/// \param x first operand
-		/// \param y second operand
-		/// \retval true if \a x less equal \a y
-		/// \retval false else
-		template<typename T,typename U> typename enable<bool,T,U>::type operator<=(T x, U y) { return functions::islessequal(x, y); }
-
-		/// Comparison for greater equal.
-		/// \param x first operand
-		/// \param y second operand
-		/// \retval true if \a x greater equal \a y
-		/// \retval false else
-		template<typename T,typename U> typename enable<bool,T,U>::type operator>=(T x, U y) { return functions::isgreaterequal(x, y); }
-
-		/// \}
-		/// \name Arithmetic operators
-		/// \{
-
-		/// Add halfs.
-		/// \param x left operand
-		/// \param y right operand
-		/// \return sum of half expressions
-		template<typename T,typename U> typename enable<expr,T,U>::type operator+(T x, U y) { return functions::plus(x, y); }
-
-		/// Subtract halfs.
-		/// \param x left operand
-		/// \param y right operand
-		/// \return difference of half expressions
-		template<typename T,typename U> typename enable<expr,T,U>::type operator-(T x, U y) { return functions::minus(x, y); }
-
-		/// Multiply halfs.
-		/// \param x left operand
-		/// \param y right operand
-		/// \return product of half expressions
-		template<typename T,typename U> typename enable<expr,T,U>::type operator*(T x, U y) { return functions::multiplies(x, y); }
-
-		/// Divide halfs.
-		/// \param x left operand
-		/// \param y right operand
-		/// \return quotient of half expressions
-		template<typename T,typename U> typename enable<expr,T,U>::type operator/(T x, U y) { return functions::divides(x, y); }
-
-		/// Identity.
-		/// \param arg operand
-		/// \return uncahnged operand
-		template<typename T> HALF_CONSTEXPR typename enable<T,T>::type operator+(T arg) { return arg; }
-
-		/// Negation.
-		/// \param arg operand
-		/// \return negated operand
-		template<typename T> HALF_CONSTEXPR typename enable<T,T>::type operator-(T arg) { return unary_specialized<T>::negate(arg); }
-
-		/// \}
-		/// \name Input and output
-		/// \{
-
-		/// Output operator.
-		/// \param out output stream to write into
-		/// \param arg half expression to write
-		/// \return reference to output stream
-		template<typename T,typename charT,typename traits> typename enable<std::basic_ostream<charT,traits>&,T>::type
-			operator<<(std::basic_ostream<charT,traits> &out, T arg) { return functions::write(out, arg); }
-
-		/// Input operator.
-		/// \param in input stream to read from
-		/// \param arg half to read into
-		/// \return reference to input stream
-		template<typename charT,typename traits> std::basic_istream<charT,traits>&
-			operator>>(std::basic_istream<charT,traits> &in, half &arg) { return functions::read(in, arg); }
-
-		/// \}
-		/// \name Basic mathematical operations
-		/// \{
-
-		/// Absolute value.
-		/// \param arg operand
-		/// \return absolute value of \a arg
-//		template<typename T> typename enable<T,T>::type abs(T arg) { return unary_specialized<T>::fabs(arg); }
-		inline half abs(half arg) { return unary_specialized<half>::fabs(arg); }
-		inline expr abs(expr arg) { return unary_specialized<expr>::fabs(arg); }
-
-		/// Absolute value.
-		/// \param arg operand
-		/// \return absolute value of \a arg
-//		template<typename T> typename enable<T,T>::type fabs(T arg) { return unary_specialized<T>::fabs(arg); }
-		inline half fabs(half arg) { return unary_specialized<half>::fabs(arg); }
-		inline expr fabs(expr arg) { return unary_specialized<expr>::fabs(arg); }
-
-		/// Remainder of division.
-		/// \param x first operand
-		/// \param y second operand
-		/// \return remainder of floating point division.
-//		template<typename T,typename U> typename enable<expr,T,U>::type fmod(T x, U y) { return functions::fmod(x, y); }
-		inline expr fmod(half x, half y) { return functions::fmod(x, y); }
-		inline expr fmod(half x, expr y) { return functions::fmod(x, y); }
-		inline expr fmod(expr x, half y) { return functions::fmod(x, y); }
-		inline expr fmod(expr x, expr y) { return functions::fmod(x, y); }
-
-		/// Remainder of division.
-		/// \param x first operand
-		/// \param y second operand
-		/// \return remainder of floating point division.
-//		template<typename T,typename U> typename enable<expr,T,U>::type remainder(T x, U y) { return functions::remainder(x, y); }
-		inline expr remainder(half x, half y) { return functions::remainder(x, y); }
-		inline expr remainder(half x, expr y) { return functions::remainder(x, y); }
-		inline expr remainder(expr x, half y) { return functions::remainder(x, y); }
-		inline expr remainder(expr x, expr y) { return functions::remainder(x, y); }
-
-		/// Remainder of division.
-		/// \param x first operand
-		/// \param y second operand
-		/// \param quo address to store some bits of quotient at
-		/// \return remainder of floating point division.
-//		template<typename T,typename U> typename enable<expr,T,U>::type remquo(T x, U y, int *quo) { return functions::remquo(x, y, quo); }
-		inline expr remquo(half x, half y, int *quo) { return functions::remquo(x, y, quo); }
-		inline expr remquo(half x, expr y, int *quo) { return functions::remquo(x, y, quo); }
-		inline expr remquo(expr x, half y, int *quo) { return functions::remquo(x, y, quo); }
-		inline expr remquo(expr x, expr y, int *quo) { return functions::remquo(x, y, quo); }
-
-		/// Fused multiply add.
-		/// \param x first operand
-		/// \param y second operand
-		/// \param z third operand
-		/// \return ( \a x * \a y ) + \a z rounded as one operation.
-//		template<typename T,typename U,typename V> typename enable<expr,T,U,V>::type fma(T x, U y, V z) { return functions::fma(x, y, z); }
-		inline expr fma(half x, half y, half z) { return functions::fma(x, y, z); }
-		inline expr fma(half x, half y, expr z) { return functions::fma(x, y, z); }
-		inline expr fma(half x, expr y, half z) { return functions::fma(x, y, z); }
-		inline expr fma(half x, expr y, expr z) { return functions::fma(x, y, z); }
-		inline expr fma(expr x, half y, half z) { return functions::fma(x, y, z); }
-		inline expr fma(expr x, half y, expr z) { return functions::fma(x, y, z); }
-		inline expr fma(expr x, expr y, half z) { return functions::fma(x, y, z); }
-		inline expr fma(expr x, expr y, expr z) { return functions::fma(x, y, z); }
-
-		/// Maximum of half expressions.
-		/// \param x first operand
-		/// \param y second operand
-		/// \return maximum of operands
-//		template<typename T,typename U> typename result<T,U>::type fmax(T x, U y) { return binary_specialized<T,U>::fmax(x, y); }
-		inline half fmax(half x, half y) { return binary_specialized<half,half>::fmax(x, y); }
-		inline expr fmax(half x, expr y) { return binary_specialized<half,expr>::fmax(x, y); }
-		inline expr fmax(expr x, half y) { return binary_specialized<expr,half>::fmax(x, y); }
-		inline expr fmax(expr x, expr y) { return binary_specialized<expr,expr>::fmax(x, y); }
-
-		/// Minimum of half expressions.
-		/// \param x first operand
-		/// \param y second operand
-		/// \return minimum of operands
-//		template<typename T,typename U> typename result<T,U>::type fmin(T x, U y) { return binary_specialized<T,U>::fmin(x, y); }
-		inline half fmin(half x, half y) { return binary_specialized<half,half>::fmin(x, y); }
-		inline expr fmin(half x, expr y) { return binary_specialized<half,expr>::fmin(x, y); }
-		inline expr fmin(expr x, half y) { return binary_specialized<expr,half>::fmin(x, y); }
-		inline expr fmin(expr x, expr y) { return binary_specialized<expr,expr>::fmin(x, y); }
-
-		/// Positive difference.
-		/// \param x first operand
-		/// \param y second operand
-		/// \return \a x - \a y or 0 if difference negative
-//		template<typename T,typename U> typename enable<expr,T,U>::type fdim(T x, U y) { return functions::fdim(x, y); }
-		inline expr fdim(half x, half y) { return functions::fdim(x, y); }
-		inline expr fdim(half x, expr y) { return functions::fdim(x, y); }
-		inline expr fdim(expr x, half y) { return functions::fdim(x, y); }
-		inline expr fdim(expr x, expr y) { return functions::fdim(x, y); }
-
-		/// Get NaN value.
-		/// \return quiet NaN
-		inline half nanh(const char*) { return functions::nanh(); }
-
-		/// \}
-		/// \name Exponential functions
-		/// \{
-
-		/// Exponential function.
-		/// \param arg function argument
-		/// \return e raised to \a arg
-//		template<typename T> typename enable<expr,T>::type exp(T arg) { return functions::exp(arg); }
-		inline expr exp(half arg) { return functions::exp(arg); }
-		inline expr exp(expr arg) { return functions::exp(arg); }
-
-		/// Exponential minus one.
-		/// \param arg function argument
-		/// \return e raised to \a arg subtracted by 1
-//		template<typename T> typename enable<expr,T>::type expm1(T arg) { return functions::expm1(arg); }
-		inline expr expm1(half arg) { return functions::expm1(arg); }
-		inline expr expm1(expr arg) { return functions::expm1(arg); }
-
-		/// Binary exponential.
-		/// \param arg function argument
-		/// \return 2 raised to \a arg
-//		template<typename T> typename enable<expr,T>::type exp2(T arg) { return functions::exp2(arg); }
-		inline expr exp2(half arg) { return functions::exp2(arg); }
-		inline expr exp2(expr arg) { return functions::exp2(arg); }
-
-		/// Natural logorithm.
-		/// \param arg function argument
-		/// \return logarithm of \a arg to base e
-//		template<typename T> typename enable<expr,T>::type log(T arg) { return functions::log(arg); }
-		inline expr log(half arg) { return functions::log(arg); }
-		inline expr log(expr arg) { return functions::log(arg); }
-
-		/// Common logorithm.
-		/// \param arg function argument
-		/// \return logarithm of \a arg to base 10
-//		template<typename T> typename enable<expr,T>::type log10(T arg) { return functions::log10(arg); }
-		inline expr log10(half arg) { return functions::log10(arg); }
-		inline expr log10(expr arg) { return functions::log10(arg); }
-
-		/// Natural logorithm.
-		/// \param arg function argument
-		/// \return logarithm of \a arg plus 1 to base e
-//		template<typename T> typename enable<expr,T>::type log1p(T arg) { return functions::log1p(arg); }
-		inline expr log1p(half arg) { return functions::log1p(arg); }
-		inline expr log1p(expr arg) { return functions::log1p(arg); }
-
-		/// Binary logorithm.
-		/// \param arg function argument
-		/// \return logarithm of \a arg to base 2
-//		template<typename T> typename enable<expr,T>::type log2(T arg) { return functions::log2(arg); }
-		inline expr log2(half arg) { return functions::log2(arg); }
-		inline expr log2(expr arg) { return functions::log2(arg); }
-
-		/// \}
-		/// \name Power functions
-		/// \{
-
-		/// Square root.
-		/// \param arg function argument
-		/// \return square root of \a arg
-//		template<typename T> typename enable<expr,T>::type sqrt(T arg) { return functions::sqrt(arg); }
-		inline expr sqrt(half arg) { return functions::sqrt(arg); }
-		inline expr sqrt(expr arg) { return functions::sqrt(arg); }
-
-		/// Cubic root.
-		/// \param arg function argument
-		/// \return cubic root of \a arg
-//		template<typename T> typename enable<expr,T>::type cbrt(T arg) { return functions::cbrt(arg); }
-		inline expr cbrt(half arg) { return functions::cbrt(arg); }
-		inline expr cbrt(expr arg) { return functions::cbrt(arg); }
-
-		/// Hypotenuse function.
-		/// \param x first argument
-		/// \param y second argument
-		/// \return square root of sum of squares without internal over- or underflows
-//		template<typename T,typename U> typename enable<expr,T,U>::type hypot(T x, U y) { return functions::hypot(x, y); }
-		inline expr hypot(half x, half y) { return functions::hypot(x, y); }
-		inline expr hypot(half x, expr y) { return functions::hypot(x, y); }
-		inline expr hypot(expr x, half y) { return functions::hypot(x, y); }
-		inline expr hypot(expr x, expr y) { return functions::hypot(x, y); }
-
-		/// Power function.
-		/// \param base first argument
-		/// \param exp second argument
-		/// \return \a base raised to \a exp
-//		template<typename T,typename U> typename enable<expr,T,U>::type pow(T base, U exp) { return functions::pow(base, exp); }
-		inline expr pow(half base, half exp) { return functions::pow(base, exp); }
-		inline expr pow(half base, expr exp) { return functions::pow(base, exp); }
-		inline expr pow(expr base, half exp) { return functions::pow(base, exp); }
-		inline expr pow(expr base, expr exp) { return functions::pow(base, exp); }
-
-		/// \}
-		/// \name Trigonometric functions
-		/// \{
-
-		/// Sine function.
-		/// \param arg function argument
-		/// \return sine value of \a arg
-//		template<typename T> typename enable<expr,T>::type sin(T arg) { return functions::sin(arg); }
-		inline expr sin(half arg) { return functions::sin(arg); }
-		inline expr sin(expr arg) { return functions::sin(arg); }
-
-		/// Cosine function.
-		/// \param arg function argument
-		/// \return cosine value of \a arg
-//		template<typename T> typename enable<expr,T>::type cos(T arg) { return functions::cos(arg); }
-		inline expr cos(half arg) { return functions::cos(arg); }
-		inline expr cos(expr arg) { return functions::cos(arg); }
-
-		/// Tangent function.
-		/// \param arg function argument
-		/// \return tangent value of \a arg
-//		template<typename T> typename enable<expr,T>::type tan(T arg) { return functions::tan(arg); }
-		inline expr tan(half arg) { return functions::tan(arg); }
-		inline expr tan(expr arg) { return functions::tan(arg); }
-
-		/// Arc sine.
-		/// \param arg function argument
-		/// \return arc sine value of \a arg
-//		template<typename T> typename enable<expr,T>::type asin(T arg) { return functions::asin(arg); }
-		inline expr asin(half arg) { return functions::asin(arg); }
-		inline expr asin(expr arg) { return functions::asin(arg); }
-
-		/// Arc cosine function.
-		/// \param arg function argument
-		/// \return arc cosine value of \a arg
-//		template<typename T> typename enable<expr,T>::type acos(T arg) { return functions::acos(arg); }
-		inline expr acos(half arg) { return functions::acos(arg); }
-		inline expr acos(expr arg) { return functions::acos(arg); }
-
-		/// Arc tangent function.
-		/// \param arg function argument
-		/// \return arc tangent value of \a arg
-//		template<typename T> typename enable<expr,T>::type atan(T arg) { return functions::atan(arg); }
-		inline expr atan(half arg) { return functions::atan(arg); }
-		inline expr atan(expr arg) { return functions::atan(arg); }
-
-		/// Arc tangent function.
-		/// \param x first argument
-		/// \param y second argument
-		/// \return arc tangent value
-//		template<typename T,typename U> typename enable<expr,T,U>::type atan2(T x, U y) { return functions::atan2(x, y); }
-		inline expr atan2(half x, half y) { return functions::atan2(x, y); }
-		inline expr atan2(half x, expr y) { return functions::atan2(x, y); }
-		inline expr atan2(expr x, half y) { return functions::atan2(x, y); }
-		inline expr atan2(expr x, expr y) { return functions::atan2(x, y); }
-
-		/// \}
-		/// \name Hyperbolic functions
-		/// \{
-
-		/// Hyperbolic sine.
-		/// \param arg function argument
-		/// \return hyperbolic sine value of \a arg
-//		template<typename T> typename enable<expr,T>::type sinh(T arg) { return functions::sinh(arg); }
-		inline expr sinh(half arg) { return functions::sinh(arg); }
-		inline expr sinh(expr arg) { return functions::sinh(arg); }
-
-		/// Hyperbolic cosine.
-		/// \param arg function argument
-		/// \return hyperbolic cosine value of \a arg
-//		template<typename T> typename enable<expr,T>::type cosh(T arg) { return functions::cosh(arg); }
-		inline expr cosh(half arg) { return functions::cosh(arg); }
-		inline expr cosh(expr arg) { return functions::cosh(arg); }
-
-		/// Hyperbolic tangent.
-		/// \param arg function argument
-		/// \return hyperbolic tangent value of \a arg
-//		template<typename T> typename enable<expr,T>::type tanh(T arg) { return functions::tanh(arg); }
-		inline expr tanh(half arg) { return functions::tanh(arg); }
-		inline expr tanh(expr arg) { return functions::tanh(arg); }
-
-		/// Hyperbolic area sine.
-		/// \param arg function argument
-		/// \return area sine value of \a arg
-//		template<typename T> typename enable<expr,T>::type asinh(T arg) { return functions::asinh(arg); }
-		inline expr asinh(half arg) { return functions::asinh(arg); }
-		inline expr asinh(expr arg) { return functions::asinh(arg); }
-
-		/// Hyperbolic area cosine.
-		/// \param arg function argument
-		/// \return area cosine value of \a arg
-//		template<typename T> typename enable<expr,T>::type acosh(T arg) { return functions::acosh(arg); }
-		inline expr acosh(half arg) { return functions::acosh(arg); }
-		inline expr acosh(expr arg) { return functions::acosh(arg); }
-
-		/// Hyperbolic area tangent.
-		/// \param arg function argument
-		/// \return area tangent value of \a arg
-//		template<typename T> typename enable<expr,T>::type atanh(T arg) { return functions::atanh(arg); }
-		inline expr atanh(half arg) { return functions::atanh(arg); }
-		inline expr atanh(expr arg) { return functions::atanh(arg); }
-
-		/// \}
-		/// \name Error and gamma functions
-		/// \{
-
-		/// Error function.
-		/// \param arg function argument
-		/// \return error function value of \a arg
-//		template<typename T> typename enable<expr,T>::type erf(T arg) { return functions::erf(arg); }
-		inline expr erf(half arg) { return functions::erf(arg); }
-		inline expr erf(expr arg) { return functions::erf(arg); }
-
-		/// Complementary error function.
-		/// \param arg function argument
-		/// \return 1 minus error function value of \a arg
-//		template<typename T> typename enable<expr,T>::type erfc(T arg) { return functions::erfc(arg); }
-		inline expr erfc(half arg) { return functions::erfc(arg); }
-		inline expr erfc(expr arg) { return functions::erfc(arg); }
-
-		/// Natural logarithm of gamma function.
-		/// \param arg function argument
-		/// \return natural logarith of gamma function for \a arg
-//		template<typename T> typename enable<expr,T>::type lgamma(T arg) { return functions::lgamma(arg); }
-		inline expr lgamma(half arg) { return functions::lgamma(arg); }
-		inline expr lgamma(expr arg) { return functions::lgamma(arg); }
-
-		/// Gamma function.
-		/// \param arg function argument
-		/// \return gamma function value of \a arg
-//		template<typename T> typename enable<expr,T>::type tgamma(T arg) { return functions::tgamma(arg); }
-		inline expr tgamma(half arg) { return functions::tgamma(arg); }
-		inline expr tgamma(expr arg) { return functions::tgamma(arg); }
-
-		/// \}
-		/// \name Rounding
-		/// \{
-
-		/// Nearest integer not less than half value.
-		/// \param arg half to round
-		/// \return nearest integer not less than \a arg
-//		template<typename T> typename enable<half,T>::type ceil(T arg) { return functions::ceil(arg); }
-		inline half ceil(half arg) { return functions::ceil(arg); }
-		inline half ceil(expr arg) { return functions::ceil(arg); }
-
-		/// Nearest integer not greater than half value.
-		/// \param arg half to round
-		/// \return nearest integer not greater than \a arg
-//		template<typename T> typename enable<half,T>::type floor(T arg) { return functions::floor(arg); }
-		inline half floor(half arg) { return functions::floor(arg); }
-		inline half floor(expr arg) { return functions::floor(arg); }
-
-		/// Nearest integer not greater in magnitude than half value.
-		/// \param arg half to round
-		/// \return nearest integer not greater in magnitude than \a arg
-//		template<typename T> typename enable<half,T>::type trunc(T arg) { return functions::trunc(arg); }
-		inline half trunc(half arg) { return functions::trunc(arg); }
-		inline half trunc(expr arg) { return functions::trunc(arg); }
-
-		/// Nearest integer.
-		/// \param arg half to round
-		/// \return nearest integer, rounded away from zero in half-way cases
-//		template<typename T> typename enable<half,T>::type round(T arg) { return functions::round(arg); }
-		inline half round(half arg) { return functions::round(arg); }
-		inline half round(expr arg) { return functions::round(arg); }
-
-		/// Nearest integer.
-		/// \param arg half to round
-		/// \return nearest integer, rounded away from zero in half-way cases
-//		template<typename T> typename enable<long,T>::type lround(T arg) { return functions::lround(arg); }
-		inline long lround(half arg) { return functions::lround(arg); }
-		inline long lround(expr arg) { return functions::lround(arg); }
-
-		/// Nearest integer using half's internal rounding mode.
-		/// \param arg half expression to round
-		/// \return nearest integer using default rounding mode
-//		template<typename T> typename enable<half,T>::type nearbyint(T arg) { return functions::nearbyint(arg); }
-		inline half nearbyint(half arg) { return functions::rint(arg); }
-		inline half nearbyint(expr arg) { return functions::rint(arg); }
-
-		/// Nearest integer using half's internal rounding mode.
-		/// \param arg half expression to round
-		/// \return nearest integer using default rounding mode
-//		template<typename T> typename enable<half,T>::type rint(T arg) { return functions::rint(arg); }
-		inline half rint(half arg) { return functions::rint(arg); }
-		inline half rint(expr arg) { return functions::rint(arg); }
-
-		/// Nearest integer using half's internal rounding mode.
-		/// \param arg half expression to round
-		/// \return nearest integer using default rounding mode
-//		template<typename T> typename enable<long,T>::type lrint(T arg) { return functions::lrint(arg); }
-		inline long lrint(half arg) { return functions::lrint(arg); }
-		inline long lrint(expr arg) { return functions::lrint(arg); }
-	#if HALF_ENABLE_CPP11_LONG_LONG
-		/// Nearest integer.
-		/// \param arg half to round
-		/// \return nearest integer, rounded away from zero in half-way cases
-//		template<typename T> typename enable<long long,T>::type llround(T arg) { return functions::llround(arg); }
-		inline long long llround(half arg) { return functions::llround(arg); }
-		inline long long llround(expr arg) { return functions::llround(arg); }
-
-		/// Nearest integer using half's internal rounding mode.
-		/// \param arg half expression to round
-		/// \return nearest integer using default rounding mode
-//		template<typename T> typename enable<long long,T>::type llrint(T arg) { return functions::llrint(arg); }
-		inline long long llrint(half arg) { return functions::llrint(arg); }
-		inline long long llrint(expr arg) { return functions::llrint(arg); }
-	#endif
-
-		/// \}
-		/// \name Floating point manipulation
-		/// \{
-
-		/// Decompress floating point number.
-		/// \param arg number to decompress
-		/// \param exp address to store exponent at
-		/// \return significant in range [0.5, 1)
-//		template<typename T> typename enable<half,T>::type frexp(T arg, int *exp) { return functions::frexp(arg, exp); }
-		inline half frexp(half arg, int *exp) { return functions::frexp(arg, exp); }
-		inline half frexp(expr arg, int *exp) { return functions::frexp(arg, exp); }
-
-		/// Multiply by power of two.
-		/// \param arg number to modify
-		/// \param exp power of two to multiply with
-		/// \return \a arg multplied by 2 raised to \a exp
-//		template<typename T> typename enable<half,T>::type ldexp(T arg, int exp) { return functions::scalbln(arg, exp); }
-		inline half ldexp(half arg, int exp) { return functions::scalbln(arg, exp); }
-		inline half ldexp(expr arg, int exp) { return functions::scalbln(arg, exp); }
-
-		/// Extract integer and fractional parts.
-		/// \param arg number to decompress
-		/// \param iptr address to store integer part at
-		/// \return fractional part
-//		template<typename T> typename enable<half,T>::type modf(T arg, half *iptr) { return functions::modf(arg, iptr); }
-		inline half modf(half arg, half *iptr) { return functions::modf(arg, iptr); }
-		inline half modf(expr arg, half *iptr) { return functions::modf(arg, iptr); }
-
-		/// Multiply by power of two.
-		/// \param arg number to modify
-		/// \param exp power of two to multiply with
-		/// \return \a arg multplied by 2 raised to \a exp
-//		template<typename T> typename enable<half,T>::type scalbn(T arg, int exp) { return functions::scalbln(arg, exp); }
-		inline half scalbn(half arg, int exp) { return functions::scalbln(arg, exp); }
-		inline half scalbn(expr arg, int exp) { return functions::scalbln(arg, exp); }
-
-		/// Multiply by power of two.
-		/// \param arg number to modify
-		/// \param exp power of two to multiply with
-		/// \return \a arg multplied by 2 raised to \a exp	
-//		template<typename T> typename enable<half,T>::type scalbln(T arg, long exp) { return functions::scalbln(arg, exp); }
-		inline half scalbln(half arg, long exp) { return functions::scalbln(arg, exp); }
-		inline half scalbln(expr arg, long exp) { return functions::scalbln(arg, exp); }
-
-		/// Extract exponent.
-		/// \param arg number to query
-		/// \return floating point exponent
-		/// \retval FP_ILOGB0 for zero
-		/// \retval FP_ILOGBNAN for NaN
-		/// \retval MAX_INT for infinity
-//		template<typename T> typename enable<int,T>::type ilogb(T arg) { return functions::ilogb(arg); }
-		inline int ilogb(half arg) { return functions::ilogb(arg); }
-		inline int ilogb(expr arg) { return functions::ilogb(arg); }
-
-		/// Extract exponent.
-		/// \param arg number to query
-		/// \return floating point exponent
-//		template<typename T> typename enable<half,T>::type logb(T arg) { return functions::logb(arg); }
-		inline half logb(half arg) { return functions::logb(arg); }
-		inline half logb(expr arg) { return functions::logb(arg); }
-
-		/// Next representable value.
-		/// \param from value to compute next representable value for
-		/// \param to direction towards which to compute next value
-		/// \return next representable value after \a from in direction towards \a to
-//		template<typename T,typename U> typename enable<half,T,U>::type nextafter(T from, U to) { return functions::nextafter(from, to); }
-		inline half nextafter(half from, half to) { return functions::nextafter(from, to); }
-		inline half nextafter(half from, expr to) { return functions::nextafter(from, to); }
-		inline half nextafter(expr from, half to) { return functions::nextafter(from, to); }
-		inline half nextafter(expr from, expr to) { return functions::nextafter(from, to); }
-
-		/// Next representable value.
-		/// \param from value to compute next representable value for
-		/// \param to direction towards which to compute next value
-		/// \return next representable value after \a from in direction towards \a to
-//		template<typename T> typename enable<half,T>::type nexttoward(T from, long double to) { return functions::nexttoward(from, to); }
-		inline half nexttoward(half from, long double to) { return functions::nexttoward(from, to); }
-		inline half nexttoward(expr from, long double to) { return functions::nexttoward(from, to); }
-
-		/// Take sign.
-		/// \param x value to change sign for
-		/// \param y value to take sign from
-		/// \return value equal to \a x in magnitude and to \a y in sign
-//		template<typename T,typename U> typename enable<half,T,U>::type copysign(T x, U y) { return functions::copysign(x, y); }
-		inline half copysign(half x, half y) { return functions::copysign(x, y); }
-		inline half copysign(half x, expr y) { return functions::copysign(x, y); }
-		inline half copysign(expr x, half y) { return functions::copysign(x, y); }
-		inline half copysign(expr x, expr y) { return functions::copysign(x, y); }
-
-		/// \}
-		/// \name Floating point classification
-		/// \{
-
-
-		/// Classify floating point value.
-		/// \param arg number to classify
-		/// \retval FP_ZERO for positive and negative zero
-		/// \retval FP_SUBNORMAL for subnormal numbers
-		/// \retval FP_INFINITY for positive and negative infinity
-		/// \retval FP_NAN for NaNs
-		/// \retval FP_NORMAL for all other (normal) values
-//		template<typename T> typename enable<int,T>::type fpclassify(T arg) { return functions::fpclassify(arg); }
-		inline int fpclassify(half arg) { return functions::fpclassify(arg); }
-		inline int fpclassify(expr arg) { return functions::fpclassify(arg); }
-
-		/// Check if finite number.
-		/// \param arg number to check
-		/// \retval true if neither infinity nor NaN
-		/// \retval false else
-//		template<typename T> typename enable<bool,T>::type isfinite(T arg) { return functions::isfinite(arg); }
-		inline bool isfinite(half arg) { return functions::isfinite(arg); }
-		inline bool isfinite(expr arg) { return functions::isfinite(arg); }
-
-		/// Check for infinity.
-		/// \param arg number to check
-		/// \retval true for positive or negative infinity
-		/// \retval false else
-//		template<typename T> typename enable<bool,T>::type isinf(T arg) { return functions::isinf(arg); }
-		inline bool isinf(half arg) { return functions::isinf(arg); }
-		inline bool isinf(expr arg) { return functions::isinf(arg); }
-
-		/// Check for NaN.
-		/// \param arg number to check
-		/// \retval true for NaNs
-		/// \retval false else
-//		template<typename T> typename enable<bool,T>::type isnan(T arg) { return functions::isnan(arg); }
-		inline bool isnan(half arg) { return functions::isnan(arg); }
-		inline bool isnan(expr arg) { return functions::isnan(arg); }
-
-		/// Check if normal number.
-		/// \param arg number to check
-		/// \retval true if normal number
-		/// \retval false if either subnormal, zero, infinity or NaN
-//		template<typename T> typename enable<bool,T>::type isnormal(T arg) { return functions::isnormal(arg); }
-		inline bool isnormal(half arg) { return functions::isnormal(arg); }
-		inline bool isnormal(expr arg) { return functions::isnormal(arg); }
-
-		/// Check sign.
-		/// \param arg number to check
-		/// \retval true for negative number
-		/// \retval false for positive number
-//		template<typename T> typename enable<bool,T>::type signbit(T arg) { return functions::signbit(arg); }
-		inline bool signbit(half arg) { return functions::signbit(arg); }
-		inline bool signbit(expr arg) { return functions::signbit(arg); }
-
-		/// \}
-		/// \name Comparison
-		/// \{
-
-		/// Comparison for greater than.
-		/// \param x first operand
-		/// \param y second operand
-		/// \retval true if \a x greater than \a y
-		/// \retval false else
-//		template<typename T,typename U> typename enable<bool,T,U>::type isgreater(T x, U y) { return functions::isgreater(x, y); }
-		inline bool isgreater(half x, half y) { return functions::isgreater(x, y); }
-		inline bool isgreater(half x, expr y) { return functions::isgreater(x, y); }
-		inline bool isgreater(expr x, half y) { return functions::isgreater(x, y); }
-		inline bool isgreater(expr x, expr y) { return functions::isgreater(x, y); }
-
-		/// Comparison for greater equal.
-		/// \param x first operand
-		/// \param y second operand
-		/// \retval true if \a x greater equal \a y
-		/// \retval false else
-//		template<typename T,typename U> typename enable<bool,T,U>::type isgreaterequal(T x, U y) { return functions::isgreaterequal(x, y); }
-		inline bool isgreaterequal(half x, half y) { return functions::isgreaterequal(x, y); }
-		inline bool isgreaterequal(half x, expr y) { return functions::isgreaterequal(x, y); }
-		inline bool isgreaterequal(expr x, half y) { return functions::isgreaterequal(x, y); }
-		inline bool isgreaterequal(expr x, expr y) { return functions::isgreaterequal(x, y); }
-
-		/// Comparison for less than.
-		/// \param x first operand
-		/// \param y second operand
-		/// \retval true if \a x less than \a y
-		/// \retval false else
-//		template<typename T,typename U> typename enable<bool,T,U>::type isless(T x, U y) { return functions::isless(x, y); }
-		inline bool isless(half x, half y) { return functions::isless(x, y); }
-		inline bool isless(half x, expr y) { return functions::isless(x, y); }
-		inline bool isless(expr x, half y) { return functions::isless(x, y); }
-		inline bool isless(expr x, expr y) { return functions::isless(x, y); }
-
-		/// Comparison for less equal.
-		/// \param x first operand
-		/// \param y second operand
-		/// \retval true if \a x less equal \a y
-		/// \retval false else
-//		template<typename T,typename U> typename enable<bool,T,U>::type islessequal(T x, U y) { return functions::islessequal(x, y); }
-		inline bool islessequal(half x, half y) { return functions::islessequal(x, y); }
-		inline bool islessequal(half x, expr y) { return functions::islessequal(x, y); }
-		inline bool islessequal(expr x, half y) { return functions::islessequal(x, y); }
-		inline bool islessequal(expr x, expr y) { return functions::islessequal(x, y); }
-
-		/// Comarison for less or greater.
-		/// \param x first operand
-		/// \param y second operand
-		/// \retval true if either less or greater
-		/// \retval false else
-//		template<typename T,typename U> typename enable<bool,T,U>::type islessgreater(T x, U y) { return functions::islessgreater(x, y); }
-		inline bool islessgreater(half x, half y) { return functions::islessgreater(x, y); }
-		inline bool islessgreater(half x, expr y) { return functions::islessgreater(x, y); }
-		inline bool islessgreater(expr x, half y) { return functions::islessgreater(x, y); }
-		inline bool islessgreater(expr x, expr y) { return functions::islessgreater(x, y); }
-
-		/// Check if unordered.
-		/// \param x first operand
-		/// \param y second operand
-		/// \retval true if unordered (one or two NaN operands)
-		/// \retval false else
-//		template<typename T,typename U> typename enable<bool,T,U>::type isunordered(T x, U y) { return functions::isunordered(x, y); }
-		inline bool isunordered(half x, half y) { return functions::isunordered(x, y); }
-		inline bool isunordered(half x, expr y) { return functions::isunordered(x, y); }
-		inline bool isunordered(expr x, half y) { return functions::isunordered(x, y); }
-		inline bool isunordered(expr x, expr y) { return functions::isunordered(x, y); }
-
-		/// \name Casting
-		/// \{
-
-		/// Cast to or from half-precision floating point number.
-		/// This casts between [half](\ref half_float::half) and any built-in arithmetic type. The values are converted 
-		/// directly using the given rounding mode, without any roundtrip over `float` that a `static_cast` would otherwise do. 
-		/// It uses the default rounding mode.
-		///
-		/// Using this cast with neither of the two types being a [half](\ref half_float::half) or with any of the two types 
-		/// not being a built-in arithmetic type (apart from [half](\ref half_float::half), of course) results in a compiler 
-		/// error and casting between [half](\ref half_float::half)s is just a no-op.
-		/// \tparam T destination type (half or built-in arithmetic type)
-		/// \tparam U source type (half or built-in arithmetic type)
-		/// \param arg value to cast
-		/// \return \a arg converted to destination type
-		template<typename T,typename U> T half_cast(U arg) { return half_caster<T,U>::cast(arg); }
-
-		/// Cast to or from half-precision floating point number.
-		/// This casts between [half](\ref half_float::half) and any built-in arithmetic type. The values are converted 
-		/// directly using the given rounding mode, without any roundtrip over `float` that a `static_cast` would otherwise do.
-		///
-		/// Using this cast with neither of the two types being a [half](\ref half_float::half) or with any of the two types 
-		/// not being a built-in arithmetic type (apart from [half](\ref half_float::half), of course) results in a compiler 
-		/// error and casting between [half](\ref half_float::half)s is just a no-op.
-		/// \tparam T destination type (half or built-in arithmetic type)
-		/// \tparam R rounding mode to use.
-		/// \tparam U source type (half or built-in arithmetic type)
-		/// \param arg value to cast
-		/// \return \a arg converted to destination type
-		template<typename T,std::float_round_style R,typename U> T half_cast(U arg) { return half_caster<T,U,R>::cast(arg); }
-		/// \}
-	}
-
-	using detail::operator==;
-	using detail::operator!=;
-	using detail::operator<;
-	using detail::operator>;
-	using detail::operator<=;
-	using detail::operator>=;
-	using detail::operator+;
-	using detail::operator-;
-	using detail::operator*;
-	using detail::operator/;
-	using detail::operator<<;
-	using detail::operator>>;
-
-	using detail::abs;
-	using detail::fabs;
-	using detail::fmod;
-	using detail::remainder;
-	using detail::remquo;
-	using detail::fma;
-	using detail::fmax;
-	using detail::fmin;
-	using detail::fdim;
-	using detail::nanh;
-	using detail::exp;
-	using detail::expm1;
-	using detail::exp2;
-	using detail::log;
-	using detail::log10;
-	using detail::log1p;
-	using detail::log2;
-	using detail::sqrt;
-	using detail::cbrt;
-	using detail::hypot;
-	using detail::pow;
-	using detail::sin;
-	using detail::cos;
-	using detail::tan;
-	using detail::asin;
-	using detail::acos;
-	using detail::atan;
-	using detail::atan2;
-	using detail::sinh;
-	using detail::cosh;
-	using detail::tanh;
-	using detail::asinh;
-	using detail::acosh;
-	using detail::atanh;
-	using detail::erf;
-	using detail::erfc;
-	using detail::lgamma;
-	using detail::tgamma;
-	using detail::ceil;
-	using detail::floor;
-	using detail::trunc;
-	using detail::round;
-	using detail::lround;
-	using detail::nearbyint;
-	using detail::rint;
-	using detail::lrint;
 #if HALF_ENABLE_CPP11_LONG_LONG
-	using detail::llround;
-	using detail::llrint;
+    /// Unsigned integer of (at least) 64 bits width.
+    template <>
+    struct bits<double>
+        : conditional<std::numeric_limits<unsigned long>::digits >= 64,
+                      unsigned long, unsigned long long>
+    {
+    };
+#else
+    /// Unsigned integer of (at least) 64 bits width.
+    template <> struct bits<double>
+    {
+      typedef unsigned long type;
+    };
 #endif
-	using detail::frexp;
-	using detail::ldexp;
-	using detail::modf;
-	using detail::scalbn;
-	using detail::scalbln;
-	using detail::ilogb;
-	using detail::logb;
-	using detail::nextafter;
-	using detail::nexttoward;
-	using detail::copysign;
-	using detail::fpclassify;
-	using detail::isfinite;
-	using detail::isinf;
-	using detail::isnan;
-	using detail::isnormal;
-	using detail::signbit;
-	using detail::isgreater;
-	using detail::isgreaterequal;
-	using detail::isless;
-	using detail::islessequal;
-	using detail::islessgreater;
-	using detail::isunordered;
+#endif
 
-	using detail::half_cast;
+    /// Tag type for binary construction.
+    struct binary_t
+    {
+    };
+
+    /// Tag for binary construction.
+    HALF_CONSTEXPR_CONST binary_t binary = binary_t();
+
+    /// Temporary half-precision expression.
+    /// This class represents a half-precision expression which just stores a
+    /// single-precision value internally.
+    struct expr
+    {
+      /// Conversion constructor.
+      /// \param f single-precision value to convert
+      explicit HALF_CONSTEXPR expr(float f) HALF_NOEXCEPT : value_(f)
+      {
+      }
+
+      /// Conversion to single-precision.
+      /// \return single precision value representing expression value
+      HALF_CONSTEXPR operator float() const HALF_NOEXCEPT
+      {
+        return value_;
+      }
+
+    private:
+      /// Internal expression value stored in single-precision.
+      float value_;
+    };
+
+    /// SFINAE helper for generic half-precision functions.
+    /// This class template has to be specialized for each valid combination of
+    /// argument types to provide a corresponding `type` member equivalent to
+    /// \a T. \tparam T type to return
+    template <typename T, typename, typename = void, typename = void>
+    struct enable
+    {
+    };
+    template <typename T> struct enable<T, half, void, void>
+    {
+      typedef T type;
+    };
+    template <typename T> struct enable<T, expr, void, void>
+    {
+      typedef T type;
+    };
+    template <typename T> struct enable<T, half, half, void>
+    {
+      typedef T type;
+    };
+    template <typename T> struct enable<T, half, expr, void>
+    {
+      typedef T type;
+    };
+    template <typename T> struct enable<T, expr, half, void>
+    {
+      typedef T type;
+    };
+    template <typename T> struct enable<T, expr, expr, void>
+    {
+      typedef T type;
+    };
+    template <typename T> struct enable<T, half, half, half>
+    {
+      typedef T type;
+    };
+    template <typename T> struct enable<T, half, half, expr>
+    {
+      typedef T type;
+    };
+    template <typename T> struct enable<T, half, expr, half>
+    {
+      typedef T type;
+    };
+    template <typename T> struct enable<T, half, expr, expr>
+    {
+      typedef T type;
+    };
+    template <typename T> struct enable<T, expr, half, half>
+    {
+      typedef T type;
+    };
+    template <typename T> struct enable<T, expr, half, expr>
+    {
+      typedef T type;
+    };
+    template <typename T> struct enable<T, expr, expr, half>
+    {
+      typedef T type;
+    };
+    template <typename T> struct enable<T, expr, expr, expr>
+    {
+      typedef T type;
+    };
+
+    /// Return type for specialized generic 2-argument half-precision
+    /// functions. This class template has to be specialized for each valid
+    /// combination of argument types to provide a corresponding `type` member
+    /// denoting the appropriate return type. \tparam T first argument type
+    /// \tparam U first argument type
+    template <typename T, typename U> struct result : enable<expr, T, U>
+    {
+    };
+    template <> struct result<half, half>
+    {
+      typedef half type;
+    };
+
+    /// \name Classification helpers
+    /// \{
+
+    /// Check for infinity.
+    /// \tparam T argument type (builtin floating point type)
+    /// \param arg value to query
+    /// \retval true if infinity
+    /// \retval false else
+    template <typename T> bool builtin_isinf(T arg)
+    {
+#if HALF_ENABLE_CPP11_CMATH
+      return std::isinf(arg);
+#elif defined(_MSC_VER)
+      return !::_finite(static_cast<double>(arg))
+             && !::_isnan(static_cast<double>(arg));
+#else
+      return arg == std::numeric_limits<T>::infinity()
+             || arg == -std::numeric_limits<T>::infinity();
+#endif
+    }
+
+    /// Check for NaN.
+    /// \tparam T argument type (builtin floating point type)
+    /// \param arg value to query
+    /// \retval true if not a number
+    /// \retval false else
+    template <typename T> bool builtin_isnan(T arg)
+    {
+#if HALF_ENABLE_CPP11_CMATH
+      return std::isnan(arg);
+#elif defined(_MSC_VER)
+      return ::_isnan(static_cast<double>(arg)) != 0;
+#else
+      return arg != arg;
+#endif
+    }
+
+    /// Check sign.
+    /// \tparam T argument type (builtin floating point type)
+    /// \param arg value to query
+    /// \retval true if signbit set
+    /// \retval false else
+    template <typename T> bool builtin_signbit(T arg)
+    {
+#if HALF_ENABLE_CPP11_CMATH
+      return std::signbit(arg);
+#else
+      return arg < T() || (arg == T() && T(1) / arg < T());
+#endif
+    }
+
+    /// \}
+    /// \name Conversion
+    /// \{
+
+    /// Convert IEEE single-precision to half-precision.
+    /// Credit for this goes to [Jeroen van der
+    /// Zijp](ftp://ftp.fox-toolkit.org/pub/fasthalffloatconversion.pdf).
+    /// \tparam R rounding mode to use, `std::round_indeterminate` for fastest
+    /// rounding \param value single-precision value \return binary
+    /// representation of half-precision value
+    template <std::float_round_style R>
+    uint16 float2half_impl(float value, true_type)
+    {
+      typedef bits<float>::type uint32;
+      uint32 bits; // = *reinterpret_cast<uint32*>(&value);
+                   // //violating strict aliasing!
+      std::memcpy(&bits, &value, sizeof(float));
+      /*			uint16 hbits = (bits>>16) & 0x8000;
+                              bits &= 0x7FFFFFFF;
+                              int exp = bits >> 23;
+                              if(exp == 255)
+                                      return hbits | 0x7C00 |
+         (0x3FF&-static_cast<unsigned>((bits&0x7FFFFF)!=0)); if(exp > 142)
+                              {
+                                      if(R == std::round_toward_infinity)
+                                              return hbits | 0x7C00 -
+         (hbits>>15); if(R == std::round_toward_neg_infinity) return hbits |
+         0x7BFF + (hbits>>15); return hbits | 0x7BFF +
+         (R!=std::round_toward_zero);
+                              }
+                              int g, s;
+                              if(exp > 112)
+                              {
+                                      g = (bits>>12) & 1;
+                                      s = (bits&0xFFF) != 0;
+                                      hbits |= ((exp-112)<<10) |
+         ((bits>>13)&0x3FF);
+                              }
+                              else if(exp > 101)
+                              {
+                                      int i = 125 - exp;
+                                      bits = (bits&0x7FFFFF) | 0x800000;
+                                      g = (bits>>i) & 1;
+                                      s = (bits&((1L<<i)-1)) != 0;
+                                      hbits |= bits >> (i+1);
+                              }
+                              else
+                              {
+                                      g = 0;
+                                      s = bits != 0;
+                              }
+                              if(R == std::round_to_nearest)
+                                      #if HALF_ROUND_TIES_TO_EVEN
+                                              hbits += g & (s|hbits);
+                                      #else
+                                              hbits += g;
+                                      #endif
+                              else if(R == std::round_toward_infinity)
+                                      hbits += ~(hbits>>15) & (s|g);
+                              else if(R == std::round_toward_neg_infinity)
+                                      hbits += (hbits>>15) & (g|s);
+      */
+      static const uint16 base_table[512] = {
+        0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
+        0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
+        0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
+        0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
+        0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
+        0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
+        0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
+        0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
+        0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
+        0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
+        0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
+        0x0000, 0x0000, 0x0000, 0x0000, 0x0001, 0x0002, 0x0004, 0x0008, 0x0010,
+        0x0020, 0x0040, 0x0080, 0x0100, 0x0200, 0x0400, 0x0800, 0x0C00, 0x1000,
+        0x1400, 0x1800, 0x1C00, 0x2000, 0x2400, 0x2800, 0x2C00, 0x3000, 0x3400,
+        0x3800, 0x3C00, 0x4000, 0x4400, 0x4800, 0x4C00, 0x5000, 0x5400, 0x5800,
+        0x5C00, 0x6000, 0x6400, 0x6800, 0x6C00, 0x7000, 0x7400, 0x7800, 0x7C00,
+        0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00,
+        0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00,
+        0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00,
+        0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00,
+        0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00,
+        0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00,
+        0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00,
+        0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00,
+        0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00,
+        0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00,
+        0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00,
+        0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x7C00,
+        0x7C00, 0x7C00, 0x7C00, 0x7C00, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000,
+        0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000,
+        0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000,
+        0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000,
+        0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000,
+        0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000,
+        0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000,
+        0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000,
+        0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000,
+        0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000,
+        0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000,
+        0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8001,
+        0x8002, 0x8004, 0x8008, 0x8010, 0x8020, 0x8040, 0x8080, 0x8100, 0x8200,
+        0x8400, 0x8800, 0x8C00, 0x9000, 0x9400, 0x9800, 0x9C00, 0xA000, 0xA400,
+        0xA800, 0xAC00, 0xB000, 0xB400, 0xB800, 0xBC00, 0xC000, 0xC400, 0xC800,
+        0xCC00, 0xD000, 0xD400, 0xD800, 0xDC00, 0xE000, 0xE400, 0xE800, 0xEC00,
+        0xF000, 0xF400, 0xF800, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00,
+        0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00,
+        0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00,
+        0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00,
+        0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00,
+        0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00,
+        0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00,
+        0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00,
+        0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00,
+        0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00,
+        0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00,
+        0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00,
+        0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00, 0xFC00
+      };
+      static const unsigned char shift_table[512] = {
+        24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+        24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+        24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+        24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+        24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+        24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 23, 22, 21, 20, 19,
+        18, 17, 16, 15, 14, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13,
+        13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 24,
+        24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+        24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+        24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+        24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+        24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+        24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+        24, 24, 24, 13, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+        24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+        24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+        24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+        24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+        24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 23,
+        22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 13, 13, 13, 13, 13, 13, 13, 13,
+        13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13,
+        13, 13, 13, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+        24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+        24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+        24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+        24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+        24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+        24, 24, 24, 24, 24, 24, 24, 13
+      };
+      uint16 hbits = base_table[bits >> 23]
+                     + static_cast<uint16>((bits & 0x7FFFFF)
+                                           >> shift_table[bits >> 23]);
+      if (R == std::round_to_nearest)
+        hbits
+            += (((bits & 0x7FFFFF) >> (shift_table[bits >> 23] - 1))
+                | (((bits >> 23) & 0xFF) == 102))
+               & ((hbits & 0x7C00) != 0x7C00)
+#if HALF_ROUND_TIES_TO_EVEN
+               & (((((static_cast<uint32>(1) << (shift_table[bits >> 23] - 1))
+                     - 1)
+                    & bits)
+                   != 0)
+                  | hbits)
+#endif
+            ;
+      else if (R == std::round_toward_zero)
+        hbits -= ((hbits & 0x7FFF) == 0x7C00) & ~shift_table[bits >> 23];
+      else if (R == std::round_toward_infinity)
+        hbits += ((((bits & 0x7FFFFF
+                     & ((static_cast<uint32>(1) << (shift_table[bits >> 23]))
+                        - 1))
+                    != 0)
+                   | (((bits >> 23) <= 102) & ((bits >> 23) != 0)))
+                  & (hbits < 0x7C00))
+                 - ((hbits == 0xFC00) & ((bits >> 23) != 511));
+      else if (R == std::round_toward_neg_infinity)
+        hbits += ((((bits & 0x7FFFFF
+                     & ((static_cast<uint32>(1) << (shift_table[bits >> 23]))
+                        - 1))
+                    != 0)
+                   | (((bits >> 23) <= 358) & ((bits >> 23) != 256)))
+                  & (hbits < 0xFC00) & (hbits >> 15))
+                 - ((hbits == 0x7C00) & ((bits >> 23) != 255));
+      return hbits;
+    }
+
+    /// Convert IEEE double-precision to half-precision.
+    /// \tparam R rounding mode to use, `std::round_indeterminate` for fastest
+    /// rounding \param value double-precision value \return binary
+    /// representation of half-precision value
+    template <std::float_round_style R>
+    uint16 float2half_impl(double value, true_type)
+    {
+      typedef bits<float>::type uint32;
+      typedef bits<double>::type uint64;
+      uint64 bits; // = *reinterpret_cast<uint64*>(&value);
+                   // //violating strict aliasing!
+      std::memcpy(&bits, &value, sizeof(double));
+      uint32 hi = bits >> 32, lo = bits & 0xFFFFFFFF;
+      uint16 hbits = (hi >> 16) & 0x8000;
+      hi &= 0x7FFFFFFF;
+      int exp = hi >> 20;
+      if (exp == 2047)
+        return hbits | 0x7C00
+               | (0x3FF
+                  & -static_cast<unsigned>((bits & 0xFFFFFFFFFFFFF) != 0));
+      if (exp > 1038)
+        {
+          if (R == std::round_toward_infinity)
+            return hbits | 0x7C00 - (hbits >> 15);
+          if (R == std::round_toward_neg_infinity)
+            return hbits | 0x7BFF + (hbits >> 15);
+          return hbits | 0x7BFF + (R != std::round_toward_zero);
+        }
+      int g, s = lo != 0;
+      if (exp > 1008)
+        {
+          g = (hi >> 9) & 1;
+          s |= (hi & 0x1FF) != 0;
+          hbits |= ((exp - 1008) << 10) | ((hi >> 10) & 0x3FF);
+        }
+      else if (exp > 997)
+        {
+          int i = 1018 - exp;
+          hi = (hi & 0xFFFFF) | 0x100000;
+          g = (hi >> i) & 1;
+          s |= (hi & ((1L << i) - 1)) != 0;
+          hbits |= hi >> (i + 1);
+        }
+      else
+        {
+          g = 0;
+          s |= hi != 0;
+        }
+      if (R == std::round_to_nearest)
+#if HALF_ROUND_TIES_TO_EVEN
+        hbits += g & (s | hbits);
+#else
+        hbits += g;
+#endif
+      else if (R == std::round_toward_infinity)
+        hbits += ~(hbits >> 15) & (s | g);
+      else if (R == std::round_toward_neg_infinity)
+        hbits += (hbits >> 15) & (g | s);
+      return hbits;
+    }
+
+    /// Convert non-IEEE floating point to half-precision.
+    /// \tparam R rounding mode to use, `std::round_indeterminate` for fastest
+    /// rounding \tparam T source type (builtin floating point type) \param
+    /// value floating point value \return binary representation of
+    /// half-precision value
+    template <std::float_round_style R, typename T>
+    uint16 float2half_impl(T value, ...)
+    {
+      uint16 hbits = static_cast<unsigned>(builtin_signbit(value)) << 15;
+      if (value == T())
+        return hbits;
+      if (builtin_isnan(value))
+        return hbits | 0x7FFF;
+      if (builtin_isinf(value))
+        return hbits | 0x7C00;
+      int exp;
+      std::frexp(value, &exp);
+      if (exp > 16)
+        {
+          if (R == std::round_toward_infinity)
+            return (hbits | 0x7C00) - (hbits >> 15);
+          else if (R == std::round_toward_neg_infinity)
+            return (hbits | 0x7BFF) + (hbits >> 15);
+          return (hbits | 0x7BFF) + (R != std::round_toward_zero);
+        }
+      if (exp < -13)
+        value = std::ldexp(value, 24);
+      else
+        {
+          value = std::ldexp(value, 11 - exp);
+          hbits |= ((exp + 13) << 10);
+        }
+      T ival, frac = std::modf(value, &ival);
+      hbits += static_cast<uint16>(std::abs(static_cast<int>(ival)));
+      if (R == std::round_to_nearest)
+        {
+          frac = std::abs(frac);
+#if HALF_ROUND_TIES_TO_EVEN
+          hbits += (frac > T(0.5)) | ((frac == T(0.5)) & hbits);
+#else
+          hbits += frac >= T(0.5);
+#endif
+        }
+      else if (R == std::round_toward_infinity)
+        hbits += frac > T();
+      else if (R == std::round_toward_neg_infinity)
+        hbits += frac < T();
+      return hbits;
+    }
+
+    /// Convert floating point to half-precision.
+    /// \tparam R rounding mode to use, `std::round_indeterminate` for fastest
+    /// rounding \tparam T source type (builtin floating point type) \param
+    /// value floating point value \return binary representation of
+    /// half-precision value
+    template <std::float_round_style R, typename T> uint16 float2half(T value)
+    {
+      return float2half_impl<R>(
+          value, bool_type < std::numeric_limits<T>::is_iec559
+                     && sizeof(typename bits<T>::type) == sizeof(T) > ());
+    }
+
+    /// Convert integer to half-precision floating point.
+    /// \tparam R rounding mode to use, `std::round_indeterminate` for fastest
+    /// rounding \tparam S `true` if value negative, `false` else \tparam T
+    /// type to convert (builtin integer type) \param value non-negative
+    /// integral value \return binary representation of half-precision value
+    template <std::float_round_style R, bool S, typename T>
+    uint16 int2half_impl(T value)
+    {
+#if HALF_ENABLE_CPP11_STATIC_ASSERT && HALF_ENABLE_CPP11_TYPE_TRAITS
+      static_assert(
+          std::is_integral<T>::value,
+          "int to half conversion only supports builtin integer types");
+#endif
+      if (S)
+        value = -value;
+      uint16 bits = S << 15;
+      if (value > 0xFFFF)
+        {
+          if (R == std::round_toward_infinity)
+            bits |= 0x7C00 - S;
+          else if (R == std::round_toward_neg_infinity)
+            bits |= 0x7BFF + S;
+          else
+            bits |= 0x7BFF + (R != std::round_toward_zero);
+        }
+      else if (value)
+        {
+          unsigned int m = value, exp = 24;
+          for (; m < 0x400; m <<= 1, --exp)
+            ;
+          for (; m > 0x7FF; m >>= 1, ++exp)
+            ;
+          bits |= (exp << 10) + m;
+          if (exp > 24)
+            {
+              if (R == std::round_to_nearest)
+                bits += (value >> (exp - 25)) & 1
+#if HALF_ROUND_TIES_TO_EVEN
+                        & (((((1 << (exp - 25)) - 1) & value) != 0) | bits)
+#endif
+                    ;
+              else if (R == std::round_toward_infinity)
+                bits += ((value & ((1 << (exp - 24)) - 1)) != 0) & !S;
+              else if (R == std::round_toward_neg_infinity)
+                bits += ((value & ((1 << (exp - 24)) - 1)) != 0) & S;
+            }
+        }
+      return bits;
+    }
+
+    /// Convert integer to half-precision floating point.
+    /// \tparam R rounding mode to use, `std::round_indeterminate` for fastest
+    /// rounding \tparam T type to convert (builtin integer type) \param value
+    /// integral value \return binary representation of half-precision value
+    template <std::float_round_style R, typename T> uint16 int2half(T value)
+    {
+      return (value < 0) ? int2half_impl<R, true>(value)
+                         : int2half_impl<R, false>(value);
+    }
+
+    /// Convert half-precision to IEEE single-precision.
+    /// Credit for this goes to [Jeroen van der
+    /// Zijp](ftp://ftp.fox-toolkit.org/pub/fasthalffloatconversion.pdf).
+    /// \param value binary representation of half-precision value
+    /// \return single-precision value
+    inline float half2float_impl(uint16 value, float, true_type)
+    {
+      typedef bits<float>::type uint32;
+      /*			uint32 bits = static_cast<uint32>(value&0x8000)
+         << 16; int abs = value & 0x7FFF; if(abs)
+                              {
+                                      bits |= 0x38000000 <<
+         static_cast<unsigned>(abs>=0x7C00); for(; abs<0x400;
+         abs<<=1,bits-=0x800000) ; bits += static_cast<uint32>(abs) << 13;
+                              }
+      */
+      static const uint32 mantissa_table[2048] = {
+        0x00000000, 0x33800000, 0x34000000, 0x34400000, 0x34800000, 0x34A00000,
+        0x34C00000, 0x34E00000, 0x35000000, 0x35100000, 0x35200000, 0x35300000,
+        0x35400000, 0x35500000, 0x35600000, 0x35700000, 0x35800000, 0x35880000,
+        0x35900000, 0x35980000, 0x35A00000, 0x35A80000, 0x35B00000, 0x35B80000,
+        0x35C00000, 0x35C80000, 0x35D00000, 0x35D80000, 0x35E00000, 0x35E80000,
+        0x35F00000, 0x35F80000, 0x36000000, 0x36040000, 0x36080000, 0x360C0000,
+        0x36100000, 0x36140000, 0x36180000, 0x361C0000, 0x36200000, 0x36240000,
+        0x36280000, 0x362C0000, 0x36300000, 0x36340000, 0x36380000, 0x363C0000,
+        0x36400000, 0x36440000, 0x36480000, 0x364C0000, 0x36500000, 0x36540000,
+        0x36580000, 0x365C0000, 0x36600000, 0x36640000, 0x36680000, 0x366C0000,
+        0x36700000, 0x36740000, 0x36780000, 0x367C0000, 0x36800000, 0x36820000,
+        0x36840000, 0x36860000, 0x36880000, 0x368A0000, 0x368C0000, 0x368E0000,
+        0x36900000, 0x36920000, 0x36940000, 0x36960000, 0x36980000, 0x369A0000,
+        0x369C0000, 0x369E0000, 0x36A00000, 0x36A20000, 0x36A40000, 0x36A60000,
+        0x36A80000, 0x36AA0000, 0x36AC0000, 0x36AE0000, 0x36B00000, 0x36B20000,
+        0x36B40000, 0x36B60000, 0x36B80000, 0x36BA0000, 0x36BC0000, 0x36BE0000,
+        0x36C00000, 0x36C20000, 0x36C40000, 0x36C60000, 0x36C80000, 0x36CA0000,
+        0x36CC0000, 0x36CE0000, 0x36D00000, 0x36D20000, 0x36D40000, 0x36D60000,
+        0x36D80000, 0x36DA0000, 0x36DC0000, 0x36DE0000, 0x36E00000, 0x36E20000,
+        0x36E40000, 0x36E60000, 0x36E80000, 0x36EA0000, 0x36EC0000, 0x36EE0000,
+        0x36F00000, 0x36F20000, 0x36F40000, 0x36F60000, 0x36F80000, 0x36FA0000,
+        0x36FC0000, 0x36FE0000, 0x37000000, 0x37010000, 0x37020000, 0x37030000,
+        0x37040000, 0x37050000, 0x37060000, 0x37070000, 0x37080000, 0x37090000,
+        0x370A0000, 0x370B0000, 0x370C0000, 0x370D0000, 0x370E0000, 0x370F0000,
+        0x37100000, 0x37110000, 0x37120000, 0x37130000, 0x37140000, 0x37150000,
+        0x37160000, 0x37170000, 0x37180000, 0x37190000, 0x371A0000, 0x371B0000,
+        0x371C0000, 0x371D0000, 0x371E0000, 0x371F0000, 0x37200000, 0x37210000,
+        0x37220000, 0x37230000, 0x37240000, 0x37250000, 0x37260000, 0x37270000,
+        0x37280000, 0x37290000, 0x372A0000, 0x372B0000, 0x372C0000, 0x372D0000,
+        0x372E0000, 0x372F0000, 0x37300000, 0x37310000, 0x37320000, 0x37330000,
+        0x37340000, 0x37350000, 0x37360000, 0x37370000, 0x37380000, 0x37390000,
+        0x373A0000, 0x373B0000, 0x373C0000, 0x373D0000, 0x373E0000, 0x373F0000,
+        0x37400000, 0x37410000, 0x37420000, 0x37430000, 0x37440000, 0x37450000,
+        0x37460000, 0x37470000, 0x37480000, 0x37490000, 0x374A0000, 0x374B0000,
+        0x374C0000, 0x374D0000, 0x374E0000, 0x374F0000, 0x37500000, 0x37510000,
+        0x37520000, 0x37530000, 0x37540000, 0x37550000, 0x37560000, 0x37570000,
+        0x37580000, 0x37590000, 0x375A0000, 0x375B0000, 0x375C0000, 0x375D0000,
+        0x375E0000, 0x375F0000, 0x37600000, 0x37610000, 0x37620000, 0x37630000,
+        0x37640000, 0x37650000, 0x37660000, 0x37670000, 0x37680000, 0x37690000,
+        0x376A0000, 0x376B0000, 0x376C0000, 0x376D0000, 0x376E0000, 0x376F0000,
+        0x37700000, 0x37710000, 0x37720000, 0x37730000, 0x37740000, 0x37750000,
+        0x37760000, 0x37770000, 0x37780000, 0x37790000, 0x377A0000, 0x377B0000,
+        0x377C0000, 0x377D0000, 0x377E0000, 0x377F0000, 0x37800000, 0x37808000,
+        0x37810000, 0x37818000, 0x37820000, 0x37828000, 0x37830000, 0x37838000,
+        0x37840000, 0x37848000, 0x37850000, 0x37858000, 0x37860000, 0x37868000,
+        0x37870000, 0x37878000, 0x37880000, 0x37888000, 0x37890000, 0x37898000,
+        0x378A0000, 0x378A8000, 0x378B0000, 0x378B8000, 0x378C0000, 0x378C8000,
+        0x378D0000, 0x378D8000, 0x378E0000, 0x378E8000, 0x378F0000, 0x378F8000,
+        0x37900000, 0x37908000, 0x37910000, 0x37918000, 0x37920000, 0x37928000,
+        0x37930000, 0x37938000, 0x37940000, 0x37948000, 0x37950000, 0x37958000,
+        0x37960000, 0x37968000, 0x37970000, 0x37978000, 0x37980000, 0x37988000,
+        0x37990000, 0x37998000, 0x379A0000, 0x379A8000, 0x379B0000, 0x379B8000,
+        0x379C0000, 0x379C8000, 0x379D0000, 0x379D8000, 0x379E0000, 0x379E8000,
+        0x379F0000, 0x379F8000, 0x37A00000, 0x37A08000, 0x37A10000, 0x37A18000,
+        0x37A20000, 0x37A28000, 0x37A30000, 0x37A38000, 0x37A40000, 0x37A48000,
+        0x37A50000, 0x37A58000, 0x37A60000, 0x37A68000, 0x37A70000, 0x37A78000,
+        0x37A80000, 0x37A88000, 0x37A90000, 0x37A98000, 0x37AA0000, 0x37AA8000,
+        0x37AB0000, 0x37AB8000, 0x37AC0000, 0x37AC8000, 0x37AD0000, 0x37AD8000,
+        0x37AE0000, 0x37AE8000, 0x37AF0000, 0x37AF8000, 0x37B00000, 0x37B08000,
+        0x37B10000, 0x37B18000, 0x37B20000, 0x37B28000, 0x37B30000, 0x37B38000,
+        0x37B40000, 0x37B48000, 0x37B50000, 0x37B58000, 0x37B60000, 0x37B68000,
+        0x37B70000, 0x37B78000, 0x37B80000, 0x37B88000, 0x37B90000, 0x37B98000,
+        0x37BA0000, 0x37BA8000, 0x37BB0000, 0x37BB8000, 0x37BC0000, 0x37BC8000,
+        0x37BD0000, 0x37BD8000, 0x37BE0000, 0x37BE8000, 0x37BF0000, 0x37BF8000,
+        0x37C00000, 0x37C08000, 0x37C10000, 0x37C18000, 0x37C20000, 0x37C28000,
+        0x37C30000, 0x37C38000, 0x37C40000, 0x37C48000, 0x37C50000, 0x37C58000,
+        0x37C60000, 0x37C68000, 0x37C70000, 0x37C78000, 0x37C80000, 0x37C88000,
+        0x37C90000, 0x37C98000, 0x37CA0000, 0x37CA8000, 0x37CB0000, 0x37CB8000,
+        0x37CC0000, 0x37CC8000, 0x37CD0000, 0x37CD8000, 0x37CE0000, 0x37CE8000,
+        0x37CF0000, 0x37CF8000, 0x37D00000, 0x37D08000, 0x37D10000, 0x37D18000,
+        0x37D20000, 0x37D28000, 0x37D30000, 0x37D38000, 0x37D40000, 0x37D48000,
+        0x37D50000, 0x37D58000, 0x37D60000, 0x37D68000, 0x37D70000, 0x37D78000,
+        0x37D80000, 0x37D88000, 0x37D90000, 0x37D98000, 0x37DA0000, 0x37DA8000,
+        0x37DB0000, 0x37DB8000, 0x37DC0000, 0x37DC8000, 0x37DD0000, 0x37DD8000,
+        0x37DE0000, 0x37DE8000, 0x37DF0000, 0x37DF8000, 0x37E00000, 0x37E08000,
+        0x37E10000, 0x37E18000, 0x37E20000, 0x37E28000, 0x37E30000, 0x37E38000,
+        0x37E40000, 0x37E48000, 0x37E50000, 0x37E58000, 0x37E60000, 0x37E68000,
+        0x37E70000, 0x37E78000, 0x37E80000, 0x37E88000, 0x37E90000, 0x37E98000,
+        0x37EA0000, 0x37EA8000, 0x37EB0000, 0x37EB8000, 0x37EC0000, 0x37EC8000,
+        0x37ED0000, 0x37ED8000, 0x37EE0000, 0x37EE8000, 0x37EF0000, 0x37EF8000,
+        0x37F00000, 0x37F08000, 0x37F10000, 0x37F18000, 0x37F20000, 0x37F28000,
+        0x37F30000, 0x37F38000, 0x37F40000, 0x37F48000, 0x37F50000, 0x37F58000,
+        0x37F60000, 0x37F68000, 0x37F70000, 0x37F78000, 0x37F80000, 0x37F88000,
+        0x37F90000, 0x37F98000, 0x37FA0000, 0x37FA8000, 0x37FB0000, 0x37FB8000,
+        0x37FC0000, 0x37FC8000, 0x37FD0000, 0x37FD8000, 0x37FE0000, 0x37FE8000,
+        0x37FF0000, 0x37FF8000, 0x38000000, 0x38004000, 0x38008000, 0x3800C000,
+        0x38010000, 0x38014000, 0x38018000, 0x3801C000, 0x38020000, 0x38024000,
+        0x38028000, 0x3802C000, 0x38030000, 0x38034000, 0x38038000, 0x3803C000,
+        0x38040000, 0x38044000, 0x38048000, 0x3804C000, 0x38050000, 0x38054000,
+        0x38058000, 0x3805C000, 0x38060000, 0x38064000, 0x38068000, 0x3806C000,
+        0x38070000, 0x38074000, 0x38078000, 0x3807C000, 0x38080000, 0x38084000,
+        0x38088000, 0x3808C000, 0x38090000, 0x38094000, 0x38098000, 0x3809C000,
+        0x380A0000, 0x380A4000, 0x380A8000, 0x380AC000, 0x380B0000, 0x380B4000,
+        0x380B8000, 0x380BC000, 0x380C0000, 0x380C4000, 0x380C8000, 0x380CC000,
+        0x380D0000, 0x380D4000, 0x380D8000, 0x380DC000, 0x380E0000, 0x380E4000,
+        0x380E8000, 0x380EC000, 0x380F0000, 0x380F4000, 0x380F8000, 0x380FC000,
+        0x38100000, 0x38104000, 0x38108000, 0x3810C000, 0x38110000, 0x38114000,
+        0x38118000, 0x3811C000, 0x38120000, 0x38124000, 0x38128000, 0x3812C000,
+        0x38130000, 0x38134000, 0x38138000, 0x3813C000, 0x38140000, 0x38144000,
+        0x38148000, 0x3814C000, 0x38150000, 0x38154000, 0x38158000, 0x3815C000,
+        0x38160000, 0x38164000, 0x38168000, 0x3816C000, 0x38170000, 0x38174000,
+        0x38178000, 0x3817C000, 0x38180000, 0x38184000, 0x38188000, 0x3818C000,
+        0x38190000, 0x38194000, 0x38198000, 0x3819C000, 0x381A0000, 0x381A4000,
+        0x381A8000, 0x381AC000, 0x381B0000, 0x381B4000, 0x381B8000, 0x381BC000,
+        0x381C0000, 0x381C4000, 0x381C8000, 0x381CC000, 0x381D0000, 0x381D4000,
+        0x381D8000, 0x381DC000, 0x381E0000, 0x381E4000, 0x381E8000, 0x381EC000,
+        0x381F0000, 0x381F4000, 0x381F8000, 0x381FC000, 0x38200000, 0x38204000,
+        0x38208000, 0x3820C000, 0x38210000, 0x38214000, 0x38218000, 0x3821C000,
+        0x38220000, 0x38224000, 0x38228000, 0x3822C000, 0x38230000, 0x38234000,
+        0x38238000, 0x3823C000, 0x38240000, 0x38244000, 0x38248000, 0x3824C000,
+        0x38250000, 0x38254000, 0x38258000, 0x3825C000, 0x38260000, 0x38264000,
+        0x38268000, 0x3826C000, 0x38270000, 0x38274000, 0x38278000, 0x3827C000,
+        0x38280000, 0x38284000, 0x38288000, 0x3828C000, 0x38290000, 0x38294000,
+        0x38298000, 0x3829C000, 0x382A0000, 0x382A4000, 0x382A8000, 0x382AC000,
+        0x382B0000, 0x382B4000, 0x382B8000, 0x382BC000, 0x382C0000, 0x382C4000,
+        0x382C8000, 0x382CC000, 0x382D0000, 0x382D4000, 0x382D8000, 0x382DC000,
+        0x382E0000, 0x382E4000, 0x382E8000, 0x382EC000, 0x382F0000, 0x382F4000,
+        0x382F8000, 0x382FC000, 0x38300000, 0x38304000, 0x38308000, 0x3830C000,
+        0x38310000, 0x38314000, 0x38318000, 0x3831C000, 0x38320000, 0x38324000,
+        0x38328000, 0x3832C000, 0x38330000, 0x38334000, 0x38338000, 0x3833C000,
+        0x38340000, 0x38344000, 0x38348000, 0x3834C000, 0x38350000, 0x38354000,
+        0x38358000, 0x3835C000, 0x38360000, 0x38364000, 0x38368000, 0x3836C000,
+        0x38370000, 0x38374000, 0x38378000, 0x3837C000, 0x38380000, 0x38384000,
+        0x38388000, 0x3838C000, 0x38390000, 0x38394000, 0x38398000, 0x3839C000,
+        0x383A0000, 0x383A4000, 0x383A8000, 0x383AC000, 0x383B0000, 0x383B4000,
+        0x383B8000, 0x383BC000, 0x383C0000, 0x383C4000, 0x383C8000, 0x383CC000,
+        0x383D0000, 0x383D4000, 0x383D8000, 0x383DC000, 0x383E0000, 0x383E4000,
+        0x383E8000, 0x383EC000, 0x383F0000, 0x383F4000, 0x383F8000, 0x383FC000,
+        0x38400000, 0x38404000, 0x38408000, 0x3840C000, 0x38410000, 0x38414000,
+        0x38418000, 0x3841C000, 0x38420000, 0x38424000, 0x38428000, 0x3842C000,
+        0x38430000, 0x38434000, 0x38438000, 0x3843C000, 0x38440000, 0x38444000,
+        0x38448000, 0x3844C000, 0x38450000, 0x38454000, 0x38458000, 0x3845C000,
+        0x38460000, 0x38464000, 0x38468000, 0x3846C000, 0x38470000, 0x38474000,
+        0x38478000, 0x3847C000, 0x38480000, 0x38484000, 0x38488000, 0x3848C000,
+        0x38490000, 0x38494000, 0x38498000, 0x3849C000, 0x384A0000, 0x384A4000,
+        0x384A8000, 0x384AC000, 0x384B0000, 0x384B4000, 0x384B8000, 0x384BC000,
+        0x384C0000, 0x384C4000, 0x384C8000, 0x384CC000, 0x384D0000, 0x384D4000,
+        0x384D8000, 0x384DC000, 0x384E0000, 0x384E4000, 0x384E8000, 0x384EC000,
+        0x384F0000, 0x384F4000, 0x384F8000, 0x384FC000, 0x38500000, 0x38504000,
+        0x38508000, 0x3850C000, 0x38510000, 0x38514000, 0x38518000, 0x3851C000,
+        0x38520000, 0x38524000, 0x38528000, 0x3852C000, 0x38530000, 0x38534000,
+        0x38538000, 0x3853C000, 0x38540000, 0x38544000, 0x38548000, 0x3854C000,
+        0x38550000, 0x38554000, 0x38558000, 0x3855C000, 0x38560000, 0x38564000,
+        0x38568000, 0x3856C000, 0x38570000, 0x38574000, 0x38578000, 0x3857C000,
+        0x38580000, 0x38584000, 0x38588000, 0x3858C000, 0x38590000, 0x38594000,
+        0x38598000, 0x3859C000, 0x385A0000, 0x385A4000, 0x385A8000, 0x385AC000,
+        0x385B0000, 0x385B4000, 0x385B8000, 0x385BC000, 0x385C0000, 0x385C4000,
+        0x385C8000, 0x385CC000, 0x385D0000, 0x385D4000, 0x385D8000, 0x385DC000,
+        0x385E0000, 0x385E4000, 0x385E8000, 0x385EC000, 0x385F0000, 0x385F4000,
+        0x385F8000, 0x385FC000, 0x38600000, 0x38604000, 0x38608000, 0x3860C000,
+        0x38610000, 0x38614000, 0x38618000, 0x3861C000, 0x38620000, 0x38624000,
+        0x38628000, 0x3862C000, 0x38630000, 0x38634000, 0x38638000, 0x3863C000,
+        0x38640000, 0x38644000, 0x38648000, 0x3864C000, 0x38650000, 0x38654000,
+        0x38658000, 0x3865C000, 0x38660000, 0x38664000, 0x38668000, 0x3866C000,
+        0x38670000, 0x38674000, 0x38678000, 0x3867C000, 0x38680000, 0x38684000,
+        0x38688000, 0x3868C000, 0x38690000, 0x38694000, 0x38698000, 0x3869C000,
+        0x386A0000, 0x386A4000, 0x386A8000, 0x386AC000, 0x386B0000, 0x386B4000,
+        0x386B8000, 0x386BC000, 0x386C0000, 0x386C4000, 0x386C8000, 0x386CC000,
+        0x386D0000, 0x386D4000, 0x386D8000, 0x386DC000, 0x386E0000, 0x386E4000,
+        0x386E8000, 0x386EC000, 0x386F0000, 0x386F4000, 0x386F8000, 0x386FC000,
+        0x38700000, 0x38704000, 0x38708000, 0x3870C000, 0x38710000, 0x38714000,
+        0x38718000, 0x3871C000, 0x38720000, 0x38724000, 0x38728000, 0x3872C000,
+        0x38730000, 0x38734000, 0x38738000, 0x3873C000, 0x38740000, 0x38744000,
+        0x38748000, 0x3874C000, 0x38750000, 0x38754000, 0x38758000, 0x3875C000,
+        0x38760000, 0x38764000, 0x38768000, 0x3876C000, 0x38770000, 0x38774000,
+        0x38778000, 0x3877C000, 0x38780000, 0x38784000, 0x38788000, 0x3878C000,
+        0x38790000, 0x38794000, 0x38798000, 0x3879C000, 0x387A0000, 0x387A4000,
+        0x387A8000, 0x387AC000, 0x387B0000, 0x387B4000, 0x387B8000, 0x387BC000,
+        0x387C0000, 0x387C4000, 0x387C8000, 0x387CC000, 0x387D0000, 0x387D4000,
+        0x387D8000, 0x387DC000, 0x387E0000, 0x387E4000, 0x387E8000, 0x387EC000,
+        0x387F0000, 0x387F4000, 0x387F8000, 0x387FC000, 0x38000000, 0x38002000,
+        0x38004000, 0x38006000, 0x38008000, 0x3800A000, 0x3800C000, 0x3800E000,
+        0x38010000, 0x38012000, 0x38014000, 0x38016000, 0x38018000, 0x3801A000,
+        0x3801C000, 0x3801E000, 0x38020000, 0x38022000, 0x38024000, 0x38026000,
+        0x38028000, 0x3802A000, 0x3802C000, 0x3802E000, 0x38030000, 0x38032000,
+        0x38034000, 0x38036000, 0x38038000, 0x3803A000, 0x3803C000, 0x3803E000,
+        0x38040000, 0x38042000, 0x38044000, 0x38046000, 0x38048000, 0x3804A000,
+        0x3804C000, 0x3804E000, 0x38050000, 0x38052000, 0x38054000, 0x38056000,
+        0x38058000, 0x3805A000, 0x3805C000, 0x3805E000, 0x38060000, 0x38062000,
+        0x38064000, 0x38066000, 0x38068000, 0x3806A000, 0x3806C000, 0x3806E000,
+        0x38070000, 0x38072000, 0x38074000, 0x38076000, 0x38078000, 0x3807A000,
+        0x3807C000, 0x3807E000, 0x38080000, 0x38082000, 0x38084000, 0x38086000,
+        0x38088000, 0x3808A000, 0x3808C000, 0x3808E000, 0x38090000, 0x38092000,
+        0x38094000, 0x38096000, 0x38098000, 0x3809A000, 0x3809C000, 0x3809E000,
+        0x380A0000, 0x380A2000, 0x380A4000, 0x380A6000, 0x380A8000, 0x380AA000,
+        0x380AC000, 0x380AE000, 0x380B0000, 0x380B2000, 0x380B4000, 0x380B6000,
+        0x380B8000, 0x380BA000, 0x380BC000, 0x380BE000, 0x380C0000, 0x380C2000,
+        0x380C4000, 0x380C6000, 0x380C8000, 0x380CA000, 0x380CC000, 0x380CE000,
+        0x380D0000, 0x380D2000, 0x380D4000, 0x380D6000, 0x380D8000, 0x380DA000,
+        0x380DC000, 0x380DE000, 0x380E0000, 0x380E2000, 0x380E4000, 0x380E6000,
+        0x380E8000, 0x380EA000, 0x380EC000, 0x380EE000, 0x380F0000, 0x380F2000,
+        0x380F4000, 0x380F6000, 0x380F8000, 0x380FA000, 0x380FC000, 0x380FE000,
+        0x38100000, 0x38102000, 0x38104000, 0x38106000, 0x38108000, 0x3810A000,
+        0x3810C000, 0x3810E000, 0x38110000, 0x38112000, 0x38114000, 0x38116000,
+        0x38118000, 0x3811A000, 0x3811C000, 0x3811E000, 0x38120000, 0x38122000,
+        0x38124000, 0x38126000, 0x38128000, 0x3812A000, 0x3812C000, 0x3812E000,
+        0x38130000, 0x38132000, 0x38134000, 0x38136000, 0x38138000, 0x3813A000,
+        0x3813C000, 0x3813E000, 0x38140000, 0x38142000, 0x38144000, 0x38146000,
+        0x38148000, 0x3814A000, 0x3814C000, 0x3814E000, 0x38150000, 0x38152000,
+        0x38154000, 0x38156000, 0x38158000, 0x3815A000, 0x3815C000, 0x3815E000,
+        0x38160000, 0x38162000, 0x38164000, 0x38166000, 0x38168000, 0x3816A000,
+        0x3816C000, 0x3816E000, 0x38170000, 0x38172000, 0x38174000, 0x38176000,
+        0x38178000, 0x3817A000, 0x3817C000, 0x3817E000, 0x38180000, 0x38182000,
+        0x38184000, 0x38186000, 0x38188000, 0x3818A000, 0x3818C000, 0x3818E000,
+        0x38190000, 0x38192000, 0x38194000, 0x38196000, 0x38198000, 0x3819A000,
+        0x3819C000, 0x3819E000, 0x381A0000, 0x381A2000, 0x381A4000, 0x381A6000,
+        0x381A8000, 0x381AA000, 0x381AC000, 0x381AE000, 0x381B0000, 0x381B2000,
+        0x381B4000, 0x381B6000, 0x381B8000, 0x381BA000, 0x381BC000, 0x381BE000,
+        0x381C0000, 0x381C2000, 0x381C4000, 0x381C6000, 0x381C8000, 0x381CA000,
+        0x381CC000, 0x381CE000, 0x381D0000, 0x381D2000, 0x381D4000, 0x381D6000,
+        0x381D8000, 0x381DA000, 0x381DC000, 0x381DE000, 0x381E0000, 0x381E2000,
+        0x381E4000, 0x381E6000, 0x381E8000, 0x381EA000, 0x381EC000, 0x381EE000,
+        0x381F0000, 0x381F2000, 0x381F4000, 0x381F6000, 0x381F8000, 0x381FA000,
+        0x381FC000, 0x381FE000, 0x38200000, 0x38202000, 0x38204000, 0x38206000,
+        0x38208000, 0x3820A000, 0x3820C000, 0x3820E000, 0x38210000, 0x38212000,
+        0x38214000, 0x38216000, 0x38218000, 0x3821A000, 0x3821C000, 0x3821E000,
+        0x38220000, 0x38222000, 0x38224000, 0x38226000, 0x38228000, 0x3822A000,
+        0x3822C000, 0x3822E000, 0x38230000, 0x38232000, 0x38234000, 0x38236000,
+        0x38238000, 0x3823A000, 0x3823C000, 0x3823E000, 0x38240000, 0x38242000,
+        0x38244000, 0x38246000, 0x38248000, 0x3824A000, 0x3824C000, 0x3824E000,
+        0x38250000, 0x38252000, 0x38254000, 0x38256000, 0x38258000, 0x3825A000,
+        0x3825C000, 0x3825E000, 0x38260000, 0x38262000, 0x38264000, 0x38266000,
+        0x38268000, 0x3826A000, 0x3826C000, 0x3826E000, 0x38270000, 0x38272000,
+        0x38274000, 0x38276000, 0x38278000, 0x3827A000, 0x3827C000, 0x3827E000,
+        0x38280000, 0x38282000, 0x38284000, 0x38286000, 0x38288000, 0x3828A000,
+        0x3828C000, 0x3828E000, 0x38290000, 0x38292000, 0x38294000, 0x38296000,
+        0x38298000, 0x3829A000, 0x3829C000, 0x3829E000, 0x382A0000, 0x382A2000,
+        0x382A4000, 0x382A6000, 0x382A8000, 0x382AA000, 0x382AC000, 0x382AE000,
+        0x382B0000, 0x382B2000, 0x382B4000, 0x382B6000, 0x382B8000, 0x382BA000,
+        0x382BC000, 0x382BE000, 0x382C0000, 0x382C2000, 0x382C4000, 0x382C6000,
+        0x382C8000, 0x382CA000, 0x382CC000, 0x382CE000, 0x382D0000, 0x382D2000,
+        0x382D4000, 0x382D6000, 0x382D8000, 0x382DA000, 0x382DC000, 0x382DE000,
+        0x382E0000, 0x382E2000, 0x382E4000, 0x382E6000, 0x382E8000, 0x382EA000,
+        0x382EC000, 0x382EE000, 0x382F0000, 0x382F2000, 0x382F4000, 0x382F6000,
+        0x382F8000, 0x382FA000, 0x382FC000, 0x382FE000, 0x38300000, 0x38302000,
+        0x38304000, 0x38306000, 0x38308000, 0x3830A000, 0x3830C000, 0x3830E000,
+        0x38310000, 0x38312000, 0x38314000, 0x38316000, 0x38318000, 0x3831A000,
+        0x3831C000, 0x3831E000, 0x38320000, 0x38322000, 0x38324000, 0x38326000,
+        0x38328000, 0x3832A000, 0x3832C000, 0x3832E000, 0x38330000, 0x38332000,
+        0x38334000, 0x38336000, 0x38338000, 0x3833A000, 0x3833C000, 0x3833E000,
+        0x38340000, 0x38342000, 0x38344000, 0x38346000, 0x38348000, 0x3834A000,
+        0x3834C000, 0x3834E000, 0x38350000, 0x38352000, 0x38354000, 0x38356000,
+        0x38358000, 0x3835A000, 0x3835C000, 0x3835E000, 0x38360000, 0x38362000,
+        0x38364000, 0x38366000, 0x38368000, 0x3836A000, 0x3836C000, 0x3836E000,
+        0x38370000, 0x38372000, 0x38374000, 0x38376000, 0x38378000, 0x3837A000,
+        0x3837C000, 0x3837E000, 0x38380000, 0x38382000, 0x38384000, 0x38386000,
+        0x38388000, 0x3838A000, 0x3838C000, 0x3838E000, 0x38390000, 0x38392000,
+        0x38394000, 0x38396000, 0x38398000, 0x3839A000, 0x3839C000, 0x3839E000,
+        0x383A0000, 0x383A2000, 0x383A4000, 0x383A6000, 0x383A8000, 0x383AA000,
+        0x383AC000, 0x383AE000, 0x383B0000, 0x383B2000, 0x383B4000, 0x383B6000,
+        0x383B8000, 0x383BA000, 0x383BC000, 0x383BE000, 0x383C0000, 0x383C2000,
+        0x383C4000, 0x383C6000, 0x383C8000, 0x383CA000, 0x383CC000, 0x383CE000,
+        0x383D0000, 0x383D2000, 0x383D4000, 0x383D6000, 0x383D8000, 0x383DA000,
+        0x383DC000, 0x383DE000, 0x383E0000, 0x383E2000, 0x383E4000, 0x383E6000,
+        0x383E8000, 0x383EA000, 0x383EC000, 0x383EE000, 0x383F0000, 0x383F2000,
+        0x383F4000, 0x383F6000, 0x383F8000, 0x383FA000, 0x383FC000, 0x383FE000,
+        0x38400000, 0x38402000, 0x38404000, 0x38406000, 0x38408000, 0x3840A000,
+        0x3840C000, 0x3840E000, 0x38410000, 0x38412000, 0x38414000, 0x38416000,
+        0x38418000, 0x3841A000, 0x3841C000, 0x3841E000, 0x38420000, 0x38422000,
+        0x38424000, 0x38426000, 0x38428000, 0x3842A000, 0x3842C000, 0x3842E000,
+        0x38430000, 0x38432000, 0x38434000, 0x38436000, 0x38438000, 0x3843A000,
+        0x3843C000, 0x3843E000, 0x38440000, 0x38442000, 0x38444000, 0x38446000,
+        0x38448000, 0x3844A000, 0x3844C000, 0x3844E000, 0x38450000, 0x38452000,
+        0x38454000, 0x38456000, 0x38458000, 0x3845A000, 0x3845C000, 0x3845E000,
+        0x38460000, 0x38462000, 0x38464000, 0x38466000, 0x38468000, 0x3846A000,
+        0x3846C000, 0x3846E000, 0x38470000, 0x38472000, 0x38474000, 0x38476000,
+        0x38478000, 0x3847A000, 0x3847C000, 0x3847E000, 0x38480000, 0x38482000,
+        0x38484000, 0x38486000, 0x38488000, 0x3848A000, 0x3848C000, 0x3848E000,
+        0x38490000, 0x38492000, 0x38494000, 0x38496000, 0x38498000, 0x3849A000,
+        0x3849C000, 0x3849E000, 0x384A0000, 0x384A2000, 0x384A4000, 0x384A6000,
+        0x384A8000, 0x384AA000, 0x384AC000, 0x384AE000, 0x384B0000, 0x384B2000,
+        0x384B4000, 0x384B6000, 0x384B8000, 0x384BA000, 0x384BC000, 0x384BE000,
+        0x384C0000, 0x384C2000, 0x384C4000, 0x384C6000, 0x384C8000, 0x384CA000,
+        0x384CC000, 0x384CE000, 0x384D0000, 0x384D2000, 0x384D4000, 0x384D6000,
+        0x384D8000, 0x384DA000, 0x384DC000, 0x384DE000, 0x384E0000, 0x384E2000,
+        0x384E4000, 0x384E6000, 0x384E8000, 0x384EA000, 0x384EC000, 0x384EE000,
+        0x384F0000, 0x384F2000, 0x384F4000, 0x384F6000, 0x384F8000, 0x384FA000,
+        0x384FC000, 0x384FE000, 0x38500000, 0x38502000, 0x38504000, 0x38506000,
+        0x38508000, 0x3850A000, 0x3850C000, 0x3850E000, 0x38510000, 0x38512000,
+        0x38514000, 0x38516000, 0x38518000, 0x3851A000, 0x3851C000, 0x3851E000,
+        0x38520000, 0x38522000, 0x38524000, 0x38526000, 0x38528000, 0x3852A000,
+        0x3852C000, 0x3852E000, 0x38530000, 0x38532000, 0x38534000, 0x38536000,
+        0x38538000, 0x3853A000, 0x3853C000, 0x3853E000, 0x38540000, 0x38542000,
+        0x38544000, 0x38546000, 0x38548000, 0x3854A000, 0x3854C000, 0x3854E000,
+        0x38550000, 0x38552000, 0x38554000, 0x38556000, 0x38558000, 0x3855A000,
+        0x3855C000, 0x3855E000, 0x38560000, 0x38562000, 0x38564000, 0x38566000,
+        0x38568000, 0x3856A000, 0x3856C000, 0x3856E000, 0x38570000, 0x38572000,
+        0x38574000, 0x38576000, 0x38578000, 0x3857A000, 0x3857C000, 0x3857E000,
+        0x38580000, 0x38582000, 0x38584000, 0x38586000, 0x38588000, 0x3858A000,
+        0x3858C000, 0x3858E000, 0x38590000, 0x38592000, 0x38594000, 0x38596000,
+        0x38598000, 0x3859A000, 0x3859C000, 0x3859E000, 0x385A0000, 0x385A2000,
+        0x385A4000, 0x385A6000, 0x385A8000, 0x385AA000, 0x385AC000, 0x385AE000,
+        0x385B0000, 0x385B2000, 0x385B4000, 0x385B6000, 0x385B8000, 0x385BA000,
+        0x385BC000, 0x385BE000, 0x385C0000, 0x385C2000, 0x385C4000, 0x385C6000,
+        0x385C8000, 0x385CA000, 0x385CC000, 0x385CE000, 0x385D0000, 0x385D2000,
+        0x385D4000, 0x385D6000, 0x385D8000, 0x385DA000, 0x385DC000, 0x385DE000,
+        0x385E0000, 0x385E2000, 0x385E4000, 0x385E6000, 0x385E8000, 0x385EA000,
+        0x385EC000, 0x385EE000, 0x385F0000, 0x385F2000, 0x385F4000, 0x385F6000,
+        0x385F8000, 0x385FA000, 0x385FC000, 0x385FE000, 0x38600000, 0x38602000,
+        0x38604000, 0x38606000, 0x38608000, 0x3860A000, 0x3860C000, 0x3860E000,
+        0x38610000, 0x38612000, 0x38614000, 0x38616000, 0x38618000, 0x3861A000,
+        0x3861C000, 0x3861E000, 0x38620000, 0x38622000, 0x38624000, 0x38626000,
+        0x38628000, 0x3862A000, 0x3862C000, 0x3862E000, 0x38630000, 0x38632000,
+        0x38634000, 0x38636000, 0x38638000, 0x3863A000, 0x3863C000, 0x3863E000,
+        0x38640000, 0x38642000, 0x38644000, 0x38646000, 0x38648000, 0x3864A000,
+        0x3864C000, 0x3864E000, 0x38650000, 0x38652000, 0x38654000, 0x38656000,
+        0x38658000, 0x3865A000, 0x3865C000, 0x3865E000, 0x38660000, 0x38662000,
+        0x38664000, 0x38666000, 0x38668000, 0x3866A000, 0x3866C000, 0x3866E000,
+        0x38670000, 0x38672000, 0x38674000, 0x38676000, 0x38678000, 0x3867A000,
+        0x3867C000, 0x3867E000, 0x38680000, 0x38682000, 0x38684000, 0x38686000,
+        0x38688000, 0x3868A000, 0x3868C000, 0x3868E000, 0x38690000, 0x38692000,
+        0x38694000, 0x38696000, 0x38698000, 0x3869A000, 0x3869C000, 0x3869E000,
+        0x386A0000, 0x386A2000, 0x386A4000, 0x386A6000, 0x386A8000, 0x386AA000,
+        0x386AC000, 0x386AE000, 0x386B0000, 0x386B2000, 0x386B4000, 0x386B6000,
+        0x386B8000, 0x386BA000, 0x386BC000, 0x386BE000, 0x386C0000, 0x386C2000,
+        0x386C4000, 0x386C6000, 0x386C8000, 0x386CA000, 0x386CC000, 0x386CE000,
+        0x386D0000, 0x386D2000, 0x386D4000, 0x386D6000, 0x386D8000, 0x386DA000,
+        0x386DC000, 0x386DE000, 0x386E0000, 0x386E2000, 0x386E4000, 0x386E6000,
+        0x386E8000, 0x386EA000, 0x386EC000, 0x386EE000, 0x386F0000, 0x386F2000,
+        0x386F4000, 0x386F6000, 0x386F8000, 0x386FA000, 0x386FC000, 0x386FE000,
+        0x38700000, 0x38702000, 0x38704000, 0x38706000, 0x38708000, 0x3870A000,
+        0x3870C000, 0x3870E000, 0x38710000, 0x38712000, 0x38714000, 0x38716000,
+        0x38718000, 0x3871A000, 0x3871C000, 0x3871E000, 0x38720000, 0x38722000,
+        0x38724000, 0x38726000, 0x38728000, 0x3872A000, 0x3872C000, 0x3872E000,
+        0x38730000, 0x38732000, 0x38734000, 0x38736000, 0x38738000, 0x3873A000,
+        0x3873C000, 0x3873E000, 0x38740000, 0x38742000, 0x38744000, 0x38746000,
+        0x38748000, 0x3874A000, 0x3874C000, 0x3874E000, 0x38750000, 0x38752000,
+        0x38754000, 0x38756000, 0x38758000, 0x3875A000, 0x3875C000, 0x3875E000,
+        0x38760000, 0x38762000, 0x38764000, 0x38766000, 0x38768000, 0x3876A000,
+        0x3876C000, 0x3876E000, 0x38770000, 0x38772000, 0x38774000, 0x38776000,
+        0x38778000, 0x3877A000, 0x3877C000, 0x3877E000, 0x38780000, 0x38782000,
+        0x38784000, 0x38786000, 0x38788000, 0x3878A000, 0x3878C000, 0x3878E000,
+        0x38790000, 0x38792000, 0x38794000, 0x38796000, 0x38798000, 0x3879A000,
+        0x3879C000, 0x3879E000, 0x387A0000, 0x387A2000, 0x387A4000, 0x387A6000,
+        0x387A8000, 0x387AA000, 0x387AC000, 0x387AE000, 0x387B0000, 0x387B2000,
+        0x387B4000, 0x387B6000, 0x387B8000, 0x387BA000, 0x387BC000, 0x387BE000,
+        0x387C0000, 0x387C2000, 0x387C4000, 0x387C6000, 0x387C8000, 0x387CA000,
+        0x387CC000, 0x387CE000, 0x387D0000, 0x387D2000, 0x387D4000, 0x387D6000,
+        0x387D8000, 0x387DA000, 0x387DC000, 0x387DE000, 0x387E0000, 0x387E2000,
+        0x387E4000, 0x387E6000, 0x387E8000, 0x387EA000, 0x387EC000, 0x387EE000,
+        0x387F0000, 0x387F2000, 0x387F4000, 0x387F6000, 0x387F8000, 0x387FA000,
+        0x387FC000, 0x387FE000
+      };
+      static const uint32 exponent_table[64] = {
+        0x00000000, 0x00800000, 0x01000000, 0x01800000, 0x02000000, 0x02800000,
+        0x03000000, 0x03800000, 0x04000000, 0x04800000, 0x05000000, 0x05800000,
+        0x06000000, 0x06800000, 0x07000000, 0x07800000, 0x08000000, 0x08800000,
+        0x09000000, 0x09800000, 0x0A000000, 0x0A800000, 0x0B000000, 0x0B800000,
+        0x0C000000, 0x0C800000, 0x0D000000, 0x0D800000, 0x0E000000, 0x0E800000,
+        0x0F000000, 0x47800000, 0x80000000, 0x80800000, 0x81000000, 0x81800000,
+        0x82000000, 0x82800000, 0x83000000, 0x83800000, 0x84000000, 0x84800000,
+        0x85000000, 0x85800000, 0x86000000, 0x86800000, 0x87000000, 0x87800000,
+        0x88000000, 0x88800000, 0x89000000, 0x89800000, 0x8A000000, 0x8A800000,
+        0x8B000000, 0x8B800000, 0x8C000000, 0x8C800000, 0x8D000000, 0x8D800000,
+        0x8E000000, 0x8E800000, 0x8F000000, 0xC7800000
+      };
+      static const unsigned short offset_table[64]
+          = { 0,    1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024,
+              1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024,
+              1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 0,
+              1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024,
+              1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024,
+              1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024 };
+      uint32 bits = mantissa_table[offset_table[value >> 10] + (value & 0x3FF)]
+                    + exponent_table[value >> 10];
+      //			return *reinterpret_cast<float*>(&bits);
+      ////violating strict aliasing!
+      float out;
+      std::memcpy(&out, &bits, sizeof(float));
+      return out;
+    }
+
+    /// Convert half-precision to IEEE double-precision.
+    /// \param value binary representation of half-precision value
+    /// \return double-precision value
+    inline double half2float_impl(uint16 value, double, true_type)
+    {
+      typedef bits<float>::type uint32;
+      typedef bits<double>::type uint64;
+      uint32 hi = static_cast<uint32>(value & 0x8000) << 16;
+      int abs = value & 0x7FFF;
+      if (abs)
+        {
+          hi |= 0x3F000000 << static_cast<unsigned>(abs >= 0x7C00);
+          for (; abs < 0x400; abs <<= 1, hi -= 0x100000)
+            ;
+          hi += static_cast<uint32>(abs) << 10;
+        }
+      uint64 bits = static_cast<uint64>(hi) << 32;
+      //			return *reinterpret_cast<double*>(&bits);
+      ////violating strict aliasing!
+      double out;
+      std::memcpy(&out, &bits, sizeof(double));
+      return out;
+    }
+
+    /// Convert half-precision to non-IEEE floating point.
+    /// \tparam T type to convert to (builtin integer type)
+    /// \param value binary representation of half-precision value
+    /// \return floating point value
+    template <typename T> T half2float_impl(uint16 value, T, ...)
+    {
+      T out;
+      int abs = value & 0x7FFF;
+      if (abs > 0x7C00)
+        out = std::numeric_limits<T>::has_quiet_NaN
+                  ? std::numeric_limits<T>::quiet_NaN()
+                  : T();
+      else if (abs == 0x7C00)
+        out = std::numeric_limits<T>::has_infinity
+                  ? std::numeric_limits<T>::infinity()
+                  : std::numeric_limits<T>::max();
+      else if (abs > 0x3FF)
+        out = std::ldexp(static_cast<T>((abs & 0x3FF) | 0x400),
+                         (abs >> 10) - 25);
+      else
+        out = std::ldexp(static_cast<T>(abs), -24);
+      return (value & 0x8000) ? -out : out;
+    }
+
+    /// Convert half-precision to floating point.
+    /// \tparam T type to convert to (builtin integer type)
+    /// \param value binary representation of half-precision value
+    /// \return floating point value
+    template <typename T> T half2float(uint16 value)
+    {
+      return half2float_impl(value, T(),
+                             bool_type < std::numeric_limits<T>::is_iec559
+                                 && sizeof(typename bits<T>::type)
+                                        == sizeof(T) > ());
+    }
+
+    /// Convert half-precision floating point to integer.
+    /// \tparam R rounding mode to use, `std::round_indeterminate` for fastest
+    /// rounding \tparam E `true` for round to even, `false` for round away
+    /// from zero \tparam T type to convert to (buitlin integer type with at
+    /// least 16 bits precision, excluding any implicit sign bits) \param value
+    /// binary representation of half-precision value \return integral value
+    template <std::float_round_style R, bool E, typename T>
+    T half2int_impl(uint16 value)
+    {
+#if HALF_ENABLE_CPP11_STATIC_ASSERT && HALF_ENABLE_CPP11_TYPE_TRAITS
+      static_assert(
+          std::is_integral<T>::value,
+          "half to int conversion only supports builtin integer types");
+#endif
+      unsigned int e = value & 0x7FFF;
+      if (e >= 0x7C00)
+        return (value & 0x8000) ? std::numeric_limits<T>::min()
+                                : std::numeric_limits<T>::max();
+      if (e < 0x3800)
+        {
+          if (R == std::round_toward_infinity)
+            return T(~(value >> 15) & (e != 0));
+          else if (R == std::round_toward_neg_infinity)
+            return -T(value > 0x8000);
+          return T();
+        }
+      unsigned int m = (value & 0x3FF) | 0x400;
+      e >>= 10;
+      if (e < 25)
+        {
+          if (R == std::round_to_nearest)
+            m += (1 << (24 - e)) - (~(m >> (25 - e)) & E);
+          else if (R == std::round_toward_infinity)
+            m += ((value >> 15) - 1) & ((1 << (25 - e)) - 1U);
+          else if (R == std::round_toward_neg_infinity)
+            m += -(value >> 15) & ((1 << (25 - e)) - 1U);
+          m >>= 25 - e;
+        }
+      else
+        m <<= e - 25;
+      return (value & 0x8000) ? -static_cast<T>(m) : static_cast<T>(m);
+    }
+
+    /// Convert half-precision floating point to integer.
+    /// \tparam R rounding mode to use, `std::round_indeterminate` for fastest
+    /// rounding \tparam T type to convert to (buitlin integer type with at
+    /// least 16 bits precision, excluding any implicit sign bits) \param value
+    /// binary representation of half-precision value \return integral value
+    template <std::float_round_style R, typename T> T half2int(uint16 value)
+    {
+      return half2int_impl<R, HALF_ROUND_TIES_TO_EVEN, T>(value);
+    }
+
+    /// Convert half-precision floating point to integer using
+    /// round-to-nearest-away-from-zero. \tparam T type to convert to (buitlin
+    /// integer type with at least 16 bits precision, excluding any implicit
+    /// sign bits) \param value binary representation of half-precision value
+    /// \return integral value
+    template <typename T> T half2int_up(uint16 value)
+    {
+      return half2int_impl<std::round_to_nearest, 0, T>(value);
+    }
+
+    /// Round half-precision number to nearest integer value.
+    /// \tparam R rounding mode to use, `std::round_indeterminate` for fastest
+    /// rounding \tparam E `true` for round to even, `false` for round away
+    /// from zero \param value binary representation of half-precision value
+    /// \return half-precision bits for nearest integral value
+    template <std::float_round_style R, bool E>
+    uint16 round_half_impl(uint16 value)
+    {
+      unsigned int e = value & 0x7FFF;
+      uint16 result = value;
+      if (e < 0x3C00)
+        {
+          result &= 0x8000;
+          if (R == std::round_to_nearest)
+            result |= 0x3C00U & -(e >= (0x3800 + E));
+          else if (R == std::round_toward_infinity)
+            result |= 0x3C00U & -(~(value >> 15) & (e != 0));
+          else if (R == std::round_toward_neg_infinity)
+            result |= 0x3C00U & -(value > 0x8000);
+        }
+      else if (e < 0x6400)
+        {
+          e = 25 - (e >> 10);
+          unsigned int mask = (1 << e) - 1;
+          if (R == std::round_to_nearest)
+            result += (1 << (e - 1)) - (~(result >> e) & E);
+          else if (R == std::round_toward_infinity)
+            result += mask & ((value >> 15) - 1);
+          else if (R == std::round_toward_neg_infinity)
+            result += mask & -(value >> 15);
+          result &= ~mask;
+        }
+      return result;
+    }
+
+    /// Round half-precision number to nearest integer value.
+    /// \tparam R rounding mode to use, `std::round_indeterminate` for fastest
+    /// rounding \param value binary representation of half-precision value
+    /// \return half-precision bits for nearest integral value
+    template <std::float_round_style R> uint16 round_half(uint16 value)
+    {
+      return round_half_impl<R, HALF_ROUND_TIES_TO_EVEN>(value);
+    }
+
+    /// Round half-precision number to nearest integer value using
+    /// round-to-nearest-away-from-zero. \param value binary representation of
+    /// half-precision value \return half-precision bits for nearest integral
+    /// value
+    inline uint16 round_half_up(uint16 value)
+    {
+      return round_half_impl<std::round_to_nearest, 0>(value);
+    }
+    /// \}
+
+    struct functions;
+    template <typename> struct unary_specialized;
+    template <typename, typename> struct binary_specialized;
+    template <typename, typename, std::float_round_style> struct half_caster;
+  }
+
+  /// Half-precision floating point type.
+  /// This class implements an IEEE-conformant half-precision floating point
+  /// type with the usual arithmetic operators and conversions. It is
+  /// implicitly convertible to single-precision floating point, which makes
+  /// artihmetic expressions and functions with mixed-type operands to be of
+  /// the most precise operand type. Additionally all arithmetic operations
+  /// (and many mathematical functions) are carried out in single-precision
+  /// internally. All conversions from single- to half-precision are done using
+  /// the library's default rounding mode, but temporary results inside chained
+  /// arithmetic expressions are kept in single-precision as long as possible
+  /// (while of course still maintaining a strong half-precision type).
+  ///
+  /// According to the C++98/03 definition, the half type is not a POD type.
+  /// But according to C++11's less strict and extended definitions it is both
+  /// a standard layout type and a trivially copyable type (even if not a POD
+  /// type), which means it can be standard-conformantly copied using raw
+  /// binary copies. But in this context some more words about the actual size
+  /// of the type. Although the half is representing an IEEE 16-bit type, it
+  /// does not neccessarily have to be of exactly 16-bits size. But on any
+  /// reasonable implementation the actual binary representation of this type
+  /// will most probably not ivolve any additional "magic" or padding beyond
+  /// the simple binary representation of the underlying 16-bit IEEE number,
+  /// even if not strictly guaranteed by the standard. But even then it only
+  /// has an actual size of 16 bits if your C++ implementation supports an
+  /// unsigned integer type of exactly 16 bits width. But this should be the
+  /// case on nearly any reasonable platform.
+  ///
+  /// So if your C++ implementation is not totally exotic or imposes special
+  /// alignment requirements, it is a reasonable assumption that the data of a
+  /// half is just comprised of the 2 bytes of the underlying IEEE
+  /// representation.
+  class half
+  {
+    friend struct detail::functions;
+    friend struct detail::unary_specialized<half>;
+    friend struct detail::binary_specialized<half, half>;
+    template <typename, typename, std::float_round_style>
+    friend struct detail::half_caster;
+    friend class std::numeric_limits<half>;
+#if HALF_ENABLE_CPP11_HASH
+    friend struct std::hash<half>;
+#endif
+#if HALF_ENABLE_CPP11_USER_LITERALS
+    friend half literal::operator""_h(long double);
+#endif
+
+  public:
+    /// Default constructor.
+    /// This initializes the half to 0. Although this does not match the
+    /// builtin types' default-initialization semantics and may be less
+    /// efficient than no initialization, it is needed to provide proper
+    /// value-initialization semantics.
+    HALF_CONSTEXPR half() HALF_NOEXCEPT : data_()
+    {
+    }
+
+    /// Copy constructor.
+    /// \tparam T type of concrete half expression
+    /// \param rhs half expression to copy from
+    half(detail::expr rhs)
+        : data_(detail::float2half<round_style>(static_cast<float>(rhs)))
+    {
+    }
+
+    /// Conversion constructor.
+    /// \param rhs float to convert
+    explicit half(float rhs) : data_(detail::float2half<round_style>(rhs))
+    {
+    }
+
+    /// Conversion to single-precision.
+    /// \return single precision value representing expression value
+    operator float() const
+    {
+      return detail::half2float<float>(data_);
+    }
+
+    /// Assignment operator.
+    /// \tparam T type of concrete half expression
+    /// \param rhs half expression to copy from
+    /// \return reference to this half
+    half &operator=(detail::expr rhs)
+    {
+      return *this = static_cast<float>(rhs);
+    }
+
+    /// Arithmetic assignment.
+    /// \tparam T type of concrete half expression
+    /// \param rhs half expression to add
+    /// \return reference to this half
+    template <typename T>
+    typename detail::enable<half &, T>::type operator+=(T rhs)
+    {
+      return *this += static_cast<float>(rhs);
+    }
+
+    /// Arithmetic assignment.
+    /// \tparam T type of concrete half expression
+    /// \param rhs half expression to subtract
+    /// \return reference to this half
+    template <typename T>
+    typename detail::enable<half &, T>::type operator-=(T rhs)
+    {
+      return *this -= static_cast<float>(rhs);
+    }
+
+    /// Arithmetic assignment.
+    /// \tparam T type of concrete half expression
+    /// \param rhs half expression to multiply with
+    /// \return reference to this half
+    template <typename T>
+    typename detail::enable<half &, T>::type operator*=(T rhs)
+    {
+      return *this *= static_cast<float>(rhs);
+    }
+
+    /// Arithmetic assignment.
+    /// \tparam T type of concrete half expression
+    /// \param rhs half expression to divide by
+    /// \return reference to this half
+    template <typename T>
+    typename detail::enable<half &, T>::type operator/=(T rhs)
+    {
+      return *this /= static_cast<float>(rhs);
+    }
+
+    /// Assignment operator.
+    /// \param rhs single-precision value to copy from
+    /// \return reference to this half
+    half &operator=(float rhs)
+    {
+      data_ = detail::float2half<round_style>(rhs);
+      return *this;
+    }
+
+    /// Arithmetic assignment.
+    /// \param rhs single-precision value to add
+    /// \return reference to this half
+    half &operator+=(float rhs)
+    {
+      data_ = detail::float2half<round_style>(detail::half2float<float>(data_)
+                                              + rhs);
+      return *this;
+    }
+
+    /// Arithmetic assignment.
+    /// \param rhs single-precision value to subtract
+    /// \return reference to this half
+    half &operator-=(float rhs)
+    {
+      data_ = detail::float2half<round_style>(detail::half2float<float>(data_)
+                                              - rhs);
+      return *this;
+    }
+
+    /// Arithmetic assignment.
+    /// \param rhs single-precision value to multiply with
+    /// \return reference to this half
+    half &operator*=(float rhs)
+    {
+      data_ = detail::float2half<round_style>(detail::half2float<float>(data_)
+                                              * rhs);
+      return *this;
+    }
+
+    /// Arithmetic assignment.
+    /// \param rhs single-precision value to divide by
+    /// \return reference to this half
+    half &operator/=(float rhs)
+    {
+      data_ = detail::float2half<round_style>(detail::half2float<float>(data_)
+                                              / rhs);
+      return *this;
+    }
+
+    /// Prefix increment.
+    /// \return incremented half value
+    half &operator++()
+    {
+      return *this += 1.0f;
+    }
+
+    /// Prefix decrement.
+    /// \return decremented half value
+    half &operator--()
+    {
+      return *this -= 1.0f;
+    }
+
+    /// Postfix increment.
+    /// \return non-incremented half value
+    half operator++(int)
+    {
+      half out(*this);
+      ++*this;
+      return out;
+    }
+
+    /// Postfix decrement.
+    /// \return non-decremented half value
+    half operator--(int)
+    {
+      half out(*this);
+      --*this;
+      return out;
+    }
+
+  private:
+    /// Rounding mode to use
+    static const std::float_round_style round_style
+        = (std::float_round_style)(HALF_ROUND_STYLE);
+
+    /// Constructor.
+    /// \param bits binary representation to set half to
+    HALF_CONSTEXPR half(detail::binary_t, detail::uint16 bits) HALF_NOEXCEPT
+        : data_(bits)
+    {
+    }
+
+    /// Internal binary representation
+    detail::uint16 data_;
+  };
+
+#if HALF_ENABLE_CPP11_USER_LITERALS
+  namespace literal
+  {
+    /// Half literal.
+    /// While this returns an actual half-precision value, half literals can
+    /// unfortunately not be constant expressions due to rather involved
+    /// conversions. \param value literal value \return half with given value
+    /// (if representable)
+    inline half operator""_h(long double value)
+    {
+      return half(detail::binary,
+                  detail::float2half<half::round_style>(value));
+    }
+  }
+#endif
+
+  namespace detail
+  {
+    /// Wrapper implementing unspecialized half-precision functions.
+    struct functions
+    {
+      /// Addition implementation.
+      /// \param x first operand
+      /// \param y second operand
+      /// \return Half-precision sum stored in single-precision
+      static expr plus(float x, float y)
+      {
+        return expr(x + y);
+      }
+
+      /// Subtraction implementation.
+      /// \param x first operand
+      /// \param y second operand
+      /// \return Half-precision difference stored in single-precision
+      static expr minus(float x, float y)
+      {
+        return expr(x - y);
+      }
+
+      /// Multiplication implementation.
+      /// \param x first operand
+      /// \param y second operand
+      /// \return Half-precision product stored in single-precision
+      static expr multiplies(float x, float y)
+      {
+        return expr(x * y);
+      }
+
+      /// Division implementation.
+      /// \param x first operand
+      /// \param y second operand
+      /// \return Half-precision quotient stored in single-precision
+      static expr divides(float x, float y)
+      {
+        return expr(x / y);
+      }
+
+      /// Output implementation.
+      /// \param out stream to write to
+      /// \param arg value to write
+      /// \return reference to stream
+      template <typename charT, typename traits>
+      static std::basic_ostream<charT, traits> &
+      write(std::basic_ostream<charT, traits> &out, float arg)
+      {
+        return out << arg;
+      }
+
+      /// Input implementation.
+      /// \param in stream to read from
+      /// \param arg half to read into
+      /// \return reference to stream
+      template <typename charT, typename traits>
+      static std::basic_istream<charT, traits> &
+      read(std::basic_istream<charT, traits> &in, half &arg)
+      {
+        float f;
+        if (in >> f)
+          arg = f;
+        return in;
+      }
+
+      /// Modulo implementation.
+      /// \param x first operand
+      /// \param y second operand
+      /// \return Half-precision division remainder stored in single-precision
+      static expr fmod(float x, float y)
+      {
+        return expr(std::fmod(x, y));
+      }
+
+      /// Remainder implementation.
+      /// \param x first operand
+      /// \param y second operand
+      /// \return Half-precision division remainder stored in single-precision
+      static expr remainder(float x, float y)
+      {
+#if HALF_ENABLE_CPP11_CMATH
+        return expr(std::remainder(x, y));
+#else
+        if (builtin_isnan(x) || builtin_isnan(y))
+          return expr(std::numeric_limits<float>::quiet_NaN());
+        float ax = std::fabs(x), ay = std::fabs(y);
+        if (ax >= 65536.0f || ay < std::ldexp(1.0f, -24))
+          return expr(std::numeric_limits<float>::quiet_NaN());
+        if (ay >= 65536.0f)
+          return expr(x);
+        if (ax == ay)
+          return expr(builtin_signbit(x) ? -0.0f : 0.0f);
+        ax = std::fmod(ax, ay + ay);
+        float y2 = 0.5f * ay;
+        if (ax > y2)
+          {
+            ax -= ay;
+            if (ax >= y2)
+              ax -= ay;
+          }
+        return expr(builtin_signbit(x) ? -ax : ax);
+#endif
+      }
+
+      /// Remainder implementation.
+      /// \param x first operand
+      /// \param y second operand
+      /// \param quo address to store quotient bits at
+      /// \return Half-precision division remainder stored in single-precision
+      static expr remquo(float x, float y, int *quo)
+      {
+#if HALF_ENABLE_CPP11_CMATH
+        return expr(std::remquo(x, y, quo));
+#else
+        if (builtin_isnan(x) || builtin_isnan(y))
+          return expr(std::numeric_limits<float>::quiet_NaN());
+        bool sign = builtin_signbit(x),
+             qsign = static_cast<bool>(sign ^ builtin_signbit(y));
+        float ax = std::fabs(x), ay = std::fabs(y);
+        if (ax >= 65536.0f || ay < std::ldexp(1.0f, -24))
+          return expr(std::numeric_limits<float>::quiet_NaN());
+        if (ay >= 65536.0f)
+          return expr(x);
+        if (ax == ay)
+          return *quo = qsign ? -1 : 1, expr(sign ? -0.0f : 0.0f);
+        ax = std::fmod(ax, 8.0f * ay);
+        int cquo = 0;
+        if (ax >= 4.0f * ay)
+          {
+            ax -= 4.0f * ay;
+            cquo += 4;
+          }
+        if (ax >= 2.0f * ay)
+          {
+            ax -= 2.0f * ay;
+            cquo += 2;
+          }
+        float y2 = 0.5f * ay;
+        if (ax > y2)
+          {
+            ax -= ay;
+            ++cquo;
+            if (ax >= y2)
+              {
+                ax -= ay;
+                ++cquo;
+              }
+          }
+        return *quo = qsign ? -cquo : cquo, expr(sign ? -ax : ax);
+#endif
+      }
+
+      /// Positive difference implementation.
+      /// \param x first operand
+      /// \param y second operand
+      /// \return Positive difference stored in single-precision
+      static expr fdim(float x, float y)
+      {
+#if HALF_ENABLE_CPP11_CMATH
+        return expr(std::fdim(x, y));
+#else
+        return expr((x <= y) ? 0.0f : (x - y));
+#endif
+      }
+
+      /// Fused multiply-add implementation.
+      /// \param x first operand
+      /// \param y second operand
+      /// \param z third operand
+      /// \return \a x * \a y + \a z stored in single-precision
+      static expr fma(float x, float y, float z)
+      {
+#if HALF_ENABLE_CPP11_CMATH && defined(FP_FAST_FMAF)
+        return expr(std::fma(x, y, z));
+#else
+        return expr(x * y + z);
+#endif
+      }
+
+      /// Get NaN.
+      /// \return Half-precision quiet NaN
+      static half nanh()
+      {
+        return half(binary, 0x7FFF);
+      }
+
+      /// Exponential implementation.
+      /// \param arg function argument
+      /// \return function value stored in single-preicision
+      static expr exp(float arg)
+      {
+        return expr(std::exp(arg));
+      }
+
+      /// Exponential implementation.
+      /// \param arg function argument
+      /// \return function value stored in single-preicision
+      static expr expm1(float arg)
+      {
+#if HALF_ENABLE_CPP11_CMATH
+        return expr(std::expm1(arg));
+#else
+        return expr(
+            static_cast<float>(std::exp(static_cast<double>(arg)) - 1.0));
+#endif
+      }
+
+      /// Binary exponential implementation.
+      /// \param arg function argument
+      /// \return function value stored in single-preicision
+      static expr exp2(float arg)
+      {
+#if HALF_ENABLE_CPP11_CMATH
+        return expr(std::exp2(arg));
+#else
+        return expr(static_cast<float>(
+            std::exp(arg * 0.69314718055994530941723212145818)));
+#endif
+      }
+
+      /// Logarithm implementation.
+      /// \param arg function argument
+      /// \return function value stored in single-preicision
+      static expr log(float arg)
+      {
+        return expr(std::log(arg));
+      }
+
+      /// Common logarithm implementation.
+      /// \param arg function argument
+      /// \return function value stored in single-preicision
+      static expr log10(float arg)
+      {
+        return expr(std::log10(arg));
+      }
+
+      /// Logarithm implementation.
+      /// \param arg function argument
+      /// \return function value stored in single-preicision
+      static expr log1p(float arg)
+      {
+#if HALF_ENABLE_CPP11_CMATH
+        return expr(std::log1p(arg));
+#else
+        return expr(static_cast<float>(std::log(1.0 + arg)));
+#endif
+      }
+
+      /// Binary logarithm implementation.
+      /// \param arg function argument
+      /// \return function value stored in single-preicision
+      static expr log2(float arg)
+      {
+#if HALF_ENABLE_CPP11_CMATH
+        return expr(std::log2(arg));
+#else
+        return expr(static_cast<float>(std::log(static_cast<double>(arg))
+                                       * 1.4426950408889634073599246810019));
+#endif
+      }
+
+      /// Square root implementation.
+      /// \param arg function argument
+      /// \return function value stored in single-preicision
+      static expr sqrt(float arg)
+      {
+        return expr(std::sqrt(arg));
+      }
+
+      /// Cubic root implementation.
+      /// \param arg function argument
+      /// \return function value stored in single-preicision
+      static expr cbrt(float arg)
+      {
+#if HALF_ENABLE_CPP11_CMATH
+        return expr(std::cbrt(arg));
+#else
+        if (builtin_isnan(arg) || builtin_isinf(arg))
+          return expr(arg);
+        return expr(builtin_signbit(arg)
+                        ? -static_cast<float>(
+                            std::pow(-static_cast<double>(arg), 1.0 / 3.0))
+                        : static_cast<float>(
+                            std::pow(static_cast<double>(arg), 1.0 / 3.0)));
+#endif
+      }
+
+      /// Hypotenuse implementation.
+      /// \param x first argument
+      /// \param y second argument
+      /// \return function value stored in single-preicision
+      static expr hypot(float x, float y)
+      {
+#if HALF_ENABLE_CPP11_CMATH
+        return expr(std::hypot(x, y));
+#else
+        return expr(
+            (builtin_isinf(x) || builtin_isinf(y))
+                ? std::numeric_limits<float>::infinity()
+                : static_cast<float>(std::sqrt(static_cast<double>(x) * x
+                                               + static_cast<double>(y) * y)));
+#endif
+      }
+
+      /// Power implementation.
+      /// \param base value to exponentiate
+      /// \param exp power to expontiate to
+      /// \return function value stored in single-preicision
+      static expr pow(float base, float exp)
+      {
+        return expr(std::pow(base, exp));
+      }
+
+      /// Sine implementation.
+      /// \param arg function argument
+      /// \return function value stored in single-preicision
+      static expr sin(float arg)
+      {
+        return expr(std::sin(arg));
+      }
+
+      /// Cosine implementation.
+      /// \param arg function argument
+      /// \return function value stored in single-preicision
+      static expr cos(float arg)
+      {
+        return expr(std::cos(arg));
+      }
+
+      /// Tan implementation.
+      /// \param arg function argument
+      /// \return function value stored in single-preicision
+      static expr tan(float arg)
+      {
+        return expr(std::tan(arg));
+      }
+
+      /// Arc sine implementation.
+      /// \param arg function argument
+      /// \return function value stored in single-preicision
+      static expr asin(float arg)
+      {
+        return expr(std::asin(arg));
+      }
+
+      /// Arc cosine implementation.
+      /// \param arg function argument
+      /// \return function value stored in single-preicision
+      static expr acos(float arg)
+      {
+        return expr(std::acos(arg));
+      }
+
+      /// Arc tangent implementation.
+      /// \param arg function argument
+      /// \return function value stored in single-preicision
+      static expr atan(float arg)
+      {
+        return expr(std::atan(arg));
+      }
+
+      /// Arc tangent implementation.
+      /// \param x first argument
+      /// \param y second argument
+      /// \return function value stored in single-preicision
+      static expr atan2(float x, float y)
+      {
+        return expr(std::atan2(x, y));
+      }
+
+      /// Hyperbolic sine implementation.
+      /// \param arg function argument
+      /// \return function value stored in single-preicision
+      static expr sinh(float arg)
+      {
+        return expr(std::sinh(arg));
+      }
+
+      /// Hyperbolic cosine implementation.
+      /// \param arg function argument
+      /// \return function value stored in single-preicision
+      static expr cosh(float arg)
+      {
+        return expr(std::cosh(arg));
+      }
+
+      /// Hyperbolic tangent implementation.
+      /// \param arg function argument
+      /// \return function value stored in single-preicision
+      static expr tanh(float arg)
+      {
+        return expr(std::tanh(arg));
+      }
+
+      /// Hyperbolic area sine implementation.
+      /// \param arg function argument
+      /// \return function value stored in single-preicision
+      static expr asinh(float arg)
+      {
+#if HALF_ENABLE_CPP11_CMATH
+        return expr(std::asinh(arg));
+#else
+        return expr((arg == -std::numeric_limits<float>::infinity())
+                        ? arg
+                        : static_cast<float>(
+                            std::log(arg + std::sqrt(arg * arg + 1.0))));
+#endif
+      }
+
+      /// Hyperbolic area cosine implementation.
+      /// \param arg function argument
+      /// \return function value stored in single-preicision
+      static expr acosh(float arg)
+      {
+#if HALF_ENABLE_CPP11_CMATH
+        return expr(std::acosh(arg));
+#else
+        return expr((arg < -1.0f) ? std::numeric_limits<float>::quiet_NaN()
+                                  : static_cast<float>(std::log(
+                                      arg + std::sqrt(arg * arg - 1.0))));
+#endif
+      }
+
+      /// Hyperbolic area tangent implementation.
+      /// \param arg function argument
+      /// \return function value stored in single-preicision
+      static expr atanh(float arg)
+      {
+#if HALF_ENABLE_CPP11_CMATH
+        return expr(std::atanh(arg));
+#else
+        return expr(
+            static_cast<float>(0.5 * std::log((1.0 + arg) / (1.0 - arg))));
+#endif
+      }
+
+      /// Error function implementation.
+      /// \param arg function argument
+      /// \return function value stored in single-preicision
+      static expr erf(float arg)
+      {
+#if HALF_ENABLE_CPP11_CMATH
+        return expr(std::erf(arg));
+#else
+        return expr(static_cast<float>(erf(static_cast<double>(arg))));
+#endif
+      }
+
+      /// Complementary implementation.
+      /// \param arg function argument
+      /// \return function value stored in single-preicision
+      static expr erfc(float arg)
+      {
+#if HALF_ENABLE_CPP11_CMATH
+        return expr(std::erfc(arg));
+#else
+        return expr(static_cast<float>(1.0 - erf(static_cast<double>(arg))));
+#endif
+      }
+
+      /// Gamma logarithm implementation.
+      /// \param arg function argument
+      /// \return function value stored in single-preicision
+      static expr lgamma(float arg)
+      {
+#if HALF_ENABLE_CPP11_CMATH
+        return expr(std::lgamma(arg));
+#else
+        if (builtin_isinf(arg))
+          return expr(std::numeric_limits<float>::infinity());
+        if (arg < 0.0f)
+          {
+            float i, f = std::modf(-arg, &i);
+            if (f == 0.0f)
+              return expr(std::numeric_limits<float>::infinity());
+            return expr(static_cast<float>(
+                1.1447298858494001741434273513531
+                - std::log(
+                    std::abs(std::sin(3.1415926535897932384626433832795 * f)))
+                - lgamma(1.0 - arg)));
+          }
+        return expr(static_cast<float>(lgamma(static_cast<double>(arg))));
+#endif
+      }
+
+      /// Gamma implementation.
+      /// \param arg function argument
+      /// \return function value stored in single-preicision
+      static expr tgamma(float arg)
+      {
+#if HALF_ENABLE_CPP11_CMATH
+        return expr(std::tgamma(arg));
+#else
+        if (arg == 0.0f)
+          return builtin_signbit(arg)
+                     ? expr(-std::numeric_limits<float>::infinity())
+                     : expr(std::numeric_limits<float>::infinity());
+        if (arg < 0.0f)
+          {
+            float i, f = std::modf(-arg, &i);
+            if (f == 0.0f)
+              return expr(std::numeric_limits<float>::quiet_NaN());
+            double value = 3.1415926535897932384626433832795
+                           / (std::sin(3.1415926535897932384626433832795 * f)
+                              * std::exp(lgamma(1.0 - arg)));
+            return expr(static_cast<float>(
+                (std::fmod(i, 2.0f) == 0.0f) ? -value : value));
+          }
+        if (builtin_isinf(arg))
+          return expr(arg);
+        return expr(
+            static_cast<float>(std::exp(lgamma(static_cast<double>(arg)))));
+#endif
+      }
+
+      /// Floor implementation.
+      /// \param arg value to round
+      /// \return rounded value
+      static half floor(half arg)
+      {
+        return half(binary,
+                    round_half<std::round_toward_neg_infinity>(arg.data_));
+      }
+
+      /// Ceiling implementation.
+      /// \param arg value to round
+      /// \return rounded value
+      static half ceil(half arg)
+      {
+        return half(binary, round_half<std::round_toward_infinity>(arg.data_));
+      }
+
+      /// Truncation implementation.
+      /// \param arg value to round
+      /// \return rounded value
+      static half trunc(half arg)
+      {
+        return half(binary, round_half<std::round_toward_zero>(arg.data_));
+      }
+
+      /// Nearest integer implementation.
+      /// \param arg value to round
+      /// \return rounded value
+      static half round(half arg)
+      {
+        return half(binary, round_half_up(arg.data_));
+      }
+
+      /// Nearest integer implementation.
+      /// \param arg value to round
+      /// \return rounded value
+      static long lround(half arg)
+      {
+        return detail::half2int_up<long>(arg.data_);
+      }
+
+      /// Nearest integer implementation.
+      /// \param arg value to round
+      /// \return rounded value
+      static half rint(half arg)
+      {
+        return half(binary, round_half<half::round_style>(arg.data_));
+      }
+
+      /// Nearest integer implementation.
+      /// \param arg value to round
+      /// \return rounded value
+      static long lrint(half arg)
+      {
+        return detail::half2int<half::round_style, long>(arg.data_);
+      }
+
+#if HALF_ENABLE_CPP11_LONG_LONG
+      /// Nearest integer implementation.
+      /// \param arg value to round
+      /// \return rounded value
+      static long long llround(half arg)
+      {
+        return detail::half2int_up<long long>(arg.data_);
+      }
+
+      /// Nearest integer implementation.
+      /// \param arg value to round
+      /// \return rounded value
+      static long long llrint(half arg)
+      {
+        return detail::half2int<half::round_style, long long>(arg.data_);
+      }
+#endif
+
+      /// Decompression implementation.
+      /// \param arg number to decompress
+      /// \param exp address to store exponent at
+      /// \return normalized significant
+      static half frexp(half arg, int *exp)
+      {
+        int m = arg.data_ & 0x7FFF, e = -14;
+        if (m >= 0x7C00 || !m)
+          return *exp = 0, arg;
+        for (; m < 0x400; m <<= 1, --e)
+          ;
+        return *exp = e + (m >> 10),
+               half(binary, (arg.data_ & 0x8000) | 0x3800 | (m & 0x3FF));
+      }
+
+      /// Decompression implementation.
+      /// \param arg number to decompress
+      /// \param iptr address to store integer part at
+      /// \return fractional part
+      static half modf(half arg, half *iptr)
+      {
+        unsigned int e = arg.data_ & 0x7FFF;
+        if (e >= 0x6400)
+          return *iptr = arg,
+                 half(binary, arg.data_ & (0x8000U | -(e > 0x7C00)));
+        if (e < 0x3C00)
+          return iptr->data_ = arg.data_ & 0x8000, arg;
+        e >>= 10;
+        unsigned int mask = (1 << (25 - e)) - 1, m = arg.data_ & mask;
+        iptr->data_ = arg.data_ & ~mask;
+        if (!m)
+          return half(binary, arg.data_ & 0x8000);
+        for (; m < 0x400; m <<= 1, --e)
+          ;
+        return half(binary, static_cast<uint16>((arg.data_ & 0x8000)
+                                                | (e << 10) | (m & 0x3FF)));
+      }
+
+      /// Scaling implementation.
+      /// \param arg number to scale
+      /// \param exp power of two to scale by
+      /// \return scaled number
+      static half scalbln(half arg, long exp)
+      {
+        unsigned int m = arg.data_ & 0x7FFF;
+        if (m >= 0x7C00 || !m)
+          return arg;
+        for (; m < 0x400; m <<= 1, --exp)
+          ;
+        exp += m >> 10;
+        uint16 value = arg.data_ & 0x8000;
+        if (exp > 30)
+          {
+            if (half::round_style == std::round_toward_zero)
+              value |= 0x7BFF;
+            else if (half::round_style == std::round_toward_infinity)
+              value |= 0x7C00 - (value >> 15);
+            else if (half::round_style == std::round_toward_neg_infinity)
+              value |= 0x7BFF + (value >> 15);
+            else
+              value |= 0x7C00;
+          }
+        else if (exp > 0)
+          value |= (exp << 10) | (m & 0x3FF);
+        else if (exp > -11)
+          {
+            m = (m & 0x3FF) | 0x400;
+            if (half::round_style == std::round_to_nearest)
+              {
+                m += 1 << -exp;
+#if HALF_ROUND_TIES_TO_EVEN
+                m -= (m >> (1 - exp)) & 1;
+#endif
+              }
+            else if (half::round_style == std::round_toward_infinity)
+              m += ((value >> 15) - 1) & ((1 << (1 - exp)) - 1U);
+            else if (half::round_style == std::round_toward_neg_infinity)
+              m += -(value >> 15) & ((1 << (1 - exp)) - 1U);
+            value |= m >> (1 - exp);
+          }
+        else if (half::round_style == std::round_toward_infinity)
+          value -= (value >> 15) - 1;
+        else if (half::round_style == std::round_toward_neg_infinity)
+          value += value >> 15;
+        return half(binary, value);
+      }
+
+      /// Exponent implementation.
+      /// \param arg number to query
+      /// \return floating point exponent
+      static int ilogb(half arg)
+      {
+        int abs = arg.data_ & 0x7FFF;
+        if (!abs)
+          return FP_ILOGB0;
+        if (abs < 0x7C00)
+          {
+            int exp = (abs >> 10) - 15;
+            if (abs < 0x400)
+              for (; abs < 0x200; abs <<= 1, --exp)
+                ;
+            return exp;
+          }
+        if (abs > 0x7C00)
+          return FP_ILOGBNAN;
+        return INT_MAX;
+      }
+
+      /// Exponent implementation.
+      /// \param arg number to query
+      /// \return floating point exponent
+      static half logb(half arg)
+      {
+        int abs = arg.data_ & 0x7FFF;
+        if (!abs)
+          return half(binary, 0xFC00);
+        if (abs < 0x7C00)
+          {
+            int exp = (abs >> 10) - 15;
+            if (abs < 0x400)
+              for (; abs < 0x200; abs <<= 1, --exp)
+                ;
+            uint16 bits = (exp < 0) << 15;
+            if (exp)
+              {
+                unsigned int m = std::abs(exp) << 6, e = 18;
+                for (; m < 0x400; m <<= 1, --e)
+                  ;
+                bits |= (e << 10) + m;
+              }
+            return half(binary, bits);
+          }
+        if (abs > 0x7C00)
+          return arg;
+        return half(binary, 0x7C00);
+      }
+
+      /// Enumeration implementation.
+      /// \param from number to increase/decrease
+      /// \param to direction to enumerate into
+      /// \return next representable number
+      static half nextafter(half from, half to)
+      {
+        uint16 fabs = from.data_ & 0x7FFF, tabs = to.data_ & 0x7FFF;
+        if (fabs > 0x7C00)
+          return from;
+        if (tabs > 0x7C00 || from.data_ == to.data_ || !(fabs | tabs))
+          return to;
+        if (!fabs)
+          return half(binary, (to.data_ & 0x8000) + 1);
+        bool lt = ((fabs == from.data_) ? static_cast<int>(fabs)
+                                        : -static_cast<int>(fabs))
+                  < ((tabs == to.data_) ? static_cast<int>(tabs)
+                                        : -static_cast<int>(tabs));
+        return half(
+            binary,
+            from.data_
+                + (((from.data_ >> 15) ^ static_cast<unsigned>(lt)) << 1) - 1);
+      }
+
+      /// Enumeration implementation.
+      /// \param from number to increase/decrease
+      /// \param to direction to enumerate into
+      /// \return next representable number
+      static half nexttoward(half from, long double to)
+      {
+        if (isnan(from))
+          return from;
+        long double lfrom = static_cast<long double>(from);
+        if (builtin_isnan(to) || lfrom == to)
+          return half(static_cast<float>(to));
+        if (!(from.data_ & 0x7FFF))
+          return half(binary,
+                      (static_cast<detail::uint16>(builtin_signbit(to)) << 15)
+                          + 1);
+        return half(
+            binary,
+            from.data_
+                + (((from.data_ >> 15) ^ static_cast<unsigned>(lfrom < to))
+                   << 1)
+                - 1);
+      }
+
+      /// Sign implementation
+      /// \param x first operand
+      /// \param y second operand
+      /// \return composed value
+      static half copysign(half x, half y)
+      {
+        return half(binary, x.data_ ^ ((x.data_ ^ y.data_) & 0x8000));
+      }
+
+      /// Classification implementation.
+      /// \param arg value to classify
+      /// \retval true if infinite number
+      /// \retval false else
+      static int fpclassify(half arg)
+      {
+        unsigned int abs = arg.data_ & 0x7FFF;
+        return abs ? ((abs > 0x3FF)
+                          ? ((abs >= 0x7C00)
+                                 ? ((abs > 0x7C00) ? FP_NAN : FP_INFINITE)
+                                 : FP_NORMAL)
+                          : FP_SUBNORMAL)
+                   : FP_ZERO;
+      }
+
+      /// Classification implementation.
+      /// \param arg value to classify
+      /// \retval true if finite number
+      /// \retval false else
+      static bool isfinite(half arg)
+      {
+        return (arg.data_ & 0x7C00) != 0x7C00;
+      }
+
+      /// Classification implementation.
+      /// \param arg value to classify
+      /// \retval true if infinite number
+      /// \retval false else
+      static bool isinf(half arg)
+      {
+        return (arg.data_ & 0x7FFF) == 0x7C00;
+      }
+
+      /// Classification implementation.
+      /// \param arg value to classify
+      /// \retval true if not a number
+      /// \retval false else
+      static bool isnan(half arg)
+      {
+        return (arg.data_ & 0x7FFF) > 0x7C00;
+      }
+
+      /// Classification implementation.
+      /// \param arg value to classify
+      /// \retval true if normal number
+      /// \retval false else
+      static bool isnormal(half arg)
+      {
+        return ((arg.data_ & 0x7C00) != 0) & ((arg.data_ & 0x7C00) != 0x7C00);
+      }
+
+      /// Sign bit implementation.
+      /// \param arg value to check
+      /// \retval true if signed
+      /// \retval false if unsigned
+      static bool signbit(half arg)
+      {
+        return (arg.data_ & 0x8000) != 0;
+      }
+
+      /// Comparison implementation.
+      /// \param x first operand
+      /// \param y second operand
+      /// \retval true if operands equal
+      /// \retval false else
+      static bool isequal(half x, half y)
+      {
+        return (x.data_ == y.data_ || !((x.data_ | y.data_) & 0x7FFF))
+               && !isnan(x);
+      }
+
+      /// Comparison implementation.
+      /// \param x first operand
+      /// \param y second operand
+      /// \retval true if operands not equal
+      /// \retval false else
+      static bool isnotequal(half x, half y)
+      {
+        return (x.data_ != y.data_ && ((x.data_ | y.data_) & 0x7FFF))
+               || isnan(x);
+      }
+
+      /// Comparison implementation.
+      /// \param x first operand
+      /// \param y second operand
+      /// \retval true if \a x > \a y
+      /// \retval false else
+      static bool isgreater(half x, half y)
+      {
+        int xabs = x.data_ & 0x7FFF, yabs = y.data_ & 0x7FFF;
+        return xabs <= 0x7C00 && yabs <= 0x7C00
+               && (((xabs == x.data_) ? xabs : -xabs)
+                   > ((yabs == y.data_) ? yabs : -yabs));
+      }
+
+      /// Comparison implementation.
+      /// \param x first operand
+      /// \param y second operand
+      /// \retval true if \a x >= \a y
+      /// \retval false else
+      static bool isgreaterequal(half x, half y)
+      {
+        int xabs = x.data_ & 0x7FFF, yabs = y.data_ & 0x7FFF;
+        return xabs <= 0x7C00 && yabs <= 0x7C00
+               && (((xabs == x.data_) ? xabs : -xabs)
+                   >= ((yabs == y.data_) ? yabs : -yabs));
+      }
+
+      /// Comparison implementation.
+      /// \param x first operand
+      /// \param y second operand
+      /// \retval true if \a x < \a y
+      /// \retval false else
+      static bool isless(half x, half y)
+      {
+        int xabs = x.data_ & 0x7FFF, yabs = y.data_ & 0x7FFF;
+        return xabs <= 0x7C00 && yabs <= 0x7C00
+               && (((xabs == x.data_) ? xabs : -xabs)
+                   < ((yabs == y.data_) ? yabs : -yabs));
+      }
+
+      /// Comparison implementation.
+      /// \param x first operand
+      /// \param y second operand
+      /// \retval true if \a x <= \a y
+      /// \retval false else
+      static bool islessequal(half x, half y)
+      {
+        int xabs = x.data_ & 0x7FFF, yabs = y.data_ & 0x7FFF;
+        return xabs <= 0x7C00 && yabs <= 0x7C00
+               && (((xabs == x.data_) ? xabs : -xabs)
+                   <= ((yabs == y.data_) ? yabs : -yabs));
+      }
+
+      /// Comparison implementation.
+      /// \param x first operand
+      /// \param y second operand
+      /// \retval true if either \a x > \a y nor \a x < \a y
+      /// \retval false else
+      static bool islessgreater(half x, half y)
+      {
+        int xabs = x.data_ & 0x7FFF, yabs = y.data_ & 0x7FFF;
+        if (xabs > 0x7C00 || yabs > 0x7C00)
+          return false;
+        int a = (xabs == x.data_) ? xabs : -xabs,
+            b = (yabs == y.data_) ? yabs : -yabs;
+        return a < b || a > b;
+      }
+
+      /// Comparison implementation.
+      /// \param x first operand
+      /// \param y second operand
+      /// \retval true if operand unordered
+      /// \retval false else
+      static bool isunordered(half x, half y)
+      {
+        return isnan(x) || isnan(y);
+      }
+
+    private:
+      static double erf(double arg)
+      {
+        if (builtin_isinf(arg))
+          return (arg < 0.0) ? -1.0 : 1.0;
+        double x2 = arg * arg, ax2 = 0.147 * x2,
+               value = std::sqrt(
+                   1.0
+                   - std::exp(-x2 * (1.2732395447351626861510701069801 + ax2)
+                              / (1.0 + ax2)));
+        return builtin_signbit(arg) ? -value : value;
+      }
+
+      static double lgamma(double arg)
+      {
+        double v = 1.0;
+        for (; arg < 8.0; ++arg)
+          v *= arg;
+        double w = 1.0 / (arg * arg);
+        return (((((((-0.02955065359477124183006535947712 * w
+                      + 0.00641025641025641025641025641026)
+                         * w
+                     + -0.00191752691752691752691752691753)
+                        * w
+                    + 8.4175084175084175084175084175084e-4)
+                       * w
+                   + -5.952380952380952380952380952381e-4)
+                      * w
+                  + 7.9365079365079365079365079365079e-4)
+                     * w
+                 + -0.00277777777777777777777777777778)
+                    * w
+                + 0.08333333333333333333333333333333)
+                   / arg
+               + 0.91893853320467274178032973640562 - std::log(v) - arg
+               + (arg - 0.5) * std::log(arg);
+      }
+    };
+
+    /// Wrapper for unary half-precision functions needing specialization for
+    /// individual argument types. \tparam T argument type
+    template <typename T> struct unary_specialized
+    {
+      /// Negation implementation.
+      /// \param arg value to negate
+      /// \return negated value
+      static HALF_CONSTEXPR half negate(half arg)
+      {
+        return half(binary, arg.data_ ^ 0x8000);
+      }
+
+      /// Absolute value implementation.
+      /// \param arg function argument
+      /// \return absolute value
+      static half fabs(half arg)
+      {
+        return half(binary, arg.data_ & 0x7FFF);
+      }
+    };
+    template <> struct unary_specialized<expr>
+    {
+      static HALF_CONSTEXPR expr negate(float arg)
+      {
+        return expr(-arg);
+      }
+      static expr fabs(float arg)
+      {
+        return expr(std::fabs(arg));
+      }
+    };
+
+    /// Wrapper for binary half-precision functions needing specialization for
+    /// individual argument types. \tparam T first argument type \tparam U
+    /// first argument type
+    template <typename T, typename U> struct binary_specialized
+    {
+      /// Minimum implementation.
+      /// \param x first operand
+      /// \param y second operand
+      /// \return minimum value
+      static expr fmin(float x, float y)
+      {
+#if HALF_ENABLE_CPP11_CMATH
+        return expr(std::fmin(x, y));
+#else
+        if (builtin_isnan(x))
+          return expr(y);
+        if (builtin_isnan(y))
+          return expr(x);
+        return expr(std::min(x, y));
+#endif
+      }
+
+      /// Maximum implementation.
+      /// \param x first operand
+      /// \param y second operand
+      /// \return maximum value
+      static expr fmax(float x, float y)
+      {
+#if HALF_ENABLE_CPP11_CMATH
+        return expr(std::fmax(x, y));
+#else
+        if (builtin_isnan(x))
+          return expr(y);
+        if (builtin_isnan(y))
+          return expr(x);
+        return expr(std::max(x, y));
+#endif
+      }
+    };
+    template <> struct binary_specialized<half, half>
+    {
+      static half fmin(half x, half y)
+      {
+        int xabs = x.data_ & 0x7FFF, yabs = y.data_ & 0x7FFF;
+        if (xabs > 0x7C00)
+          return y;
+        if (yabs > 0x7C00)
+          return x;
+        return (((xabs == x.data_) ? xabs : -xabs)
+                > ((yabs == y.data_) ? yabs : -yabs))
+                   ? y
+                   : x;
+      }
+      static half fmax(half x, half y)
+      {
+        int xabs = x.data_ & 0x7FFF, yabs = y.data_ & 0x7FFF;
+        if (xabs > 0x7C00)
+          return y;
+        if (yabs > 0x7C00)
+          return x;
+        return (((xabs == x.data_) ? xabs : -xabs)
+                < ((yabs == y.data_) ? yabs : -yabs))
+                   ? y
+                   : x;
+      }
+    };
+
+    /// Helper class for half casts.
+    /// This class template has to be specialized for all valid cast argument
+    /// to define an appropriate static `cast` member function and a
+    /// corresponding `type` member denoting its return type. \tparam T
+    /// destination type \tparam U source type \tparam R rounding mode to use
+    template <typename T, typename U,
+              std::float_round_style R
+              = (std::float_round_style)(HALF_ROUND_STYLE)>
+    struct half_caster
+    {
+    };
+    template <typename U, std::float_round_style R>
+    struct half_caster<half, U, R>
+    {
+#if HALF_ENABLE_CPP11_STATIC_ASSERT && HALF_ENABLE_CPP11_TYPE_TRAITS
+      static_assert(std::is_arithmetic<U>::value,
+                    "half_cast from non-arithmetic type unsupported");
+#endif
+
+      static half cast(U arg)
+      {
+        return cast_impl(arg, is_float<U>());
+      };
+
+    private:
+      static half cast_impl(U arg, true_type)
+      {
+        return half(binary, float2half<R>(arg));
+      }
+      static half cast_impl(U arg, false_type)
+      {
+        return half(binary, int2half<R>(arg));
+      }
+    };
+    template <typename T, std::float_round_style R>
+    struct half_caster<T, half, R>
+    {
+#if HALF_ENABLE_CPP11_STATIC_ASSERT && HALF_ENABLE_CPP11_TYPE_TRAITS
+      static_assert(std::is_arithmetic<T>::value,
+                    "half_cast to non-arithmetic type unsupported");
+#endif
+
+      static T cast(half arg)
+      {
+        return cast_impl(arg, is_float<T>());
+      }
+
+    private:
+      static T cast_impl(half arg, true_type)
+      {
+        return half2float<T>(arg.data_);
+      }
+      static T cast_impl(half arg, false_type)
+      {
+        return half2int<R, T>(arg.data_);
+      }
+    };
+    template <typename T, std::float_round_style R>
+    struct half_caster<T, expr, R>
+    {
+#if HALF_ENABLE_CPP11_STATIC_ASSERT && HALF_ENABLE_CPP11_TYPE_TRAITS
+      static_assert(std::is_arithmetic<T>::value,
+                    "half_cast to non-arithmetic type unsupported");
+#endif
+
+      static T cast(expr arg)
+      {
+        return cast_impl(arg, is_float<T>());
+      }
+
+    private:
+      static T cast_impl(float arg, true_type)
+      {
+        return static_cast<T>(arg);
+      }
+      static T cast_impl(half arg, false_type)
+      {
+        return half2int<R, T>(arg.data_);
+      }
+    };
+    template <std::float_round_style R> struct half_caster<half, half, R>
+    {
+      static half cast(half arg)
+      {
+        return arg;
+      }
+    };
+    template <std::float_round_style R>
+    struct half_caster<half, expr, R> : half_caster<half, half, R>
+    {
+    };
+
+    /// \name Comparison operators
+    /// \{
+
+    /// Comparison for equality.
+    /// \param x first operand
+    /// \param y second operand
+    /// \retval true if operands equal
+    /// \retval false else
+    template <typename T, typename U>
+    typename enable<bool, T, U>::type operator==(T x, U y)
+    {
+      return functions::isequal(x, y);
+    }
+
+    /// Comparison for inequality.
+    /// \param x first operand
+    /// \param y second operand
+    /// \retval true if operands not equal
+    /// \retval false else
+    template <typename T, typename U>
+    typename enable<bool, T, U>::type operator!=(T x, U y)
+    {
+      return functions::isnotequal(x, y);
+    }
+
+    /// Comparison for less than.
+    /// \param x first operand
+    /// \param y second operand
+    /// \retval true if \a x less than \a y
+    /// \retval false else
+    template <typename T, typename U>
+    typename enable<bool, T, U>::type operator<(T x, U y)
+    {
+      return functions::isless(x, y);
+    }
+
+    /// Comparison for greater than.
+    /// \param x first operand
+    /// \param y second operand
+    /// \retval true if \a x greater than \a y
+    /// \retval false else
+    template <typename T, typename U>
+    typename enable<bool, T, U>::type operator>(T x, U y)
+    {
+      return functions::isgreater(x, y);
+    }
+
+    /// Comparison for less equal.
+    /// \param x first operand
+    /// \param y second operand
+    /// \retval true if \a x less equal \a y
+    /// \retval false else
+    template <typename T, typename U>
+    typename enable<bool, T, U>::type operator<=(T x, U y)
+    {
+      return functions::islessequal(x, y);
+    }
+
+    /// Comparison for greater equal.
+    /// \param x first operand
+    /// \param y second operand
+    /// \retval true if \a x greater equal \a y
+    /// \retval false else
+    template <typename T, typename U>
+    typename enable<bool, T, U>::type operator>=(T x, U y)
+    {
+      return functions::isgreaterequal(x, y);
+    }
+
+    /// \}
+    /// \name Arithmetic operators
+    /// \{
+
+    /// Add halfs.
+    /// \param x left operand
+    /// \param y right operand
+    /// \return sum of half expressions
+    template <typename T, typename U>
+    typename enable<expr, T, U>::type operator+(T x, U y)
+    {
+      return functions::plus(x, y);
+    }
+
+    /// Subtract halfs.
+    /// \param x left operand
+    /// \param y right operand
+    /// \return difference of half expressions
+    template <typename T, typename U>
+    typename enable<expr, T, U>::type operator-(T x, U y)
+    {
+      return functions::minus(x, y);
+    }
+
+    /// Multiply halfs.
+    /// \param x left operand
+    /// \param y right operand
+    /// \return product of half expressions
+    template <typename T, typename U>
+    typename enable<expr, T, U>::type operator*(T x, U y)
+    {
+      return functions::multiplies(x, y);
+    }
+
+    /// Divide halfs.
+    /// \param x left operand
+    /// \param y right operand
+    /// \return quotient of half expressions
+    template <typename T, typename U>
+    typename enable<expr, T, U>::type operator/(T x, U y)
+    {
+      return functions::divides(x, y);
+    }
+
+    /// Identity.
+    /// \param arg operand
+    /// \return uncahnged operand
+    template <typename T>
+    HALF_CONSTEXPR typename enable<T, T>::type operator+(T arg)
+    {
+      return arg;
+    }
+
+    /// Negation.
+    /// \param arg operand
+    /// \return negated operand
+    template <typename T>
+    HALF_CONSTEXPR typename enable<T, T>::type operator-(T arg)
+    {
+      return unary_specialized<T>::negate(arg);
+    }
+
+    /// \}
+    /// \name Input and output
+    /// \{
+
+    /// Output operator.
+    /// \param out output stream to write into
+    /// \param arg half expression to write
+    /// \return reference to output stream
+    template <typename T, typename charT, typename traits>
+    typename enable<std::basic_ostream<charT, traits> &, T>::type
+    operator<<(std::basic_ostream<charT, traits> &out, T arg)
+    {
+      return functions::write(out, arg);
+    }
+
+    /// Input operator.
+    /// \param in input stream to read from
+    /// \param arg half to read into
+    /// \return reference to input stream
+    template <typename charT, typename traits>
+    std::basic_istream<charT, traits> &
+    operator>>(std::basic_istream<charT, traits> &in, half &arg)
+    {
+      return functions::read(in, arg);
+    }
+
+    /// \}
+    /// \name Basic mathematical operations
+    /// \{
+
+    /// Absolute value.
+    /// \param arg operand
+    /// \return absolute value of \a arg
+    //		template<typename T> typename enable<T,T>::type abs(T arg) {
+    // return unary_specialized<T>::fabs(arg); }
+    inline half abs(half arg)
+    {
+      return unary_specialized<half>::fabs(arg);
+    }
+    inline expr abs(expr arg)
+    {
+      return unary_specialized<expr>::fabs(arg);
+    }
+
+    /// Absolute value.
+    /// \param arg operand
+    /// \return absolute value of \a arg
+    //		template<typename T> typename enable<T,T>::type fabs(T arg) {
+    // return unary_specialized<T>::fabs(arg); }
+    inline half fabs(half arg)
+    {
+      return unary_specialized<half>::fabs(arg);
+    }
+    inline expr fabs(expr arg)
+    {
+      return unary_specialized<expr>::fabs(arg);
+    }
+
+    /// Remainder of division.
+    /// \param x first operand
+    /// \param y second operand
+    /// \return remainder of floating point division.
+    //		template<typename T,typename U> typename enable<expr,T,U>::type
+    // fmod(T x, U y) { return functions::fmod(x, y); }
+    inline expr fmod(half x, half y)
+    {
+      return functions::fmod(x, y);
+    }
+    inline expr fmod(half x, expr y)
+    {
+      return functions::fmod(x, y);
+    }
+    inline expr fmod(expr x, half y)
+    {
+      return functions::fmod(x, y);
+    }
+    inline expr fmod(expr x, expr y)
+    {
+      return functions::fmod(x, y);
+    }
+
+    /// Remainder of division.
+    /// \param x first operand
+    /// \param y second operand
+    /// \return remainder of floating point division.
+    //		template<typename T,typename U> typename enable<expr,T,U>::type
+    // remainder(T x, U y) { return functions::remainder(x, y); }
+    inline expr remainder(half x, half y)
+    {
+      return functions::remainder(x, y);
+    }
+    inline expr remainder(half x, expr y)
+    {
+      return functions::remainder(x, y);
+    }
+    inline expr remainder(expr x, half y)
+    {
+      return functions::remainder(x, y);
+    }
+    inline expr remainder(expr x, expr y)
+    {
+      return functions::remainder(x, y);
+    }
+
+    /// Remainder of division.
+    /// \param x first operand
+    /// \param y second operand
+    /// \param quo address to store some bits of quotient at
+    /// \return remainder of floating point division.
+    //		template<typename T,typename U> typename enable<expr,T,U>::type
+    // remquo(T x, U y, int *quo) { return functions::remquo(x, y, quo); }
+    inline expr remquo(half x, half y, int *quo)
+    {
+      return functions::remquo(x, y, quo);
+    }
+    inline expr remquo(half x, expr y, int *quo)
+    {
+      return functions::remquo(x, y, quo);
+    }
+    inline expr remquo(expr x, half y, int *quo)
+    {
+      return functions::remquo(x, y, quo);
+    }
+    inline expr remquo(expr x, expr y, int *quo)
+    {
+      return functions::remquo(x, y, quo);
+    }
+
+    /// Fused multiply add.
+    /// \param x first operand
+    /// \param y second operand
+    /// \param z third operand
+    /// \return ( \a x * \a y ) + \a z rounded as one operation.
+    //		template<typename T,typename U,typename V> typename
+    // enable<expr,T,U,V>::type fma(T x, U y, V z) { return functions::fma(x,
+    // y, z); }
+    inline expr fma(half x, half y, half z)
+    {
+      return functions::fma(x, y, z);
+    }
+    inline expr fma(half x, half y, expr z)
+    {
+      return functions::fma(x, y, z);
+    }
+    inline expr fma(half x, expr y, half z)
+    {
+      return functions::fma(x, y, z);
+    }
+    inline expr fma(half x, expr y, expr z)
+    {
+      return functions::fma(x, y, z);
+    }
+    inline expr fma(expr x, half y, half z)
+    {
+      return functions::fma(x, y, z);
+    }
+    inline expr fma(expr x, half y, expr z)
+    {
+      return functions::fma(x, y, z);
+    }
+    inline expr fma(expr x, expr y, half z)
+    {
+      return functions::fma(x, y, z);
+    }
+    inline expr fma(expr x, expr y, expr z)
+    {
+      return functions::fma(x, y, z);
+    }
+
+    /// Maximum of half expressions.
+    /// \param x first operand
+    /// \param y second operand
+    /// \return maximum of operands
+    //		template<typename T,typename U> typename result<T,U>::type
+    // fmax(T x, U y) { return binary_specialized<T,U>::fmax(x, y); }
+    inline half fmax(half x, half y)
+    {
+      return binary_specialized<half, half>::fmax(x, y);
+    }
+    inline expr fmax(half x, expr y)
+    {
+      return binary_specialized<half, expr>::fmax(x, y);
+    }
+    inline expr fmax(expr x, half y)
+    {
+      return binary_specialized<expr, half>::fmax(x, y);
+    }
+    inline expr fmax(expr x, expr y)
+    {
+      return binary_specialized<expr, expr>::fmax(x, y);
+    }
+
+    /// Minimum of half expressions.
+    /// \param x first operand
+    /// \param y second operand
+    /// \return minimum of operands
+    //		template<typename T,typename U> typename result<T,U>::type
+    // fmin(T x, U y) { return binary_specialized<T,U>::fmin(x, y); }
+    inline half fmin(half x, half y)
+    {
+      return binary_specialized<half, half>::fmin(x, y);
+    }
+    inline expr fmin(half x, expr y)
+    {
+      return binary_specialized<half, expr>::fmin(x, y);
+    }
+    inline expr fmin(expr x, half y)
+    {
+      return binary_specialized<expr, half>::fmin(x, y);
+    }
+    inline expr fmin(expr x, expr y)
+    {
+      return binary_specialized<expr, expr>::fmin(x, y);
+    }
+
+    /// Positive difference.
+    /// \param x first operand
+    /// \param y second operand
+    /// \return \a x - \a y or 0 if difference negative
+    //		template<typename T,typename U> typename enable<expr,T,U>::type
+    // fdim(T x, U y) { return functions::fdim(x, y); }
+    inline expr fdim(half x, half y)
+    {
+      return functions::fdim(x, y);
+    }
+    inline expr fdim(half x, expr y)
+    {
+      return functions::fdim(x, y);
+    }
+    inline expr fdim(expr x, half y)
+    {
+      return functions::fdim(x, y);
+    }
+    inline expr fdim(expr x, expr y)
+    {
+      return functions::fdim(x, y);
+    }
+
+    /// Get NaN value.
+    /// \return quiet NaN
+    inline half nanh(const char *)
+    {
+      return functions::nanh();
+    }
+
+    /// \}
+    /// \name Exponential functions
+    /// \{
+
+    /// Exponential function.
+    /// \param arg function argument
+    /// \return e raised to \a arg
+    //		template<typename T> typename enable<expr,T>::type exp(T arg) {
+    // return functions::exp(arg); }
+    inline expr exp(half arg)
+    {
+      return functions::exp(arg);
+    }
+    inline expr exp(expr arg)
+    {
+      return functions::exp(arg);
+    }
+
+    /// Exponential minus one.
+    /// \param arg function argument
+    /// \return e raised to \a arg subtracted by 1
+    //		template<typename T> typename enable<expr,T>::type expm1(T arg)
+    //{ return functions::expm1(arg); }
+    inline expr expm1(half arg)
+    {
+      return functions::expm1(arg);
+    }
+    inline expr expm1(expr arg)
+    {
+      return functions::expm1(arg);
+    }
+
+    /// Binary exponential.
+    /// \param arg function argument
+    /// \return 2 raised to \a arg
+    //		template<typename T> typename enable<expr,T>::type exp2(T arg)
+    //{ return functions::exp2(arg); }
+    inline expr exp2(half arg)
+    {
+      return functions::exp2(arg);
+    }
+    inline expr exp2(expr arg)
+    {
+      return functions::exp2(arg);
+    }
+
+    /// Natural logorithm.
+    /// \param arg function argument
+    /// \return logarithm of \a arg to base e
+    //		template<typename T> typename enable<expr,T>::type log(T arg) {
+    // return functions::log(arg); }
+    inline expr log(half arg)
+    {
+      return functions::log(arg);
+    }
+    inline expr log(expr arg)
+    {
+      return functions::log(arg);
+    }
+
+    /// Common logorithm.
+    /// \param arg function argument
+    /// \return logarithm of \a arg to base 10
+    //		template<typename T> typename enable<expr,T>::type log10(T arg)
+    //{ return functions::log10(arg); }
+    inline expr log10(half arg)
+    {
+      return functions::log10(arg);
+    }
+    inline expr log10(expr arg)
+    {
+      return functions::log10(arg);
+    }
+
+    /// Natural logorithm.
+    /// \param arg function argument
+    /// \return logarithm of \a arg plus 1 to base e
+    //		template<typename T> typename enable<expr,T>::type log1p(T arg)
+    //{ return functions::log1p(arg); }
+    inline expr log1p(half arg)
+    {
+      return functions::log1p(arg);
+    }
+    inline expr log1p(expr arg)
+    {
+      return functions::log1p(arg);
+    }
+
+    /// Binary logorithm.
+    /// \param arg function argument
+    /// \return logarithm of \a arg to base 2
+    //		template<typename T> typename enable<expr,T>::type log2(T arg)
+    //{ return functions::log2(arg); }
+    inline expr log2(half arg)
+    {
+      return functions::log2(arg);
+    }
+    inline expr log2(expr arg)
+    {
+      return functions::log2(arg);
+    }
+
+    /// \}
+    /// \name Power functions
+    /// \{
+
+    /// Square root.
+    /// \param arg function argument
+    /// \return square root of \a arg
+    //		template<typename T> typename enable<expr,T>::type sqrt(T arg)
+    //{ return functions::sqrt(arg); }
+    inline expr sqrt(half arg)
+    {
+      return functions::sqrt(arg);
+    }
+    inline expr sqrt(expr arg)
+    {
+      return functions::sqrt(arg);
+    }
+
+    /// Cubic root.
+    /// \param arg function argument
+    /// \return cubic root of \a arg
+    //		template<typename T> typename enable<expr,T>::type cbrt(T arg)
+    //{ return functions::cbrt(arg); }
+    inline expr cbrt(half arg)
+    {
+      return functions::cbrt(arg);
+    }
+    inline expr cbrt(expr arg)
+    {
+      return functions::cbrt(arg);
+    }
+
+    /// Hypotenuse function.
+    /// \param x first argument
+    /// \param y second argument
+    /// \return square root of sum of squares without internal over- or
+    /// underflows
+    //		template<typename T,typename U> typename enable<expr,T,U>::type
+    // hypot(T x, U y) { return functions::hypot(x, y); }
+    inline expr hypot(half x, half y)
+    {
+      return functions::hypot(x, y);
+    }
+    inline expr hypot(half x, expr y)
+    {
+      return functions::hypot(x, y);
+    }
+    inline expr hypot(expr x, half y)
+    {
+      return functions::hypot(x, y);
+    }
+    inline expr hypot(expr x, expr y)
+    {
+      return functions::hypot(x, y);
+    }
+
+    /// Power function.
+    /// \param base first argument
+    /// \param exp second argument
+    /// \return \a base raised to \a exp
+    //		template<typename T,typename U> typename enable<expr,T,U>::type
+    // pow(T base, U exp) { return functions::pow(base, exp); }
+    inline expr pow(half base, half exp)
+    {
+      return functions::pow(base, exp);
+    }
+    inline expr pow(half base, expr exp)
+    {
+      return functions::pow(base, exp);
+    }
+    inline expr pow(expr base, half exp)
+    {
+      return functions::pow(base, exp);
+    }
+    inline expr pow(expr base, expr exp)
+    {
+      return functions::pow(base, exp);
+    }
+
+    /// \}
+    /// \name Trigonometric functions
+    /// \{
+
+    /// Sine function.
+    /// \param arg function argument
+    /// \return sine value of \a arg
+    //		template<typename T> typename enable<expr,T>::type sin(T arg) {
+    // return functions::sin(arg); }
+    inline expr sin(half arg)
+    {
+      return functions::sin(arg);
+    }
+    inline expr sin(expr arg)
+    {
+      return functions::sin(arg);
+    }
+
+    /// Cosine function.
+    /// \param arg function argument
+    /// \return cosine value of \a arg
+    //		template<typename T> typename enable<expr,T>::type cos(T arg) {
+    // return functions::cos(arg); }
+    inline expr cos(half arg)
+    {
+      return functions::cos(arg);
+    }
+    inline expr cos(expr arg)
+    {
+      return functions::cos(arg);
+    }
+
+    /// Tangent function.
+    /// \param arg function argument
+    /// \return tangent value of \a arg
+    //		template<typename T> typename enable<expr,T>::type tan(T arg) {
+    // return functions::tan(arg); }
+    inline expr tan(half arg)
+    {
+      return functions::tan(arg);
+    }
+    inline expr tan(expr arg)
+    {
+      return functions::tan(arg);
+    }
+
+    /// Arc sine.
+    /// \param arg function argument
+    /// \return arc sine value of \a arg
+    //		template<typename T> typename enable<expr,T>::type asin(T arg)
+    //{ return functions::asin(arg); }
+    inline expr asin(half arg)
+    {
+      return functions::asin(arg);
+    }
+    inline expr asin(expr arg)
+    {
+      return functions::asin(arg);
+    }
+
+    /// Arc cosine function.
+    /// \param arg function argument
+    /// \return arc cosine value of \a arg
+    //		template<typename T> typename enable<expr,T>::type acos(T arg)
+    //{ return functions::acos(arg); }
+    inline expr acos(half arg)
+    {
+      return functions::acos(arg);
+    }
+    inline expr acos(expr arg)
+    {
+      return functions::acos(arg);
+    }
+
+    /// Arc tangent function.
+    /// \param arg function argument
+    /// \return arc tangent value of \a arg
+    //		template<typename T> typename enable<expr,T>::type atan(T arg)
+    //{ return functions::atan(arg); }
+    inline expr atan(half arg)
+    {
+      return functions::atan(arg);
+    }
+    inline expr atan(expr arg)
+    {
+      return functions::atan(arg);
+    }
+
+    /// Arc tangent function.
+    /// \param x first argument
+    /// \param y second argument
+    /// \return arc tangent value
+    //		template<typename T,typename U> typename enable<expr,T,U>::type
+    // atan2(T x, U y) { return functions::atan2(x, y); }
+    inline expr atan2(half x, half y)
+    {
+      return functions::atan2(x, y);
+    }
+    inline expr atan2(half x, expr y)
+    {
+      return functions::atan2(x, y);
+    }
+    inline expr atan2(expr x, half y)
+    {
+      return functions::atan2(x, y);
+    }
+    inline expr atan2(expr x, expr y)
+    {
+      return functions::atan2(x, y);
+    }
+
+    /// \}
+    /// \name Hyperbolic functions
+    /// \{
+
+    /// Hyperbolic sine.
+    /// \param arg function argument
+    /// \return hyperbolic sine value of \a arg
+    //		template<typename T> typename enable<expr,T>::type sinh(T arg)
+    //{ return functions::sinh(arg); }
+    inline expr sinh(half arg)
+    {
+      return functions::sinh(arg);
+    }
+    inline expr sinh(expr arg)
+    {
+      return functions::sinh(arg);
+    }
+
+    /// Hyperbolic cosine.
+    /// \param arg function argument
+    /// \return hyperbolic cosine value of \a arg
+    //		template<typename T> typename enable<expr,T>::type cosh(T arg)
+    //{ return functions::cosh(arg); }
+    inline expr cosh(half arg)
+    {
+      return functions::cosh(arg);
+    }
+    inline expr cosh(expr arg)
+    {
+      return functions::cosh(arg);
+    }
+
+    /// Hyperbolic tangent.
+    /// \param arg function argument
+    /// \return hyperbolic tangent value of \a arg
+    //		template<typename T> typename enable<expr,T>::type tanh(T arg)
+    //{ return functions::tanh(arg); }
+    inline expr tanh(half arg)
+    {
+      return functions::tanh(arg);
+    }
+    inline expr tanh(expr arg)
+    {
+      return functions::tanh(arg);
+    }
+
+    /// Hyperbolic area sine.
+    /// \param arg function argument
+    /// \return area sine value of \a arg
+    //		template<typename T> typename enable<expr,T>::type asinh(T arg)
+    //{ return functions::asinh(arg); }
+    inline expr asinh(half arg)
+    {
+      return functions::asinh(arg);
+    }
+    inline expr asinh(expr arg)
+    {
+      return functions::asinh(arg);
+    }
+
+    /// Hyperbolic area cosine.
+    /// \param arg function argument
+    /// \return area cosine value of \a arg
+    //		template<typename T> typename enable<expr,T>::type acosh(T arg)
+    //{ return functions::acosh(arg); }
+    inline expr acosh(half arg)
+    {
+      return functions::acosh(arg);
+    }
+    inline expr acosh(expr arg)
+    {
+      return functions::acosh(arg);
+    }
+
+    /// Hyperbolic area tangent.
+    /// \param arg function argument
+    /// \return area tangent value of \a arg
+    //		template<typename T> typename enable<expr,T>::type atanh(T arg)
+    //{ return functions::atanh(arg); }
+    inline expr atanh(half arg)
+    {
+      return functions::atanh(arg);
+    }
+    inline expr atanh(expr arg)
+    {
+      return functions::atanh(arg);
+    }
+
+    /// \}
+    /// \name Error and gamma functions
+    /// \{
+
+    /// Error function.
+    /// \param arg function argument
+    /// \return error function value of \a arg
+    //		template<typename T> typename enable<expr,T>::type erf(T arg) {
+    // return functions::erf(arg); }
+    inline expr erf(half arg)
+    {
+      return functions::erf(arg);
+    }
+    inline expr erf(expr arg)
+    {
+      return functions::erf(arg);
+    }
+
+    /// Complementary error function.
+    /// \param arg function argument
+    /// \return 1 minus error function value of \a arg
+    //		template<typename T> typename enable<expr,T>::type erfc(T arg)
+    //{ return functions::erfc(arg); }
+    inline expr erfc(half arg)
+    {
+      return functions::erfc(arg);
+    }
+    inline expr erfc(expr arg)
+    {
+      return functions::erfc(arg);
+    }
+
+    /// Natural logarithm of gamma function.
+    /// \param arg function argument
+    /// \return natural logarith of gamma function for \a arg
+    //		template<typename T> typename enable<expr,T>::type lgamma(T
+    // arg) { return functions::lgamma(arg); }
+    inline expr lgamma(half arg)
+    {
+      return functions::lgamma(arg);
+    }
+    inline expr lgamma(expr arg)
+    {
+      return functions::lgamma(arg);
+    }
+
+    /// Gamma function.
+    /// \param arg function argument
+    /// \return gamma function value of \a arg
+    //		template<typename T> typename enable<expr,T>::type tgamma(T
+    // arg) { return functions::tgamma(arg); }
+    inline expr tgamma(half arg)
+    {
+      return functions::tgamma(arg);
+    }
+    inline expr tgamma(expr arg)
+    {
+      return functions::tgamma(arg);
+    }
+
+    /// \}
+    /// \name Rounding
+    /// \{
+
+    /// Nearest integer not less than half value.
+    /// \param arg half to round
+    /// \return nearest integer not less than \a arg
+    //		template<typename T> typename enable<half,T>::type ceil(T arg)
+    //{ return functions::ceil(arg); }
+    inline half ceil(half arg)
+    {
+      return functions::ceil(arg);
+    }
+    inline half ceil(expr arg)
+    {
+      return functions::ceil(arg);
+    }
+
+    /// Nearest integer not greater than half value.
+    /// \param arg half to round
+    /// \return nearest integer not greater than \a arg
+    //		template<typename T> typename enable<half,T>::type floor(T arg)
+    //{ return functions::floor(arg); }
+    inline half floor(half arg)
+    {
+      return functions::floor(arg);
+    }
+    inline half floor(expr arg)
+    {
+      return functions::floor(arg);
+    }
+
+    /// Nearest integer not greater in magnitude than half value.
+    /// \param arg half to round
+    /// \return nearest integer not greater in magnitude than \a arg
+    //		template<typename T> typename enable<half,T>::type trunc(T arg)
+    //{ return functions::trunc(arg); }
+    inline half trunc(half arg)
+    {
+      return functions::trunc(arg);
+    }
+    inline half trunc(expr arg)
+    {
+      return functions::trunc(arg);
+    }
+
+    /// Nearest integer.
+    /// \param arg half to round
+    /// \return nearest integer, rounded away from zero in half-way cases
+    //		template<typename T> typename enable<half,T>::type round(T arg)
+    //{ return functions::round(arg); }
+    inline half round(half arg)
+    {
+      return functions::round(arg);
+    }
+    inline half round(expr arg)
+    {
+      return functions::round(arg);
+    }
+
+    /// Nearest integer.
+    /// \param arg half to round
+    /// \return nearest integer, rounded away from zero in half-way cases
+    //		template<typename T> typename enable<long,T>::type lround(T
+    // arg) { return functions::lround(arg); }
+    inline long lround(half arg)
+    {
+      return functions::lround(arg);
+    }
+    inline long lround(expr arg)
+    {
+      return functions::lround(arg);
+    }
+
+    /// Nearest integer using half's internal rounding mode.
+    /// \param arg half expression to round
+    /// \return nearest integer using default rounding mode
+    //		template<typename T> typename enable<half,T>::type nearbyint(T
+    // arg) { return functions::nearbyint(arg); }
+    inline half nearbyint(half arg)
+    {
+      return functions::rint(arg);
+    }
+    inline half nearbyint(expr arg)
+    {
+      return functions::rint(arg);
+    }
+
+    /// Nearest integer using half's internal rounding mode.
+    /// \param arg half expression to round
+    /// \return nearest integer using default rounding mode
+    //		template<typename T> typename enable<half,T>::type rint(T arg)
+    //{ return functions::rint(arg); }
+    inline half rint(half arg)
+    {
+      return functions::rint(arg);
+    }
+    inline half rint(expr arg)
+    {
+      return functions::rint(arg);
+    }
+
+    /// Nearest integer using half's internal rounding mode.
+    /// \param arg half expression to round
+    /// \return nearest integer using default rounding mode
+    //		template<typename T> typename enable<long,T>::type lrint(T arg)
+    //{ return functions::lrint(arg); }
+    inline long lrint(half arg)
+    {
+      return functions::lrint(arg);
+    }
+    inline long lrint(expr arg)
+    {
+      return functions::lrint(arg);
+    }
+#if HALF_ENABLE_CPP11_LONG_LONG
+    /// Nearest integer.
+    /// \param arg half to round
+    /// \return nearest integer, rounded away from zero in half-way cases
+    //		template<typename T> typename enable<long long,T>::type
+    // llround(T arg) { return functions::llround(arg); }
+    inline long long llround(half arg)
+    {
+      return functions::llround(arg);
+    }
+    inline long long llround(expr arg)
+    {
+      return functions::llround(arg);
+    }
+
+    /// Nearest integer using half's internal rounding mode.
+    /// \param arg half expression to round
+    /// \return nearest integer using default rounding mode
+    //		template<typename T> typename enable<long long,T>::type
+    // llrint(T arg) { return functions::llrint(arg); }
+    inline long long llrint(half arg)
+    {
+      return functions::llrint(arg);
+    }
+    inline long long llrint(expr arg)
+    {
+      return functions::llrint(arg);
+    }
+#endif
+
+    /// \}
+    /// \name Floating point manipulation
+    /// \{
+
+    /// Decompress floating point number.
+    /// \param arg number to decompress
+    /// \param exp address to store exponent at
+    /// \return significant in range [0.5, 1)
+    //		template<typename T> typename enable<half,T>::type frexp(T arg,
+    // int *exp) { return functions::frexp(arg, exp); }
+    inline half frexp(half arg, int *exp)
+    {
+      return functions::frexp(arg, exp);
+    }
+    inline half frexp(expr arg, int *exp)
+    {
+      return functions::frexp(arg, exp);
+    }
+
+    /// Multiply by power of two.
+    /// \param arg number to modify
+    /// \param exp power of two to multiply with
+    /// \return \a arg multplied by 2 raised to \a exp
+    //		template<typename T> typename enable<half,T>::type ldexp(T arg,
+    // int exp) { return functions::scalbln(arg, exp); }
+    inline half ldexp(half arg, int exp)
+    {
+      return functions::scalbln(arg, exp);
+    }
+    inline half ldexp(expr arg, int exp)
+    {
+      return functions::scalbln(arg, exp);
+    }
+
+    /// Extract integer and fractional parts.
+    /// \param arg number to decompress
+    /// \param iptr address to store integer part at
+    /// \return fractional part
+    //		template<typename T> typename enable<half,T>::type modf(T arg,
+    // half *iptr) { return functions::modf(arg, iptr); }
+    inline half modf(half arg, half *iptr)
+    {
+      return functions::modf(arg, iptr);
+    }
+    inline half modf(expr arg, half *iptr)
+    {
+      return functions::modf(arg, iptr);
+    }
+
+    /// Multiply by power of two.
+    /// \param arg number to modify
+    /// \param exp power of two to multiply with
+    /// \return \a arg multplied by 2 raised to \a exp
+    //		template<typename T> typename enable<half,T>::type scalbn(T
+    // arg, int exp) { return functions::scalbln(arg, exp); }
+    inline half scalbn(half arg, int exp)
+    {
+      return functions::scalbln(arg, exp);
+    }
+    inline half scalbn(expr arg, int exp)
+    {
+      return functions::scalbln(arg, exp);
+    }
+
+    /// Multiply by power of two.
+    /// \param arg number to modify
+    /// \param exp power of two to multiply with
+    /// \return \a arg multplied by 2 raised to \a exp
+    //		template<typename T> typename enable<half,T>::type scalbln(T
+    // arg, long exp) { return functions::scalbln(arg, exp); }
+    inline half scalbln(half arg, long exp)
+    {
+      return functions::scalbln(arg, exp);
+    }
+    inline half scalbln(expr arg, long exp)
+    {
+      return functions::scalbln(arg, exp);
+    }
+
+    /// Extract exponent.
+    /// \param arg number to query
+    /// \return floating point exponent
+    /// \retval FP_ILOGB0 for zero
+    /// \retval FP_ILOGBNAN for NaN
+    /// \retval MAX_INT for infinity
+    //		template<typename T> typename enable<int,T>::type ilogb(T arg)
+    //{ return functions::ilogb(arg); }
+    inline int ilogb(half arg)
+    {
+      return functions::ilogb(arg);
+    }
+    inline int ilogb(expr arg)
+    {
+      return functions::ilogb(arg);
+    }
+
+    /// Extract exponent.
+    /// \param arg number to query
+    /// \return floating point exponent
+    //		template<typename T> typename enable<half,T>::type logb(T arg)
+    //{ return functions::logb(arg); }
+    inline half logb(half arg)
+    {
+      return functions::logb(arg);
+    }
+    inline half logb(expr arg)
+    {
+      return functions::logb(arg);
+    }
+
+    /// Next representable value.
+    /// \param from value to compute next representable value for
+    /// \param to direction towards which to compute next value
+    /// \return next representable value after \a from in direction towards \a
+    /// to
+    //		template<typename T,typename U> typename enable<half,T,U>::type
+    // nextafter(T from, U to) { return functions::nextafter(from, to); }
+    inline half nextafter(half from, half to)
+    {
+      return functions::nextafter(from, to);
+    }
+    inline half nextafter(half from, expr to)
+    {
+      return functions::nextafter(from, to);
+    }
+    inline half nextafter(expr from, half to)
+    {
+      return functions::nextafter(from, to);
+    }
+    inline half nextafter(expr from, expr to)
+    {
+      return functions::nextafter(from, to);
+    }
+
+    /// Next representable value.
+    /// \param from value to compute next representable value for
+    /// \param to direction towards which to compute next value
+    /// \return next representable value after \a from in direction towards \a
+    /// to
+    //		template<typename T> typename enable<half,T>::type nexttoward(T
+    // from, long double to) { return functions::nexttoward(from, to); }
+    inline half nexttoward(half from, long double to)
+    {
+      return functions::nexttoward(from, to);
+    }
+    inline half nexttoward(expr from, long double to)
+    {
+      return functions::nexttoward(from, to);
+    }
+
+    /// Take sign.
+    /// \param x value to change sign for
+    /// \param y value to take sign from
+    /// \return value equal to \a x in magnitude and to \a y in sign
+    //		template<typename T,typename U> typename enable<half,T,U>::type
+    // copysign(T x, U y) { return functions::copysign(x, y); }
+    inline half copysign(half x, half y)
+    {
+      return functions::copysign(x, y);
+    }
+    inline half copysign(half x, expr y)
+    {
+      return functions::copysign(x, y);
+    }
+    inline half copysign(expr x, half y)
+    {
+      return functions::copysign(x, y);
+    }
+    inline half copysign(expr x, expr y)
+    {
+      return functions::copysign(x, y);
+    }
+
+    /// \}
+    /// \name Floating point classification
+    /// \{
+
+    /// Classify floating point value.
+    /// \param arg number to classify
+    /// \retval FP_ZERO for positive and negative zero
+    /// \retval FP_SUBNORMAL for subnormal numbers
+    /// \retval FP_INFINITY for positive and negative infinity
+    /// \retval FP_NAN for NaNs
+    /// \retval FP_NORMAL for all other (normal) values
+    //		template<typename T> typename enable<int,T>::type fpclassify(T
+    // arg) { return functions::fpclassify(arg); }
+    inline int fpclassify(half arg)
+    {
+      return functions::fpclassify(arg);
+    }
+    inline int fpclassify(expr arg)
+    {
+      return functions::fpclassify(arg);
+    }
+
+    /// Check if finite number.
+    /// \param arg number to check
+    /// \retval true if neither infinity nor NaN
+    /// \retval false else
+    //		template<typename T> typename enable<bool,T>::type isfinite(T
+    // arg) { return functions::isfinite(arg); }
+    inline bool isfinite(half arg)
+    {
+      return functions::isfinite(arg);
+    }
+    inline bool isfinite(expr arg)
+    {
+      return functions::isfinite(arg);
+    }
+
+    /// Check for infinity.
+    /// \param arg number to check
+    /// \retval true for positive or negative infinity
+    /// \retval false else
+    //		template<typename T> typename enable<bool,T>::type isinf(T arg)
+    //{ return functions::isinf(arg); }
+    inline bool isinf(half arg)
+    {
+      return functions::isinf(arg);
+    }
+    inline bool isinf(expr arg)
+    {
+      return functions::isinf(arg);
+    }
+
+    /// Check for NaN.
+    /// \param arg number to check
+    /// \retval true for NaNs
+    /// \retval false else
+    //		template<typename T> typename enable<bool,T>::type isnan(T arg)
+    //{ return functions::isnan(arg); }
+    inline bool isnan(half arg)
+    {
+      return functions::isnan(arg);
+    }
+    inline bool isnan(expr arg)
+    {
+      return functions::isnan(arg);
+    }
+
+    /// Check if normal number.
+    /// \param arg number to check
+    /// \retval true if normal number
+    /// \retval false if either subnormal, zero, infinity or NaN
+    //		template<typename T> typename enable<bool,T>::type isnormal(T
+    // arg) { return functions::isnormal(arg); }
+    inline bool isnormal(half arg)
+    {
+      return functions::isnormal(arg);
+    }
+    inline bool isnormal(expr arg)
+    {
+      return functions::isnormal(arg);
+    }
+
+    /// Check sign.
+    /// \param arg number to check
+    /// \retval true for negative number
+    /// \retval false for positive number
+    //		template<typename T> typename enable<bool,T>::type signbit(T
+    // arg) { return functions::signbit(arg); }
+    inline bool signbit(half arg)
+    {
+      return functions::signbit(arg);
+    }
+    inline bool signbit(expr arg)
+    {
+      return functions::signbit(arg);
+    }
+
+    /// \}
+    /// \name Comparison
+    /// \{
+
+    /// Comparison for greater than.
+    /// \param x first operand
+    /// \param y second operand
+    /// \retval true if \a x greater than \a y
+    /// \retval false else
+    //		template<typename T,typename U> typename enable<bool,T,U>::type
+    // isgreater(T x, U y) { return functions::isgreater(x, y); }
+    inline bool isgreater(half x, half y)
+    {
+      return functions::isgreater(x, y);
+    }
+    inline bool isgreater(half x, expr y)
+    {
+      return functions::isgreater(x, y);
+    }
+    inline bool isgreater(expr x, half y)
+    {
+      return functions::isgreater(x, y);
+    }
+    inline bool isgreater(expr x, expr y)
+    {
+      return functions::isgreater(x, y);
+    }
+
+    /// Comparison for greater equal.
+    /// \param x first operand
+    /// \param y second operand
+    /// \retval true if \a x greater equal \a y
+    /// \retval false else
+    //		template<typename T,typename U> typename enable<bool,T,U>::type
+    // isgreaterequal(T x, U y) { return functions::isgreaterequal(x, y); }
+    inline bool isgreaterequal(half x, half y)
+    {
+      return functions::isgreaterequal(x, y);
+    }
+    inline bool isgreaterequal(half x, expr y)
+    {
+      return functions::isgreaterequal(x, y);
+    }
+    inline bool isgreaterequal(expr x, half y)
+    {
+      return functions::isgreaterequal(x, y);
+    }
+    inline bool isgreaterequal(expr x, expr y)
+    {
+      return functions::isgreaterequal(x, y);
+    }
+
+    /// Comparison for less than.
+    /// \param x first operand
+    /// \param y second operand
+    /// \retval true if \a x less than \a y
+    /// \retval false else
+    //		template<typename T,typename U> typename enable<bool,T,U>::type
+    // isless(T x, U y) { return functions::isless(x, y); }
+    inline bool isless(half x, half y)
+    {
+      return functions::isless(x, y);
+    }
+    inline bool isless(half x, expr y)
+    {
+      return functions::isless(x, y);
+    }
+    inline bool isless(expr x, half y)
+    {
+      return functions::isless(x, y);
+    }
+    inline bool isless(expr x, expr y)
+    {
+      return functions::isless(x, y);
+    }
+
+    /// Comparison for less equal.
+    /// \param x first operand
+    /// \param y second operand
+    /// \retval true if \a x less equal \a y
+    /// \retval false else
+    //		template<typename T,typename U> typename enable<bool,T,U>::type
+    // islessequal(T x, U y) { return functions::islessequal(x, y); }
+    inline bool islessequal(half x, half y)
+    {
+      return functions::islessequal(x, y);
+    }
+    inline bool islessequal(half x, expr y)
+    {
+      return functions::islessequal(x, y);
+    }
+    inline bool islessequal(expr x, half y)
+    {
+      return functions::islessequal(x, y);
+    }
+    inline bool islessequal(expr x, expr y)
+    {
+      return functions::islessequal(x, y);
+    }
+
+    /// Comarison for less or greater.
+    /// \param x first operand
+    /// \param y second operand
+    /// \retval true if either less or greater
+    /// \retval false else
+    //		template<typename T,typename U> typename enable<bool,T,U>::type
+    // islessgreater(T x, U y) { return functions::islessgreater(x, y); }
+    inline bool islessgreater(half x, half y)
+    {
+      return functions::islessgreater(x, y);
+    }
+    inline bool islessgreater(half x, expr y)
+    {
+      return functions::islessgreater(x, y);
+    }
+    inline bool islessgreater(expr x, half y)
+    {
+      return functions::islessgreater(x, y);
+    }
+    inline bool islessgreater(expr x, expr y)
+    {
+      return functions::islessgreater(x, y);
+    }
+
+    /// Check if unordered.
+    /// \param x first operand
+    /// \param y second operand
+    /// \retval true if unordered (one or two NaN operands)
+    /// \retval false else
+    //		template<typename T,typename U> typename enable<bool,T,U>::type
+    // isunordered(T x, U y) { return functions::isunordered(x, y); }
+    inline bool isunordered(half x, half y)
+    {
+      return functions::isunordered(x, y);
+    }
+    inline bool isunordered(half x, expr y)
+    {
+      return functions::isunordered(x, y);
+    }
+    inline bool isunordered(expr x, half y)
+    {
+      return functions::isunordered(x, y);
+    }
+    inline bool isunordered(expr x, expr y)
+    {
+      return functions::isunordered(x, y);
+    }
+
+    /// \name Casting
+    /// \{
+
+    /// Cast to or from half-precision floating point number.
+    /// This casts between [half](\ref half_float::half) and any built-in
+    /// arithmetic type. The values are converted directly using the given
+    /// rounding mode, without any roundtrip over `float` that a `static_cast`
+    /// would otherwise do. It uses the default rounding mode.
+    ///
+    /// Using this cast with neither of the two types being a [half](\ref
+    /// half_float::half) or with any of the two types not being a built-in
+    /// arithmetic type (apart from [half](\ref half_float::half), of course)
+    /// results in a compiler error and casting between [half](\ref
+    /// half_float::half)s is just a no-op. \tparam T destination type (half or
+    /// built-in arithmetic type) \tparam U source type (half or built-in
+    /// arithmetic type) \param arg value to cast \return \a arg converted to
+    /// destination type
+    template <typename T, typename U> T half_cast(U arg)
+    {
+      return half_caster<T, U>::cast(arg);
+    }
+
+    /// Cast to or from half-precision floating point number.
+    /// This casts between [half](\ref half_float::half) and any built-in
+    /// arithmetic type. The values are converted directly using the given
+    /// rounding mode, without any roundtrip over `float` that a `static_cast`
+    /// would otherwise do.
+    ///
+    /// Using this cast with neither of the two types being a [half](\ref
+    /// half_float::half) or with any of the two types not being a built-in
+    /// arithmetic type (apart from [half](\ref half_float::half), of course)
+    /// results in a compiler error and casting between [half](\ref
+    /// half_float::half)s is just a no-op. \tparam T destination type (half or
+    /// built-in arithmetic type) \tparam R rounding mode to use. \tparam U
+    /// source type (half or built-in arithmetic type) \param arg value to cast
+    /// \return \a arg converted to destination type
+    template <typename T, std::float_round_style R, typename U>
+    T half_cast(U arg)
+    {
+      return half_caster<T, U, R>::cast(arg);
+    }
+    /// \}
+  }
+
+  using detail::operator==;
+  using detail::operator!=;
+  using detail::operator<;
+  using detail::operator>;
+  using detail::operator<=;
+  using detail::operator>=;
+  using detail::operator+;
+  using detail::operator-;
+  using detail::operator*;
+  using detail::operator/;
+  using detail::operator<<;
+  using detail::operator>>;
+
+  using detail::abs;
+  using detail::acos;
+  using detail::acosh;
+  using detail::asin;
+  using detail::asinh;
+  using detail::atan;
+  using detail::atan2;
+  using detail::atanh;
+  using detail::cbrt;
+  using detail::ceil;
+  using detail::cos;
+  using detail::cosh;
+  using detail::erf;
+  using detail::erfc;
+  using detail::exp;
+  using detail::exp2;
+  using detail::expm1;
+  using detail::fabs;
+  using detail::fdim;
+  using detail::floor;
+  using detail::fma;
+  using detail::fmax;
+  using detail::fmin;
+  using detail::fmod;
+  using detail::hypot;
+  using detail::lgamma;
+  using detail::log;
+  using detail::log10;
+  using detail::log1p;
+  using detail::log2;
+  using detail::lrint;
+  using detail::lround;
+  using detail::nanh;
+  using detail::nearbyint;
+  using detail::pow;
+  using detail::remainder;
+  using detail::remquo;
+  using detail::rint;
+  using detail::round;
+  using detail::sin;
+  using detail::sinh;
+  using detail::sqrt;
+  using detail::tan;
+  using detail::tanh;
+  using detail::tgamma;
+  using detail::trunc;
+#if HALF_ENABLE_CPP11_LONG_LONG
+  using detail::llrint;
+  using detail::llround;
+#endif
+  using detail::copysign;
+  using detail::fpclassify;
+  using detail::frexp;
+  using detail::ilogb;
+  using detail::isfinite;
+  using detail::isgreater;
+  using detail::isgreaterequal;
+  using detail::isinf;
+  using detail::isless;
+  using detail::islessequal;
+  using detail::islessgreater;
+  using detail::isnan;
+  using detail::isnormal;
+  using detail::isunordered;
+  using detail::ldexp;
+  using detail::logb;
+  using detail::modf;
+  using detail::nextafter;
+  using detail::nexttoward;
+  using detail::scalbln;
+  using detail::scalbn;
+  using detail::signbit;
+
+  using detail::half_cast;
 }
-
 
 /// Extensions to the C++ standard library.
 namespace std
 {
-	/// Numeric limits for half-precision floats.
-	/// Because of the underlying single-precision implementation of many operations, it inherits some properties from 
-	/// `std::numeric_limits<float>`.
-	template<> class numeric_limits<half_float::half> : public numeric_limits<float>
-	{
-	public:
-		/// Supports signed values.
-		static HALF_CONSTEXPR_CONST bool is_signed = true;
+  /// Numeric limits for half-precision floats.
+  /// Because of the underlying single-precision implementation of many
+  /// operations, it inherits some properties from
+  /// `std::numeric_limits<float>`.
+  template <>
+  class numeric_limits<half_float::half> : public numeric_limits<float>
+  {
+  public:
+    /// Supports signed values.
+    static HALF_CONSTEXPR_CONST bool is_signed = true;
 
-		/// Is not exact.
-		static HALF_CONSTEXPR_CONST bool is_exact = false;
+    /// Is not exact.
+    static HALF_CONSTEXPR_CONST bool is_exact = false;
 
-		/// Doesn't provide modulo arithmetic.
-		static HALF_CONSTEXPR_CONST bool is_modulo = false;
+    /// Doesn't provide modulo arithmetic.
+    static HALF_CONSTEXPR_CONST bool is_modulo = false;
 
-		/// IEEE conformant.
-		static HALF_CONSTEXPR_CONST bool is_iec559 = true;
+    /// IEEE conformant.
+    static HALF_CONSTEXPR_CONST bool is_iec559 = true;
 
-		/// Supports infinity.
-		static HALF_CONSTEXPR_CONST bool has_infinity = true;
+    /// Supports infinity.
+    static HALF_CONSTEXPR_CONST bool has_infinity = true;
 
-		/// Supports quiet NaNs.
-		static HALF_CONSTEXPR_CONST bool has_quiet_NaN = true;
+    /// Supports quiet NaNs.
+    static HALF_CONSTEXPR_CONST bool has_quiet_NaN = true;
 
-		/// Supports subnormal values.
-		static HALF_CONSTEXPR_CONST float_denorm_style has_denorm = denorm_present;
+    /// Supports subnormal values.
+    static HALF_CONSTEXPR_CONST float_denorm_style has_denorm = denorm_present;
 
-		/// Rounding mode.
-		/// Due to the mix of internal single-precision computations (using the rounding mode of the underlying 
-		/// single-precision implementation) with the rounding mode of the single-to-half conversions, the actual rounding 
-		/// mode might be `std::round_indeterminate` if the default half-precision rounding mode doesn't match the 
-		/// single-precision rounding mode.
-		static HALF_CONSTEXPR_CONST float_round_style round_style = (std::numeric_limits<float>::round_style==
-			half_float::half::round_style) ? half_float::half::round_style : round_indeterminate;
+    /// Rounding mode.
+    /// Due to the mix of internal single-precision computations (using the
+    /// rounding mode of the underlying single-precision implementation) with
+    /// the rounding mode of the single-to-half conversions, the actual
+    /// rounding mode might be `std::round_indeterminate` if the default
+    /// half-precision rounding mode doesn't match the single-precision
+    /// rounding mode.
+    static HALF_CONSTEXPR_CONST float_round_style round_style
+        = (std::numeric_limits<float>::round_style
+           == half_float::half::round_style)
+              ? half_float::half::round_style
+              : round_indeterminate;
 
-		/// Significant digits.
-		static HALF_CONSTEXPR_CONST int digits = 11;
+    /// Significant digits.
+    static HALF_CONSTEXPR_CONST int digits = 11;
 
-		/// Significant decimal digits.
-		static HALF_CONSTEXPR_CONST int digits10 = 3;
+    /// Significant decimal digits.
+    static HALF_CONSTEXPR_CONST int digits10 = 3;
 
-		/// Required decimal digits to represent all possible values.
-		static HALF_CONSTEXPR_CONST int max_digits10 = 5;
+    /// Required decimal digits to represent all possible values.
+    static HALF_CONSTEXPR_CONST int max_digits10 = 5;
 
-		/// Number base.
-		static HALF_CONSTEXPR_CONST int radix = 2;
+    /// Number base.
+    static HALF_CONSTEXPR_CONST int radix = 2;
 
-		/// One more than smallest exponent.
-		static HALF_CONSTEXPR_CONST int min_exponent = -13;
+    /// One more than smallest exponent.
+    static HALF_CONSTEXPR_CONST int min_exponent = -13;
 
-		/// Smallest normalized representable power of 10.
-		static HALF_CONSTEXPR_CONST int min_exponent10 = -4;
+    /// Smallest normalized representable power of 10.
+    static HALF_CONSTEXPR_CONST int min_exponent10 = -4;
 
-		/// One more than largest exponent
-		static HALF_CONSTEXPR_CONST int max_exponent = 16;
+    /// One more than largest exponent
+    static HALF_CONSTEXPR_CONST int max_exponent = 16;
 
-		/// Largest finitely representable power of 10.
-		static HALF_CONSTEXPR_CONST int max_exponent10 = 4;
+    /// Largest finitely representable power of 10.
+    static HALF_CONSTEXPR_CONST int max_exponent10 = 4;
 
-		/// Smallest positive normal value.
-		static HALF_CONSTEXPR half_float::half min() HALF_NOTHROW { return half_float::half(half_float::detail::binary, 0x0400); }
+    /// Smallest positive normal value.
+    static HALF_CONSTEXPR half_float::half min() HALF_NOTHROW
+    {
+      return half_float::half(half_float::detail::binary, 0x0400);
+    }
 
-		/// Smallest finite value.
-		static HALF_CONSTEXPR half_float::half lowest() HALF_NOTHROW { return half_float::half(half_float::detail::binary, 0xFBFF); }
+    /// Smallest finite value.
+    static HALF_CONSTEXPR half_float::half lowest() HALF_NOTHROW
+    {
+      return half_float::half(half_float::detail::binary, 0xFBFF);
+    }
 
-		/// Largest finite value.
-		static HALF_CONSTEXPR half_float::half max() HALF_NOTHROW { return half_float::half(half_float::detail::binary, 0x7BFF); }
+    /// Largest finite value.
+    static HALF_CONSTEXPR half_float::half max() HALF_NOTHROW
+    {
+      return half_float::half(half_float::detail::binary, 0x7BFF);
+    }
 
-		/// Difference between one and next representable value.
-		static HALF_CONSTEXPR half_float::half epsilon() HALF_NOTHROW { return half_float::half(half_float::detail::binary, 0x1400); }
+    /// Difference between one and next representable value.
+    static HALF_CONSTEXPR half_float::half epsilon() HALF_NOTHROW
+    {
+      return half_float::half(half_float::detail::binary, 0x1400);
+    }
 
-		/// Maximum rounding error.
-		static HALF_CONSTEXPR half_float::half round_error() HALF_NOTHROW
-			{ return half_float::half(half_float::detail::binary, (round_style==std::round_to_nearest) ? 0x3800 : 0x3C00); }
+    /// Maximum rounding error.
+    static HALF_CONSTEXPR half_float::half round_error() HALF_NOTHROW
+    {
+      return half_float::half(half_float::detail::binary,
+                              (round_style == std::round_to_nearest) ? 0x3800
+                                                                     : 0x3C00);
+    }
 
-		/// Positive infinity.
-		static HALF_CONSTEXPR half_float::half infinity() HALF_NOTHROW { return half_float::half(half_float::detail::binary, 0x7C00); }
+    /// Positive infinity.
+    static HALF_CONSTEXPR half_float::half infinity() HALF_NOTHROW
+    {
+      return half_float::half(half_float::detail::binary, 0x7C00);
+    }
 
-		/// Quiet NaN.
-		static HALF_CONSTEXPR half_float::half quiet_NaN() HALF_NOTHROW { return half_float::half(half_float::detail::binary, 0x7FFF); }
+    /// Quiet NaN.
+    static HALF_CONSTEXPR half_float::half quiet_NaN() HALF_NOTHROW
+    {
+      return half_float::half(half_float::detail::binary, 0x7FFF);
+    }
 
-		/// Signalling NaN.
-		static HALF_CONSTEXPR half_float::half signaling_NaN() HALF_NOTHROW { return half_float::half(half_float::detail::binary, 0x7DFF); }
+    /// Signalling NaN.
+    static HALF_CONSTEXPR half_float::half signaling_NaN() HALF_NOTHROW
+    {
+      return half_float::half(half_float::detail::binary, 0x7DFF);
+    }
 
-		/// Smallest positive subnormal value.
-		static HALF_CONSTEXPR half_float::half denorm_min() HALF_NOTHROW { return half_float::half(half_float::detail::binary, 0x0001); }
-	};
+    /// Smallest positive subnormal value.
+    static HALF_CONSTEXPR half_float::half denorm_min() HALF_NOTHROW
+    {
+      return half_float::half(half_float::detail::binary, 0x0001);
+    }
+  };
 
 #if HALF_ENABLE_CPP11_HASH
-	/// Hash function for half-precision floats.
-	/// This is only defined if C++11 `std::hash` is supported and enabled.
-	template<> struct hash<half_float::half> //: unary_function<half_float::half,size_t>
-	{
-		/// Type of function argument.
-		typedef half_float::half argument_type;
+  /// Hash function for half-precision floats.
+  /// This is only defined if C++11 `std::hash` is supported and enabled.
+  template <>
+  struct hash<half_float::half> //: unary_function<half_float::half,size_t>
+  {
+    /// Type of function argument.
+    typedef half_float::half argument_type;
 
-		/// Function return type.
-		typedef size_t result_type;
+    /// Function return type.
+    typedef size_t result_type;
 
-		/// Compute hash function.
-		/// \param arg half to hash
-		/// \return hash value
-		result_type operator()(argument_type arg) const
-			{ return hash<half_float::detail::uint16>()(static_cast<unsigned>(arg.data_)&-(arg.data_!=0x8000)); }
-	};
+    /// Compute hash function.
+    /// \param arg half to hash
+    /// \return hash value
+    result_type operator()(argument_type arg) const
+    {
+      return hash<half_float::detail::uint16>()(
+          static_cast<unsigned>(arg.data_) & -(arg.data_ != 0x8000));
+    }
+  };
 #endif
 }
-
 
 #undef HALF_CONSTEXPR
 #undef HALF_CONSTEXPR_CONST
 #undef HALF_NOEXCEPT
 #undef HALF_NOTHROW
 #ifdef HALF_POP_WARNINGS
-	#pragma warning(pop)
-	#undef HALF_POP_WARNINGS
+#pragma warning(pop)
+#undef HALF_POP_WARNINGS
 #endif
 
 #endif

--- a/src/backends/tensorrt/protoUtils.cc
+++ b/src/backends/tensorrt/protoUtils.cc
@@ -20,8 +20,8 @@
 
 #include "protoUtils.h"
 
-#include <google/protobuf/io/coded_stream.h>                                                            
-#include <google/protobuf/io/zero_copy_stream_impl.h>                                                   
+#include <google/protobuf/io/coded_stream.h>
+#include <google/protobuf/io/zero_copy_stream_impl.h>
 #include <google/protobuf/text_format.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -29,144 +29,143 @@
 #include <unistd.h>
 #include "src/caffe.pb.h"
 
-using google::protobuf::io::FileInputStream;                                                            
-using google::protobuf::io::FileOutputStream;                                                           
-using google::protobuf::io::ZeroCopyInputStream;                                                        
-using google::protobuf::io::CodedInputStream;                                                           
-using google::protobuf::io::ZeroCopyOutputStream;                                                       
-using google::protobuf::io::CodedOutputStream;                                                          
-
-
+using google::protobuf::io::CodedInputStream;
+using google::protobuf::io::CodedOutputStream;
+using google::protobuf::io::FileInputStream;
+using google::protobuf::io::FileOutputStream;
+using google::protobuf::io::ZeroCopyInputStream;
+using google::protobuf::io::ZeroCopyOutputStream;
 
 namespace dd
 {
 
-int findNClasses(const std::string source, bool bbox)
-{
-  caffe::NetParameter net;
-  if (!TRTReadProtoFromTextFile(source.c_str(),&net))
+  int findNClasses(const std::string source, bool bbox)
+  {
+    caffe::NetParameter net;
+    if (!TRTReadProtoFromTextFile(source.c_str(), &net))
+      return -1;
+    int nlayers = net.layer_size();
+    if (bbox)
+      {
+        for (int i = nlayers - 1; i >= 0; --i)
+          {
+            caffe::LayerParameter lparam = net.layer(i);
+            if (lparam.type() == "DetectionOutput")
+              return lparam.detection_output_param().num_classes();
+          }
+      }
+    for (int i = nlayers - 1; i >= 0; --i)
+      {
+        caffe::LayerParameter lparam = net.layer(i);
+        if (lparam.type() == "InnerProduct")
+          return lparam.inner_product_param().num_output();
+
+        if (net.layer(0).name() == "squeezenet"
+            && lparam.type() == "Convolution")
+          return lparam.convolution_param().num_output();
+      }
     return -1;
-  int nlayers = net.layer_size();
-  if (bbox)
-    {
-      for (int i= nlayers-1; i>= 0; --i)
-	{
-	  caffe::LayerParameter lparam = net.layer(i);
-	  if (lparam.type() == "DetectionOutput")
-	    return lparam.detection_output_param().num_classes();
-	}
-    }
-  for (int i= nlayers-1; i>= 0; --i)
-    {
-      caffe::LayerParameter lparam = net.layer(i);
-      if (lparam.type() == "InnerProduct")
-	return lparam.inner_product_param().num_output();
-      
-      if (net.layer(0).name() == "squeezenet" && lparam.type() == "Convolution")
-	return lparam.convolution_param().num_output();
-    }
-  return -1;
-}
+  }
 
-int findTopK(const std::string source)
-{
-  caffe::NetParameter net;
-  if (!TRTReadProtoFromTextFile(source.c_str(),&net))
+  int findTopK(const std::string source)
+  {
+    caffe::NetParameter net;
+    if (!TRTReadProtoFromTextFile(source.c_str(), &net))
+      return -1;
+    int nlayers = net.layer_size();
+    for (int i = nlayers - 1; i >= 0; --i)
+      {
+        caffe::LayerParameter lparam = net.layer(i);
+        if (lparam.type() == "DetectionOutput")
+          return lparam.detection_output_param().nms_param().top_k();
+      }
     return -1;
-  int nlayers = net.layer_size();
-  for (int i= nlayers-1; i>= 0; --i)
-    {
-      caffe::LayerParameter lparam = net.layer(i);
-      if (lparam.type() == "DetectionOutput")
-        return lparam.detection_output_param().nms_param().top_k();
-    }
-  return -1;
-}
+  }
 
+  int fixProto(const std::string dest, const std::string source)
+  {
+    caffe::NetParameter source_net;
+    caffe::NetParameter dest_net;
+    if (!TRTReadProtoFromTextFile(source.c_str(), &source_net))
+      return 1;
 
-int fixProto(const std::string dest, const std::string source)
-{
-  caffe::NetParameter source_net;
-  caffe::NetParameter dest_net;
-  if (!TRTReadProtoFromTextFile(source.c_str(),&source_net))
-    return 1;
+    dest_net.set_name(source_net.name());
+    int nlayers = source_net.layer_size();
 
-  dest_net.set_name(source_net.name());
-  int nlayers = source_net.layer_size();
+    for (int i = 0; i < nlayers; ++i)
+      {
+        caffe::LayerParameter lparam = source_net.layer(i);
+        if (lparam.type() == "MemoryData")
+          {
+            dest_net.add_input(lparam.top(0));
+            caffe::BlobShape *is = dest_net.add_input_shape();
+            is->add_dim(lparam.memory_data_param().batch_size());
+            is->add_dim(lparam.memory_data_param().channels());
+            is->add_dim(lparam.memory_data_param().height());
+            is->add_dim(lparam.memory_data_param().width());
+          }
+        else if (lparam.type() == "Flatten")
+          {
+            caffe::LayerParameter *rparam = dest_net.add_layer();
+            rparam->set_name(lparam.name());
+            rparam->set_type("Reshape");
+            rparam->add_bottom(lparam.bottom(0));
+            rparam->add_top(lparam.top(0));
+            int faxis = lparam.flatten_param().axis();
+            caffe::ReshapeParameter *rp = rparam->mutable_reshape_param();
+            caffe::BlobShape *bs = rp->mutable_shape();
+            for (int i = 0; i < faxis; ++i)
+              bs->add_dim(0);
+            bs->add_dim(-1);
+            for (int i = faxis + 1; i < 4; ++i)
+              bs->add_dim(1);
+          }
+        else if (lparam.type() == "DetectionOutput")
+          {
+            caffe::LayerParameter *dlparam = dest_net.add_layer();
+            caffe::NonMaximumSuppressionParameter *nmsp
+                = lparam.mutable_detection_output_param()->mutable_nms_param();
+            nmsp->clear_soft_nms();
+            nmsp->clear_theta();
+            *dlparam = lparam;
+            dlparam->add_top("keep_count");
+          }
+        else
+          {
+            caffe::LayerParameter *dlparam = dest_net.add_layer();
+            *dlparam = lparam;
+          }
+      }
 
-  for (int i =0; i<nlayers; ++i)
-    {
-      caffe::LayerParameter lparam = source_net.layer(i);
-      if (lparam.type() == "MemoryData")
-	{
-	  dest_net.add_input(lparam.top(0));
-	  caffe::BlobShape* is = dest_net.add_input_shape();
-	  is->add_dim(lparam.memory_data_param().batch_size());
-	  is->add_dim(lparam.memory_data_param().channels());
-	  is->add_dim(lparam.memory_data_param().height());
-	  is->add_dim(lparam.memory_data_param().width());
-	}
-      else if (lparam.type() == "Flatten")
-	{
-	  caffe::LayerParameter* rparam = dest_net.add_layer();
-	  rparam->set_name(lparam.name());
-	  rparam->set_type("Reshape");
-	  rparam->add_bottom(lparam.bottom(0));
-	  rparam->add_top(lparam.top(0));
-	  int faxis = lparam.flatten_param().axis();
-	  caffe::ReshapeParameter * rp = rparam->mutable_reshape_param();
-	  caffe::BlobShape* bs = rp->mutable_shape();
-	  for (int i=0; i<faxis; ++i)
-	    bs->add_dim(0);
-	  bs->add_dim(-1);
-	  for (int i=faxis+1; i<4; ++i)
-	    bs->add_dim(1);
-	}
-      else if (lparam.type() == "DetectionOutput")
-	{	  
-	  caffe::LayerParameter* dlparam = dest_net.add_layer();
-	  caffe::NonMaximumSuppressionParameter* nmsp =
-	    lparam.mutable_detection_output_param()->mutable_nms_param();
-	  nmsp->clear_soft_nms();
-	  nmsp->clear_theta();
-	  *dlparam = lparam;
-	  dlparam->add_top("keep_count");
-	}
-      else
-	{
-	  caffe::LayerParameter* dlparam = dest_net.add_layer();
-	  *dlparam = lparam;
-	}
-    }
+    if (!TRTWriteProtoToTextFile(dest_net, dest.c_str()))
+      return 2;
+    return 0;
+  }
 
-  
-  if (!TRTWriteProtoToTextFile(dest_net,dest.c_str()))
-    return 2;
-  return 0;
-}
+  bool TRTReadProtoFromTextFile(const char *filename,
+                                google::protobuf::Message *proto)
+  {
+    int fd = open(filename, O_RDONLY);
+    if (fd == -1)
+      return false;
+    FileInputStream *input = new FileInputStream(fd);
+    bool success = google::protobuf::TextFormat::Parse(input, proto);
+    delete input;
+    close(fd);
+    return success;
+  }
 
-  bool TRTReadProtoFromTextFile(const char* filename, google::protobuf::Message* proto)
-{   
-  int fd = open(filename, O_RDONLY);
-  if (fd == -1)
-    return false;
-  FileInputStream* input = new FileInputStream(fd);                                                     
-  bool success = google::protobuf::TextFormat::Parse(input, proto);                                     
-  delete input;                                                                                         
-  close(fd);                                                                                            
-  return success;                                                                                       
-}                                                                                                       
-                                                                                                        
-  bool TRTWriteProtoToTextFile(const google::protobuf::Message& proto, const char* filename)
-{     
-  int fd = open(filename, O_WRONLY | O_CREAT | O_TRUNC, 0644);
-  if (fd == -1)
-    return false;
-  FileOutputStream* output = new FileOutputStream(fd);
-  bool success = google::protobuf::TextFormat::Print(proto, output);
-  delete output;                                                                                        
-  close(fd);
-  return success;
-}
+  bool TRTWriteProtoToTextFile(const google::protobuf::Message &proto,
+                               const char *filename)
+  {
+    int fd = open(filename, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    if (fd == -1)
+      return false;
+    FileOutputStream *output = new FileOutputStream(fd);
+    bool success = google::protobuf::TextFormat::Print(proto, output);
+    delete output;
+    close(fd);
+    return success;
+  }
 
 }

--- a/src/backends/tensorrt/protoUtils.h
+++ b/src/backends/tensorrt/protoUtils.h
@@ -18,14 +18,12 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-
 #ifndef PROTO_UTILS_H
 #define PROTO_UTILS_H
 
-
-#include <google/protobuf/io/coded_stream.h>                                                            
-#include <google/protobuf/io/zero_copy_stream_impl.h>                                                   
-#include <google/protobuf/text_format.h>                                                                
+#include <google/protobuf/io/coded_stream.h>
+#include <google/protobuf/io/zero_copy_stream_impl.h>
+#include <google/protobuf/text_format.h>
 
 namespace dd
 {
@@ -37,7 +35,9 @@ namespace dd
   int fixProto(const std::string dest, const std::string source);
   int findNClasses(const std::string source, bool bbox);
   int findTopK(const std::string source);
-  bool TRTReadProtoFromTextFile(const char* filename, google::protobuf::Message* proto);
-  bool TRTWriteProtoToTextFile(const google::protobuf::Message& proto, const char* filename);
+  bool TRTReadProtoFromTextFile(const char *filename,
+                                google::protobuf::Message *proto);
+  bool TRTWriteProtoToTextFile(const google::protobuf::Message &proto,
+                               const char *filename);
 }
 #endif

--- a/src/backends/tensorrt/tensorrtinputconns.h
+++ b/src/backends/tensorrt/tensorrtinputconns.h
@@ -32,33 +32,41 @@ namespace dd
   {
   public:
     TensorRTInputInterface()
-      {
-      }
-  TensorRTInputInterface(const TensorRTInputInterface &i) : _buf(i._buf)
-   { }
+    {
+    }
+    TensorRTInputInterface(const TensorRTInputInterface &i) : _buf(i._buf)
+    {
+    }
 
-    ~TensorRTInputInterface() {}
+    ~TensorRTInputInterface()
+    {
+    }
 
     bool _has_mean_file = false; /**< image model mean.binaryproto. */
     std::vector<float> _buf;
 
-    float * data()
+    float *data()
     {
       return _buf.data();
     }
   };
 
-  class ImgTensorRTInputFileConn : public ImgInputFileConn, public TensorRTInputInterface
+  class ImgTensorRTInputFileConn : public ImgInputFileConn,
+                                   public TensorRTInputInterface
   {
   public:
-    ImgTensorRTInputFileConn()
-      :ImgInputFileConn() {}
+    ImgTensorRTInputFileConn() : ImgInputFileConn()
+    {
+    }
     ImgTensorRTInputFileConn(const ImgTensorRTInputFileConn &i)
-      :ImgInputFileConn(i),TensorRTInputInterface(i), _imgs_size(i._imgs_size)
+        : ImgInputFileConn(i), TensorRTInputInterface(i),
+          _imgs_size(i._imgs_size)
     {
       this->_has_mean_file = i._has_mean_file;
     }
-    ~ImgTensorRTInputFileConn() {}
+    ~ImgTensorRTInputFileConn()
+    {
+    }
 
     // for API info only
     int width() const
@@ -76,23 +84,22 @@ namespace dd
     {
       ImgInputFileConn::init(ad);
     }
-        
+
     void transform(const APIData &ad);
 
     std::string _meanfname = "mean.binaryproto";
     std::string _correspname = "corresp.txt";
     int _batch_index = 0;
     int process_batch(const unsigned int batch_size);
-    std::unordered_map<std::string,std::pair<int,int>> _imgs_size; /**< image sizes, used in detection. */
+    std::unordered_map<std::string, std::pair<int, int>>
+        _imgs_size; /**< image sizes, used in detection. */
 
   private:
     void applyMeanToRTBuf(int channels, int i);
     void applyMeanToRTBuf(float *mean, int channels, int i);
     void CVMatToRTBuffer(cv::Mat &img, int i);
+  };
 
-    };
-
-
-  }
+}
 
 #endif

--- a/src/backends/tensorrt/tensorrtlib.cc
+++ b/src/backends/tensorrt/tensorrtlib.cc
@@ -18,7 +18,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-
 #include "outputconnectorstrategy.h"
 #include "tensorrtlib.h"
 #include "utils/apitools.h"
@@ -37,39 +36,44 @@ namespace dd
   static int findEngineBS(std::string repo, std::string engineFileName)
   {
     std::unordered_set<std::string> lfiles;
-    fileops::list_directory(repo, true, false,false, lfiles);
+    fileops::list_directory(repo, true, false, false, lfiles);
     for (std::string s : lfiles)
       {
-	if (s.find(engineFileName) != std::string::npos)
-	  {
-	    std::string bs_str;
-	    for (auto it = s.crbegin(); it != s.crend(); ++it)
-	      {
-		if (isdigit(*it))
-		  bs_str += (*it);
-		else break;
-	      }
-	    std::reverse(bs_str.begin(),bs_str.end());
-        if (bs_str.length() == 0)
-          return -1;
-	    return std::stoi(bs_str);
-	  }
+        if (s.find(engineFileName) != std::string::npos)
+          {
+            std::string bs_str;
+            for (auto it = s.crbegin(); it != s.crend(); ++it)
+              {
+                if (isdigit(*it))
+                  bs_str += (*it);
+                else
+                  break;
+              }
+            std::reverse(bs_str.begin(), bs_str.end());
+            if (bs_str.length() == 0)
+              return -1;
+            return std::stoi(bs_str);
+          }
       }
     return -1;
   }
 
-  
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  TensorRTLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::TensorRTLib(const TensorRTModel &cmodel)
-    :MLLib<TInputConnectorStrategy,TOutputConnectorStrategy,TensorRTModel>(cmodel)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  TensorRTLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+              TMLModel>::TensorRTLib(const TensorRTModel &cmodel)
+      : MLLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+              TensorRTModel>(cmodel)
   {
     this->_libname = "tensorrt";
   }
 
-
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  TensorRTLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::TensorRTLib(TensorRTLib &&tl) noexcept
-    :MLLib<TInputConnectorStrategy,TOutputConnectorStrategy,TensorRTModel>(std::move(tl))
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  TensorRTLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+              TMLModel>::TensorRTLib(TensorRTLib &&tl) noexcept
+      : MLLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+              TensorRTModel>(std::move(tl))
   {
     this->_libname = "tensorrt";
     _nclasses = tl._nclasses;
@@ -83,10 +87,10 @@ namespace dd
     _readEngine = tl._readEngine;
     _writeEngine = tl._writeEngine;
     _TRTContextReady = tl._TRTContextReady;
-    _timeserie = tl._timeserie;    
+    _timeserie = tl._timeserie;
     _buffers = tl._buffers;
     _bbox = tl._bbox;
-    _ctc = tl._ctc;    
+    _ctc = tl._ctc;
     _inputIndex = tl._inputIndex;
     _outputIndex0 = tl._outputIndex0;
     _outputIndex1 = tl._outputIndex1;
@@ -94,119 +98,125 @@ namespace dd
     _keepCount = tl._keepCount;
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  TensorRTLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::~TensorRTLib()
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  TensorRTLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+              TMLModel>::~TensorRTLib()
   {
   }
 
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void TensorRTLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+                   TMLModel>::init_mllib(const APIData &ad)
+  {
+    trtLogger.setLogger(this->_logger);
+    initLibNvInferPlugins(&trtLogger, "");
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void TensorRTLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::init_mllib(const APIData &ad)
-    {
-      trtLogger.setLogger(this->_logger);
-      initLibNvInferPlugins(&trtLogger,"");
+    if (ad.has("tensorRTEngineFile"))
+      _engineFileName = ad.get("tensorRTEngineFile").get<std::string>();
+    if (ad.has("readEngine"))
+      _readEngine = ad.get("readEngine").get<bool>();
+    if (ad.has("writeEngine"))
+      _writeEngine = ad.get("writeEngine").get<bool>();
 
-      if (ad.has("tensorRTEngineFile"))
-	_engineFileName = ad.get("tensorRTEngineFile").get<std::string>();
-      if (ad.has("readEngine"))
-	_readEngine = ad.get("readEngine").get<bool>();
-      if (ad.has("writeEngine"))
-	_writeEngine = ad.get("writeEngine").get<bool>();
+    if (ad.has("maxWorkspaceSize"))
+      {
+        _max_workspace_size
+            = ad.get("maxWorkspaceSize").get<int>() * (1 << 20);
+        this->_logger->info("setting max workspace size to {}",
+                            _max_workspace_size);
+      }
+    if (ad.has("maxBatchSize"))
+      {
+        int nmbs = ad.get("maxBatchSize").get<int>();
+        _max_batch_size = nmbs;
+        this->_logger->info("setting max batch size to {}", _max_batch_size);
+      }
 
+    if (ad.has("dla"))
+      _dla = ad.get("dla").get<int>();
 
-      if (ad.has("maxWorkspaceSize"))
-	{
-	  _max_workspace_size = ad.get("maxWorkspaceSize").get<int>() * (1<<20);
-	  this->_logger->info("setting max workspace size to {}", _max_workspace_size);
-	}
-      if (ad.has("maxBatchSize"))
-	{
-	  int nmbs =  ad.get("maxBatchSize").get<int>();
-	  _max_batch_size = nmbs;
-	  this->_logger->info("setting max batch size to {}", _max_batch_size);
-	}      
+    if (ad.has("datatype"))
+      {
+        std::string datatype = ad.get("datatype").get<std::string>();
+        if (datatype == "fp32")
+          _datatype = nvinfer1::DataType::kFLOAT;
+        else if (datatype == "fp16")
+          _datatype = nvinfer1::DataType::kHALF;
+        else if (datatype == "int32")
+          _datatype = nvinfer1::DataType::kINT32;
+        else if (datatype == "int8")
+          _datatype = nvinfer1::DataType::kINT8;
+      }
 
-      if (ad.has("dla"))
-	_dla = ad.get("dla").get<int>();
+    if (ad.has("gpuid"))
+      _gpuid = ad.get("gpuid").get<int>();
+    cudaSetDevice(_gpuid);
 
+    model_type(this->_mlmodel._def, this->_mltype);
 
-      if (ad.has("datatype"))
-	{
-	  std::string datatype = ad.get("datatype").get<std::string>();
-	  if (datatype == "fp32")
-	    _datatype = nvinfer1::DataType::kFLOAT;
-	  else if (datatype == "fp16")
-	    _datatype = nvinfer1::DataType::kHALF;
-	  else if (datatype == "int32")
-	    _datatype = nvinfer1::DataType::kINT32;
-	  else if (datatype == "int8")
-	    _datatype = nvinfer1::DataType::kINT8;
-	}
+    _builder = std::shared_ptr<nvinfer1::IBuilder>(
+        nvinfer1::createInferBuilder(trtLogger),
+        [=](nvinfer1::IBuilder *b) { b->destroy(); });
+    if (_dla != -1)
+      {
+        if (_builder->getNbDLACores() == 0)
+          this->_logger->info("Trying to use DLA core on a platform  that "
+                              "doesn't have any DLA cores");
+        else
+          {
+            if (_datatype == nvinfer1::DataType::kINT32)
+              {
+                this->_logger->info("asked for int32 on dla : forcing int8");
+                _datatype = nvinfer1::DataType::kINT8;
+              }
+            else if (_datatype == nvinfer1::DataType::kFLOAT)
+              {
+                this->_logger->info(
+                    "asked for float32 on dla : forcing float16");
+                _datatype = nvinfer1::DataType::kHALF;
+              }
+            _builder->allowGPUFallback(true);
+            if (_datatype == nvinfer1::DataType::kINT8)
+              {
+                _builder->setInt8Mode(true);
+                _builder->setFp16Mode(false);
+              }
+            else
+              {
+                _builder->setInt8Mode(false);
+                _builder->setFp16Mode(true);
+              }
+            _builder->setDefaultDeviceType(nvinfer1::DeviceType::kDLA);
+            _builder->setDLACore(_dla);
+          }
+      }
+    else
+      {
+        if (_datatype == nvinfer1::DataType::kHALF)
+          {
+            _builder->setInt8Mode(false);
+            if (_builder->platformHasFastFp16())
+              {
+                _builder->setFp16Mode(true);
+                this->_logger->info("Setting FP16 mode");
+              }
+            else
+              this->_logger->info("Platform does not has Fast TP16 mode");
+          }
+        else
+          {
+            _builder->setInt8Mode(false);
+            _builder->setFp16Mode(false);
+          }
+      }
+  }
 
-      if (ad.has("gpuid"))
-        _gpuid = ad.get("gpuid").get<int>();
-      cudaSetDevice(_gpuid);
-      
-      model_type(this->_mlmodel._def,this->_mltype);
-
-      _builder = std::shared_ptr<nvinfer1::IBuilder>(nvinfer1::createInferBuilder(trtLogger),
-						     [=] (nvinfer1::IBuilder* b) {b->destroy();});
-      if (_dla != -1)
-	{
-	  if (_builder->getNbDLACores() == 0)
-	    this->_logger->info("Trying to use DLA core on a platform  that doesn't have any DLA cores");
-	  else
-	    {
-	      if (_datatype == nvinfer1::DataType::kINT32)
-		{
-		  this->_logger->info("asked for int32 on dla : forcing int8");
-		  _datatype = nvinfer1::DataType::kINT8;
-		}
-	      else if (_datatype == nvinfer1::DataType::kFLOAT)
-		{
-		  this->_logger->info("asked for float32 on dla : forcing float16");
-		  _datatype = nvinfer1::DataType::kHALF;
-		}
-	      _builder->allowGPUFallback(true);
-	      if (_datatype == nvinfer1::DataType::kINT8)
-		{
-		  _builder->setInt8Mode(true);
-		  _builder->setFp16Mode(false);
-		}
-	      else
-		{
-		  _builder->setInt8Mode(false);
-		  _builder->setFp16Mode(true);
-		}	      
-	      _builder->setDefaultDeviceType(nvinfer1::DeviceType::kDLA);
-	      _builder->setDLACore(_dla);
-	    }
-	}
-      else
-	{
-	  if (_datatype == nvinfer1::DataType::kHALF)
-	    {
-	      _builder->setInt8Mode(false);
-	      if (_builder->platformHasFastFp16())
-		{
-		  _builder->setFp16Mode(true);
-		  this->_logger->info("Setting FP16 mode");
-		}
-	      else
-		  this->_logger->info("Platform does not has Fast TP16 mode"); 
-	    }
-	  else
-	    {
-	      _builder->setInt8Mode(false);
-	      _builder->setFp16Mode(false);
-	    }
-	    
-	}
-    }
-
-
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void TensorRTLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::clear_mllib(const APIData &ad)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void TensorRTLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+                   TMLModel>::clear_mllib(const APIData &ad)
   {
     (void)ad;
     nvcaffeparser1::shutdownProtobufLibrary();
@@ -216,10 +226,10 @@ namespace dd
       cudaFree(_buffers.data()[_outputIndex1]);
   }
 
-
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  int TensorRTLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::train(const APIData &ad,
-                                                                                APIData &out)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  int TensorRTLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+                  TMLModel>::train(const APIData &ad, APIData &out)
   {
     this->_logger->warn("Training not supported on tensorRT backend");
     (void)ad;
@@ -227,395 +237,452 @@ namespace dd
     return 0;
   }
 
-
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  int TensorRTLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::predict(const APIData &ad,
-                                                                                      APIData &out)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  int TensorRTLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+                  TMLModel>::predict(const APIData &ad, APIData &out)
   {
-    std::lock_guard<std::mutex> lock(_net_mutex); // no concurrent calls since the net is not re-instantiated
+    std::lock_guard<std::mutex> lock(
+        _net_mutex); // no concurrent calls since the net is not
+                     // re-instantiated
 
     if (ad.getobj("parameters").getobj("mllib").has("gpuid"))
       _gpuid = ad.getobj("parameters").getobj("mllib").get("gpuid").get<int>();
     cudaSetDevice(_gpuid);
 
-    APIData ad_output = ad.getobj("parameters").getobj("output");    
+    APIData ad_output = ad.getobj("parameters").getobj("output");
     int blank_label = -1;
     std::string out_blob = "prob";
     TInputConnectorStrategy inputc(this->_inputc);
 
-
     if (!_TRTContextReady)
       {
-	if (ad_output.has("bbox"))
-	  _bbox = ad_output.get("bbox").get<bool>();
-	// Ctc model
-	if (ad_output.has("ctc"))
-	  {
-	    _ctc = ad_output.get("ctc").get<bool>();
-	    if (_ctc)
-	      {
-		if (ad_output.has("blank_label"))
-		  blank_label = ad_output.get("blank_label").get<int>();
-	      }
-	  }
-	
-	if (_bbox == true)
-	  out_blob = "detection_out";
-	else if (_ctc == true)
-	  {
-	    out_blob = "probs";
-	    throw MLLibBadParamException("ocr not yet implemented over tensorRT backend");
-	  }
-	else if (_timeserie)
-	  {
-	    out_blob = "rnn_pred";
-	    throw MLLibBadParamException("timeseries not yet implemented over tensorRT backend");
-	  } 
+        if (ad_output.has("bbox"))
+          _bbox = ad_output.get("bbox").get<bool>();
+        // Ctc model
+        if (ad_output.has("ctc"))
+          {
+            _ctc = ad_output.get("ctc").get<bool>();
+            if (_ctc)
+              {
+                if (ad_output.has("blank_label"))
+                  blank_label = ad_output.get("blank_label").get<int>();
+              }
+          }
 
-	_nclasses = findNClasses(this->_mlmodel._def, _bbox);
-       if (_bbox)
-         _top_k = findTopK(this->_mlmodel._def);
+        if (_bbox == true)
+          out_blob = "detection_out";
+        else if (_ctc == true)
+          {
+            out_blob = "probs";
+            throw MLLibBadParamException(
+                "ocr not yet implemented over tensorRT backend");
+          }
+        else if (_timeserie)
+          {
+            out_blob = "rnn_pred";
+            throw MLLibBadParamException(
+                "timeseries not yet implemented over tensorRT backend");
+          }
 
-	if (_nclasses <=0)
-	  this->_logger->error("could not determine number of classes");
-	
-	bool engineRead = false;
-	
-	if (_readEngine)
-	  {
-	    int bs = findEngineBS(this->_mlmodel._repo, _engineFileName);
-	    if (bs != _max_batch_size && bs != -1)
-		this->_logger->warn("found existing engine with max_batch_size {}, using it",  bs);
-	    std::ifstream file(this->_mlmodel._repo+"/"+_engineFileName+"_bs"+std::to_string(bs),
-			       std::ios::binary);
-	    if (file.good())
-	      {
-		std::vector<char> trtModelStream;
-		size_t size{0};
-		file.seekg(0, file.end);
-		size = file.tellg();
-		file.seekg(0, file.beg);
-		trtModelStream.resize(size);
-		file.read(trtModelStream.data(), size);
-		file.close();
-		nvinfer1::IRuntime* runtime = nvinfer1::createInferRuntime(trtLogger);
-		_engine = std::shared_ptr<nvinfer1::ICudaEngine>
-		  (runtime->deserializeCudaEngine(trtModelStream.data(),
-						  trtModelStream.size(), nullptr),
-		   [=] (nvinfer1::ICudaEngine* e) {e->destroy();});
-		runtime->destroy();
-		engineRead = true;
-	      }
-	  }
-	
-	if (!engineRead)
-	  {
+        _nclasses = findNClasses(this->_mlmodel._def, _bbox);
+        if (_bbox)
+          _top_k = findTopK(this->_mlmodel._def);
 
-	    int fixcode = fixProto(this->_mlmodel._repo + "/" +"net_tensorRT.proto", this->_mlmodel._def);
-	    switch(fixcode)
-	      {
-	      case 1:
-		this->_logger->error("TRT backend could not open model prototxt");
-		break;
-	      case 2:
-		this->_logger->error("TRT backend  could not write transformed model prototxt");
-		break;
-	      default:
-		break;
-	      }
-	    
-	    nvinfer1::INetworkDefinition *network = _builder->createNetwork();
-	    nvcaffeparser1::ICaffeParser *caffeParser = nvcaffeparser1::createCaffeParser();
+        if (_nclasses <= 0)
+          this->_logger->error("could not determine number of classes");
 
-	    const nvcaffeparser1::IBlobNameToTensor* blobNameToTensor
-	      = caffeParser->parse(std::string(this->_mlmodel._repo + "/" +"net_tensorRT.proto").c_str(),
-				   this->_mlmodel._weights.c_str(),
-				   *network, _datatype);
-	    if (!blobNameToTensor)
-	      throw MLLibInternalException("Error while parsing caffe model for conversion to TensorRT");
-	    
-	    network->markOutput(*blobNameToTensor->find(out_blob.c_str()));
-	    
-	    if (out_blob == "detection_out")
-	      network->markOutput(*blobNameToTensor->find("keep_count"));
-	    _builder->setMaxBatchSize(_max_batch_size);	
-	    _builder->setMaxWorkspaceSize(_max_workspace_size);
+        bool engineRead = false;
 
-	    network->getLayer(0)->setPrecision(nvinfer1::DataType::kFLOAT);
-	    
-	    nvinfer1::ILayer *outl = NULL;
-	    int idx = network->getNbLayers() -1;
-	    while (outl == NULL)
-	      {
-		nvinfer1::ILayer * l = network->getLayer(idx);
-		if (strcmp(l->getName(),out_blob.c_str()) == 0)
-		  {
-		    outl = l;
-		    break;
-		  }
-		idx--;
-	      }
-	    // force output to be float32
-	    outl->setPrecision(nvinfer1::DataType::kFLOAT);
+        if (_readEngine)
+          {
+            int bs = findEngineBS(this->_mlmodel._repo, _engineFileName);
+            if (bs != _max_batch_size && bs != -1)
+              this->_logger->warn(
+                  "found existing engine with max_batch_size {}, using it",
+                  bs);
+            std::ifstream file(this->_mlmodel._repo + "/" + _engineFileName
+                                   + "_bs" + std::to_string(bs),
+                               std::ios::binary);
+            if (file.good())
+              {
+                std::vector<char> trtModelStream;
+                size_t size{ 0 };
+                file.seekg(0, file.end);
+                size = file.tellg();
+                file.seekg(0, file.beg);
+                trtModelStream.resize(size);
+                file.read(trtModelStream.data(), size);
+                file.close();
+                nvinfer1::IRuntime *runtime
+                    = nvinfer1::createInferRuntime(trtLogger);
+                _engine = std::shared_ptr<nvinfer1::ICudaEngine>(
+                    runtime->deserializeCudaEngine(
+                        trtModelStream.data(), trtModelStream.size(), nullptr),
+                    [=](nvinfer1::ICudaEngine *e) { e->destroy(); });
+                runtime->destroy();
+                engineRead = true;
+              }
+          }
 
-	    nvinfer1::ICudaEngine * le = _builder->buildCudaEngine(*network);
-	    _engine = std::shared_ptr<nvinfer1::ICudaEngine>
-	      (le, [=] (nvinfer1::ICudaEngine* e) {e->destroy();});
-	
-	    if (_writeEngine)
-	      {
-		std::ofstream p(this->_mlmodel._repo+"/"+_engineFileName+"_bs"+std::to_string(_max_batch_size), std::ios::binary);
-		nvinfer1::IHostMemory* trtModelStream  = _engine->serialize();
-		p.write(reinterpret_cast<const char*>(trtModelStream->data()), trtModelStream->size());
-		trtModelStream->destroy();
-	      }
-	    
-	    network->destroy();
-	    caffeParser->destroy();
-	  }
+        if (!engineRead)
+          {
 
-	_context =  std::shared_ptr<nvinfer1::IExecutionContext>
-	  (_engine->createExecutionContext(),
-	   [=] (nvinfer1::IExecutionContext* e) {e->destroy();});
-	_TRTContextReady = true;
+            int fixcode
+                = fixProto(this->_mlmodel._repo + "/" + "net_tensorRT.proto",
+                           this->_mlmodel._def);
+            switch (fixcode)
+              {
+              case 1:
+                this->_logger->error(
+                    "TRT backend could not open model prototxt");
+                break;
+              case 2:
+                this->_logger->error(
+                    "TRT backend  could not write transformed model prototxt");
+                break;
+              default:
+                break;
+              }
 
-	
-	_inputIndex = _engine->getBindingIndex("data");
-	_outputIndex0 = _engine->getBindingIndex(out_blob.c_str());
+            nvinfer1::INetworkDefinition *network = _builder->createNetwork();
+            nvcaffeparser1::ICaffeParser *caffeParser
+                = nvcaffeparser1::createCaffeParser();
 
-	if (_bbox)
-	  {
-	    _outputIndex1 = _engine->getBindingIndex("keep_count");	    
-	    _buffers.resize(3);
-	    _floatOut.resize(_max_batch_size * _top_k * 7);
-	    _keepCount.resize(_max_batch_size);
-	    if (inputc._bw)
-	      cudaMalloc(&_buffers.data()[_inputIndex], _max_batch_size  * inputc._height * inputc._width * sizeof(float));
-	    else
-	      cudaMalloc(&_buffers.data()[_inputIndex], _max_batch_size * 3 * inputc._height * inputc._width * sizeof(float));
-	    cudaMalloc(&_buffers.data()[_outputIndex0], _max_batch_size * _top_k * 7 * sizeof(float));               
-	    cudaMalloc(&_buffers.data()[_outputIndex1], _max_batch_size * sizeof(int));
-	  }
-	else if (_ctc)
-	  {
-	    throw MLLibBadParamException("ocr not yet implemented over tensorRT backend");
-	  }
-	else if (_timeserie)
-	  {
-	    throw MLLibBadParamException("timeseries not yet implemented over tensorRT backend");
-	  }
-	else // classification
-	  {
-	    _buffers.resize(2);
-	    _floatOut.resize(_max_batch_size * this->_nclasses);
-	    if (inputc._bw)
-	      cudaMalloc(&_buffers.data()[_inputIndex], _max_batch_size  * inputc._height * inputc._width * sizeof(float));
-	    else
-	      cudaMalloc(&_buffers.data()[_inputIndex], _max_batch_size * 3 * inputc._height * inputc._width * sizeof(float));
-	    cudaMalloc(&_buffers.data()[_outputIndex0], _max_batch_size * _nclasses * sizeof(float));     
-	  }
+            const nvcaffeparser1::IBlobNameToTensor *blobNameToTensor
+                = caffeParser->parse(std::string(this->_mlmodel._repo + "/"
+                                                 + "net_tensorRT.proto")
+                                         .c_str(),
+                                     this->_mlmodel._weights.c_str(), *network,
+                                     _datatype);
+            if (!blobNameToTensor)
+              throw MLLibInternalException("Error while parsing caffe model "
+                                           "for conversion to TensorRT");
+
+            network->markOutput(*blobNameToTensor->find(out_blob.c_str()));
+
+            if (out_blob == "detection_out")
+              network->markOutput(*blobNameToTensor->find("keep_count"));
+            _builder->setMaxBatchSize(_max_batch_size);
+            _builder->setMaxWorkspaceSize(_max_workspace_size);
+
+            network->getLayer(0)->setPrecision(nvinfer1::DataType::kFLOAT);
+
+            nvinfer1::ILayer *outl = NULL;
+            int idx = network->getNbLayers() - 1;
+            while (outl == NULL)
+              {
+                nvinfer1::ILayer *l = network->getLayer(idx);
+                if (strcmp(l->getName(), out_blob.c_str()) == 0)
+                  {
+                    outl = l;
+                    break;
+                  }
+                idx--;
+              }
+            // force output to be float32
+            outl->setPrecision(nvinfer1::DataType::kFLOAT);
+
+            nvinfer1::ICudaEngine *le = _builder->buildCudaEngine(*network);
+            _engine = std::shared_ptr<nvinfer1::ICudaEngine>(
+                le, [=](nvinfer1::ICudaEngine *e) { e->destroy(); });
+
+            if (_writeEngine)
+              {
+                std::ofstream p(this->_mlmodel._repo + "/" + _engineFileName
+                                    + "_bs" + std::to_string(_max_batch_size),
+                                std::ios::binary);
+                nvinfer1::IHostMemory *trtModelStream = _engine->serialize();
+                p.write(reinterpret_cast<const char *>(trtModelStream->data()),
+                        trtModelStream->size());
+                trtModelStream->destroy();
+              }
+
+            network->destroy();
+            caffeParser->destroy();
+          }
+
+        _context = std::shared_ptr<nvinfer1::IExecutionContext>(
+            _engine->createExecutionContext(),
+            [=](nvinfer1::IExecutionContext *e) { e->destroy(); });
+        _TRTContextReady = true;
+
+        _inputIndex = _engine->getBindingIndex("data");
+        _outputIndex0 = _engine->getBindingIndex(out_blob.c_str());
+
+        if (_bbox)
+          {
+            _outputIndex1 = _engine->getBindingIndex("keep_count");
+            _buffers.resize(3);
+            _floatOut.resize(_max_batch_size * _top_k * 7);
+            _keepCount.resize(_max_batch_size);
+            if (inputc._bw)
+              cudaMalloc(&_buffers.data()[_inputIndex],
+                         _max_batch_size * inputc._height * inputc._width
+                             * sizeof(float));
+            else
+              cudaMalloc(&_buffers.data()[_inputIndex],
+                         _max_batch_size * 3 * inputc._height * inputc._width
+                             * sizeof(float));
+            cudaMalloc(&_buffers.data()[_outputIndex0],
+                       _max_batch_size * _top_k * 7 * sizeof(float));
+            cudaMalloc(&_buffers.data()[_outputIndex1],
+                       _max_batch_size * sizeof(int));
+          }
+        else if (_ctc)
+          {
+            throw MLLibBadParamException(
+                "ocr not yet implemented over tensorRT backend");
+          }
+        else if (_timeserie)
+          {
+            throw MLLibBadParamException(
+                "timeseries not yet implemented over tensorRT backend");
+          }
+        else // classification
+          {
+            _buffers.resize(2);
+            _floatOut.resize(_max_batch_size * this->_nclasses);
+            if (inputc._bw)
+              cudaMalloc(&_buffers.data()[_inputIndex],
+                         _max_batch_size * inputc._height * inputc._width
+                             * sizeof(float));
+            else
+              cudaMalloc(&_buffers.data()[_inputIndex],
+                         _max_batch_size * 3 * inputc._height * inputc._width
+                             * sizeof(float));
+            cudaMalloc(&_buffers.data()[_outputIndex0],
+                       _max_batch_size * _nclasses * sizeof(float));
+          }
       }
-    
+
     APIData cad = ad;
 
     TOutputConnectorStrategy tout(this->_outputc);
-    try {
-      inputc.transform(cad);
-    } catch (...) {
-      throw;
-    }
-    
+    try
+      {
+        inputc.transform(cad);
+      }
+    catch (...)
+      {
+        throw;
+      }
+
     int idoffset = 0;
     std::vector<APIData> vrad;
 
     cudaSetDevice(_gpuid);
     cudaStream_t cstream;
-    cudaStreamCreate(&cstream);	
+    cudaStreamCreate(&cstream);
 
     while (true)
       {
-    
-	int num_processed = inputc.process_batch(_max_batch_size);
-	if (num_processed == 0)
-	  break;
 
-	try
-	  {
-	    if (_bbox)
-	      {
-		if (inputc._bw)
-		  cudaMemcpyAsync(_buffers.data()[_inputIndex], inputc.data(),
-				  num_processed *  inputc._height * inputc._width * sizeof(float),
-				  cudaMemcpyHostToDevice, cstream);
-		else
-		  cudaMemcpyAsync(_buffers.data()[_inputIndex], inputc.data(),
-				  num_processed * 3 * inputc._height * inputc._width * sizeof(float),
-				  cudaMemcpyHostToDevice, cstream);
-		_context->enqueue(num_processed, _buffers.data(), cstream, nullptr);
-		cudaMemcpyAsync(_floatOut.data(), _buffers.data()[_outputIndex0],
-				num_processed * _top_k * 7 * sizeof(float),
-				cudaMemcpyDeviceToHost, cstream);
-		cudaMemcpyAsync(_keepCount.data(), _buffers.data()[_outputIndex1], num_processed * sizeof(int),
-				cudaMemcpyDeviceToHost, cstream);
-		cudaStreamSynchronize(cstream);
-	      }
-	    else if (_ctc)
-	      {
-		throw MLLibBadParamException("ocr not yet implemented over tensorRT backend");
-	      }
-	    else if (_timeserie)
-	      {
-		throw MLLibBadParamException("timeseries not yet implemented over tensorRT backend");
-	      }
-	    else // classification
-	      {
-		if (inputc._bw)
-		  cudaMemcpyAsync(_buffers.data()[_inputIndex], inputc.data(),
-				  num_processed *  inputc._height * inputc._width * sizeof(float),
-				  cudaMemcpyHostToDevice, cstream);
-		else
-		  cudaMemcpyAsync(_buffers.data()[_inputIndex], inputc.data(),
-				  num_processed * 3 * inputc._height * inputc._width * sizeof(float),
-				  cudaMemcpyHostToDevice, cstream);
-		_context->enqueue(num_processed, _buffers.data(), cstream, nullptr);
-		cudaMemcpyAsync(_floatOut.data(), _buffers.data()[_outputIndex0],
-				num_processed * _nclasses * sizeof(float),
-				cudaMemcpyDeviceToHost, cstream);
-		cudaStreamSynchronize(cstream);
-	      }
-	  }
-	catch(std::exception &e)
-	  {
-	    this->_logger->error("Error while processing forward TRT pass, not enough memory ? {}",e.what());
-	    throw;
-	  }		
+        int num_processed = inputc.process_batch(_max_batch_size);
+        if (num_processed == 0)
+          break;
 
-	std::vector<double> probs;
-	std::vector<std::string> cats;
-	std::vector<APIData> bboxes;
-	std::vector<APIData> series;
-	
-	// Get confidence_threshold
-	float confidence_threshold = 0.0;
-	if (ad_output.has("confidence_threshold")) {
-	  apitools::get_float(ad_output, "confidence_threshold", confidence_threshold);
-	}
+        try
+          {
+            if (_bbox)
+              {
+                if (inputc._bw)
+                  cudaMemcpyAsync(_buffers.data()[_inputIndex], inputc.data(),
+                                  num_processed * inputc._height
+                                      * inputc._width * sizeof(float),
+                                  cudaMemcpyHostToDevice, cstream);
+                else
+                  cudaMemcpyAsync(_buffers.data()[_inputIndex], inputc.data(),
+                                  num_processed * 3 * inputc._height
+                                      * inputc._width * sizeof(float),
+                                  cudaMemcpyHostToDevice, cstream);
+                _context->enqueue(num_processed, _buffers.data(), cstream,
+                                  nullptr);
+                cudaMemcpyAsync(_floatOut.data(),
+                                _buffers.data()[_outputIndex0],
+                                num_processed * _top_k * 7 * sizeof(float),
+                                cudaMemcpyDeviceToHost, cstream);
+                cudaMemcpyAsync(_keepCount.data(),
+                                _buffers.data()[_outputIndex1],
+                                num_processed * sizeof(int),
+                                cudaMemcpyDeviceToHost, cstream);
+                cudaStreamSynchronize(cstream);
+              }
+            else if (_ctc)
+              {
+                throw MLLibBadParamException(
+                    "ocr not yet implemented over tensorRT backend");
+              }
+            else if (_timeserie)
+              {
+                throw MLLibBadParamException(
+                    "timeseries not yet implemented over tensorRT backend");
+              }
+            else // classification
+              {
+                if (inputc._bw)
+                  cudaMemcpyAsync(_buffers.data()[_inputIndex], inputc.data(),
+                                  num_processed * inputc._height
+                                      * inputc._width * sizeof(float),
+                                  cudaMemcpyHostToDevice, cstream);
+                else
+                  cudaMemcpyAsync(_buffers.data()[_inputIndex], inputc.data(),
+                                  num_processed * 3 * inputc._height
+                                      * inputc._width * sizeof(float),
+                                  cudaMemcpyHostToDevice, cstream);
+                _context->enqueue(num_processed, _buffers.data(), cstream,
+                                  nullptr);
+                cudaMemcpyAsync(_floatOut.data(),
+                                _buffers.data()[_outputIndex0],
+                                num_processed * _nclasses * sizeof(float),
+                                cudaMemcpyDeviceToHost, cstream);
+                cudaStreamSynchronize(cstream);
+              }
+          }
+        catch (std::exception &e)
+          {
+            this->_logger->error("Error while processing forward TRT pass, "
+                                 "not enough memory ? {}",
+                                 e.what());
+            throw;
+          }
 
-	if (_bbox)
-	  {
-	    int results_height = _top_k; 
-	    const int det_size = 7;
+        std::vector<double> probs;
+        std::vector<std::string> cats;
+        std::vector<APIData> bboxes;
+        std::vector<APIData> series;
 
-	    const float *outr = _floatOut.data();
-	    
-	    for (int j=0;j<num_processed;j++)
-	      {
-		int k = 0;
-		std::vector<double> probs;
-		std::vector<std::string> cats;
-		std::vector<APIData> bboxes;
-		APIData rad;
-		std::string uri = inputc._ids.at(idoffset+j);
-		auto bit = inputc._imgs_size.find(uri);
-		int rows = 1;
-		int cols = 1;
-		if (bit != inputc._imgs_size.end())
-		  {
-		    // original image size
-		    rows = (*bit).second.first;
-		    cols = (*bit).second.second;
-		  }
-		else
-		  {
-		    this->_logger->error("couldn't find original image size for {}",uri);
-		  }
-		bool leave = false;
-		int curi = -1;
-		while(true && k<results_height)
-		  {
-		    if (outr[0] == -1)
-		      {
-			// skipping invalid detection
-			this->_logger->error("skipping invalid detection");
-			outr += det_size;
-			leave = true;
-			break;
-		      }
-		    std::vector<float> detection(outr, outr + det_size);
-		    if (curi == -1)
-		      curi = detection[0]; // first pass
-		    else if (curi != detection[0])
-		      break; // this belongs to next image
-		    ++k;
-		    outr += det_size;
-		    if (detection[2] < confidence_threshold)
-		      continue;
+        // Get confidence_threshold
+        float confidence_threshold = 0.0;
+        if (ad_output.has("confidence_threshold"))
+          {
+            apitools::get_float(ad_output, "confidence_threshold",
+                                confidence_threshold);
+          }
 
-		    // Fix border of bboxes
-		    detection[3] = std::max(((float) detection[3]), 0.0f);
-		    detection[4] = std::max(((float) detection[4]), 0.0f);
-		    detection[5] = std::min(((float) detection[5]), 1.0f);
-		    detection[6] = std::min(((float) detection[6]), 1.0f);
+        if (_bbox)
+          {
+            int results_height = _top_k;
+            const int det_size = 7;
 
-		    probs.push_back(detection[2]);
-		    cats.push_back(this->_mlmodel.get_hcorresp(detection[1]));
-		    APIData ad_bbox;
-		    ad_bbox.add("xmin",static_cast<double>(detection[3]*(cols-1)));
-		    ad_bbox.add("ymin",static_cast<double>(detection[4]*(rows-1)));
-		    ad_bbox.add("xmax",static_cast<double>(detection[5]*(cols-1)));
-		    ad_bbox.add("ymax",static_cast<double>(detection[6]*(rows-1)));
-		    bboxes.push_back(ad_bbox);
-		  }
-		if (leave)
-		      continue;
-		rad.add("uri",uri);
-		rad.add("loss",0.0); // XXX: unused
-		rad.add("probs",probs);
-		rad.add("cats",cats);
-		rad.add("bboxes",bboxes); 
-		vrad.push_back(rad);
-	      }
-	  }
-	
-	else if (_ctc)
-	  {
-	    throw MLLibBadParamException("timeseries not yet implemented over tensorRT backend");
-	  }
-	else if (_timeserie)
-	  {
-	    throw MLLibBadParamException("timeseries not yet implemented over tensorRT backend");
-	  }
-	else // classification
-	  {
-	    for (int j=0;j<num_processed;j++)
-	      {
-		APIData rad;
-		if (!inputc._ids.empty())
-		  rad.add("uri",inputc._ids.at(idoffset+j));
-		else rad.add("uri",std::to_string(idoffset+j));
-		rad.add("loss",0.0);
-		std::vector<double> probs;
-		std::vector<std::string> cats;
-		
-		    for (int i=0;i<_nclasses;i++)
-		      {
-			double prob = _floatOut.at(j*_nclasses+i);
-			if (prob < confidence_threshold)
-			  continue;
-			probs.push_back(prob);
-			cats.push_back(this->_mlmodel.get_hcorresp(i));
-		      }
+            const float *outr = _floatOut.data();
 
-		rad.add("probs",probs);
-		rad.add("cats",cats);
-		vrad.push_back(rad);
-	      }
-	  }
-	idoffset += num_processed;
+            for (int j = 0; j < num_processed; j++)
+              {
+                int k = 0;
+                std::vector<double> probs;
+                std::vector<std::string> cats;
+                std::vector<APIData> bboxes;
+                APIData rad;
+                std::string uri = inputc._ids.at(idoffset + j);
+                auto bit = inputc._imgs_size.find(uri);
+                int rows = 1;
+                int cols = 1;
+                if (bit != inputc._imgs_size.end())
+                  {
+                    // original image size
+                    rows = (*bit).second.first;
+                    cols = (*bit).second.second;
+                  }
+                else
+                  {
+                    this->_logger->error(
+                        "couldn't find original image size for {}", uri);
+                  }
+                bool leave = false;
+                int curi = -1;
+                while (true && k < results_height)
+                  {
+                    if (outr[0] == -1)
+                      {
+                        // skipping invalid detection
+                        this->_logger->error("skipping invalid detection");
+                        outr += det_size;
+                        leave = true;
+                        break;
+                      }
+                    std::vector<float> detection(outr, outr + det_size);
+                    if (curi == -1)
+                      curi = detection[0]; // first pass
+                    else if (curi != detection[0])
+                      break; // this belongs to next image
+                    ++k;
+                    outr += det_size;
+                    if (detection[2] < confidence_threshold)
+                      continue;
+
+                    // Fix border of bboxes
+                    detection[3] = std::max(((float)detection[3]), 0.0f);
+                    detection[4] = std::max(((float)detection[4]), 0.0f);
+                    detection[5] = std::min(((float)detection[5]), 1.0f);
+                    detection[6] = std::min(((float)detection[6]), 1.0f);
+
+                    probs.push_back(detection[2]);
+                    cats.push_back(this->_mlmodel.get_hcorresp(detection[1]));
+                    APIData ad_bbox;
+                    ad_bbox.add("xmin", static_cast<double>(detection[3]
+                                                            * (cols - 1)));
+                    ad_bbox.add("ymin", static_cast<double>(detection[4]
+                                                            * (rows - 1)));
+                    ad_bbox.add("xmax", static_cast<double>(detection[5]
+                                                            * (cols - 1)));
+                    ad_bbox.add("ymax", static_cast<double>(detection[6]
+                                                            * (rows - 1)));
+                    bboxes.push_back(ad_bbox);
+                  }
+                if (leave)
+                  continue;
+                rad.add("uri", uri);
+                rad.add("loss", 0.0); // XXX: unused
+                rad.add("probs", probs);
+                rad.add("cats", cats);
+                rad.add("bboxes", bboxes);
+                vrad.push_back(rad);
+              }
+          }
+
+        else if (_ctc)
+          {
+            throw MLLibBadParamException(
+                "timeseries not yet implemented over tensorRT backend");
+          }
+        else if (_timeserie)
+          {
+            throw MLLibBadParamException(
+                "timeseries not yet implemented over tensorRT backend");
+          }
+        else // classification
+          {
+            for (int j = 0; j < num_processed; j++)
+              {
+                APIData rad;
+                if (!inputc._ids.empty())
+                  rad.add("uri", inputc._ids.at(idoffset + j));
+                else
+                  rad.add("uri", std::to_string(idoffset + j));
+                rad.add("loss", 0.0);
+                std::vector<double> probs;
+                std::vector<std::string> cats;
+
+                for (int i = 0; i < _nclasses; i++)
+                  {
+                    double prob = _floatOut.at(j * _nclasses + i);
+                    if (prob < confidence_threshold)
+                      continue;
+                    probs.push_back(prob);
+                    cats.push_back(this->_mlmodel.get_hcorresp(i));
+                  }
+
+                rad.add("probs", probs);
+                rad.add("cats", cats);
+                vrad.push_back(rad);
+              }
+          }
+        idoffset += num_processed;
       }
 
     cudaStreamDestroy(cstream);
-    
+
     tout.add_results(vrad);
 
     out.add("nclasses", this->_nclasses);
@@ -623,29 +690,40 @@ namespace dd
       out.add("bbox", true);
     out.add("roi", false);
     out.add("multibox_rois", false);
-    tout.finalize(ad.getobj("parameters").getobj("output"),out,static_cast<MLModel*>(&this->_mlmodel));
+    tout.finalize(ad.getobj("parameters").getobj("output"), out,
+                  static_cast<MLModel *>(&this->_mlmodel));
 
     if (ad.has("chain") && ad.get("chain").get<bool>())
       {
-	if (typeid(inputc) == typeid(ImgTensorRTInputFileConn))
-	  {
-	    APIData chain_input;
-	    if (!reinterpret_cast<ImgTensorRTInputFileConn*>(&inputc)->_orig_images.empty())
-	      chain_input.add("imgs",reinterpret_cast<ImgTensorRTInputFileConn*>(&inputc)->_orig_images);
-	    else
-	      chain_input.add("imgs",reinterpret_cast<ImgTensorRTInputFileConn*>(&inputc)->_images);
-	    chain_input.add("imgs_size",reinterpret_cast<ImgTensorRTInputFileConn*>(&inputc)->_images_size);
-	    out.add("input",chain_input);
-	  }
+        if (typeid(inputc) == typeid(ImgTensorRTInputFileConn))
+          {
+            APIData chain_input;
+            if (!reinterpret_cast<ImgTensorRTInputFileConn *>(&inputc)
+                     ->_orig_images.empty())
+              chain_input.add(
+                  "imgs", reinterpret_cast<ImgTensorRTInputFileConn *>(&inputc)
+                              ->_orig_images);
+            else
+              chain_input.add(
+                  "imgs", reinterpret_cast<ImgTensorRTInputFileConn *>(&inputc)
+                              ->_images);
+            chain_input.add(
+                "imgs_size",
+                reinterpret_cast<ImgTensorRTInputFileConn *>(&inputc)
+                    ->_images_size);
+            out.add("input", chain_input);
+          }
       }
 
     out.add("status", 0);
     return 0;
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void TensorRTLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::model_type(const std::string &param_file,
-                                                                                          std::string &mltype)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void TensorRTLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+                   TMLModel>::model_type(const std::string &param_file,
+                                         std::string &mltype)
   {
     std::ifstream paramf(param_file);
     std::stringstream content;
@@ -666,6 +744,7 @@ namespace dd
     mltype = "classification";
   }
 
-  template class TensorRTLib<ImgTensorRTInputFileConn,SupervisedOutput,TensorRTModel>;
+  template class TensorRTLib<ImgTensorRTInputFileConn, SupervisedOutput,
+                             TensorRTModel>;
 
 }

--- a/src/backends/tensorrt/tensorrtlib.h
+++ b/src/backends/tensorrt/tensorrtlib.h
@@ -28,11 +28,9 @@
 namespace dd
 {
 
-
   struct TRTInferDeleter
   {
-    template <typename T>
-    void operator()(T* obj) const
+    template <typename T> void operator()(T *obj) const
     {
       if (obj)
         {
@@ -42,17 +40,18 @@ namespace dd
   };
 
   template <typename T>
-    using TRTUniquePtr = std::unique_ptr<T, TRTInferDeleter>;
+  using TRTUniquePtr = std::unique_ptr<T, TRTInferDeleter>;
 
   class TRTLogger : public nvinfer1::ILogger
   {
-  public :
-    TRTLogger(nvinfer1::ILogger::Severity severity = nvinfer1::ILogger::Severity::kWARNING)
-      : mReportableSeverity(severity)
+  public:
+    TRTLogger(nvinfer1::ILogger::Severity severity
+              = nvinfer1::ILogger::Severity::kWARNING)
+        : mReportableSeverity(severity)
     {
     }
 
-    void log(nvinfer1::ILogger::Severity severity, const char* msg) override
+    void log(nvinfer1::ILogger::Severity severity, const char *msg) override
     {
       switch (severity)
         {
@@ -75,25 +74,23 @@ namespace dd
       mReportableSeverity = severity;
     }
 
-
-    void setLogger(std::shared_ptr<spdlog::logger>& l)
+    void setLogger(std::shared_ptr<spdlog::logger> &l)
     {
       _logger = l.get();
     }
-    
+
   private:
     nvinfer1::ILogger::Severity mReportableSeverity;
-    spdlog::logger* _logger;
+    spdlog::logger *_logger;
   };
 
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel = TensorRTModel>
+  class TensorRTLib : public MLLib<TInputConnectorStrategy,
+                                   TOutputConnectorStrategy, TMLModel>
+  {
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel=TensorRTModel>
-    class TensorRTLib : public MLLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>
-    {
-
-
-
-    public:
+  public:
     TensorRTLib(const TensorRTModel &tmodel);
     TensorRTLib(TensorRTLib &&tl) noexcept;
     ~TensorRTLib();
@@ -107,17 +104,16 @@ namespace dd
 
     int predict(const APIData &ad, APIData &out);
 
-    void model_type(const std::string &param_file,
-                    std::string &mltype);
+    void model_type(const std::string &param_file, std::string &mltype);
 
-
-    public:
+  public:
     int _nclasses = 0;
     int _dla = -1;
     nvinfer1::DataType _datatype = nvinfer1::DataType::kFLOAT;
     int _max_batch_size = 48;
     int _max_workspace_size = 1 << 30; // 1GB
-    int _top_k = 200;  // top_k parameters in ssd in dede templates, can be overriden
+    int _top_k
+        = 200; // top_k parameters in ssd in dede templates, can be overriden
     std::string _engineFileName = "TRTengine";
     bool _readEngine = true;
     bool _writeEngine = true;
@@ -128,11 +124,10 @@ namespace dd
     std::shared_ptr<nvinfer1::IBuilder> _builder = nullptr;
     std::shared_ptr<nvinfer1::IExecutionContext> _context = nullptr;
 
-
     bool _bbox = false;
     bool _ctc = false;
-    
-    std::vector<void*> _buffers;
+
+    std::vector<void *> _buffers;
 
     bool _TRTContextReady = false;
     bool _timeserie = false;
@@ -144,8 +139,10 @@ namespace dd
     std::vector<float> _floatOut;
     std::vector<int> _keepCount;
 
-    std::mutex _net_mutex; /**< mutex around net, e.g. no concurrent predict calls as net is not re-instantiated. Use batches instead. */
-    };
+    std::mutex
+        _net_mutex; /**< mutex around net, e.g. no concurrent predict calls as
+                       net is not re-instantiated. Use batches instead. */
+  };
 
 }
 #endif

--- a/src/backends/tensorrt/tensorrtmodel.cc
+++ b/src/backends/tensorrt/tensorrtmodel.cc
@@ -17,54 +17,55 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-
 #include "tensorrtmodel.h"
 
 namespace dd
 {
-  int TensorRTModel::read_from_repository(const std::shared_ptr<spdlog::logger> &logger)
+  int TensorRTModel::read_from_repository(
+      const std::shared_ptr<spdlog::logger> &logger)
   {
     static std::string deploy = "deploy.prototxt";
     static std::string weights = ".caffemodel";
     static std::string corresp = "corresp";
     static std::string meanf = "mean.binaryproto";
     std::unordered_set<std::string> lfiles;
-    int e = fileops::list_directory(_repo,true,false,false,lfiles);
+    int e = fileops::list_directory(_repo, true, false, false, lfiles);
     if (e != 0)
       {
-        logger->error("error reading or listing caffe models in repository {}",_repo);
+        logger->error("error reading or listing caffe models in repository {}",
+                      _repo);
         return 1;
       }
-    std::string deployf,weightsf,correspf;
-    long int  weight_t=-1;
+    std::string deployf, weightsf, correspf;
+    long int weight_t = -1;
     auto hit = lfiles.begin();
-    while(hit!=lfiles.end())
+    while (hit != lfiles.end())
       {
-	if ((*hit).find(meanf)!=std::string::npos)
-	  {
-	    _has_mean_file = true;
-	  }
-	else if ((*hit).find(weights)!=std::string::npos)
-	  {
-	    // stat file to pick the latest one
-	    long int wt = fileops::file_last_modif((*hit));
-	    if (wt > weight_t)
-	      {
-		weightsf = (*hit);
-		weight_t = wt;
-	      }
-	  }
-	else if ((*hit).find(corresp)!=std::string::npos)
-	  correspf = (*hit);
-	else if ((*hit).find("~")!=std::string::npos
-	    || (*hit).find(".prototxt")==std::string::npos)
-	  {
-	    ++hit;
-	    continue;
-	  }
-	else if ((*hit).find(deploy)!=std::string::npos)
-	  deployf = (*hit);
-	++hit;
+        if ((*hit).find(meanf) != std::string::npos)
+          {
+            _has_mean_file = true;
+          }
+        else if ((*hit).find(weights) != std::string::npos)
+          {
+            // stat file to pick the latest one
+            long int wt = fileops::file_last_modif((*hit));
+            if (wt > weight_t)
+              {
+                weightsf = (*hit);
+                weight_t = wt;
+              }
+          }
+        else if ((*hit).find(corresp) != std::string::npos)
+          correspf = (*hit);
+        else if ((*hit).find("~") != std::string::npos
+                 || (*hit).find(".prototxt") == std::string::npos)
+          {
+            ++hit;
+            continue;
+          }
+        else if ((*hit).find(deploy) != std::string::npos)
+          deployf = (*hit);
+        ++hit;
       }
     if (_def.empty())
       _def = deployf;

--- a/src/backends/tensorrt/tensorrtmodel.h
+++ b/src/backends/tensorrt/tensorrtmodel.h
@@ -17,7 +17,6 @@
 /* You should have received a copy of the GNU General Public License */
 /* along with this program. If not, see <http://www.gnu.org/licenses/>. */
 
-
 #ifndef TENSORRTMODEL_H
 #define TENSORRTMODEL_H
 
@@ -25,15 +24,18 @@
 #include "mlmodel.h"
 #include "apidata.h"
 
-
 namespace dd
 {
   class TensorRTModel : public MLModel
   {
   public:
-  TensorRTModel() : MLModel() {}
-    TensorRTModel(const APIData &ad, APIData &adg, const std::shared_ptr<spdlog::logger> &logger)
-      :MLModel(ad,adg,logger) {
+    TensorRTModel() : MLModel()
+    {
+    }
+    TensorRTModel(const APIData &ad, APIData &adg,
+                  const std::shared_ptr<spdlog::logger> &logger)
+        : MLModel(ad, adg, logger)
+    {
       if (ad.has("repository"))
         {
           this->_repo = ad.get("repository").get<std::string>();
@@ -41,12 +43,15 @@ namespace dd
           read_corresp_file();
         }
     }
-    TensorRTModel(const std::string &repo) : MLModel(repo) {}
+    TensorRTModel(const std::string &repo) : MLModel(repo)
+    {
+    }
 
-    ~TensorRTModel() {}
+    ~TensorRTModel()
+    {
+    }
 
     int read_from_repository(const std::shared_ptr<spdlog::logger> &logger);
-
 
     std::string _def;
     std::string _weights;

--- a/src/backends/tf/tflib.cc
+++ b/src/backends/tf/tflib.cc
@@ -28,21 +28,27 @@
 #include "tensorflow/core/platform/env.h"
 #include "tensorflow/core/framework/tensor.h"
 #include "tensorflow/cc/ops/standard_ops.h"
-#include "tensorflow/core/graph/default_device.h" 
+#include "tensorflow/core/graph/default_device.h"
 
 namespace dd
 {
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  TFLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::TFLib(const TFModel &cmodel)
-    :MLLib<TInputConnectorStrategy,TOutputConnectorStrategy,TFModel>(cmodel)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  TFLib<TInputConnectorStrategy, TOutputConnectorStrategy, TMLModel>::TFLib(
+      const TFModel &cmodel)
+      : MLLib<TInputConnectorStrategy, TOutputConnectorStrategy, TFModel>(
+          cmodel)
   {
     this->_libname = "tensorflow";
   }
-  
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  TFLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::TFLib(TFLib &&cl) noexcept
-    :MLLib<TInputConnectorStrategy,TOutputConnectorStrategy,TFModel>(std::move(cl))
+
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  TFLib<TInputConnectorStrategy, TOutputConnectorStrategy, TMLModel>::TFLib(
+      TFLib &&cl) noexcept
+      : MLLib<TInputConnectorStrategy, TOutputConnectorStrategy, TFModel>(
+          std::move(cl))
   {
     this->_libname = "tensorflow";
     _nclasses = cl._nclasses;
@@ -54,223 +60,255 @@ namespace dd
     this->_mltype = "classification";
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  TFLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::~TFLib()
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  TFLib<TInputConnectorStrategy, TOutputConnectorStrategy, TMLModel>::~TFLib()
   {
     std::lock_guard<std::mutex> lock(_net_mutex);
     if (_session)
       {
-	_session->Close();
-	_session.reset();
+        _session->Close();
+        _session.reset();
       }
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void TFLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::init_mllib(const APIData &ad)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void TFLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+             TMLModel>::init_mllib(const APIData &ad)
   {
     if (ad.has("nclasses"))
       _nclasses = ad.get("nclasses").get<int>();
     if (ad.has("regression") && ad.get("regression").get<bool>())
       {
-	_regression = true; // XXX: unsupported
-	_nclasses = 1;
+        _regression = true; // XXX: unsupported
+        _nclasses = 1;
       }
     // setting the value of Input Layer for Tensorflow graph
     if (ad.has("inputlayer"))
       {
-	_inputLayer = ad.get("inputlayer").get<std::string>();
+        _inputLayer = ad.get("inputlayer").get<std::string>();
       }
     // setting the final Output Layer for Tensorflow graph
     if (ad.has("outputlayer"))
-    {
-      _outputLayer = ad.get("outputlayer").get<std::string>();
-    }
+      {
+        _outputLayer = ad.get("outputlayer").get<std::string>();
+      }
     if (ad.has("input_flag"))
       {
-	_inputFlag = ad.getobj("input_flag");
+        _inputFlag = ad.getobj("input_flag");
       }
     if (ad.has("ntargets")) // XXX: unsupported
       _ntargets = ad.get("ntargets").get<int>();
     if (_nclasses == 0)
-      throw MLLibBadParamException("number of classes is unknown (nclasses == 0)");
+      throw MLLibBadParamException(
+          "number of classes is unknown (nclasses == 0)");
     if (_regression && _ntargets == 0)
-      throw MLLibBadParamException("number of regression targets is unknown (ntargets == 0)");
-    this->_mlmodel.read_from_repository(this->_mlmodel._repo,this->_logger);
+      throw MLLibBadParamException(
+          "number of regression targets is unknown (ntargets == 0)");
+    this->_mlmodel.read_from_repository(this->_mlmodel._repo, this->_logger);
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void TFLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::clear_mllib(const APIData &ad)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void TFLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+             TMLModel>::clear_mllib(const APIData &ad)
   {
     // NOT IMPLEMENTED
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void TFLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::tf_concat(const std::vector<tensorflow::Tensor> &dv,
-										   std::vector<tensorflow::Tensor> &vtfinputs)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void TFLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+             TMLModel>::tf_concat(const std::vector<tensorflow::Tensor> &dv,
+                                  std::vector<tensorflow::Tensor> &vtfinputs)
   {
     /*
-      as incredible as it seems, code below is the bloated tf way of concatenating
-      tensors to produce the intput to the neural net graph.
+      as incredible as it seems, code below is the bloated tf way of
+      concatenating tensors to produce the intput to the neural net graph.
     */
     int rbatch_size = dv.size();
     auto root = tensorflow::Scope::NewRootScope();
     std::string concat_name = "concatenated";
     std::vector<tensorflow::Input> ops_inputs;
-    for (int i=0;i<rbatch_size;i++)
+    for (int i = 0; i < rbatch_size; i++)
       ops_inputs.push_back(std::move(tensorflow::Input(dv[i])));
-    tensorflow::gtl::ArraySlice<tensorflow::Input> ipl(&ops_inputs[0],ops_inputs.size());
+    tensorflow::gtl::ArraySlice<tensorflow::Input> ipl(&ops_inputs[0],
+                                                       ops_inputs.size());
     tensorflow::InputList toil(ipl);
-    auto concatout = tensorflow::ops::Concat(root.WithOpName(concat_name),toil,0);
-    std::unique_ptr<tensorflow::Session> concat_session(tensorflow::NewSession(tensorflow::SessionOptions()));
+    auto concatout
+        = tensorflow::ops::Concat(root.WithOpName(concat_name), toil, 0);
+    std::unique_ptr<tensorflow::Session> concat_session(
+        tensorflow::NewSession(tensorflow::SessionOptions()));
     tensorflow::GraphDef graph;
     root.ToGraphDef(&graph);
     concat_session->Create(graph);
-    tensorflow::Status concat_run_status = concat_session->Run({}, {concat_name}, {}, &vtfinputs);
+    tensorflow::Status concat_run_status
+        = concat_session->Run({}, { concat_name }, {}, &vtfinputs);
     if (!concat_run_status.ok())
       {
-	std::cout << concat_run_status.ToString() << std::endl;
-	throw MLLibInternalException(concat_run_status.ToString());
+        std::cout << concat_run_status.ToString() << std::endl;
+        throw MLLibInternalException(concat_run_status.ToString());
       }
   }
-  
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  int TFLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::train(const APIData &ad,
-									       APIData &out)
+
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  int TFLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+            TMLModel>::train(const APIData &ad, APIData &out)
   {
     // NOT IMPLEMENTED
     return 0;
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void TFLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::test(const APIData &ad,
-									      APIData &out)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void
+  TFLib<TInputConnectorStrategy, TOutputConnectorStrategy, TMLModel>::test(
+      const APIData &ad, APIData &out)
   {
     APIData ad_out = ad.getobj("parameters").getobj("output");
     if (!ad_out.has("measure"))
       {
-	APIData ad_res;
-	SupervisedOutput::measure(ad_res,ad_out,out);
-	return;
+        APIData ad_res;
+        SupervisedOutput::measure(ad_res, ad_out, out);
+        return;
       }
-    
+
     TInputConnectorStrategy inputc(this->_inputc);
     TOutputConnectorStrategy tout(this->_outputc);
     APIData cad = ad;
-    cad.add("model_repo",this->_mlmodel._repo);
+    cad.add("model_repo", this->_mlmodel._repo);
     try
       {
-	inputc.transform(cad);
+        inputc.transform(cad);
       }
     catch (std::exception &e)
       {
-	throw;
+        throw;
       }
-    
+
     APIData ad_mllib = ad.getobj("parameters").getobj("mllib");
     APIData ad_output = ad.getobj("parameters").getobj("output");
     int batch_size = inputc.batch_size();
     if (ad_mllib.has("test_batch_size"))
       {
-	batch_size = ad_mllib.get("test_batch_size").get<int>();
+        batch_size = ad_mllib.get("test_batch_size").get<int>();
       }
 
     tensorflow::GraphDef graph_def;
     std::string graphFile = this->_mlmodel._graphName;
     if (graphFile.empty())
-      throw MLLibBadParamException("No pre-trained model found in model repository");
-    this->_logger->info("test: using graphFile dir={}",graphFile);
+      throw MLLibBadParamException(
+          "No pre-trained model found in model repository");
+    this->_logger->info("test: using graphFile dir={}", graphFile);
     // Loading the graph to the given variable
-    tensorflow::Status graphLoadedStatus = ReadBinaryProto(tensorflow::Env::Default(),graphFile,&graph_def);
-    
+    tensorflow::Status graphLoadedStatus
+        = ReadBinaryProto(tensorflow::Env::Default(), graphFile, &graph_def);
+
     if (!graphLoadedStatus.ok())
       {
-	this->_logger->error("failed loading tensorflow graph with status={}",graphLoadedStatus.ToString());
-	throw MLLibBadParamException("failed loading tensorflow graph with status=" + graphLoadedStatus.ToString());
+        this->_logger->error("failed loading tensorflow graph with status={}",
+                             graphLoadedStatus.ToString());
+        throw MLLibBadParamException(
+            "failed loading tensorflow graph with status="
+            + graphLoadedStatus.ToString());
       }
     std::string inputLayer = _inputLayer;
     std::string outputLayer = _outputLayer;
     if (inputLayer.empty())
       {
-	inputLayer = graph_def.node(0).name();
-	this->_logger->info("testing: using input layer={}",inputLayer);
+        inputLayer = graph_def.node(0).name();
+        this->_logger->info("testing: using input layer={}", inputLayer);
       }
     if (outputLayer.empty())
       {
-	outputLayer = graph_def.node(graph_def.node_size()-1).name();
-	this->_logger->info("testing: using output layer={}",outputLayer);
+        outputLayer = graph_def.node(graph_def.node_size() - 1).name();
+        this->_logger->info("testing: using output layer={}", outputLayer);
       }
-    
+
     // creating a session with the graph
     tensorflow::SessionOptions options;
     tensorflow::ConfigProto &config = options.config;
-    config.mutable_gpu_options()->set_allow_growth(true); // default is we prevent tf from holding all memory across all GPUs
-    auto session = std::unique_ptr<tensorflow::Session>(tensorflow::NewSession(options));
+    config.mutable_gpu_options()->set_allow_growth(
+        true); // default is we prevent tf from holding all memory across all
+               // GPUs
+    auto session = std::unique_ptr<tensorflow::Session>(
+        tensorflow::NewSession(options));
     tensorflow::Status session_create_status = session->Create(graph_def);
-    
+
     if (!session_create_status.ok())
       {
-	std::cout << session_create_status.ToString()<<std::endl;
-	throw MLLibInternalException(session_create_status.ToString());
+        std::cout << session_create_status.ToString() << std::endl;
+        throw MLLibInternalException(session_create_status.ToString());
       }
-    
-    // vector for storing  the outputAPI of the file 
+
+    // vector for storing  the outputAPI of the file
     APIData ad_res;
-    ad_res.add("nclasses",_nclasses);
+    ad_res.add("nclasses", _nclasses);
     int tresults = 0;
-    
+
     inputc.reset_dv();
     int idoffset = 0;
-    while(true)
+    while (true)
       {
-	std::vector<int> dv_labels = inputc._test_labels;
-	std::vector<tensorflow::Tensor> dv = inputc.get_dv(batch_size);
-	if (dv.empty())
-	  break;
-	std::vector<tensorflow::Tensor> vtfinputs;
-	if (dv.size() > 1)
-	  tf_concat(dv,vtfinputs);
-	else vtfinputs = dv;
-	
-	// running the loded graph and saving the generated output 
-	std::vector<tensorflow::Tensor> finalOutput; // To save the final Output generated by the tensorflow
-	tensorflow::Status run_status  = session->Run({{inputLayer,*(vtfinputs.begin())}},{outputLayer},{},&finalOutput);
-	if (!run_status.ok())
-	  {
-	    std::cout << run_status.ToString() << std::endl;
-	    throw MLLibInternalException(run_status.ToString()); //XXX: does not separate bad param from internal errors
-	  }
-	tensorflow::Tensor output = std::move(finalOutput.at(0));
-	
-	auto scores = output.flat<float>();
-	std::vector<double> predictions;
-	for (size_t i=0;i<dv.size();i++)
-	  {
-	    APIData bad;
-	    for (int c=0;c<_nclasses;c++)
-	      predictions.push_back(scores(i*_nclasses+c));
-	    double target = dv_labels.at(i);
-	    bad.add("target",target);
-	    bad.add("pred",predictions);
-	    ad_res.add(std::to_string(tresults+i),bad);
-	  }
-	tresults += dv.size();
+        std::vector<int> dv_labels = inputc._test_labels;
+        std::vector<tensorflow::Tensor> dv = inputc.get_dv(batch_size);
+        if (dv.empty())
+          break;
+        std::vector<tensorflow::Tensor> vtfinputs;
+        if (dv.size() > 1)
+          tf_concat(dv, vtfinputs);
+        else
+          vtfinputs = dv;
+
+        // running the loded graph and saving the generated output
+        std::vector<tensorflow::Tensor>
+            finalOutput; // To save the final Output generated by the
+                         // tensorflow
+        tensorflow::Status run_status
+            = session->Run({ { inputLayer, *(vtfinputs.begin()) } },
+                           { outputLayer }, {}, &finalOutput);
+        if (!run_status.ok())
+          {
+            std::cout << run_status.ToString() << std::endl;
+            throw MLLibInternalException(
+                run_status.ToString()); // XXX: does not separate bad param
+                                        // from internal errors
+          }
+        tensorflow::Tensor output = std::move(finalOutput.at(0));
+
+        auto scores = output.flat<float>();
+        std::vector<double> predictions;
+        for (size_t i = 0; i < dv.size(); i++)
+          {
+            APIData bad;
+            for (int c = 0; c < _nclasses; c++)
+              predictions.push_back(scores(i * _nclasses + c));
+            double target = dv_labels.at(i);
+            bad.add("target", target);
+            bad.add("pred", predictions);
+            ad_res.add(std::to_string(tresults + i), bad);
+          }
+        tresults += dv.size();
       } // end prediction loop over batches
-    
+
     std::vector<std::string> clnames;
-    for (int i=0;i<_nclasses;i++)
+    for (int i = 0; i < _nclasses; i++)
       clnames.push_back(this->_mlmodel.get_hcorresp(i));
-    ad_res.add("clnames",clnames);
-    ad_res.add("batch_size",tresults);
-    
-    SupervisedOutput::measure(ad_res,ad_out,out);
+    ad_res.add("clnames", clnames);
+    ad_res.add("batch_size", tresults);
+
+    SupervisedOutput::measure(ad_res, ad_out, out);
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  int TFLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::predict(const APIData &ad,
-										APIData &out)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  int TFLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+            TMLModel>::predict(const APIData &ad, APIData &out)
   {
     // TF sessions support concurrent calls, however server design enforces
-    // preference for using batches to max out resources instead of 
+    // preference for using batches to max out resources instead of
     // cumulated calls that may overflow the resources.
     // This policy may be subjected to futur changes.
     std::lock_guard<std::mutex> lock(_net_mutex);
@@ -278,180 +316,204 @@ namespace dd
     APIData ad_output = ad.getobj("parameters").getobj("output");
     if (ad_output.has("measure"))
       {
-	test(ad,out);
-	APIData out_meas = out.getobj("measure");
-	out.add("measure",out_meas);
-	return 0;
+        test(ad, out);
+        APIData out_meas = out.getobj("measure");
+        out.add("measure", out_meas);
+        return 0;
       }
     double confidence_threshold = 0.0;
     if (ad_output.has("confidence_threshold"))
-      confidence_threshold = ad_output.get("confidence_threshold").get<double>();
+      confidence_threshold
+          = ad_output.get("confidence_threshold").get<double>();
     TInputConnectorStrategy inputc(this->_inputc);
     TOutputConnectorStrategy tout;
     APIData cad = ad;
-    cad.add("model_repo",this->_mlmodel._repo);
+    cad.add("model_repo", this->_mlmodel._repo);
     try
       {
-	inputc.transform(cad);
+        inputc.transform(cad);
       }
     catch (std::exception &e)
       {
-	throw;
+        throw;
       }
-    
+
     APIData ad_mllib = ad.getobj("parameters").getobj("mllib");
     int batch_size = inputc.batch_size();
     if (ad_mllib.has("test_batch_size"))
       batch_size = ad_mllib.get("test_batch_size").get<int>();
 
     std::string extract_layer;
-    if (ad_mllib.has("extract_layer") && !ad_mllib.get("extract_layer").get<std::string>().empty())
+    if (ad_mllib.has("extract_layer")
+        && !ad_mllib.get("extract_layer").get<std::string>().empty())
       {
-       	_outputLayer = ad_mllib.get("extract_layer").get<std::string>();
-	extract_layer = _outputLayer;
+        _outputLayer = ad_mllib.get("extract_layer").get<std::string>();
+        extract_layer = _outputLayer;
       }
-      
+
     if (!_session)
       {
-	tensorflow::GraphDef graph_def;
-	std::string graphFile = this->_mlmodel._graphName;
-	if (graphFile.empty())
-	  throw MLLibBadParamException("No pre-trained model found in model repository");
-	this->_logger->info("predict: using graphFile dir={}",graphFile);
-	// Loading the graph to the given variable
-	tensorflow::Status graphLoadedStatus = ReadBinaryProto(tensorflow::Env::Default(),graphFile,&graph_def);
-	
-	if (!graphLoadedStatus.ok())
-	  {
-	    this->_logger->error("failed loading tensorflow graph with status={}",graphLoadedStatus.ToString());
-	    throw MLLibBadParamException("failed loading tensorflow graph with status=" + graphLoadedStatus.ToString());
-	  }
+        tensorflow::GraphDef graph_def;
+        std::string graphFile = this->_mlmodel._graphName;
+        if (graphFile.empty())
+          throw MLLibBadParamException(
+              "No pre-trained model found in model repository");
+        this->_logger->info("predict: using graphFile dir={}", graphFile);
+        // Loading the graph to the given variable
+        tensorflow::Status graphLoadedStatus = ReadBinaryProto(
+            tensorflow::Env::Default(), graphFile, &graph_def);
 
-	/*for (int l=0;l<graph_def.node_size();l++)
-	  {
-	    std::cerr << graph_def.node(l).name() << std::endl;
-	    }*/
-	
-	if (_inputLayer.empty())
-	  {
-	    _inputLayer = graph_def.node(0).name();
-	    this->_logger->info("using input layer={}",_inputLayer);
-	  }
-	if (_outputLayer.empty())
-	  {
-	    _outputLayer = graph_def.node(graph_def.node_size()-1).name();
-	    this->_logger->info("using output layer={}",_outputLayer);
-	  }
-	//tensorflow::graph::SetDefaultDevice(device, &graph_def);
-	
-	// creating a session with the graph
-	tensorflow::SessionOptions options;
-	tensorflow::ConfigProto &config = options.config;
-	config.mutable_gpu_options()->set_allow_growth(true); // default is we prevent tf from holding all memory across all GPUs
-	_session = std::unique_ptr<tensorflow::Session>(tensorflow::NewSession(options));
-	tensorflow::Status session_create_status = _session->Create(graph_def);
-	
-	if (!session_create_status.ok())
-	  {
-	    std::cout << session_create_status.ToString()<<std::endl;
-	    _session = nullptr;
-	    throw MLLibInternalException(session_create_status.ToString());
-	  }
+        if (!graphLoadedStatus.ok())
+          {
+            this->_logger->error(
+                "failed loading tensorflow graph with status={}",
+                graphLoadedStatus.ToString());
+            throw MLLibBadParamException(
+                "failed loading tensorflow graph with status="
+                + graphLoadedStatus.ToString());
+          }
+
+        /*for (int l=0;l<graph_def.node_size();l++)
+          {
+            std::cerr << graph_def.node(l).name() << std::endl;
+            }*/
+
+        if (_inputLayer.empty())
+          {
+            _inputLayer = graph_def.node(0).name();
+            this->_logger->info("using input layer={}", _inputLayer);
+          }
+        if (_outputLayer.empty())
+          {
+            _outputLayer = graph_def.node(graph_def.node_size() - 1).name();
+            this->_logger->info("using output layer={}", _outputLayer);
+          }
+        // tensorflow::graph::SetDefaultDevice(device, &graph_def);
+
+        // creating a session with the graph
+        tensorflow::SessionOptions options;
+        tensorflow::ConfigProto &config = options.config;
+        config.mutable_gpu_options()->set_allow_growth(
+            true); // default is we prevent tf from holding all memory across
+                   // all GPUs
+        _session = std::unique_ptr<tensorflow::Session>(
+            tensorflow::NewSession(options));
+        tensorflow::Status session_create_status = _session->Create(graph_def);
+
+        if (!session_create_status.ok())
+          {
+            std::cout << session_create_status.ToString() << std::endl;
+            _session = nullptr;
+            throw MLLibInternalException(session_create_status.ToString());
+          }
       }
-    
-    // vector for storing  the outputAPI of the file 
+
+    // vector for storing  the outputAPI of the file
     std::vector<APIData> vrad;
     inputc.reset_dv();
     int idoffset = 0;
-    while(true)
+    while (true)
       {
-	std::vector<tensorflow::Tensor> dv = inputc.get_dv(batch_size);
-	if (dv.empty())
-	  break;
-	std::vector<tensorflow::Tensor> vtfinputs;
-	if (dv.size() > 1)
-	  tf_concat(dv,vtfinputs);
-	else vtfinputs = dv;
-	
-	// other input variables
-	std::pair<std::string,tensorflow::Tensor> othertfinputs;
-	std::vector<std::string> lkeys = _inputFlag.list_keys();
-	bool has_input_vars = false;
-	for (auto k: lkeys)
-	  {
-	    tensorflow::Tensor ivar(tensorflow::DT_BOOL,tensorflow::TensorShape());
-	    ivar.scalar<bool>()() = _inputFlag.get(k).get<bool>();
-	    othertfinputs.first = k;
-	    othertfinputs.second = ivar;
-	    has_input_vars = true;
-	    break; // a single key for now, may have to use ClientSession for another scheme
-	  }
+        std::vector<tensorflow::Tensor> dv = inputc.get_dv(batch_size);
+        if (dv.empty())
+          break;
+        std::vector<tensorflow::Tensor> vtfinputs;
+        if (dv.size() > 1)
+          tf_concat(dv, vtfinputs);
+        else
+          vtfinputs = dv;
 
-	
-	// running the loded graph and saving the generated output 
-	std::vector<tensorflow::Tensor> finalOutput; // To save the final output generated by the tensorflow
-	tensorflow::Status run_status;
-	if (has_input_vars)
-	  run_status = _session->Run({{_inputLayer,*(vtfinputs.begin())},othertfinputs},{_outputLayer},{},&finalOutput);
-	else run_status = _session->Run({{_inputLayer,*(vtfinputs.begin())}},{_outputLayer},{},&finalOutput);
-	if (!run_status.ok())
-	  {
-	    std::cout <<run_status.ToString()<<std::endl;
-	    throw MLLibInternalException(run_status.ToString()); //TODO: separate bad param and internal errors
-	  }
-	tensorflow::Tensor output = std::move(finalOutput.at(0));
+        // other input variables
+        std::pair<std::string, tensorflow::Tensor> othertfinputs;
+        std::vector<std::string> lkeys = _inputFlag.list_keys();
+        bool has_input_vars = false;
+        for (auto k : lkeys)
+          {
+            tensorflow::Tensor ivar(tensorflow::DT_BOOL,
+                                    tensorflow::TensorShape());
+            ivar.scalar<bool>()() = _inputFlag.get(k).get<bool>();
+            othertfinputs.first = k;
+            othertfinputs.second = ivar;
+            has_input_vars = true;
+            break; // a single key for now, may have to use ClientSession for
+                   // another scheme
+          }
 
-	APIData rad;
-	if (extract_layer.empty()) // supervised setting
-	  {
-	    auto scores = output.flat<float>();
-	    for (size_t i=0;i<dv.size();i++)
-	      {
-		rad.add("uri",inputc._ids.at(idoffset+i));
-		std::vector<double> probs;
-		std::vector<std::string> cats;
-		for (int c=0;c<_nclasses;c++)
-		  {
-		    //std::cerr << "score=" << scores(c) << " / c=" << c << std::endl;
-		    double prob = scores(i*_nclasses+c);
-		    if (prob < confidence_threshold)
-		      continue;
-		    probs.push_back(prob);
-		    cats.push_back(this->_mlmodel.get_hcorresp(c));
-		  }
-		rad.add("probs",probs);
-		rad.add("cats",cats);
-		rad.add("loss",0.0);
-		vrad.push_back(rad);
-	      }
-	    idoffset += dv.size();
-	  }
-	else // unsupervised
-	  {
-	    auto layer_vals = output.flat<float>();
-	    int embedding_size = layer_vals.size() / static_cast<float>(dv.size());
-	    int offset = 0;
-	    for (size_t i=0;i<dv.size();i++)
-	      {
-		std::vector<double> vals;
-		vals.reserve(embedding_size);//layer_vals.size());
-		for (int c=0;c<embedding_size;c++)
-		  vals.push_back(layer_vals.data()[offset+c]);
-		rad.add("uri",inputc._ids.at(idoffset+i));
-		rad.add("vals",vals);
-		vrad.push_back(rad);
-		offset += embedding_size;
-	      }
-	    idoffset += dv.size();
-	  }
+        // running the loded graph and saving the generated output
+        std::vector<tensorflow::Tensor>
+            finalOutput; // To save the final output generated by the
+                         // tensorflow
+        tensorflow::Status run_status;
+        if (has_input_vars)
+          run_status = _session->Run(
+              { { _inputLayer, *(vtfinputs.begin()) }, othertfinputs },
+              { _outputLayer }, {}, &finalOutput);
+        else
+          run_status = _session->Run({ { _inputLayer, *(vtfinputs.begin()) } },
+                                     { _outputLayer }, {}, &finalOutput);
+        if (!run_status.ok())
+          {
+            std::cout << run_status.ToString() << std::endl;
+            throw MLLibInternalException(
+                run_status.ToString()); // TODO: separate bad param and
+                                        // internal errors
+          }
+        tensorflow::Tensor output = std::move(finalOutput.at(0));
+
+        APIData rad;
+        if (extract_layer.empty()) // supervised setting
+          {
+            auto scores = output.flat<float>();
+            for (size_t i = 0; i < dv.size(); i++)
+              {
+                rad.add("uri", inputc._ids.at(idoffset + i));
+                std::vector<double> probs;
+                std::vector<std::string> cats;
+                for (int c = 0; c < _nclasses; c++)
+                  {
+                    // std::cerr << "score=" << scores(c) << " / c=" << c <<
+                    // std::endl;
+                    double prob = scores(i * _nclasses + c);
+                    if (prob < confidence_threshold)
+                      continue;
+                    probs.push_back(prob);
+                    cats.push_back(this->_mlmodel.get_hcorresp(c));
+                  }
+                rad.add("probs", probs);
+                rad.add("cats", cats);
+                rad.add("loss", 0.0);
+                vrad.push_back(rad);
+              }
+            idoffset += dv.size();
+          }
+        else // unsupervised
+          {
+            auto layer_vals = output.flat<float>();
+            int embedding_size
+                = layer_vals.size() / static_cast<float>(dv.size());
+            int offset = 0;
+            for (size_t i = 0; i < dv.size(); i++)
+              {
+                std::vector<double> vals;
+                vals.reserve(embedding_size); // layer_vals.size());
+                for (int c = 0; c < embedding_size; c++)
+                  vals.push_back(layer_vals.data()[offset + c]);
+                rad.add("uri", inputc._ids.at(idoffset + i));
+                rad.add("vals", vals);
+                vrad.push_back(rad);
+                offset += embedding_size;
+              }
+            idoffset += dv.size();
+          }
       } // end prediction loop over batches
     tout.add_results(vrad);
-    out.add("nclasses",_nclasses);
-    tout.finalize(ad.getobj("parameters").getobj("output"),out,static_cast<MLModel*>(&this->_mlmodel));
-    out.add("status",0);
+    out.add("nclasses", _nclasses);
+    tout.finalize(ad.getobj("parameters").getobj("output"), out,
+                  static_cast<MLModel *>(&this->_mlmodel));
+    out.add("status", 0);
     return 0;
   }
-  
-  template class TFLib<ImgTFInputFileConn,SupervisedOutput,TFModel>;
-  template class TFLib<ImgTFInputFileConn,UnsupervisedOutput,TFModel>;
+
+  template class TFLib<ImgTFInputFileConn, SupervisedOutput, TFModel>;
+  template class TFLib<ImgTFInputFileConn, UnsupervisedOutput, TFModel>;
 }

--- a/src/backends/tf/tflib.h
+++ b/src/backends/tf/tflib.h
@@ -25,22 +25,24 @@
 #include "mllibstrategy.h"
 #include "tfmodel.h"
 
-# include <string>
+#include <string>
 #include "tensorflow/core/public/session.h"
 #include "tensorflow/core/platform/env.h"
 #include "tensorflow/core/framework/tensor.h"
 
 namespace dd
 {
-  template<class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel=TFModel>
-    class TFLib : public MLLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>
-    {
-    public:
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel = TFModel>
+  class TFLib : public MLLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+                             TMLModel>
+  {
+  public:
     TFLib(const TFModel &tfmodel);
     TFLib(TFLib &&tl) noexcept;
     ~TFLib();
 
-        /*- from mllib -*/
+    /*- from mllib -*/
     void init_mllib(const APIData &ad);
 
     void clear_mllib(const APIData &d);
@@ -48,26 +50,27 @@ namespace dd
     int train(const APIData &ad, APIData &out);
 
     void test(const APIData &ad, APIData &out);
-    
+
     int predict(const APIData &ad, APIData &out);
 
     /*- local functions -*/
     void tf_concat(const std::vector<tensorflow::Tensor> &dv,
-		   std::vector<tensorflow::Tensor> &vtfinputs);
-    
+                   std::vector<tensorflow::Tensor> &vtfinputs);
 
-    public:
+  public:
     // general parameters
-    int _nclasses = 0; /**< required. */
+    int _nclasses = 0;        /**< required. */
     bool _regression = false; /**< whether the net acts as a regressor. */
     int _ntargets = 0; /**< number of classification or regression targets. */
-    std::string _inputLayer; // input Layer of the model
+    std::string _inputLayer;  // input Layer of the model
     std::string _outputLayer; // output layer of the model
-    APIData _inputFlag; // boolean input to the model
+    APIData _inputFlag;       // boolean input to the model
     std::unique_ptr<tensorflow::Session> _session = nullptr;
-    std::mutex _net_mutex; /**< mutex around net, e.g. no concurrent predict calls as net is not re-instantiated. Use batches instead. */
-    };
-  
+    std::mutex
+        _net_mutex; /**< mutex around net, e.g. no concurrent predict calls as
+                       net is not re-instantiated. Use batches instead. */
+  };
+
 }
 
 #endif

--- a/src/backends/tf/tfmodel.h
+++ b/src/backends/tf/tfmodel.h
@@ -32,29 +32,37 @@ namespace dd
   class TFModel : public MLModel
   {
   public:
-    TFModel():MLModel() {}
+    TFModel() : MLModel()
+    {
+    }
     TFModel(const APIData &ad, APIData &adg,
-	    const std::shared_ptr<spdlog::logger> &logger);
-    TFModel(const std::string &repo)
-      :MLModel(repo) {}
-    ~TFModel() {}
-    
-    int read_from_repository(const std:: string &repo,
-			     const std::shared_ptr<spdlog::logger> &logger);
+            const std::shared_ptr<spdlog::logger> &logger);
+    TFModel(const std::string &repo) : MLModel(repo)
+    {
+    }
+    ~TFModel()
+    {
+    }
+
+    int read_from_repository(const std::string &repo,
+                             const std::shared_ptr<spdlog::logger> &logger);
 
     int read_corresp_file(const std::shared_ptr<spdlog::logger> &logger);
 
     inline std::string get_hcorresp(const int &i)
     {
       if (_hcorresp.empty())
-	return std::to_string(i);
-      else return _hcorresp[i];
+        return std::to_string(i);
+      else
+        return _hcorresp[i];
     }
-    
-    std::string _graphName; // Name of the graph 
+
+    std::string _graphName; // Name of the graph
     std::string _modelRepo;
-    std::string _corresp; /**< file name of the class correspondences (e.g. house / 23) */
-    std::unordered_map<int,std::string> _hcorresp; /**< table of class correspondences. */
+    std::string _corresp; /**< file name of the class correspondences (e.g.
+                             house / 23) */
+    std::unordered_map<int, std::string>
+        _hcorresp; /**< table of class correspondences. */
   };
 
 }

--- a/src/backends/torch/db.cpp
+++ b/src/backends/torch/db.cpp
@@ -3,23 +3,28 @@
 
 #include <string>
 
-namespace dd { namespace db {
+namespace dd
+{
+  namespace db
+  {
 
-    DB* GetDB(const std::string& backend) {
+    DB *GetDB(const std::string &backend)
+    {
       // #ifdef USE_LEVELDB
       //   if (backend == "leveldb") {
       //     return new LevelDB();
       //   }
       // #endif  // USE_LEVELDB
       // #ifdef USE_LMDB
-      if (backend == "lmdb") {
-        return new LMDB();
-      }
+      if (backend == "lmdb")
+        {
+          return new LMDB();
+        }
       // #endif  // USE_LMDB
       LOG(ERROR) << "Unknown database backend";
       LOG(FATAL) << "fatal error";
-        return NULL;
+      return NULL;
     }
 
-  }  // namespace db
-}  // namespace dd
+  } // namespace db
+} // namespace dd

--- a/src/backends/torch/db.hpp
+++ b/src/backends/torch/db.hpp
@@ -3,63 +3,83 @@
 
 // Disable the copy and assignment operator for a class.
 #ifndef DISABLE_COPY_AND_ASSIGN
-#define DISABLE_COPY_AND_ASSIGN(classname)      \
-  private:                                      \
-  classname(const classname&);                  \
-  classname& operator=(const classname&)
+#define DISABLE_COPY_AND_ASSIGN(classname)                                    \
+private:                                                                      \
+  classname(const classname &);                                               \
+  classname &operator=(const classname &)
 #endif
-
 
 #include <string>
 #include "backends/torch/llogging.h"
 
+namespace dd
+{
+  namespace db
+  {
 
-namespace dd { namespace db {
+    enum Mode
+    {
+      READ,
+      WRITE,
+      NEW
+    };
 
-    enum Mode { READ, WRITE, NEW };
-
-    class Cursor {
+    class Cursor
+    {
     public:
-      Cursor() { }
-      virtual ~Cursor() { }
+      Cursor()
+      {
+      }
+      virtual ~Cursor()
+      {
+      }
       virtual void SeekToFirst() = 0;
       virtual void Next() = 0;
       virtual std::string key() = 0;
       virtual std::string value() = 0;
       virtual bool valid() = 0;
-  
+
       DISABLE_COPY_AND_ASSIGN(Cursor);
     };
 
-    class Transaction {
+    class Transaction
+    {
     public:
-      Transaction() { }
-      virtual ~Transaction() { }
-      virtual void Put(const std::string& key, const std::string& value) = 0;
+      Transaction()
+      {
+      }
+      virtual ~Transaction()
+      {
+      }
+      virtual void Put(const std::string &key, const std::string &value) = 0;
       virtual void Commit() = 0;
 
       DISABLE_COPY_AND_ASSIGN(Transaction);
     };
 
-    class DB {
+    class DB
+    {
     public:
-      DB() { }
-      virtual ~DB() { }
-      virtual void Open(const std::string& source, Mode mode) = 0;
+      DB()
+      {
+      }
+      virtual ~DB()
+      {
+      }
+      virtual void Open(const std::string &source, Mode mode) = 0;
       virtual void Close() = 0;
-      virtual Cursor* NewCursor() = 0;
-      virtual Transaction* NewTransaction() = 0;
+      virtual Cursor *NewCursor() = 0;
+      virtual Transaction *NewTransaction() = 0;
       virtual int Count() = 0;
-      virtual void Get(const std::string &key,
-                       std::string &data_val) = 0;
+      virtual void Get(const std::string &key, std::string &data_val) = 0;
       virtual void Remove(const std::string &key) = 0;
-  
+
       DISABLE_COPY_AND_ASSIGN(DB);
     };
 
-    DB* GetDB(const std::string& backend);
+    DB *GetDB(const std::string &backend);
 
-  }  // namespace db
-}  // namespace dd
+  } // namespace db
+} // namespace dd
 
-#endif  // DD_DB_HPP
+#endif // DD_DB_HPP

--- a/src/backends/torch/db_lmdb.cpp
+++ b/src/backends/torch/db_lmdb.cpp
@@ -7,81 +7,94 @@
 #include <cstring>
 #include <iostream>
 
-namespace dd { namespace db {
+namespace dd
+{
+  namespace db
+  {
 
-    void LMDB::Open(const std::string& source, Mode mode) {
-  MDB_CHECK(mdb_env_create(&mdb_env_));
-  if (mode == NEW) {
-    int mk = mkdir(source.c_str(), 0744);
-    if (mk != 0)
-      {
-	CHECK_EQ(mkdir(source.c_str(), 0744), 0) << "mkdir " << source << " failed";
-      }
-  }
-  int flags = 0;
-  if (mode == READ) {
-    flags = MDB_RDONLY | MDB_NOTLS | MDB_NORDAHEAD;
-  }
-  int rc = mdb_env_open(mdb_env_, source.c_str(), flags, 0664);
+    void LMDB::Open(const std::string &source, Mode mode)
+    {
+      MDB_CHECK(mdb_env_create(&mdb_env_));
+      if (mode == NEW)
+        {
+          int mk = mkdir(source.c_str(), 0744);
+          if (mk != 0)
+            {
+              CHECK_EQ(mkdir(source.c_str(), 0744), 0)
+                  << "mkdir " << source << " failed";
+            }
+        }
+      int flags = 0;
+      if (mode == READ)
+        {
+          flags = MDB_RDONLY | MDB_NOTLS | MDB_NORDAHEAD;
+        }
+      int rc = mdb_env_open(mdb_env_, source.c_str(), flags, 0664);
 #ifndef ALLOW_LMDB_NOLOCK
-  MDB_CHECK(rc);
+      MDB_CHECK(rc);
 #else
-  if (rc == EACCES) {
-    LOG(WARNING) << "Permission denied. Trying with MDB_NOLOCK ...";
-    // Close and re-open environment handle
-    mdb_env_close(mdb_env_);
-    MDB_CHECK(mdb_env_create(&mdb_env_));
-    // Try again with MDB_NOLOCK
-    flags |= MDB_NOLOCK;
-    MDB_CHECK(mdb_env_open(mdb_env_, source.c_str(), flags, 0664));
-  } else {
-    MDB_CHECK(rc);
-  }
+      if (rc == EACCES)
+        {
+          LOG(WARNING) << "Permission denied. Trying with MDB_NOLOCK ...";
+          // Close and re-open environment handle
+          mdb_env_close(mdb_env_);
+          MDB_CHECK(mdb_env_create(&mdb_env_));
+          // Try again with MDB_NOLOCK
+          flags |= MDB_NOLOCK;
+          MDB_CHECK(mdb_env_open(mdb_env_, source.c_str(), flags, 0664));
+        }
+      else
+        {
+          MDB_CHECK(rc);
+        }
 #endif
-  LOG(INFO) << "Opened lmdb " << source;
-}
+      LOG(INFO) << "Opened lmdb " << source;
+    }
 
-LMDBCursor* LMDB::NewCursor() {
-  MDB_txn* mdb_txn;
-  MDB_cursor* mdb_cursor;
-  MDB_CHECK(mdb_txn_begin(mdb_env_, NULL, MDB_RDONLY, &mdb_txn));
-  MDB_CHECK(mdb_dbi_open(mdb_txn, NULL, 0, &mdb_dbi_));
-  MDB_CHECK(mdb_cursor_open(mdb_txn, mdb_dbi_, &mdb_cursor));
-  return new LMDBCursor(mdb_txn, mdb_cursor);
-}
+    LMDBCursor *LMDB::NewCursor()
+    {
+      MDB_txn *mdb_txn;
+      MDB_cursor *mdb_cursor;
+      MDB_CHECK(mdb_txn_begin(mdb_env_, NULL, MDB_RDONLY, &mdb_txn));
+      MDB_CHECK(mdb_dbi_open(mdb_txn, NULL, 0, &mdb_dbi_));
+      MDB_CHECK(mdb_cursor_open(mdb_txn, mdb_dbi_, &mdb_cursor));
+      return new LMDBCursor(mdb_txn, mdb_cursor);
+    }
 
-LMDBTransaction* LMDB::NewTransaction() {
-  return new LMDBTransaction(mdb_env_);
-}
+    LMDBTransaction *LMDB::NewTransaction()
+    {
+      return new LMDBTransaction(mdb_env_);
+    }
 
-int LMDB::Count() {
-  MDB_stat stats;
-  int err = mdb_env_stat(mdb_env_,&stats);
-  if (err != 0)
-    return -1;
-  return stats.ms_entries;
-}
+    int LMDB::Count()
+    {
+      MDB_stat stats;
+      int err = mdb_env_stat(mdb_env_, &stats);
+      if (err != 0)
+        return -1;
+      return stats.ms_entries;
+    }
 
-void LMDB::Get(const std::string &key,
-	       std::string &data_val) {
+    void LMDB::Get(const std::string &key, std::string &data_val)
+    {
 
-  MDB_val data;
-  MDB_txn *mdb_txn;
-  MDB_CHECK(mdb_txn_begin(mdb_env_, NULL, MDB_RDONLY, &mdb_txn));
-  MDB_dbi mdb_dbi;
-  MDB_CHECK(mdb_dbi_open(mdb_txn, NULL, 0, &mdb_dbi));
-  MDB_val mdb_key;
-  mdb_key.mv_size = key.size();
-  mdb_key.mv_data = const_cast<char*>(key.data());
-  mdb_get(mdb_txn,mdb_dbi,&mdb_key,&data);
-  char *data_raw = new char[data.mv_size+1];
-  memcpy(data_raw, data.mv_data, data.mv_size);
-  data_raw[data.mv_size] = 0;
-  data_val = std::string(data_raw,data.mv_size);
-  delete[] data_raw;
-  mdb_txn_commit(mdb_txn);
-  mdb_dbi_close(mdb_env_, mdb_dbi);
-}
+      MDB_val data;
+      MDB_txn *mdb_txn;
+      MDB_CHECK(mdb_txn_begin(mdb_env_, NULL, MDB_RDONLY, &mdb_txn));
+      MDB_dbi mdb_dbi;
+      MDB_CHECK(mdb_dbi_open(mdb_txn, NULL, 0, &mdb_dbi));
+      MDB_val mdb_key;
+      mdb_key.mv_size = key.size();
+      mdb_key.mv_data = const_cast<char *>(key.data());
+      mdb_get(mdb_txn, mdb_dbi, &mdb_key, &data);
+      char *data_raw = new char[data.mv_size + 1];
+      memcpy(data_raw, data.mv_data, data.mv_size);
+      data_raw[data.mv_size] = 0;
+      data_val = std::string(data_raw, data.mv_size);
+      delete[] data_raw;
+      mdb_txn_commit(mdb_txn);
+      mdb_dbi_close(mdb_env_, mdb_dbi);
+    }
 
     void LMDB::Remove(const std::string &key)
     {
@@ -91,72 +104,79 @@ void LMDB::Get(const std::string &key,
       MDB_CHECK(mdb_dbi_open(mdb_txn, NULL, 0, &mdb_dbi));
       MDB_val mdb_key;
       mdb_key.mv_size = key.size();
-      mdb_key.mv_data = const_cast<char*>(key.data());
-      mdb_del(mdb_txn,mdb_dbi,&mdb_key, NULL);
+      mdb_key.mv_data = const_cast<char *>(key.data());
+      mdb_del(mdb_txn, mdb_dbi, &mdb_key, NULL);
       mdb_txn_commit(mdb_txn);
       mdb_dbi_close(mdb_env_, mdb_dbi);
     }
-  
-    void LMDBTransaction::Put(const std::string& key, const std::string& value) {
-  keys.push_back(key);
-  values.push_back(value);
-}
 
-void LMDBTransaction::Commit() {
-  MDB_dbi mdb_dbi;
-  MDB_val mdb_key, mdb_data;
-  MDB_txn *mdb_txn;
-
-  // Initialize MDB variables
-  MDB_CHECK(mdb_txn_begin(mdb_env_, NULL, 0, &mdb_txn));
-  MDB_CHECK(mdb_dbi_open(mdb_txn, NULL, 0, &mdb_dbi));
-
-  for (unsigned int i = 0; i < keys.size(); i++) {
-    mdb_key.mv_size = keys[i].size();
-    mdb_key.mv_data = const_cast<char*>(keys[i].data());
-    mdb_data.mv_size = values[i].size();
-    mdb_data.mv_data = const_cast<char*>(values[i].data());
-
-    // Add data to the transaction
-    int put_rc = mdb_put(mdb_txn, mdb_dbi, &mdb_key, &mdb_data, 0);
-    if (put_rc == MDB_MAP_FULL) {
-      // Out of memory - double the map size and retry
-      mdb_txn_abort(mdb_txn);
-      mdb_dbi_close(mdb_env_, mdb_dbi);
-      DoubleMapSize();
-      Commit();
-      return;
+    void LMDBTransaction::Put(const std::string &key, const std::string &value)
+    {
+      keys.push_back(key);
+      values.push_back(value);
     }
-    // May have failed for some other reason
-    MDB_CHECK(put_rc);
-  }
 
-  // Commit the transaction
-  int commit_rc = mdb_txn_commit(mdb_txn);
-  if (commit_rc == MDB_MAP_FULL) {
-    // Out of memory - double the map size and retry
-    mdb_dbi_close(mdb_env_, mdb_dbi);
-    DoubleMapSize();
-    Commit();
-    return;
-  }
-  // May have failed for some other reason
-  MDB_CHECK(commit_rc);
+    void LMDBTransaction::Commit()
+    {
+      MDB_dbi mdb_dbi;
+      MDB_val mdb_key, mdb_data;
+      MDB_txn *mdb_txn;
 
-  // Cleanup after successful commit
-  mdb_dbi_close(mdb_env_, mdb_dbi);
-  keys.clear();
-  values.clear();
-}
+      // Initialize MDB variables
+      MDB_CHECK(mdb_txn_begin(mdb_env_, NULL, 0, &mdb_txn));
+      MDB_CHECK(mdb_dbi_open(mdb_txn, NULL, 0, &mdb_dbi));
 
-void LMDBTransaction::DoubleMapSize() {
-  struct MDB_envinfo current_info;
-  MDB_CHECK(mdb_env_info(mdb_env_, &current_info));
-  size_t new_size = current_info.me_mapsize * 2;
-  DLOG(INFO) << "Doubling LMDB map size to " << (new_size>>20) << "MB ...";
-  MDB_CHECK(mdb_env_set_mapsize(mdb_env_, new_size));
-}
+      for (unsigned int i = 0; i < keys.size(); i++)
+        {
+          mdb_key.mv_size = keys[i].size();
+          mdb_key.mv_data = const_cast<char *>(keys[i].data());
+          mdb_data.mv_size = values[i].size();
+          mdb_data.mv_data = const_cast<char *>(values[i].data());
 
-}  // namespace db
-}  // namespace dd
-#endif  // USE_LMDB
+          // Add data to the transaction
+          int put_rc = mdb_put(mdb_txn, mdb_dbi, &mdb_key, &mdb_data, 0);
+          if (put_rc == MDB_MAP_FULL)
+            {
+              // Out of memory - double the map size and retry
+              mdb_txn_abort(mdb_txn);
+              mdb_dbi_close(mdb_env_, mdb_dbi);
+              DoubleMapSize();
+              Commit();
+              return;
+            }
+          // May have failed for some other reason
+          MDB_CHECK(put_rc);
+        }
+
+      // Commit the transaction
+      int commit_rc = mdb_txn_commit(mdb_txn);
+      if (commit_rc == MDB_MAP_FULL)
+        {
+          // Out of memory - double the map size and retry
+          mdb_dbi_close(mdb_env_, mdb_dbi);
+          DoubleMapSize();
+          Commit();
+          return;
+        }
+      // May have failed for some other reason
+      MDB_CHECK(commit_rc);
+
+      // Cleanup after successful commit
+      mdb_dbi_close(mdb_env_, mdb_dbi);
+      keys.clear();
+      values.clear();
+    }
+
+    void LMDBTransaction::DoubleMapSize()
+    {
+      struct MDB_envinfo current_info;
+      MDB_CHECK(mdb_env_info(mdb_env_, &current_info));
+      size_t new_size = current_info.me_mapsize * 2;
+      DLOG(INFO) << "Doubling LMDB map size to " << (new_size >> 20)
+                 << "MB ...";
+      MDB_CHECK(mdb_env_set_mapsize(mdb_env_, new_size));
+    }
+
+  } // namespace db
+} // namespace dd
+#endif // USE_LMDB

--- a/src/backends/torch/llogging.h
+++ b/src/backends/torch/llogging.h
@@ -9,14 +9,17 @@
 #include <boost/algorithm/string.hpp>
 #include <iostream>
 
-class DateLogger {
- public:
-  DateLogger() {
+class DateLogger
+{
+public:
+  DateLogger()
+  {
 #if defined(_MSC_VER)
     _tzset();
 #endif
   }
-  const char* HumanDate() {
+  const char *HumanDate()
+  {
 #if defined(_MSC_VER)
     _strtime_s(buffer_, sizeof(buffer_));
 #else
@@ -26,15 +29,15 @@ class DateLogger {
     struct tm now;
     pnow = localtime_r(&time_value, &now);
 #else
-    pnow = localtime(&time_value);  // NOLINT(*)
+    pnow = localtime(&time_value); // NOLINT(*)
 #endif
-    snprintf(buffer_, sizeof(buffer_), "%02d:%02d:%02d",
-             pnow->tm_hour, pnow->tm_min, pnow->tm_sec);
+    snprintf(buffer_, sizeof(buffer_), "%02d:%02d:%02d", pnow->tm_hour,
+             pnow->tm_min, pnow->tm_sec);
 #endif
     return buffer_;
   }
 
- private:
+private:
   char buffer_[9];
 };
 
@@ -69,21 +72,29 @@ class DateLogger {
 
 #ifdef CAFFE_THROW_ON_ERROR
 #include <sstream>
-#define SSTR( x ) dynamic_cast< std::ostringstream & >( \
-		 ( std::ostringstream() << std::dec << x ) ).str()
+#define SSTR(x)                                                               \
+  dynamic_cast<std::ostringstream &>((std::ostringstream() << std::dec << x)) \
+      .str()
 class CaffeErrorException : public std::exception
 {
 public:
-  CaffeErrorException(const std::string &s):_s(s) {}
-  ~CaffeErrorException() throw() {}
-  const char* what() const throw() { return _s.c_str(); }
+  CaffeErrorException(const std::string &s) : _s(s)
+  {
+  }
+  ~CaffeErrorException() throw()
+  {
+  }
+  const char *what() const throw()
+  {
+    return _s.c_str();
+  }
   std::string _s;
 };
 
-static std::string INFO="INFO";
-static std::string WARNING="WARNING";
-static std::string ERROR="ERROR";
-static std::string FATAL="FATAL";
+static std::string INFO = "INFO";
+static std::string WARNING = "WARNING";
+static std::string ERROR = "ERROR";
+static std::string FATAL = "FATAL";
 
 #define GLOG_NO_ABBREVIATED_SEVERITIES
 
@@ -94,11 +105,11 @@ static std::string FATAL="FATAL";
 
 static std::ostream nullstream(0);
 
-#define CHECK(condition)						\
-  if (!(condition)) \
-    throw CaffeErrorException(std::string(__FILE__) + ":" + SSTR(__LINE__) + " / Check failed (custom): " #condition ""); \
-  nullstream									\
-  << "Check failed (custom): " #condition " "
+#define CHECK(condition)                                                      \
+  if (!(condition))                                                           \
+    throw CaffeErrorException(std::string(__FILE__) + ":" + SSTR(__LINE__)    \
+                              + " / Check failed (custom): " #condition "");  \
+  nullstream << "Check failed (custom): " #condition " "
 
 #define CHECK_LT(x, y) CHECK((x) < (y))
 #define CHECK_GT(x, y) CHECK((x) > (y))
@@ -107,30 +118,38 @@ static std::ostream nullstream(0);
 #define CHECK_EQ(x, y) CHECK((x) == (y))
 #define CHECK_NE(x, y) CHECK((x) != (y))
 
-#define CHECK_OP_LOG(name, op, val1, val2, log) CHECK((val1) op (val2))
+#define CHECK_OP_LOG(name, op, val1, val2, log) CHECK((val1)op(val2))
 /* #ifdef DEBUG */
 /* #define CHECK_EQ(val1,val2) if (0) std::cerr */
 /* #endif */
 #endif
 
-#define CHECK_NOTNULL(x) \
-  ((x) == NULL ? LOG(FATAL) << "Check  notnull: "  #x << ' ', (x) : (x)) // NOLINT(*)
+#define CHECK_NOTNULL(x)                                                      \
+  ((x) == NULL ? LOG(FATAL) << "Check  notnull: " #x << ' ',                  \
+   (x) : (x)) // NOLINT(*)
 
 #ifdef NDEBUG
-#define DCHECK(x) \
-  while (false) CHECK(x)
-#define DCHECK_LT(x, y) \
-  while (false) CHECK((x) < (y))
-#define DCHECK_GT(x, y) \
-  while (false) CHECK((x) > (y))
-#define DCHECK_LE(x, y) \
-  while (false) CHECK((x) <= (y))
-#define DCHECK_GE(x, y) \
-  while (false) CHECK((x) >= (y))
-#define DCHECK_EQ(x, y) \
-  while (false) CHECK((x) == (y))
-#define DCHECK_NE(x, y) \
-  while (false) CHECK((x) != (y))
+#define DCHECK(x)                                                             \
+  while (false)                                                               \
+  CHECK(x)
+#define DCHECK_LT(x, y)                                                       \
+  while (false)                                                               \
+  CHECK((x) < (y))
+#define DCHECK_GT(x, y)                                                       \
+  while (false)                                                               \
+  CHECK((x) > (y))
+#define DCHECK_LE(x, y)                                                       \
+  while (false)                                                               \
+  CHECK((x) <= (y))
+#define DCHECK_GE(x, y)                                                       \
+  while (false)                                                               \
+  CHECK((x) >= (y))
+#define DCHECK_EQ(x, y)                                                       \
+  while (false)                                                               \
+  CHECK((x) == (y))
+#define DCHECK_NE(x, y)                                                       \
+  while (false)                                                               \
+  CHECK((x) != (y))
 #else
 #define DCHECK(x) CHECK(x)
 #define DCHECK_LT(x, y) CHECK((x) < (y))
@@ -139,13 +158,12 @@ static std::ostream nullstream(0);
 #define DCHECK_GE(x, y) CHECK((x) >= (y))
 #define DCHECK_EQ(x, y) CHECK((x) == (y))
 #define DCHECK_NE(x, y) CHECK((x) != (y))
-#endif  // NDEBUG
+#endif // NDEBUG
 
 class CaffeLogger
 {
- public:
-  CaffeLogger(const std::string &severity)
-    :_severity(severity)
+public:
+  CaffeLogger(const std::string &severity) : _severity(severity)
   {
     _console = spdlog::get("torchlib");
     if (!_console)
@@ -157,40 +175,43 @@ class CaffeLogger
   }
 
   ~CaffeLogger()
-    {
-      if (_severity == "none" || _str.empty()) // ignore
-	{}
-      else if (_severity == INFO)
-	_console->info(_str);
-      else if (_severity == WARNING)
-	_console->warn(_str);
-      else if (_severity == ERROR)
-	_console->error(_str);
-    }
-  
-  friend CaffeLogger& operator<<(const CaffeLogger &cl, const std::string &rstr)
+  {
+    if (_severity == "none" || _str.empty()) // ignore
+      {
+      }
+    else if (_severity == INFO)
+      _console->info(_str);
+    else if (_severity == WARNING)
+      _console->warn(_str);
+    else if (_severity == ERROR)
+      _console->error(_str);
+  }
+
+  friend CaffeLogger &operator<<(const CaffeLogger &cl,
+                                 const std::string &rstr)
   {
     std::string str = rstr;
-    const_cast<CaffeLogger&>(cl)._str += str;
-    return const_cast<CaffeLogger&>(cl);
+    const_cast<CaffeLogger &>(cl)._str += str;
+    return const_cast<CaffeLogger &>(cl);
   }
 
-  friend CaffeLogger& operator<<(const CaffeLogger &cl, const double &d)
+  friend CaffeLogger &operator<<(const CaffeLogger &cl, const double &d)
   {
     std::string str = std::to_string(d);
-    boost::trim_right_if(str,boost::is_any_of("\n"));
-    const_cast<CaffeLogger&>(cl)._str += str;
-    return const_cast<CaffeLogger&>(cl);
+    boost::trim_right_if(str, boost::is_any_of("\n"));
+    const_cast<CaffeLogger &>(cl)._str += str;
+    return const_cast<CaffeLogger &>(cl);
   }
 
-  friend CaffeLogger& operator<<(const CaffeLogger &cl, const std::ostream &out)
+  friend CaffeLogger &operator<<(const CaffeLogger &cl,
+                                 const std::ostream &out)
   {
     std::stringstream sstr;
     sstr << out.rdbuf();
-    const_cast<CaffeLogger&>(cl)._str += sstr.str();
-    return const_cast<CaffeLogger&>(cl);
+    const_cast<CaffeLogger &>(cl)._str += sstr.str();
+    return const_cast<CaffeLogger &>(cl);
   }
-  
+
   std::string _severity = INFO;
   std::shared_ptr<spdlog::logger> _console;
   std::string _str;
@@ -199,20 +220,24 @@ class CaffeLogger
 inline CaffeLogger LOG(const std::string &severity)
 {
   if (severity != FATAL)
-  {
-    return CaffeLogger(severity);
-  }
+    {
+      return CaffeLogger(severity);
+    }
   else
     {
-      throw CaffeErrorException(std::string(__FILE__) + ":" + SSTR(__LINE__) + " / Fatal Caffe error"); // XXX: cannot report the exact location of the trigger...
+      throw CaffeErrorException(
+          std::string(__FILE__) + ":" + SSTR(__LINE__)
+          + " / Fatal Caffe error"); // XXX: cannot report the exact location
+                                     // of the trigger...
     }
 }
 
-inline CaffeLogger LOG_IF(const std::string &severity,const bool &condition)
+inline CaffeLogger LOG_IF(const std::string &severity, const bool &condition)
 {
   if (condition)
     return LOG(severity);
-  else return CaffeLogger("none");
+  else
+    return CaffeLogger("none");
 }
 
 #ifdef NDEBUG

--- a/src/backends/torch/torchgraphbackend.cc
+++ b/src/backends/torch/torchgraphbackend.cc
@@ -19,225 +19,234 @@
  * along with deepdetect.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
 #include "torchgraphbackend.h"
-
 
 namespace dd
 {
+  using torch::Tensor;
   using torch::nn::AnyModule;
-  using torch::nn::RNN;
-  using torch::nn::RNNOptions;
-  using torch::nn::LSTM;
-  using torch::nn::LSTMOptions;
   using torch::nn::Linear;
   using torch::nn::LinearOptions;
-  using torch::Tensor;
-
+  using torch::nn::LSTM;
+  using torch::nn::LSTMOptions;
+  using torch::nn::RNN;
+  using torch::nn::RNNOptions;
 
   void TorchGraphBackend::set_input(torch::Tensor input)
   {
-	std::vector<int> dim(input.sizes().begin(),input.sizes().end());
-	this->set_input_dim(dim);
-	_variables[_inputname] = input;
-	BaseGraph::finalize();
-	allocate_modules();
+    std::vector<int> dim(input.sizes().begin(), input.sizes().end());
+    this->set_input_dim(dim);
+    _variables[_inputname] = input;
+    BaseGraph::finalize();
+    allocate_modules();
   }
 
   void TorchGraphBackend::finalize()
   {
-	BaseGraph::finalize();
-	allocate_modules();
+    BaseGraph::finalize();
+    allocate_modules();
   }
-
 
   void TorchGraphBackend::finalize(at::IntArrayRef dim)
   {
-	finalize(dim.vec());
+    finalize(dim.vec());
   }
 
   void TorchGraphBackend::finalize(std::vector<int> dim)
   {
-	this->set_input_dim(dim);
-	BaseGraph::finalize();
-	allocate_modules();
+    this->set_input_dim(dim);
+    BaseGraph::finalize();
+    allocate_modules();
   }
-
 
   void TorchGraphBackend::finalize(std::vector<int64_t> dim)
   {
-	std::vector<int> dimint;
-	for (auto d:dim)
-	  dimint.push_back(d);
-	finalize(dimint);
+    std::vector<int> dimint;
+    for (auto d : dim)
+      dimint.push_back(d);
+    finalize(dimint);
   }
-
-
-
 
   torch::Tensor TorchGraphBackend::forward(torch::Tensor inputTensor)
   {
-	set_input(inputTensor);
-	bool output_computed = false;
-	for (BaseGraph::Vertex o: _sortedOps)
-	  {
-		std::vector<torch::Tensor> out = forward(o);
-		std::vector<BaseGraph::Vertex> outputVars = this->outputs(o);
-		for (unsigned int i=0; i<outputVars.size(); ++i)
-		  {
-			if (varname(outputVars[i]) == _outputname)
-			  output_computed = true;
-			_variables[varname(outputVars[i])] = out[i];
-		  }
-	  }
-	if (!output_computed)
-	  throw TorchGraphException("did not compute output, please check NN graph");
-	return _variables[_outputname];
+    set_input(inputTensor);
+    bool output_computed = false;
+    for (BaseGraph::Vertex o : _sortedOps)
+      {
+        std::vector<torch::Tensor> out = forward(o);
+        std::vector<BaseGraph::Vertex> outputVars = this->outputs(o);
+        for (unsigned int i = 0; i < outputVars.size(); ++i)
+          {
+            if (varname(outputVars[i]) == _outputname)
+              output_computed = true;
+            _variables[varname(outputVars[i])] = out[i];
+          }
+      }
+    if (!output_computed)
+      throw TorchGraphException(
+          "did not compute output, please check NN graph");
+    return _variables[_outputname];
   }
 
   std::vector<torch::Tensor> TorchGraphBackend::forward(BaseGraph::Vertex v)
   {
 
-	std::vector<torch::Tensor> inputsTensor;
-	for (BaseGraph::Vertex vi: this->inputs(v))
-	  {
-		inputsTensor.push_back(_variables[varname(vi)]);
-	  }
+    std::vector<torch::Tensor> inputsTensor;
+    for (BaseGraph::Vertex vi : this->inputs(v))
+      {
+        inputsTensor.push_back(_variables[varname(vi)]);
+      }
 
     auto opname_v = opname(v);
-	std::vector<torch::Tensor> output;
-	std::string optype = this->optype(v);
-	if (optype == "LSTM" || optype == "RNN")
-	  {
-		//get<0>(f()) for all outputs / hidden
-		//get<0>(get<1>(f)) for last output
-		//get<1>(get<1>(f)) for last internal state
-		std::tuple<torch::Tensor, std::tuple<torch::Tensor, torch::Tensor>> full_output;
-		if (_lstm_continuation && _rnn_has_memories[opname_v])
-		  {
-			full_output = _modules[opname_v].
-			  forward<std::tuple<Tensor,std::tuple<Tensor,Tensor>>>
-			  (inputsTensor[0],
-			   torch::optional<std::tuple<torch::Tensor,torch::Tensor>>(_rnn_memories[opname_v]));
-		  }
-		else
-		  full_output = _modules[opname_v].
-			forward<std::tuple<Tensor,std::tuple<Tensor,Tensor>>>
-			(inputsTensor[0]);
-		output.push_back(std::get<0>(full_output));
-		if (_lstm_continuation)
-		  {
-			_rnn_memories[opname_v] = std::get<1>(full_output);
-			_rnn_has_memories[opname_v] = true;
-		  }
-
-	  }
-	else if (optype == "InnerProduct")
-	  output.push_back(_modules[opname_v].forward(inputsTensor[0]));
-	else
-	  throw TorchGraphException("unknown optype " + optype + " for operator " + opname_v);
-	return output;
+    std::vector<torch::Tensor> output;
+    std::string optype = this->optype(v);
+    if (optype == "LSTM" || optype == "RNN")
+      {
+        // get<0>(f()) for all outputs / hidden
+        // get<0>(get<1>(f)) for last output
+        // get<1>(get<1>(f)) for last internal state
+        std::tuple<torch::Tensor, std::tuple<torch::Tensor, torch::Tensor>>
+            full_output;
+        if (_lstm_continuation && _rnn_has_memories[opname_v])
+          {
+            full_output
+                = _modules[opname_v]
+                      .forward<std::tuple<Tensor, std::tuple<Tensor, Tensor>>>(
+                          inputsTensor[0],
+                          torch::optional<
+                              std::tuple<torch::Tensor, torch::Tensor>>(
+                              _rnn_memories[opname_v]));
+          }
+        else
+          full_output
+              = _modules[opname_v]
+                    .forward<std::tuple<Tensor, std::tuple<Tensor, Tensor>>>(
+                        inputsTensor[0]);
+        output.push_back(std::get<0>(full_output));
+        if (_lstm_continuation)
+          {
+            _rnn_memories[opname_v] = std::get<1>(full_output);
+            _rnn_has_memories[opname_v] = true;
+          }
+      }
+    else if (optype == "InnerProduct")
+      output.push_back(_modules[opname_v].forward(inputsTensor[0]));
+    else
+      throw TorchGraphException("unknown optype " + optype + " for operator "
+                                + opname_v);
+    return output;
   }
-
 
   void TorchGraphBackend::allocate_modules()
   {
-	for (BaseGraph::Vertex v: _sortedOps)
-	  {
-		if (!_graph[v].alloc_needed)
-		  continue;
-		if (_parameters_used)
-		  throw TorchGraphException("parameters reallocation necessary while they are used elsewhere. You should module.forward() / module.set_input() / module.finalize() with correct input dimensions before modules.parameters() or  module.parameters_release() if you know what you are doing");
-		std::string optype = this->optype(v);
-		std::string opname = this->opname(v);
-		if (_modules.find(opname) != _modules.end())
-		  unregister_module(opname);
+    for (BaseGraph::Vertex v : _sortedOps)
+      {
+        if (!_graph[v].alloc_needed)
+          continue;
+        if (_parameters_used)
+          throw TorchGraphException(
+              "parameters reallocation necessary while they are used "
+              "elsewhere. You should module.forward() / module.set_input() / "
+              "module.finalize() with correct input dimensions before "
+              "modules.parameters() or  module.parameters_release() if you "
+              "know what you are doing");
+        std::string optype = this->optype(v);
+        std::string opname = this->opname(v);
+        if (_modules.find(opname) != _modules.end())
+          unregister_module(opname);
 
-		torch::nn::AnyModule m;
-		if (optype == "LSTM")
-		  {
-			//dim(v,0,2) is 2nd dimension of input 0 of v, ie datadim for lstm
-			LSTM m = register_module(opname, LSTM(LSTMOptions(dim(v,0,2),
-															  num_output(v))
-												  .num_layers(1)
-												  .batch_first(true)
-												  .bidirectional(false)));
+        torch::nn::AnyModule m;
+        if (optype == "LSTM")
+          {
+            // dim(v,0,2) is 2nd dimension of input 0 of v, ie datadim for lstm
+            LSTM m = register_module(
+                opname, LSTM(LSTMOptions(dim(v, 0, 2), num_output(v))
+                                 .num_layers(1)
+                                 .batch_first(true)
+                                 .bidirectional(false)));
 
-			_modules[opname] = AnyModule(m);
-			_graph[v].alloc_needed = false;
-			_rnn_has_memories[opname] = false;
-		  }
-		else if (optype == "RNN")
-		  {
-			//dim(v,0,2) is 2nd dimension of input 0 of v, ie datadim for lstm
-			RNN m = register_module(opname,RNN(RNNOptions(dim(v,0,2),
-														  num_output(v))
-											   .num_layers(1)
-											   .batch_first(true)
-											   .bidirectional(false)));
-			_modules[opname] = AnyModule(m);
-			_graph[v].alloc_needed = false;
-			_rnn_has_memories[opname] = false;
-		  }
-		else if (optype == "InnerProduct")
-		  {
-			//dim(v,0,2) is 2nd dimension of input 0 of v, ie datadim for lstm output
-			Linear m = register_module(opname,
-									   Linear(LinearOptions(dim(v,0,2),
-															num_output(v))
-											  .bias(true)));
-			_modules[opname] = AnyModule(m);
-			_graph[v].alloc_needed = false;
-		  }
-	  }
-	to(_device,_dtype);
+            _modules[opname] = AnyModule(m);
+            _graph[v].alloc_needed = false;
+            _rnn_has_memories[opname] = false;
+          }
+        else if (optype == "RNN")
+          {
+            // dim(v,0,2) is 2nd dimension of input 0 of v, ie datadim for lstm
+            RNN m = register_module(opname,
+                                    RNN(RNNOptions(dim(v, 0, 2), num_output(v))
+                                            .num_layers(1)
+                                            .batch_first(true)
+                                            .bidirectional(false)));
+            _modules[opname] = AnyModule(m);
+            _graph[v].alloc_needed = false;
+            _rnn_has_memories[opname] = false;
+          }
+        else if (optype == "InnerProduct")
+          {
+            // dim(v,0,2) is 2nd dimension of input 0 of v, ie datadim for lstm
+            // output
+            Linear m = register_module(
+                opname,
+                Linear(LinearOptions(dim(v, 0, 2), num_output(v)).bias(true)));
+            _modules[opname] = AnyModule(m);
+            _graph[v].alloc_needed = false;
+          }
+      }
+    to(_device, _dtype);
   }
 
-  void TorchGraphBackend::to(torch::Device device, torch::Dtype dtype, bool non_blocking)
+  void TorchGraphBackend::to(torch::Device device, torch::Dtype dtype,
+                             bool non_blocking)
   {
-	if (!allocated())
-	  throw TorchGraphException("trying to move NN to gpu/cpu / cast before its effective allocation. finalize(inputdim) or forward() it once before to()");
-	else
-	  {
-		torch::nn::Module::to(device, dtype, non_blocking);
-		_device = device;
-		_dtype = dtype;
-	  }
+    if (!allocated())
+      throw TorchGraphException(
+          "trying to move NN to gpu/cpu / cast before its effective "
+          "allocation. finalize(inputdim) or forward() it once before to()");
+    else
+      {
+        torch::nn::Module::to(device, dtype, non_blocking);
+        _device = device;
+        _dtype = dtype;
+      }
   }
 
   void TorchGraphBackend::to(torch::Dtype dtype, bool non_blocking)
   {
-	if (!allocated())
-	  throw TorchGraphException("trying to cast params before their effective allocation. finalize(inputdim) or forward() it once before to()");
-	else
-	  {
-		torch::nn::Module::to(dtype, non_blocking);
-		_dtype = dtype;
-	  }
+    if (!allocated())
+      throw TorchGraphException(
+          "trying to cast params before their effective allocation. "
+          "finalize(inputdim) or forward() it once before to()");
+    else
+      {
+        torch::nn::Module::to(dtype, non_blocking);
+        _dtype = dtype;
+      }
   }
 
   void TorchGraphBackend::to(torch::Device device, bool non_blocking)
   {
-	if (!allocated())
-	  throw TorchGraphException("trying to move NN to gpu/cpu before its effective allocation. finalize(inputdim) or forward() it once before to()");
-	else
-	  {
-		torch::nn::Module::to(device, non_blocking);
-		_device = device;
-	  }
+    if (!allocated())
+      throw TorchGraphException(
+          "trying to move NN to gpu/cpu before its effective allocation. "
+          "finalize(inputdim) or forward() it once before to()");
+    else
+      {
+        torch::nn::Module::to(device, non_blocking);
+        _device = device;
+      }
   }
 
   std::vector<torch::Tensor> TorchGraphBackend::parameters(bool recurse)
   {
-  	if (!allocated())
-  	  throw TorchGraphException("trying to get parameters (for optim?) before their effective allocation. finalize(inputdim) or forward() it once before to()");
-  	else
-  	  {
-  		_parameters_used =true;
-  		return torch::nn::Module::parameters(recurse);
-  	  }
+    if (!allocated())
+      throw TorchGraphException(
+          "trying to get parameters (for optim?) before their effective "
+          "allocation. finalize(inputdim) or forward() it once before to()");
+    else
+      {
+        _parameters_used = true;
+        return torch::nn::Module::parameters(recurse);
+      }
   }
-
 
 }

--- a/src/backends/torch/torchinputconns.cc
+++ b/src/backends/torch/torchinputconns.cc
@@ -22,39 +22,42 @@
 
 #include "torchinputconns.h"
 
-namespace dd {
-
-using namespace torch;
-
-
-void TorchInputInterface::build_test_datadb_from_full_datadb(double tsplit)
+namespace dd
 {
-  _tilogger->info("splitting : using {} of dataset as test set", tsplit);
-  _dataset.reset(db::WRITE);
-  std::vector<int64_t> indicestest;
-  int64_t ntest = _dataset._indices.size() * tsplit;
-  auto seed = static_cast<long>(time(NULL));
-  std::mt19937 rng(seed);
 
-  for (int64_t i=0; i< ntest; i++)
-    {
-      std::uniform_int_distribution<int64_t> index_distrib(0, _dataset._indices.size()-1);
-      int64_t index = _dataset._indices[index_distrib(rng)];
-      std::string data;
-      std::string target;
-      _dataset.pop(index,data,target);
-      _test_dataset.add_elt(index, data,target);
-    }
-  _test_dataset.finalize_db();
-  _dataset.finalize_db();
-}
+  using namespace torch;
 
-  bool TorchInputInterface::has_to_create_db(const APIData&ad, double test_split)
+  void TorchInputInterface::build_test_datadb_from_full_datadb(double tsplit)
   {
-    //here force db paths manually if given at call time
-    std::vector<std::string> uris = ad.get("data").get<std::vector<std::string>>();
+    _tilogger->info("splitting : using {} of dataset as test set", tsplit);
+    _dataset.reset(db::WRITE);
+    std::vector<int64_t> indicestest;
+    int64_t ntest = _dataset._indices.size() * tsplit;
+    auto seed = static_cast<long>(time(NULL));
+    std::mt19937 rng(seed);
 
-    if (uris.size() >=1)
+    for (int64_t i = 0; i < ntest; i++)
+      {
+        std::uniform_int_distribution<int64_t> index_distrib(
+            0, _dataset._indices.size() - 1);
+        int64_t index = _dataset._indices[index_distrib(rng)];
+        std::string data;
+        std::string target;
+        _dataset.pop(index, data, target);
+        _test_dataset.add_elt(index, data, target);
+      }
+    _test_dataset.finalize_db();
+    _dataset.finalize_db();
+  }
+
+  bool TorchInputInterface::has_to_create_db(const APIData &ad,
+                                             double test_split)
+  {
+    // here force db paths manually if given at call time
+    std::vector<std::string> uris
+        = ad.get("data").get<std::vector<std::string>>();
+
+    if (uris.size() >= 1)
       {
         if (fileops::dir_exists(uris[0]) && fileops::is_db(uris[0]))
           {
@@ -65,7 +68,8 @@ void TorchInputInterface::build_test_datadb_from_full_datadb(double tsplit)
       }
     if (fileops::file_exists(_dataset._dbFullName))
       {
-        _tilogger->warn("db {} already exists, not rebuilding it",_dataset._dbFullName);
+        _tilogger->warn("db {} already exists, not rebuilding it",
+                        _dataset._dbFullName);
         if (!fileops::file_exists(_test_dataset._dbFullName))
           {
             if (test_split != 0.0)
@@ -74,7 +78,7 @@ void TorchInputInterface::build_test_datadb_from_full_datadb(double tsplit)
         else
           {
             _tilogger->warn("test db {} already exists, not rebuilding it",
-                          _test_dataset._dbFullName);
+                            _test_dataset._dbFullName);
           }
         return false;
       }
@@ -85,10 +89,11 @@ void TorchInputInterface::build_test_datadb_from_full_datadb(double tsplit)
 
   void TorchDataset::finalize_db()
   {
-    if (_current_index % _batches_per_transaction != 0) {
-      _txn->Commit();
-      _logger->info("Put {} tensors in db",_current_index);
-    }
+    if (_current_index % _batches_per_transaction != 0)
+      {
+        _txn->Commit();
+        _logger->info("Put {} tensors in db", _current_index);
+      }
     if (_dbData != nullptr)
       {
         _dbData->Close();
@@ -98,7 +103,7 @@ void TorchInputInterface::build_test_datadb_from_full_datadb(double tsplit)
     _current_index = 0;
   }
 
-  void TorchDataset::pop(int64_t index, std::string&data, std::string&target)
+  void TorchDataset::pop(int64_t index, std::string &data, std::string &target)
   {
     if (_dbData == nullptr)
       {
@@ -108,7 +113,7 @@ void TorchInputInterface::build_test_datadb_from_full_datadb(double tsplit)
     std::stringstream data_key;
     std::stringstream target_key;
 
-    data_key<< std::to_string(index)<<"_data";
+    data_key << std::to_string(index) << "_data";
     target_key << std::to_string(index) << "_target";
 
     _dbData->Get(data_key.str(), data);
@@ -129,8 +134,8 @@ void TorchInputInterface::build_test_datadb_from_full_datadb(double tsplit)
       }
   }
 
-
-  void TorchDataset::add_elt(int64_t index, std::string data, std::string target)
+  void TorchDataset::add_elt(int64_t index, std::string data,
+                             std::string target)
   {
     if (_dbData == nullptr)
       {
@@ -141,7 +146,7 @@ void TorchInputInterface::build_test_datadb_from_full_datadb(double tsplit)
     std::stringstream data_key;
     std::stringstream target_key;
 
-    data_key<< std::to_string(index)<<"_data";
+    data_key << std::to_string(index) << "_data";
     target_key << std::to_string(index) << "_target";
     _txn->Put(data_key.str(), data);
     _txn->Put(target_key.str(), target);
@@ -150,8 +155,8 @@ void TorchInputInterface::build_test_datadb_from_full_datadb(double tsplit)
     _indices.push_back(index);
   }
 
-
-  void TorchDataset::write_tensors_to_db(std::vector<at::Tensor> data, std::vector<at::Tensor> target)
+  void TorchDataset::write_tensors_to_db(std::vector<at::Tensor> data,
+                                         std::vector<at::Tensor> target)
   {
     std::ostringstream dstream;
     torch::save(data, dstream);
@@ -168,14 +173,13 @@ void TorchInputInterface::build_test_datadb_from_full_datadb(double tsplit)
     std::stringstream data_key;
     std::stringstream target_key;
 
-    data_key<< std::to_string(_current_index)<<"_data";
+    data_key << std::to_string(_current_index) << "_data";
     target_key << std::to_string(_current_index) << "_target";
 
     _txn->Put(data_key.str(), dstream.str());
     _txn->Put(target_key.str(), tstream.str());
 
-
-    //should not commit transations every time;
+    // should not commit transations every time;
     if (++_current_index % _batches_per_transaction == 0)
       {
         _txn->Commit();
@@ -184,133 +188,137 @@ void TorchInputInterface::build_test_datadb_from_full_datadb(double tsplit)
       }
   }
 
-
-  void TorchDataset::add_batch(std::vector<at::Tensor> data, std::vector<at::Tensor> target)
-{
-  if (!_db)
+  void TorchDataset::add_batch(std::vector<at::Tensor> data,
+                               std::vector<at::Tensor> target)
+  {
+    if (!_db)
       _batches.push_back(TorchBatch(data, target));
-  else
+    else
       write_tensors_to_db(data, target);
-}
+  }
 
-void TorchDataset::reset(bool shuffle, db::Mode dbmode)
-{
-  _shuffle = shuffle;
-  if (!_db)
-    {
-      _indices.clear();
+  void TorchDataset::reset(bool shuffle, db::Mode dbmode)
+  {
+    _shuffle = shuffle;
+    if (!_db)
+      {
+        _indices.clear();
 
-      for (unsigned int i = 0; i < _batches.size(); ++i) {
-        _indices.push_back(i);
+        for (unsigned int i = 0; i < _batches.size(); ++i)
+          {
+            _indices.push_back(i);
+          }
       }
-    }
-  else  //below db case
-    {
-      _indices.clear();
-      if (_dbData == nullptr)
-        {
-          _dbData = std::shared_ptr<db::DB>(db::GetDB(_backend));
-          _dbData->Open(_dbFullName, dbmode);
-        }
+    else // below db case
+      {
+        _indices.clear();
+        if (_dbData == nullptr)
+          {
+            _dbData = std::shared_ptr<db::DB>(db::GetDB(_backend));
+            _dbData->Open(_dbFullName, dbmode);
+          }
 
-      db::Cursor* cursor = _dbData->NewCursor();
-      while(cursor->valid())
-        {
-          std::string key = cursor->key();
-          size_t pos = key.find("_data");
-          if (pos != std::string::npos)
-            {
-              std::string sid = key.substr(0,pos);
-              int64_t id = std::stoll(sid);
-              _indices.push_back(id);
-            }
-          cursor->Next();
-        }
-      delete(cursor);
-    }
+        db::Cursor *cursor = _dbData->NewCursor();
+        while (cursor->valid())
+          {
+            std::string key = cursor->key();
+            size_t pos = key.find("_data");
+            if (pos != std::string::npos)
+              {
+                std::string sid = key.substr(0, pos);
+                int64_t id = std::stoll(sid);
+                _indices.push_back(id);
+              }
+            cursor->Next();
+          }
+        delete (cursor);
+      }
 
     if (_shuffle)
-    {
+      {
         auto seed = _seed == -1 ? static_cast<long>(time(NULL)) : _seed;
         std::shuffle(_indices.begin(), _indices.end(), std::mt19937(seed));
-    }
-}
+      }
+  }
 
-// `request` holds the size of the batch
-// Data selection and batch construction are done in this method
-c10::optional<TorchBatch> TorchDataset::get_batch(BatchRequestType request)
-{
+  // `request` holds the size of the batch
+  // Data selection and batch construction are done in this method
+  c10::optional<TorchBatch> TorchDataset::get_batch(BatchRequestType request)
+  {
     size_t count = request[0];
     std::vector<Tensor> data_tensors;
     std::vector<Tensor> target_tensors;
 
     count = count < _indices.size() ? count : _indices.size();
 
-    if (count == 0) {
-      return torch::nullopt;
-    }
+    if (count == 0)
+      {
+        return torch::nullopt;
+      }
 
     std::vector<std::vector<Tensor>> data, target;
 
     if (!_db)
       {
-        while(count != 0) {
-          auto id = _indices.back();
-          auto entry = _batches[id];
+        while (count != 0)
+          {
+            auto id = _indices.back();
+            auto entry = _batches[id];
 
-          for (unsigned int i = 0; i < entry.data.size(); ++i)
-            {
-              while (i >= data.size())
-                data.emplace_back();
-              data[i].push_back(entry.data.at(i));
-            }
-          for (unsigned int i = 0; i < entry.target.size(); ++i)
-            {
-              while (i >= target.size())
-                target.emplace_back();
-              target[i].push_back(entry.target.at(i));
-            }
+            for (unsigned int i = 0; i < entry.data.size(); ++i)
+              {
+                while (i >= data.size())
+                  data.emplace_back();
+                data[i].push_back(entry.data.at(i));
+              }
+            for (unsigned int i = 0; i < entry.target.size(); ++i)
+              {
+                while (i >= target.size())
+                  target.emplace_back();
+                target[i].push_back(entry.target.at(i));
+              }
 
-          _indices.pop_back();
-          count--;
-        }
+            _indices.pop_back();
+            count--;
+          }
       }
     else // below db case
       {
-        while(count != 0) {
-          auto id = _indices.back();
-          std::stringstream data_key;
-          std::stringstream target_key;
-          data_key << id << "_data";
-          target_key << id << "_target";
+        while (count != 0)
+          {
+            auto id = _indices.back();
+            std::stringstream data_key;
+            std::stringstream target_key;
+            data_key << id << "_data";
+            target_key << id << "_target";
 
-          std::string targets;
-          std::string datas;
-          _dbData->Get(data_key.str(), datas);
-          _dbData->Get(target_key.str(), targets);
-          std::stringstream datastream(datas);
-          std::stringstream targetstream(targets);
-          std::vector<Tensor> d;
-          std::vector<Tensor> t;
-          torch::load(d, datastream);
-          torch::load(t, targetstream);
+            std::string targets;
+            std::string datas;
+            _dbData->Get(data_key.str(), datas);
+            _dbData->Get(target_key.str(), targets);
+            std::stringstream datastream(datas);
+            std::stringstream targetstream(targets);
+            std::vector<Tensor> d;
+            std::vector<Tensor> t;
+            torch::load(d, datastream);
+            torch::load(t, targetstream);
 
-          for (unsigned int i = 0; i < d.size(); ++i)
-            {
-              while (i >= data.size())
-                data.emplace_back();
-              data[i].push_back(d.at(i));
-            }
-          for (unsigned int i = 0; i < t.size(); ++i)
-            {
-              while (i >= target.size())
-                target.emplace_back();
-              target[i].push_back(t.at(i));
-            }
+            for (unsigned int i = 0; i < d.size(); ++i)
+              {
+                while (i >= data.size())
+                  data.emplace_back();
+                data[i].push_back(d.at(i));
+              }
+            for (unsigned int i = 0; i < t.size(); ++i)
+              {
+                while (i >= target.size())
+                  target.emplace_back();
+                target[i].push_back(t.at(i));
+              }
 
-          _indices.pop_back();
-          count--;
-        }
+            _indices.pop_back();
+            count--;
+          }
       }
 
     for (auto vec : data)
@@ -319,31 +327,31 @@ c10::optional<TorchBatch> TorchDataset::get_batch(BatchRequestType request)
     for (auto vec : target)
       target_tensors.push_back(torch::stack(vec));
 
-
     return TorchBatch{ data_tensors, target_tensors };
-}
+  }
 
-TorchBatch TorchDataset::get_cached() {
+  TorchBatch TorchDataset::get_cached()
+  {
     reset();
-    auto batch = get_batch({cache_size()});
+    auto batch = get_batch({ cache_size() });
     if (!batch)
-        throw InputConnectorInternalException("No data provided");
+      throw InputConnectorInternalException("No data provided");
     return batch.value();
-}
+  }
 
-TorchDataset TorchDataset::split(double start, double stop)
-{
+  TorchDataset TorchDataset::split(double start, double stop)
+  {
     auto datasize = _batches.size();
     auto start_it = _batches.begin() + static_cast<int64_t>(datasize * start);
-    auto stop_it = _batches.end() - static_cast<int64_t>(datasize * (1 - stop));
+    auto stop_it
+        = _batches.end() - static_cast<int64_t>(datasize * (1 - stop));
 
     TorchDataset new_dataset;
     new_dataset._batches.insert(new_dataset._batches.end(), start_it, stop_it);
     return new_dataset;
-}
+  }
 
-
-// ===== TxtTorchInputFileConn
+  // ===== TxtTorchInputFileConn
 
   void TxtTorchInputFileConn::parse_content(const std::string &content,
                                             const float &target,
@@ -355,45 +363,42 @@ TorchDataset TorchDataset::split(double start, double stop)
       push_to_db(test);
   }
 
-void TxtTorchInputFileConn::fillup_parameters(const APIData &ad_input)
-{
-  TxtInputFileConn::fillup_parameters(ad_input);
-  if (ad_input.has("db"))
-	_db = ad_input.get("db").get<bool>();
+  void TxtTorchInputFileConn::fillup_parameters(const APIData &ad_input)
+  {
+    TxtInputFileConn::fillup_parameters(ad_input);
+    if (ad_input.has("db"))
+      _db = ad_input.get("db").get<bool>();
+  }
 
-}
+  void TxtTorchInputFileConn::push_to_db(bool test)
+  {
+    if (!test)
+      {
+        _logger->info("pushing to train_db");
+        fill_dataset(_dataset, _txt);
+        destroy_txt_entries(_txt);
+      }
+    else
+      {
+        _logger->info("pushing to test_db");
+        fill_dataset(_test_dataset, _test_txt);
+        destroy_txt_entries(_test_txt);
+      }
+  }
 
-
-void TxtTorchInputFileConn::push_to_db(bool test)
-{
-  if (!test)
-    {
-      _logger->info("pushing to train_db");
-      fill_dataset(_dataset, _txt);
-      destroy_txt_entries(_txt);
-    }
-  else
-    {
-      _logger->info("pushing to test_db");
-      fill_dataset(_test_dataset, _test_txt);
-      destroy_txt_entries(_test_txt);
-    }
-}
-
-void TxtTorchInputFileConn::transform(const APIData &ad) {
+  void TxtTorchInputFileConn::transform(const APIData &ad)
+  {
     // if (_finetuning)
     // XXX: Generating vocab from scratch is not currently
 
-  if (!_ordered_words || _characters)
-    throw InputConnectorBadParamException("Need ordered_words = true with backend torch");
+    if (!_ordered_words || _characters)
+      throw InputConnectorBadParamException(
+          "Need ordered_words = true with backend torch");
 
+    _generate_vocab = false;
 
-
-  _generate_vocab = false;
-
-  if (!_characters && (!_train || _ordered_words) && _vocab.empty())
-	deserialize_vocab();
-
+    if (!_characters && (!_train || _ordered_words) && _vocab.empty())
+      deserialize_vocab();
 
     // XXX: move in txtinputconn?
     make_inv_vocab();
@@ -410,7 +415,6 @@ void TxtTorchInputFileConn::transform(const APIData &ad) {
         _eot_pos = _vocab.at("<|endoftext|>")._pos;
       }
 
-
     if (ad.has("parameters") && ad.getobj("parameters").has("input"))
       {
         APIData ad_input = ad.getobj("parameters").getobj("input");
@@ -418,34 +422,32 @@ void TxtTorchInputFileConn::transform(const APIData &ad) {
       }
 
     try
-    {
+      {
 
-      if (_db)
-        {
-          if (TorchInputInterface::has_to_create_db(ad,_test_split))
-            {
-              double save_ts = _test_split;
-              _test_split = 0.0;
-              TxtInputFileConn::transform(ad);
-              _test_split = save_ts;
-              _dataset.finalize_db();
-              bool has_test_data = _test_dataset._dbData != nullptr;
-              _test_dataset.finalize_db();
-              if (_test_split != 0.0 && !has_test_data)
-                build_test_datadb_from_full_datadb(_test_split);
-            }
+        if (_db)
+          {
+            if (TorchInputInterface::has_to_create_db(ad, _test_split))
+              {
+                double save_ts = _test_split;
+                _test_split = 0.0;
+                TxtInputFileConn::transform(ad);
+                _test_split = save_ts;
+                _dataset.finalize_db();
+                bool has_test_data = _test_dataset._dbData != nullptr;
+                _test_dataset.finalize_db();
+                if (_test_split != 0.0 && !has_test_data)
+                  build_test_datadb_from_full_datadb(_test_split);
+              }
           }
-      else
-        {
-          TxtInputFileConn::transform(ad);
-        }
-
-    }
-    catch(const std::exception& e)
-    {
+        else
+          {
+            TxtInputFileConn::transform(ad);
+          }
+      }
+    catch (const std::exception &e)
+      {
         throw;
-    }
-
+      }
 
     if (!_db)
       {
@@ -457,10 +459,11 @@ void TxtTorchInputFileConn::transform(const APIData &ad) {
             destroy_txt_entries(_test_txt);
           }
       }
-}
+  }
 
-TorchBatch TxtTorchInputFileConn::generate_masked_lm_batch(const TorchBatch &example)
-{
+  TorchBatch
+  TxtTorchInputFileConn::generate_masked_lm_batch(const TorchBatch &example)
+  {
     std::uniform_real_distribution<double> uniform(0, 1);
     std::uniform_int_distribution<int64_t> vocab_distrib(0, vocab_size() - 1);
     Tensor input_ids = example.data.at(0).clone();
@@ -469,102 +472,104 @@ TorchBatch TxtTorchInputFileConn::generate_masked_lm_batch(const TorchBatch &exa
     Tensor lm_labels = torch::ones_like(input_ids, TensorOptions(kLong)) * -1;
 
     // mask random tokens
-    auto input_acc = input_ids.accessor<int64_t,2>();
-    auto att_mask_acc = example.data.at(2).accessor<int64_t,2>();
-    auto labels_acc = lm_labels.accessor<int64_t,2>();
+    auto input_acc = input_ids.accessor<int64_t, 2>();
+    auto att_mask_acc = example.data.at(2).accessor<int64_t, 2>();
+    auto labels_acc = lm_labels.accessor<int64_t, 2>();
     for (int i = 0; i < input_ids.size(0); ++i)
-    {
+      {
         int j = 1; // skip [CLS] token
         while (j < input_ids.size(1) && att_mask_acc[i][j] != 0)
-        {
+          {
             double rand_num = uniform(_rng);
-            if (rand_num < _lm_params._change_prob && input_acc[i][j] != _sep_pos)
-            {
+            if (rand_num < _lm_params._change_prob
+                && input_acc[i][j] != _sep_pos)
+              {
                 labels_acc[i][j] = input_acc[i][j];
 
                 rand_num = uniform(_rng);
                 if (rand_num < _lm_params._mask_prob)
-                {
+                  {
                     input_acc[i][j] = mask_id();
-                }
-                else if (rand_num < _lm_params._mask_prob + _lm_params._rand_prob)
-                {
+                  }
+                else if (rand_num
+                         < _lm_params._mask_prob + _lm_params._rand_prob)
+                  {
                     input_acc[i][j] = vocab_distrib(_rng);
-                }
-            }
+                  }
+              }
             ++j;
-        }
-    }
+          }
+      }
 
     TorchBatch output;
     output.target.push_back(lm_labels);
     output.data.push_back(input_ids);
     for (unsigned int i = 1; i < example.data.size(); ++i)
-    {
+      {
         output.data.push_back(example.data[i]);
-    }
+      }
     return output;
-}
+  }
 
-void TxtTorchInputFileConn::fill_dataset(TorchDataset &dataset,
-                                         const std::vector<TxtEntry<double>*> &entries)
-{
+  void TxtTorchInputFileConn::fill_dataset(
+      TorchDataset &dataset, const std::vector<TxtEntry<double> *> &entries)
+  {
 
-  _ndbed = 0;
+    _ndbed = 0;
     for (auto *te : entries)
-    {
+      {
         TxtOrderedWordsEntry *tow = static_cast<TxtOrderedWordsEntry *>(te);
         tow->reset();
         std::string word;
         double val;
         std::vector<int64_t> ids;
 
-        while(tow->has_elt())
-        {
+        while (tow->has_elt())
+          {
             if (ids.size() >= _width)
-                break;
+              break;
 
             tow->get_next_elt(word, val);
-            std::unordered_map<std::string,Word>::iterator it;
+            std::unordered_map<std::string, Word>::iterator it;
 
             if ((it = _vocab.find(word)) != _vocab.end())
-            {
+              {
                 ids.push_back(it->second._pos);
-            }
+              }
             else if (_input_format == "bert")
-            {
+              {
                 ids.push_back(_unk_pos);
-            }
-        }
+              }
+          }
 
         // Extract last token (needed by gpt2)
         int64_t last_token = 0;
         if (tow->has_elt())
-        {
+          {
             tow->get_next_elt(word, val);
-            std::unordered_map<std::string,Word>::iterator it;
+            std::unordered_map<std::string, Word>::iterator it;
 
             if ((it = _vocab.find(word)) != _vocab.end())
-                last_token = it->second._pos;
-        }
+              last_token = it->second._pos;
+          }
 
         // Post-processing for each model
         if (_input_format == "bert")
-        {
+          {
             // make room for cls and sep token
             while (ids.size() > _width - 2)
-                ids.pop_back();
+              ids.pop_back();
 
             ids.insert(ids.begin(), _cls_pos);
             ids.push_back(_sep_pos);
-        }
+          }
         else if (_input_format == "gpt2")
-        {
+          {
             if (ids.size() < _width)
-            {
+              {
                 ids.push_back(_eot_pos);
-            }
-        }
+              }
+          }
 
         at::Tensor ids_tensor = toLongTensor(ids);
         at::Tensor mask_tensor = torch::ones_like(ids_tensor);
@@ -573,169 +578,190 @@ void TxtTorchInputFileConn::fill_dataset(TorchDataset &dataset,
         int64_t seq_len = ids_tensor.sizes().back();
         int64_t padding_size = _width - seq_len;
         _lengths.push_back(seq_len);
-        ids_tensor = torch::constant_pad_nd(
-            ids_tensor, at::IntList{0, padding_size}, 0);
+        ids_tensor = torch::constant_pad_nd(ids_tensor,
+                                            at::IntList{ 0, padding_size }, 0);
         mask_tensor = torch::constant_pad_nd(
-            mask_tensor, at::IntList{0, padding_size}, 0);
+            mask_tensor, at::IntList{ 0, padding_size }, 0);
         token_type_ids_tensor = torch::constant_pad_nd(
-            token_type_ids_tensor, at::IntList{0, padding_size}, 0);
+            token_type_ids_tensor, at::IntList{ 0, padding_size }, 0);
         at::Tensor position_ids = torch::arange((int)_width, at::kLong);
 
         std::vector<Tensor> target_vec;
         int target_val = static_cast<int>(tow->_target);
 
         if (target_val != -1)
-        {
+          {
             Tensor target_tensor = torch::full(1, target_val, torch::kLong);
             target_vec.push_back(target_tensor);
-        }
+          }
 
         if (_input_format == "bert")
-            dataset.add_batch({ids_tensor, token_type_ids_tensor, mask_tensor}, std::move(target_vec));
+          dataset.add_batch({ ids_tensor, token_type_ids_tensor, mask_tensor },
+                            std::move(target_vec));
         else if (_input_format == "gpt2")
-        {
-            std::vector<Tensor> out_vec { ids_tensor.slice(0, 1) };
+          {
+            std::vector<Tensor> out_vec{ ids_tensor.slice(0, 1) };
             out_vec.push_back(torch::full(1, last_token, torch::kLong));
             target_vec.insert(target_vec.begin(), torch::cat(out_vec, 0));
-            dataset.add_batch({ids_tensor, position_ids}, std::move(target_vec));
-        }
+            dataset.add_batch({ ids_tensor, position_ids },
+                              std::move(target_vec));
+          }
         _ndbed++;
-    }
-}
+      }
+  }
 
-void CSVTSTorchInputFileConn::set_datadim(bool is_test_data)
-{
-  if (_train && _ntargets != _label.size())
-	{
-	  _logger->warn("something went wrong in ntargets, computed  " + std::to_string(_ntargets) + " at service creation time, and " + std::to_string(_label.size()) + " at data processing time");
-	  throw InputConnectorBadParamException("something went wrong in ntargets, computed  " + std::to_string(_ntargets) + " at service creation time, and " + std::to_string(_label.size()) + " at data processing time");
-	}
+  void CSVTSTorchInputFileConn::set_datadim(bool is_test_data)
+  {
+    if (_train && _ntargets != _label.size())
+      {
+        _logger->warn(
+            "something went wrong in ntargets, computed  "
+            + std::to_string(_ntargets) + " at service creation time, and "
+            + std::to_string(_label.size()) + " at data processing time");
+        throw InputConnectorBadParamException(
+            "something went wrong in ntargets, computed  "
+            + std::to_string(_ntargets) + " at service creation time, and "
+            + std::to_string(_label.size()) + " at data processing time");
+      }
 
-	if (_datadim != -1)
-		return;
-	if (is_test_data)
-		_datadim = _csvtsdata_test[0][0]._v.size();
-	else
-		_datadim = _csvtsdata[0][0]._v.size();
+    if (_datadim != -1)
+      return;
+    if (is_test_data)
+      _datadim = _csvtsdata_test[0][0]._v.size();
+    else
+      _datadim = _csvtsdata[0][0]._v.size();
+  }
 
-}
+  void CSVTSTorchInputFileConn::transform(const APIData &ad)
+  {
+    APIData ad_input = ad.getobj("parameters").getobj("input");
 
-void CSVTSTorchInputFileConn::transform(const APIData &ad)
-{
-	APIData ad_input = ad.getobj("parameters").getobj("input");
+    init(ad_input);
+    get_data(ad);
 
-	init(ad_input);
-	get_data(ad);
+    try
+      {
+        CSVTSInputFileConn::transform(ad);
+        set_datadim();
+      }
+    catch (std::exception &e)
+      {
+        throw;
+      }
 
-	try
-		{
-			CSVTSInputFileConn::transform(ad);
-			set_datadim();
-		}
-	catch (std::exception &e)
-		{
-			throw;
-		}
+    if (_train)
+      {
+        fill_dataset(_dataset, false);
+        _csvtsdata.clear();
+        fill_dataset(_test_dataset, true);
+        _csvtsdata_test.clear();
+      }
+    else
+      {
+        // in test mode, prevent connector to split serie in training chunks
+        _timesteps = _csvtsdata[0].size();
+        fill_dataset(_dataset, false);
+        _csvtsdata.clear();
+        _csvtsdata_test.clear();
+      }
+  }
 
-	if (_train)
-		{
-			fill_dataset(_dataset,false);
-			_csvtsdata.clear();
-			fill_dataset(_test_dataset,true);
-			_csvtsdata_test.clear();
-		}
-	else
-		{
-          // in test mode, prevent connector to split serie in training chunks
-          _timesteps = _csvtsdata[0].size();
-		  fill_dataset(_dataset, false);
-          _csvtsdata.clear();
-          _csvtsdata_test.clear();
-		}
-}
+  void CSVTSTorchInputFileConn::fill_dataset(TorchDataset &dataset,
+                                             bool use_csvtsdata_test)
+  {
+    _ids.clear();
+    // we have _csvtsdata and csvtsdata_test to put into TorchDataset _dataset
+    // , _test_dataset
+    std::vector<std::vector<CSVline>> *data;
+    if (use_csvtsdata_test)
+      data = &this->_csvtsdata_test;
+    else
+      data = &this->_csvtsdata;
 
-void CSVTSTorchInputFileConn::fill_dataset(TorchDataset& dataset, bool use_csvtsdata_test)
-{
-  _ids.clear();
-	// we have _csvtsdata and csvtsdata_test to put into TorchDataset _dataset , _test_dataset
-	std::vector<std::vector<CSVline>> * data;
-	if (use_csvtsdata_test)
-	  data = &this->_csvtsdata_test;
-	else
-	  data = &this->_csvtsdata;
+    unsigned int label_size = _label_pos.size();
+    unsigned int data_size = _datadim - label_size;
+    int vecindex = -1;
 
-	unsigned int label_size = _label_pos.size();
-	unsigned int data_size = _datadim - label_size;
-	int vecindex = -1;
+    for (std::vector<CSVline> &seq : *data)
+      {
+        vecindex++;
+        std::div_t dv{};
+        dv = std::div(seq.size() - _timesteps, _offset);
+        for (int i = 0; i <= dv.quot; ++i)
+          // construct timeseries here	, using timesteps and offset from data
+          // pointer above
+          {
+            std::vector<at::Tensor> data_sequence;
+            std::vector<at::Tensor> label_sequence;
+            int tstart = i * _offset;
+            _ids.push_back(_fnames[vecindex] + " #" + std::to_string(tstart)
+                           + "_" + std::to_string(tstart + _timesteps - 1));
+            for (int ti = tstart; ti < tstart + _timesteps; ++ti)
+              {
+                std::vector<double> datavec;
+                std::vector<double> labelvec;
 
-	for (std::vector<CSVline>& seq : *data)
-	  {
-		vecindex++;
-		std::div_t dv{};
-		dv = std::div(seq.size()-_timesteps, _offset);
-		for (int i=0; i<= dv.quot; ++i)
-		  // construct timeseries here	, using timesteps and offset from data pointer above
-		  {
-			std::vector<at::Tensor> data_sequence;
-			std::vector<at::Tensor> label_sequence;
-			int tstart = i*_offset;
-			_ids.push_back(_fnames[vecindex] +" #" +std::to_string(tstart)
-						   + "_"+std::to_string(tstart+_timesteps-1));
-			for (int ti=tstart; ti<tstart+_timesteps; ++ti)
-			  {
-				std::vector<double> datavec;
-				std::vector<double> labelvec;
+                for (unsigned int li = 0; li < label_size; ++li)
+                  labelvec.push_back(seq[ti]._v[_label_pos[li]]);
+                for (int di = 0; di < this->_datadim - 1; ++di)
+                  if (std::find(_label_pos.begin(), _label_pos.end(), di)
+                      == _label_pos.end())
+                    datavec.push_back(seq[ti]._v[di]);
 
-				for (unsigned int li =0; li < label_size; ++li)
-				  labelvec.push_back(seq[ti]._v[_label_pos[li]]);
-				for (int di = 0; di<this->_datadim-1; ++di)
-				  if (std::find(_label_pos.begin(),_label_pos.end(), di) == _label_pos.end())
-					datavec.push_back(seq[ti]._v[di]);
+                at::Tensor data
+                    = torch::from_blob(&datavec[0], at::IntList{ data_size },
+                                       torch::kFloat64)
+                          .clone()
+                          .to(torch::kFloat32);
+                at::Tensor label
+                    = torch::from_blob(&labelvec[0], at::IntList{ label_size },
+                                       torch::kFloat64)
+                          .clone()
+                          .to(torch::kFloat32);
+                data_sequence.push_back(data);
+                label_sequence.push_back(label);
+              }
+            at::Tensor dst = torch::stack(data_sequence);
+            at::Tensor lst = torch::stack(label_sequence);
+            dataset.add_batch({ dst }, { lst });
+          }
+        if (dv.rem != 0)
+          {
+            std::vector<at::Tensor> data_sequence;
+            std::vector<at::Tensor> label_sequence;
 
-				at::Tensor data = torch::from_blob(&datavec[0],
-												   at::IntList{data_size},
-												   torch::kFloat64).clone().to(torch::kFloat32);
-				at::Tensor label = torch::from_blob(&labelvec[0],
-													at::IntList{label_size},
-													torch::kFloat64).clone().to(torch::kFloat32);
-				data_sequence.push_back(data);
-				label_sequence.push_back(label);
-			  }
-			at::Tensor dst = torch::stack(data_sequence);
-			at::Tensor lst = torch::stack(label_sequence);
-			dataset.add_batch({dst}, {lst});
-		  }
-		if (dv.rem != 0)
-		  {
-			std::vector<at::Tensor> data_sequence;
-			std::vector<at::Tensor> label_sequence;
+            int tstart = seq.size() - _timesteps;
+            _ids.push_back(_fnames[vecindex] + " #" + std::to_string(tstart)
+                           + "_" + std::to_string(tstart + _timesteps - 1));
+            for (int ti = tstart; ti < tstart + _timesteps; ++ti)
+              {
+                std::vector<double> datavec;
+                std::vector<double> labelvec;
+                for (unsigned int li = 0; li < label_size; ++li)
+                  labelvec.push_back(seq[ti]._v[_label_pos[li]]);
+                for (int di = 0; di < this->_datadim - 1; ++di)
+                  if (std::find(_label_pos.begin(), _label_pos.end(), di)
+                      == _label_pos.end())
+                    datavec.push_back(seq[ti]._v[di]);
 
-			int tstart  = seq.size()-_timesteps;
-			_ids.push_back(_fnames[vecindex] +" #" +std::to_string(tstart)
-						   + "_"+std::to_string(tstart+_timesteps-1));
-			for (int ti=tstart; ti<tstart+_timesteps; ++ti)
-			  {
-				std::vector<double> datavec;
-				std::vector<double> labelvec;
-				for (unsigned int li =0; li < label_size; ++li)
-				  labelvec.push_back(seq[ti]._v[_label_pos[li]]);
-				for (int di = 0; di<this->_datadim-1; ++di)
-				  if (std::find(_label_pos.begin(),_label_pos.end(), di) == _label_pos.end())
-					datavec.push_back(seq[ti]._v[di]);
-
-				at::Tensor data = torch::from_blob(&datavec[0],
-												   at::IntList{data_size},
-												   torch::kFloat64).clone().to(torch::kFloat32);
-				at::Tensor label = torch::from_blob(&labelvec[0],
-													at::IntList{label_size},
-													torch::kFloat64).clone().to(torch::kFloat32);
-				data_sequence.push_back(data);
-				label_sequence.push_back(label);
-			  }
-			dataset.add_batch({torch::stack(data_sequence)}, {torch::stack(label_sequence)});
-		  }
-	  }
-	dataset.reset();
-}
+                at::Tensor data
+                    = torch::from_blob(&datavec[0], at::IntList{ data_size },
+                                       torch::kFloat64)
+                          .clone()
+                          .to(torch::kFloat32);
+                at::Tensor label
+                    = torch::from_blob(&labelvec[0], at::IntList{ label_size },
+                                       torch::kFloat64)
+                          .clone()
+                          .to(torch::kFloat32);
+                data_sequence.push_back(data);
+                label_sequence.push_back(label);
+              }
+            dataset.add_batch({ torch::stack(data_sequence) },
+                              { torch::stack(label_sequence) });
+          }
+      }
+    dataset.reset();
+  }
 
 }

--- a/src/backends/torch/torchinputconns.h
+++ b/src/backends/torch/torchinputconns.h
@@ -27,7 +27,6 @@
 
 #include <torch/torch.h>
 
-
 #include "imginputfileconn.h"
 #include "txtinputfileconn.h"
 #include "backends/torch/db.hpp"
@@ -40,414 +39,474 @@
 namespace dd
 {
 
-    typedef torch::data::Example<std::vector<at::Tensor>, std::vector<at::Tensor>> TorchBatch;
+  typedef torch::data::Example<std::vector<at::Tensor>,
+                               std::vector<at::Tensor>>
+      TorchBatch;
 
-    class TorchDataset : public torch::data::BatchDataset
-        <TorchDataset, c10::optional<TorchBatch>>
+  class TorchDataset
+      : public torch::data::BatchDataset<TorchDataset,
+                                         c10::optional<TorchBatch>>
+  {
+  private:
+    bool _shuffle = false;
+    long _seed = -1;
+    int64_t _current_index = 0;
+    std::string _backend;
+    bool _db;
+    int32_t _batches_per_transaction = 10;
+    std::shared_ptr<db::Transaction> _txn;
+    std::shared_ptr<spdlog::logger> _logger;
+
+  public:
+    std::shared_ptr<db::DB> _dbData;
+    std::vector<int64_t> _indices;
+    /// Vector containing the whole dataset (the "cached data").
+    std::vector<TorchBatch> _batches;
+    std::string _dbFullName;
+
+    TorchDataset()
     {
-    private:
-        bool _shuffle = false;
-        long _seed = -1;
-        int64_t _current_index = 0;
-        std::string _backend;
-        bool _db;
-        int32_t _batches_per_transaction = 10;
-      std::shared_ptr<db::Transaction> _txn;
-      std::shared_ptr<spdlog::logger> _logger;
+    }
 
-
-    public:
-      std::shared_ptr<db::DB> _dbData;
-        std::vector<int64_t> _indices;
-        /// Vector containing the whole dataset (the "cached data").
-        std::vector<TorchBatch> _batches;
-        std::string _dbFullName;
-
-        TorchDataset() {}
-
-
-
-      TorchDataset(const TorchDataset &d)
-        : _shuffle(d._shuffle), _seed(d._seed), _current_index(d._current_index),
-		  _backend(d._backend), _db(d._db),
-		  _batches_per_transaction(d._batches_per_transaction),
-		  _txn(d._txn), _logger(d._logger),
-		  _dbData(d._dbData), _indices(d._indices), _batches(d._batches),
-		  _dbFullName(d._dbFullName)   {}
-
-        void set_transation_size(int32_t tsize) {_batches_per_transaction = tsize;}
-
-        void add_batch(std::vector<at::Tensor> data, std::vector<at::Tensor> target = {});
-        void finalize_db();
-        void pop(int64_t index, std::string&data, std::string&target);
-        void add_elt(int64_t index, std::string data, std::string target);
-
-        void write_tensors_to_db(std::vector<at::Tensor> data, std::vector<at::Tensor> target);
-
-        void reset(bool shuffle = true, db::Mode dbmode = db::READ);
-
-        void set_shuffle(bool shuf) {_shuffle = shuf;}
-
-        void set_dbParams(bool db, std::string backend, std::string dbname)
-        {
-          _db = db;
-          _backend = backend;
-          _dbFullName = dbname + "." + _backend;
-        }
-
-        void set_dbFile(std::string dbfname)
-        {
-          _db = true;
-          _backend = "lmdb";
-          _dbFullName = dbfname;
-        }
-
-
-      void set_logger(std::shared_ptr<spdlog::logger> logger)
-      {
-        _logger = logger;
-      }
-
-        /// Size of data loaded in memory
-        size_t cache_size() const { return _batches.size(); }
-
-        c10::optional<size_t> size() const override {
-            return cache_size();
-        }
-
-        bool empty() const
-        {
-          return (!_db && cache_size() == 0) || (_db && _dbFullName.empty());
-        }
-
-        c10::optional<TorchBatch> get_batch(BatchRequestType request) override;
-
-        /// Returns a batch containing all the cached data
-        TorchBatch get_cached();
-
-        /// Split a percentage of this dataset
-        TorchDataset split(double start, double stop);
-
-    };
-
-
-    struct MaskedLMParams
+    TorchDataset(const TorchDataset &d)
+        : _shuffle(d._shuffle), _seed(d._seed),
+          _current_index(d._current_index), _backend(d._backend), _db(d._db),
+          _batches_per_transaction(d._batches_per_transaction), _txn(d._txn),
+          _logger(d._logger), _dbData(d._dbData), _indices(d._indices),
+          _batches(d._batches), _dbFullName(d._dbFullName)
     {
-        double _change_prob = 0.15; /**< When masked LM learning, probability of changing a token (mask/randomize/keep). */
-        double _mask_prob =  0.8; /**< When masked LM learning, probability of masking a token. */
-        double _rand_prob = 0.1; /**< When masked LM learning, probability of randomizing a token. */
-    };
+    }
 
-
-    class TorchInputInterface
+    void set_transation_size(int32_t tsize)
     {
-    public:
-        TorchInputInterface()  {}
-        TorchInputInterface(const TorchInputInterface &i)
-             : _finetuning(i._finetuning),
-             _lm_params(i._lm_params),
-               _dataset(i._dataset),
-               _test_dataset(i._test_dataset),
-               _input_format(i._input_format),
-		  _ntargets(i._ntargets),
-          _tilogger(i._tilogger), _db(i._db)  {}
+      _batches_per_transaction = tsize;
+    }
 
-        ~TorchInputInterface() {}
+    void add_batch(std::vector<at::Tensor> data,
+                   std::vector<at::Tensor> target = {});
+    void finalize_db();
+    void pop(int64_t index, std::string &data, std::string &target);
+    void add_elt(int64_t index, std::string data, std::string target);
 
-      void init(const APIData &ad, std::string model_repo, std::shared_ptr<spdlog::logger> logger)
-        {
-          if (ad.has("db") && ad.get("db").get<bool>())
-			_db = true;
-          if (ad.has("shuffle"))
-            _dataset.set_shuffle(ad.get("shuffle").get<bool>());
-          _dataset.set_dbParams(_db, _backend, model_repo + "/train");
-          _dataset.set_logger(logger);
-          _tilogger = logger;
-          _test_dataset.set_dbParams(_db, _backend, model_repo + "/test");
-          _test_dataset.set_logger(logger);
-        }
+    void write_tensors_to_db(std::vector<at::Tensor> data,
+                             std::vector<at::Tensor> target);
 
-      void build_test_datadb_from_full_datadb(double tsplit);
+    void reset(bool shuffle = true, db::Mode dbmode = db::READ);
 
-      bool has_to_create_db(const APIData&ad, double tsplit);
-
-        torch::Tensor toLongTensor(std::vector<int64_t> &values) {
-            int64_t val_size = values.size();
-            return torch::from_blob(&values[0], at::IntList{val_size}, at::kLong).clone();
-        }
-
-        TorchBatch generate_masked_lm_batch(const TorchBatch &example) { return {}; }
-
-        void set_transation_size(int32_t tsize)
-        {
-          _dataset.set_transation_size(tsize);
-          _test_dataset.set_transation_size(tsize);
-        }
-
-        int64_t mask_id() const { return 0; }
-        int64_t vocab_size() const { return 0; }
-        std::string get_word(int64_t id) const { return ""; }
-
-
-
-        bool _finetuning;
-        MaskedLMParams _lm_params;
-        /** Tell which inputs should be provided to the models.
-         * see*/
-        TorchDataset _dataset;
-        TorchDataset _test_dataset;
-        std::string _input_format;
-
-		unsigned int _ntargets = 0;
-
-        std::vector<int64_t> _lengths;/**< length of each sentence with txt connector. */
-        std::shared_ptr<spdlog::logger> _tilogger;
-
-        bool _db = false;
-        std::string _dbname = "train";
-        std::string _db_fname;
-        std::string _test_db_name = "test";
-        std::string _backend = "lmdb";
-    };
-
-    class ImgTorchInputFileConn : public ImgInputFileConn, public TorchInputInterface
+    void set_shuffle(bool shuf)
     {
-    public:
-        ImgTorchInputFileConn()
-            :ImgInputFileConn()
-        {
-          set_transation_size(TORCH_IMG_TRANSACTION_SIZE);
-        }
-        ImgTorchInputFileConn(const ImgTorchInputFileConn &i)
-          :ImgInputFileConn(i),TorchInputInterface(i) {set_transation_size(10);}
-        ~ImgTorchInputFileConn() {}
+      _shuffle = shuf;
+    }
 
-        // for API info only
-        int width() const
+    void set_dbParams(bool db, std::string backend, std::string dbname)
+    {
+      _db = db;
+      _backend = backend;
+      _dbFullName = dbname + "." + _backend;
+    }
+
+    void set_dbFile(std::string dbfname)
+    {
+      _db = true;
+      _backend = "lmdb";
+      _dbFullName = dbfname;
+    }
+
+    void set_logger(std::shared_ptr<spdlog::logger> logger)
+    {
+      _logger = logger;
+    }
+
+    /// Size of data loaded in memory
+    size_t cache_size() const
+    {
+      return _batches.size();
+    }
+
+    c10::optional<size_t> size() const override
+    {
+      return cache_size();
+    }
+
+    bool empty() const
+    {
+      return (!_db && cache_size() == 0) || (_db && _dbFullName.empty());
+    }
+
+    c10::optional<TorchBatch> get_batch(BatchRequestType request) override;
+
+    /// Returns a batch containing all the cached data
+    TorchBatch get_cached();
+
+    /// Split a percentage of this dataset
+    TorchDataset split(double start, double stop);
+  };
+
+  struct MaskedLMParams
+  {
+    double _change_prob = 0.15; /**< When masked LM learning, probability of
+                                   changing a token (mask/randomize/keep). */
+    double _mask_prob
+        = 0.8; /**< When masked LM learning, probability of masking a token. */
+    double _rand_prob = 0.1; /**< When masked LM learning, probability of
+                                randomizing a token. */
+  };
+
+  class TorchInputInterface
+  {
+  public:
+    TorchInputInterface()
+    {
+    }
+    TorchInputInterface(const TorchInputInterface &i)
+        : _finetuning(i._finetuning), _lm_params(i._lm_params),
+          _dataset(i._dataset), _test_dataset(i._test_dataset),
+          _input_format(i._input_format), _ntargets(i._ntargets),
+          _tilogger(i._tilogger), _db(i._db)
+    {
+    }
+
+    ~TorchInputInterface()
+    {
+    }
+
+    void init(const APIData &ad, std::string model_repo,
+              std::shared_ptr<spdlog::logger> logger)
+    {
+      if (ad.has("db") && ad.get("db").get<bool>())
+        _db = true;
+      if (ad.has("shuffle"))
+        _dataset.set_shuffle(ad.get("shuffle").get<bool>());
+      _dataset.set_dbParams(_db, _backend, model_repo + "/train");
+      _dataset.set_logger(logger);
+      _tilogger = logger;
+      _test_dataset.set_dbParams(_db, _backend, model_repo + "/test");
+      _test_dataset.set_logger(logger);
+    }
+
+    void build_test_datadb_from_full_datadb(double tsplit);
+
+    bool has_to_create_db(const APIData &ad, double tsplit);
+
+    torch::Tensor toLongTensor(std::vector<int64_t> &values)
+    {
+      int64_t val_size = values.size();
+      return torch::from_blob(&values[0], at::IntList{ val_size }, at::kLong)
+          .clone();
+    }
+
+    TorchBatch generate_masked_lm_batch(const TorchBatch &example)
+    {
+      return {};
+    }
+
+    void set_transation_size(int32_t tsize)
+    {
+      _dataset.set_transation_size(tsize);
+      _test_dataset.set_transation_size(tsize);
+    }
+
+    int64_t mask_id() const
+    {
+      return 0;
+    }
+    int64_t vocab_size() const
+    {
+      return 0;
+    }
+    std::string get_word(int64_t id) const
+    {
+      return "";
+    }
+
+    bool _finetuning;
+    MaskedLMParams _lm_params;
+    /** Tell which inputs should be provided to the models.
+     * see*/
+    TorchDataset _dataset;
+    TorchDataset _test_dataset;
+    std::string _input_format;
+
+    unsigned int _ntargets = 0;
+
+    std::vector<int64_t>
+        _lengths; /**< length of each sentence with txt connector. */
+    std::shared_ptr<spdlog::logger> _tilogger;
+
+    bool _db = false;
+    std::string _dbname = "train";
+    std::string _db_fname;
+    std::string _test_db_name = "test";
+    std::string _backend = "lmdb";
+  };
+
+  class ImgTorchInputFileConn : public ImgInputFileConn,
+                                public TorchInputInterface
+  {
+  public:
+    ImgTorchInputFileConn() : ImgInputFileConn()
+    {
+      set_transation_size(TORCH_IMG_TRANSACTION_SIZE);
+    }
+    ImgTorchInputFileConn(const ImgTorchInputFileConn &i)
+        : ImgInputFileConn(i), TorchInputInterface(i)
+    {
+      set_transation_size(10);
+    }
+    ~ImgTorchInputFileConn()
+    {
+    }
+
+    // for API info only
+    int width() const
+    {
+      return _width;
+    }
+
+    // for API info only
+    int height() const
+    {
+      return _height;
+    }
+
+    void init(const APIData &ad)
+    {
+      TorchInputInterface::init(ad, _model_repo, _logger);
+      ImgInputFileConn::init(ad);
+    }
+
+    void transform(const APIData &ad)
+    {
+      try
         {
-            return _width;
+          ImgInputFileConn::transform(ad);
+        }
+      catch (const std::exception &e)
+        {
+          throw;
         }
 
-        // for API info only
-        int height() const
-        {
-            return _height;
-        }
+      std::vector<at::Tensor> tensors;
+      std::vector<int64_t> sizes{ _height, _width, 3 };
+      at::TensorOptions options(at::ScalarType::Byte);
 
-        void init(const APIData &ad)
+      for (const cv::Mat &bgr : this->_images)
         {
-          TorchInputInterface::init(ad, _model_repo, _logger);
-            ImgInputFileConn::init(ad);
+          at::Tensor imgt
+              = torch::from_blob(bgr.data, at::IntList(sizes), options);
+          imgt = imgt.toType(at::kFloat).permute({ 2, 0, 1 });
+          size_t nchannels = imgt.size(0);
+          if (_scale != 1.0)
+            imgt = imgt.mul(_scale);
+          if (!_mean.empty() && _mean.size() != nchannels)
+            throw InputConnectorBadParamException(
+                "mean vector be of size the number of channels ("
+                + std::to_string(nchannels) + ")");
+          for (size_t m = 0; m < _mean.size(); m++)
+            imgt[0][m] = imgt[0][m].sub_(_mean.at(m));
+          if (!_std.empty() && _std.size() != nchannels)
+            throw InputConnectorBadParamException(
+                "std vector be of size the number of channels ("
+                + std::to_string(nchannels) + ")");
+          for (size_t s = 0; s < _std.size(); s++)
+            imgt[0][s] = imgt[0][s].div_(_std.at(s));
+          tensors.push_back(imgt);
+          _dataset.add_batch({ imgt });
         }
+    }
 
-        void transform(const APIData &ad)
+  public:
+    at::Tensor _in;
+  };
+
+  class TxtTorchInputFileConn : public TxtInputFileConn,
+                                public TorchInputInterface
+  {
+  public:
+    TxtTorchInputFileConn() : TxtInputFileConn()
+    {
+      _vocab_sep = '\t';
+      set_transation_size(100);
+    }
+    TxtTorchInputFileConn(const TxtTorchInputFileConn &i)
+        : TxtInputFileConn(i), TorchInputInterface(i), _width(i._width),
+          _height(i._height)
+    {
+      set_transation_size(TORCH_TEXT_TRANSATION_SIZE);
+    }
+    ~TxtTorchInputFileConn()
+    {
+    }
+
+    void init(const APIData &ad)
+    {
+      TxtInputFileConn::init(ad);
+      TorchInputInterface::init(ad, _model_repo, _logger);
+      fillup_parameters(ad);
+    }
+
+    void fillup_parameters(const APIData &ad_input);
+
+    // for API info only
+    int width() const
+    {
+      return _width;
+    }
+
+    // for API info only
+    int height() const
+    {
+      return _height;
+    }
+
+    int64_t mask_id() const
+    {
+      return _mask_id;
+    }
+
+    int64_t vocab_size() const
+    {
+      return _vocab.size();
+    }
+
+    std::string get_word(int64_t id) const
+    {
+      return _inv_vocab.at(id);
+    }
+
+    void transform(const APIData &ad);
+
+    TorchBatch generate_masked_lm_batch(const TorchBatch &example);
+
+    void fill_dataset(TorchDataset &dataset,
+                      const std::vector<TxtEntry<double> *> &entries);
+
+    virtual void parse_content(const std::string &content,
+                               const float &target = -1,
+                               const bool &test = false);
+
+    void push_to_db(bool test);
+
+  public:
+    /** width of the input tensor */
+    unsigned int _width = 512;
+    unsigned int _height = 0;
+    std::mt19937 _rng;
+    /// token id to vocabulary word
+    std::map<int, std::string> _inv_vocab;
+
+    int64_t _mask_id = -1; /**< ID of mask token in the vocabulary. */
+    int64_t _cls_pos = -1;
+    int64_t _sep_pos = -1;
+    int64_t _unk_pos = -1;
+    int64_t _eot_pos = -1; /**< end of text */
+
+    void make_inv_vocab()
+    {
+      _inv_vocab.clear();
+
+      for (auto &entry : _vocab)
         {
-            try
+          _inv_vocab[entry.second._pos] = entry.first;
+        }
+    }
+  };
+
+  class CSVTSTorchInputFileConn : public CSVTSInputFileConn,
+                                  public TorchInputInterface
+  {
+  public:
+    CSVTSTorchInputFileConn() : CSVTSInputFileConn()
+    {
+    }
+
+    CSVTSTorchInputFileConn(const CSVTSTorchInputFileConn &i)
+        : CSVTSInputFileConn(i), TorchInputInterface(i), _offset(i._offset),
+          _channels(i._channels), _timesteps(i._timesteps),
+          _datadim(i._datadim)
+    {
+    }
+    ~CSVTSTorchInputFileConn()
+    {
+    }
+
+    void transform(
+        const APIData &ad); // calls CSVTSInputfileconn::transform and db stuff
+    void set_datadim(bool is_test_data = false);
+
+    void fill_dataset(TorchDataset &dataset, bool use_csvtsdata_test);
+    void init(const APIData &ad)
+    {
+      TorchInputInterface::init(ad, _model_repo, _logger);
+      fillup_parameters(ad);
+    }
+
+    void fillup_parameters(const APIData &ad_input)
+    {
+      CSVTSInputFileConn::fillup_parameters(ad_input);
+      if (_ntargets == 0 && ad_input.has("label"))
+        {
+          try
             {
-                ImgInputFileConn::transform(ad);
+              _ntargets = ad_input.get("label")
+                              .get<std::vector<std::string>>()
+                              .size();
             }
-            catch(const std::exception& e)
+          catch (std::exception &e)
             {
-                throw;
-            }
-
-            std::vector<at::Tensor> tensors;
-            std::vector<int64_t> sizes{ _height, _width, 3 };
-            at::TensorOptions options(at::ScalarType::Byte);
-
-            for (const cv::Mat &bgr : this->_images) {
-              at::Tensor imgt = torch::from_blob(bgr.data, at::IntList(sizes), options);
-              imgt = imgt.toType(at::kFloat).permute({2, 0, 1});
-              size_t nchannels = imgt.size(0);
-              if (_scale != 1.0)
-                imgt = imgt.mul(_scale);
-              if (!_mean.empty() && _mean.size() != nchannels)
-                throw InputConnectorBadParamException("mean vector be of size the number of channels (" + std::to_string(nchannels) + ")");
-              for (size_t m=0;m<_mean.size();m++)
-                imgt[0][m] = imgt[0][m].sub_(_mean.at(m));
-              if (!_std.empty() && _std.size() != nchannels)
-                throw InputConnectorBadParamException("std vector be of size the number of channels (" + std::to_string(nchannels) + ")");
-              for (size_t s=0;s<_std.size();s++)
-                imgt[0][s] = imgt[0][s].div_(_std.at(s));
-              tensors.push_back(imgt);
-              _dataset.add_batch({imgt});
+              try
+                {
+                  std::string l = ad_input.get("label").get<std::string>();
+                  _ntargets = 1;
+                }
+              catch (std::exception &e)
+                {
+                  throw InputConnectorBadParamException(
+                      "no label given in input parameters, cannot determine "
+                      "output size");
+                }
             }
         }
+      _offset = _timesteps;
+      if (ad_input.has("timesteps"))
+        {
+          _timesteps = ad_input.get("timesteps").get<int>();
+          _offset = _timesteps;
+        }
+      if (ad_input.has("offset"))
+        _offset = ad_input.get("offset").get<int>();
+    }
 
-    public:
-        at::Tensor _in;
-    };
-
-
-    class TxtTorchInputFileConn : public TxtInputFileConn, public TorchInputInterface
+    int channels() const
     {
-    public:
-        TxtTorchInputFileConn()
-            : TxtInputFileConn() {
-            _vocab_sep = '\t';
-            set_transation_size(100);
-        }
-        TxtTorchInputFileConn(const TxtTorchInputFileConn &i)
-            : TxtInputFileConn(i), TorchInputInterface(i),
-        _width(i._width), _height(i._height)
-        {
-          set_transation_size(TORCH_TEXT_TRANSATION_SIZE);
-        }
-        ~TxtTorchInputFileConn() {}
+      return _timesteps;
+    }
 
-        void init(const APIData &ad)
-        {
-            TxtInputFileConn::init(ad);
-            TorchInputInterface::init(ad, _model_repo, _logger);
-            fillup_parameters(ad);
+    int height() const
+    {
+      return _datadim;
+    }
 
-        }
+    int width() const
+    {
+      return 1;
+    }
 
-        void fillup_parameters(const APIData &ad_input);
+    int batch_size() const
+    {
+      return 1;
+    }
 
-        // for API info only
-        int width() const
-        {
-            return _width;
-        }
+    int test_batch_size() const
+    {
+      return 1;
+    }
 
-        // for API info only
-        int height() const
-        {
-            return _height;
-        }
-
-        int64_t mask_id() const { return _mask_id; }
-
-        int64_t vocab_size() const { return _vocab.size(); }
-
-        std::string get_word(int64_t id) const {
-            return _inv_vocab.at(id);
-        }
-
-        void transform(const APIData &ad);
-
-        TorchBatch generate_masked_lm_batch(const TorchBatch &example);
-
-        void fill_dataset(TorchDataset &dataset, const std::vector<TxtEntry<double>*> &entries);
-
-        virtual void parse_content(const std::string &content,
-                                   const float &target=-1,
-                                   const bool &test=false);
-
-        void push_to_db(bool test);
-
-    public:
-        /** width of the input tensor */
-        unsigned int _width = 512;
-		unsigned int _height = 0;
-        std::mt19937 _rng;
-        /// token id to vocabulary word
-        std::map<int, std::string> _inv_vocab;
-
-        int64_t _mask_id = -1; /**< ID of mask token in the vocabulary. */
-        int64_t _cls_pos = -1;
-        int64_t _sep_pos = -1;
-        int64_t _unk_pos = -1;
-        int64_t _eot_pos = -1; /**< end of text */
-
-
-        void make_inv_vocab() {
-            _inv_vocab.clear();
-
-            for (auto &entry : _vocab)
-            {
-                _inv_vocab[entry.second._pos] = entry.first;
-            }
-        }
-    };
-
-
-	class CSVTSTorchInputFileConn : public CSVTSInputFileConn, public TorchInputInterface
-	{
-	public:
-
-		CSVTSTorchInputFileConn() :	CSVTSInputFileConn() {}
-
-		CSVTSTorchInputFileConn(const CSVTSTorchInputFileConn&i) :
-			CSVTSInputFileConn(i), TorchInputInterface(i), _offset(i._offset),
-			_channels(i._channels), _timesteps(i._timesteps), _datadim(i._datadim) {}
-		~CSVTSTorchInputFileConn() {}
-
-		void transform(const APIData &ad); // calls CSVTSInputfileconn::transform and db stuff
-		void set_datadim(bool is_test_data = false);
-
-	  void fill_dataset(TorchDataset &dataset, bool use_csvtsdata_test);
-		void init(const APIData &ad)
-		{
-		  TorchInputInterface::init(ad, _model_repo, _logger);
-		  fillup_parameters(ad);
-		}
-
-		void fillup_parameters(const APIData &ad_input)
-		{
-		  CSVTSInputFileConn::fillup_parameters(ad_input);
-		  if (_ntargets == 0 && ad_input.has("label"))
-			{
-			  try
-				{
-				  _ntargets = ad_input.get("label").get<std::vector<std::string>>().size();
-				}
-			  catch(std::exception &e)
-				{
-				  try
-					{
-					  std::string l = ad_input.get("label").get<std::string>();
-					  _ntargets = 1;
-					}
-				  catch(std::exception &e)
-					{
-					  throw InputConnectorBadParamException("no label given in input parameters, cannot determine output size");
-					}
-				}
-			}
-			_offset = _timesteps;
-			if (ad_input.has("timesteps"))
-				{
-					_timesteps= ad_input.get("timesteps").get<int>();
-					_offset = _timesteps;
-				}
-			if (ad_input.has("offset"))
-				_offset= ad_input.get("offset").get<int>();
-
-		}
-
-
-		int channels() const
-		{
-			return _timesteps;
-		}
-
-		int height() const
-		{
-			return _datadim;
-		}
-
-		int width() const
-		{
-			return 1;
-		}
-
-		int batch_size() const
-		{
-			return 1;
-		}
-
-		int test_batch_size() const
-		{
-			return 1;
-		}
-
-		int _offset = -1;
-		int _channels = 0;
-		int _timesteps = -1;
-		int _datadim = -1;
-	};
+    int _offset = -1;
+    int _channels = 0;
+    int _timesteps = -1;
+    int _datadim = -1;
+  };
 } // namespace dd
 
 #endif // TORCHINPUTCONNS_H

--- a/src/backends/torch/torchlib.cc
+++ b/src/backends/torch/torchlib.cc
@@ -41,370 +41,408 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 
-
 using namespace torch;
 
+using google::protobuf::io::CodedInputStream;
+using google::protobuf::io::CodedOutputStream;
 using google::protobuf::io::FileInputStream;
 using google::protobuf::io::FileOutputStream;
 using google::protobuf::io::ZeroCopyInputStream;
-using google::protobuf::io::CodedInputStream;
 using google::protobuf::io::ZeroCopyOutputStream;
-using google::protobuf::io::CodedOutputStream;
-
 
 namespace dd
 {
 
-  bool torch_write_proto_to_text_file(const google::protobuf::Message& proto, std::string filename)
-	{
-	  int fd = open(filename.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0644);
-		if (fd == -1)
-			return false;
-		FileOutputStream* output = new FileOutputStream(fd);
-		bool success = google::protobuf::TextFormat::Print(proto, output);
-		delete output;
-		close(fd);
-		return success;
-	}
-
-
-    inline void empty_cuda_cache() {
-        #if !defined(CPU_ONLY)
-        c10::cuda::CUDACachingAllocator::emptyCache();
-        #endif
-    }
-
-  void add_parameters(std::shared_ptr<torch::jit::script::Module> module, std::vector<Tensor> &params, bool requires_grad = true) {
-        for (const auto &tensor : module->parameters()) {
-            if (tensor.requires_grad() && requires_grad)
-                params.push_back(tensor);
-        }
-        for (auto child : module->children()) {
-          add_parameters(std::make_shared<torch::jit::script::Module>(child), params);
-        }
-    }
-
-    /// Convert IValue to Tensor and throw an exception if the IValue is not a Tensor.
-    Tensor to_tensor_safe(const IValue &value) {
-        if (!value.isTensor())
-            throw MLLibInternalException("Expected Tensor, found " + value.tagKind());
-        return value.toTensor();
-    }
-
-    /// Convert id Tensor to one_hot Tensor
-    void fill_one_hot(Tensor &one_hot, Tensor ids, int nclasses)
-    {
-        one_hot.zero_();
-        for (int i = 0; i < ids.size(0); ++i)
-        {
-            one_hot[i][ids[i].item<int>()] = 1;
-        }
-    }
-
-    Tensor to_one_hot(Tensor ids, int nclasses)
-    {
-        Tensor one_hot = torch::zeros(IntList{ids.size(0), nclasses});
-        for (int i = 0; i < ids.size(0); ++i)
-        {
-            one_hot[i][ids[i].item<int>()] = 1;
-        }
-        return one_hot;
-    }
-
-    // ======= TORCH MODULE
-
-
-    TorchModule::TorchModule() : _device{"cpu"} {}
-
-    c10::IValue TorchModule::forward(std::vector<c10::IValue> source)
-    {
-	  if (_native) // native modules take only one tensor as input for now
-		return _native->forward(to_tensor_safe(source[0]));
-        if (_traced)
-        {
-            auto output = _traced->forward(source);
-            if (output.isTensorList()) {
-                auto elems = output.toTensorList();
-                source = std::vector<c10::IValue>(elems.begin(), elems.end());
-            }
-            else if (output.isTuple()) {
-                auto &elems = output.toTuple()->elements();
-                source = std::vector<c10::IValue>(elems.begin(), elems.end());
-            }
-            else {
-                source = { output };
-            }
-        }
-        c10::IValue out_val = source.at(_classif_in);
-        if (_hidden_states)
-        {
-            // out_val is a tuple containing tensors of dimension n_batch * sequence_lenght * n_features
-            // We want a tensor of size n_batch * n_features from the last hidden state
-            auto &elems = out_val.toTuple()->elements();
-            out_val = elems.back().toTensor().slice(1, 0, 1).squeeze(1);
-        }
-        if (_classif)
-        {
-            out_val = _classif->forward(to_tensor_safe(out_val));
-        }
-        return out_val;
-    }
-
-    void TorchModule::freeze_traced(bool freeze)
-    {
-        if (freeze != _freeze_traced)
-        {
-            _freeze_traced = freeze;
-            std::vector<Tensor> params;
-            add_parameters(_traced, params, false);
-            for (auto &param : params)
-            {
-                param.set_requires_grad(!freeze);
-            }
-        }
-    }
-
-    std::vector<Tensor> TorchModule::parameters()
-    {
-	  if (_native)
-		return _native->parameters();
-	  std::vector<Tensor> params;
-	  if (_traced)
-            add_parameters(_traced, params);
-	  if (_classif)
-        {
-		  auto classif_params = _classif->parameters();
-		  params.insert(params.end(), classif_params.begin(), classif_params.end());
-        }
-	  return params;
-    }
-
-    void TorchModule::save_checkpoint(TorchModel &model, const std::string &name)
-    {
-	    if (_traced)
-            _traced->save(model._repo + "/checkpoint-" + name + ".pt");
-        if (_classif)
-            torch::save(_classif, model._repo + "/checkpoint-" + name + ".ptw");
-        if (_native)
-            torch::save(_native, model._repo + "/checkpoint-" + name + ".pt");
-    }
-
-    void TorchModule::load(TorchModel &model)
-    {
-	  if (!model._traced.empty() && model._proto.empty())
-		_traced = std::make_shared<torch::jit::script::Module>
-		  (torch::jit::load(model._traced, _device));
-	  if (!model._weights.empty() && _classif)
-		  torch::load(_classif, model._weights,_device);
-	  if (!model._proto.empty())
-		{
-		  _native = std::make_shared<CaffeToTorch>(model._proto);
-		  if (!model._traced.empty())
-            torch::load(_native, model._traced, _device);
-		}
-    }
-
-    void TorchModule::eval()
-	{
-	  if (_native)
-		  _native->eval();
-	  if (_traced)
-		  _traced->eval();
-	  if (_classif)
-		  _classif->eval();
-    }
-
-    void TorchModule::train()
-	{
-        if (_native)
-          _native->train();
-        if (_traced)
-          _traced->train();
-        if (_classif)
-          _classif->train();
-    }
-
-    void TorchModule::free()
-    {
-	    _native = nullptr;
-        _traced = nullptr;
-        _classif = nullptr;
-    }
-
-
-    // ======= TORCHLIB
-
-    template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-    TorchLib<TInputConnectorStrategy, TOutputConnectorStrategy, TMLModel>::TorchLib(const TorchModel &tmodel)
-        : MLLib<TInputConnectorStrategy,TOutputConnectorStrategy,TorchModel>(tmodel)
-    {
-        this->_libname = "torch";
-    }
-
-    template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-    TorchLib<TInputConnectorStrategy, TOutputConnectorStrategy, TMLModel>::TorchLib(TorchLib &&tl) noexcept
-	  : MLLib<TInputConnectorStrategy,TOutputConnectorStrategy,TorchModel>(std::move(tl))
-    {
-        this->_libname = "torch";
-        _module = std::move(tl._module);
-        _template = tl._template;
-        _nclasses = tl._nclasses;
-        _device = tl._device;
-        _masked_lm = tl._masked_lm;
-        _seq_training = tl._seq_training;
-        _finetuning = tl._finetuning;
-        _best_metrics = tl._best_metrics;
-        _best_metric_value = tl._best_metric_value;
-        _classification = tl._classification;
-		_timeserie = tl._timeserie;
-		_loss = tl._loss;
-    }
-
-    template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-    TorchLib<TInputConnectorStrategy, TOutputConnectorStrategy, TMLModel>::~TorchLib()
-    {
-        _module.free();
-        empty_cuda_cache();
-    }
-
-    /*- from mllib -*/
-    template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-    void TorchLib<TInputConnectorStrategy, TOutputConnectorStrategy, TMLModel>::init_mllib(const APIData &lib_ad)
-    {
-        bool gpu = false;
-        int gpuid = -1;
-        bool freeze_traced = false;
-        int embedding_size = 768;
-        std::string self_supervised = "";
-
-        if (lib_ad.has("template"))
-            _template = lib_ad.get("template").get<std::string>();
-        if (lib_ad.has("gpu"))
-            gpu = lib_ad.get("gpu").get<bool>() && torch::cuda::is_available();
-        if (lib_ad.has("gpuid"))
-            gpuid = lib_ad.get("gpuid").get<int>();
-        if (lib_ad.has("nclasses"))
-        {
-            _classification = true;
-            _nclasses = lib_ad.get("nclasses").get<int>();
-        }
-        if (lib_ad.has("self_supervised"))
-            self_supervised = lib_ad.get("self_supervised").get<std::string>();
-        if (lib_ad.has("embedding_size"))
-            embedding_size = lib_ad.get("embedding_size").get<int>();
-        if (lib_ad.has("finetuning"))
-            _finetuning = lib_ad.get("finetuning").get<bool>();
-        if (lib_ad.has("freeze_traced"))
-            freeze_traced = lib_ad.get("freeze_traced").get<bool>();
-		if (lib_ad.has("loss"))
-			_loss = lib_ad.get("loss").get<std::string>();
-
-
-        _device = gpu ? torch::Device(DeviceType::CUDA, gpuid) : torch::Device(DeviceType::CPU);
-        _module._device = _device;
-
-		if (_template.find("recurrent")!= std::string::npos)
-		 	{
-			  // call caffe net generator before verything else
-                std::string dest_net = this->_mlmodel._repo + '/' + _template + ".prototxt";
-                if (!fileops::file_exists(dest_net))
-                  {
-                    caffe::NetParameter net_param;
-                    configure_recurrent_template(lib_ad,this->_inputc,net_param,this->_logger);
-                    torch_write_proto_to_text_file(net_param,dest_net);
-                  }
-                else
-                  {
-                    this->_logger->info("prototxt net definition already present in repo : using old file");
-                  }
-                this->_mlmodel._proto = dest_net;
-		 	}
-
-		// Create the model
-		if (this->_mlmodel._traced.empty() && this->_mlmodel._proto.empty())
-            throw MLLibInternalException("Use of libtorch backend needs either traced net or protofile");
-
-        this->_inputc._input_format = "bert";
-        if (_template == "bert")
-        {
-            if (_classification)
-            {
-                _module._classif = nn::Linear(embedding_size, _nclasses);
-                _module._classif->to(_device);
-                _module._hidden_states = true;
-                _module._classif_in = 1;
-            }
-            else if (!self_supervised.empty())
-            {
-                if (self_supervised != "mask")
-                {
-                    throw MLLibBadParamException("self_supervised");
-                }
-                this->_logger->info("Masked Language model");
-                _masked_lm = true;
-                _seq_training = true;
-            }
-            else
-            {
-                throw MLLibBadParamException("BERT only supports self-supervised or classification");
-            }
-        }
-        else if (_template == "gpt2")
-        {
-            this->_inputc._input_format = "gpt2";
-            _seq_training = true;
-        }
-		else if (_template.find("recurrent")!= std::string::npos)
-		  {
-			_timeserie = true;
-		  }
-        else if (!_template.empty())
-        {
-            throw MLLibBadParamException("template");
-        }
-
-        if (!this->_mlmodel._traced.empty())
-          this->_logger->info("Loading ml model from file {}.", this->_mlmodel._traced);
-        if (!this->_mlmodel._proto.empty())
-          this->_logger->info("Loading ml model from file {}.", this->_mlmodel._proto);
-        if (!this->_mlmodel._weights.empty())
-            this->_logger->info("Loading weights from file {}.", this->_mlmodel._weights);
-        _module.load(this->_mlmodel);
-        _module.freeze_traced(freeze_traced);
-
-		if (_classification)
-		  this->_mltype = "classification";
-
-		_best_metrics = {"map", "meaniou", "mlacc", "delta_score_0.1", "bacc", "f1", "net_meas", "acc", "L1_mean_error", "eucll"};
-		_best_metric_value = std::numeric_limits<double>::infinity();
-
-			}
-
-
-    template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-    void TorchLib<TInputConnectorStrategy, TOutputConnectorStrategy, TMLModel>::clear_mllib(const APIData &ad)
-    {
-        std::vector<std::string> extensions{".json", ".pt", ".ptw"};
-        fileops::remove_directory_files(this->_mlmodel._repo, extensions);
-        this->_logger->info("Torchlib service cleared");
-    }
-
-
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  bool TorchLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::is_better(double v1, double v2, std::string metric_name)
+  bool torch_write_proto_to_text_file(const google::protobuf::Message &proto,
+                                      std::string filename)
   {
-    if (metric_name == "eucll" || metric_name == "delta_score_0.1" || metric_name == "L1_mean_error")
+    int fd = open(filename.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    if (fd == -1)
+      return false;
+    FileOutputStream *output = new FileOutputStream(fd);
+    bool success = google::protobuf::TextFormat::Print(proto, output);
+    delete output;
+    close(fd);
+    return success;
+  }
+
+  inline void empty_cuda_cache()
+  {
+#if !defined(CPU_ONLY)
+    c10::cuda::CUDACachingAllocator::emptyCache();
+#endif
+  }
+
+  void add_parameters(std::shared_ptr<torch::jit::script::Module> module,
+                      std::vector<Tensor> &params, bool requires_grad = true)
+  {
+    for (const auto &tensor : module->parameters())
+      {
+        if (tensor.requires_grad() && requires_grad)
+          params.push_back(tensor);
+      }
+    for (auto child : module->children())
+      {
+        add_parameters(std::make_shared<torch::jit::script::Module>(child),
+                       params);
+      }
+  }
+
+  /// Convert IValue to Tensor and throw an exception if the IValue is not a
+  /// Tensor.
+  Tensor to_tensor_safe(const IValue &value)
+  {
+    if (!value.isTensor())
+      throw MLLibInternalException("Expected Tensor, found "
+                                   + value.tagKind());
+    return value.toTensor();
+  }
+
+  /// Convert id Tensor to one_hot Tensor
+  void fill_one_hot(Tensor &one_hot, Tensor ids, int nclasses)
+  {
+    one_hot.zero_();
+    for (int i = 0; i < ids.size(0); ++i)
+      {
+        one_hot[i][ids[i].item<int>()] = 1;
+      }
+  }
+
+  Tensor to_one_hot(Tensor ids, int nclasses)
+  {
+    Tensor one_hot = torch::zeros(IntList{ ids.size(0), nclasses });
+    for (int i = 0; i < ids.size(0); ++i)
+      {
+        one_hot[i][ids[i].item<int>()] = 1;
+      }
+    return one_hot;
+  }
+
+  // ======= TORCH MODULE
+
+  TorchModule::TorchModule() : _device{ "cpu" }
+  {
+  }
+
+  c10::IValue TorchModule::forward(std::vector<c10::IValue> source)
+  {
+    if (_native) // native modules take only one tensor as input for now
+      return _native->forward(to_tensor_safe(source[0]));
+    if (_traced)
+      {
+        auto output = _traced->forward(source);
+        if (output.isTensorList())
+          {
+            auto elems = output.toTensorList();
+            source = std::vector<c10::IValue>(elems.begin(), elems.end());
+          }
+        else if (output.isTuple())
+          {
+            auto &elems = output.toTuple()->elements();
+            source = std::vector<c10::IValue>(elems.begin(), elems.end());
+          }
+        else
+          {
+            source = { output };
+          }
+      }
+    c10::IValue out_val = source.at(_classif_in);
+    if (_hidden_states)
+      {
+        // out_val is a tuple containing tensors of dimension n_batch *
+        // sequence_lenght * n_features We want a tensor of size n_batch *
+        // n_features from the last hidden state
+        auto &elems = out_val.toTuple()->elements();
+        out_val = elems.back().toTensor().slice(1, 0, 1).squeeze(1);
+      }
+    if (_classif)
+      {
+        out_val = _classif->forward(to_tensor_safe(out_val));
+      }
+    return out_val;
+  }
+
+  void TorchModule::freeze_traced(bool freeze)
+  {
+    if (freeze != _freeze_traced)
+      {
+        _freeze_traced = freeze;
+        std::vector<Tensor> params;
+        add_parameters(_traced, params, false);
+        for (auto &param : params)
+          {
+            param.set_requires_grad(!freeze);
+          }
+      }
+  }
+
+  std::vector<Tensor> TorchModule::parameters()
+  {
+    if (_native)
+      return _native->parameters();
+    std::vector<Tensor> params;
+    if (_traced)
+      add_parameters(_traced, params);
+    if (_classif)
+      {
+        auto classif_params = _classif->parameters();
+        params.insert(params.end(), classif_params.begin(),
+                      classif_params.end());
+      }
+    return params;
+  }
+
+  void TorchModule::save_checkpoint(TorchModel &model, const std::string &name)
+  {
+    if (_traced)
+      _traced->save(model._repo + "/checkpoint-" + name + ".pt");
+    if (_classif)
+      torch::save(_classif, model._repo + "/checkpoint-" + name + ".ptw");
+    if (_native)
+      torch::save(_native, model._repo + "/checkpoint-" + name + ".pt");
+  }
+
+  void TorchModule::load(TorchModel &model)
+  {
+    if (!model._traced.empty() && model._proto.empty())
+      _traced = std::make_shared<torch::jit::script::Module>(
+          torch::jit::load(model._traced, _device));
+    if (!model._weights.empty() && _classif)
+      torch::load(_classif, model._weights, _device);
+    if (!model._proto.empty())
+      {
+        _native = std::make_shared<CaffeToTorch>(model._proto);
+        if (!model._traced.empty())
+          torch::load(_native, model._traced, _device);
+      }
+  }
+
+  void TorchModule::eval()
+  {
+    if (_native)
+      _native->eval();
+    if (_traced)
+      _traced->eval();
+    if (_classif)
+      _classif->eval();
+  }
+
+  void TorchModule::train()
+  {
+    if (_native)
+      _native->train();
+    if (_traced)
+      _traced->train();
+    if (_classif)
+      _classif->train();
+  }
+
+  void TorchModule::free()
+  {
+    _native = nullptr;
+    _traced = nullptr;
+    _classif = nullptr;
+  }
+
+  // ======= TORCHLIB
+
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  TorchLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+           TMLModel>::TorchLib(const TorchModel &tmodel)
+      : MLLib<TInputConnectorStrategy, TOutputConnectorStrategy, TorchModel>(
+          tmodel)
+  {
+    this->_libname = "torch";
+  }
+
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  TorchLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+           TMLModel>::TorchLib(TorchLib &&tl) noexcept
+      : MLLib<TInputConnectorStrategy, TOutputConnectorStrategy, TorchModel>(
+          std::move(tl))
+  {
+    this->_libname = "torch";
+    _module = std::move(tl._module);
+    _template = tl._template;
+    _nclasses = tl._nclasses;
+    _device = tl._device;
+    _masked_lm = tl._masked_lm;
+    _seq_training = tl._seq_training;
+    _finetuning = tl._finetuning;
+    _best_metrics = tl._best_metrics;
+    _best_metric_value = tl._best_metric_value;
+    _classification = tl._classification;
+    _timeserie = tl._timeserie;
+    _loss = tl._loss;
+  }
+
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  TorchLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+           TMLModel>::~TorchLib()
+  {
+    _module.free();
+    empty_cuda_cache();
+  }
+
+  /*- from mllib -*/
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void TorchLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+                TMLModel>::init_mllib(const APIData &lib_ad)
+  {
+    bool gpu = false;
+    int gpuid = -1;
+    bool freeze_traced = false;
+    int embedding_size = 768;
+    std::string self_supervised = "";
+
+    if (lib_ad.has("template"))
+      _template = lib_ad.get("template").get<std::string>();
+    if (lib_ad.has("gpu"))
+      gpu = lib_ad.get("gpu").get<bool>() && torch::cuda::is_available();
+    if (lib_ad.has("gpuid"))
+      gpuid = lib_ad.get("gpuid").get<int>();
+    if (lib_ad.has("nclasses"))
+      {
+        _classification = true;
+        _nclasses = lib_ad.get("nclasses").get<int>();
+      }
+    if (lib_ad.has("self_supervised"))
+      self_supervised = lib_ad.get("self_supervised").get<std::string>();
+    if (lib_ad.has("embedding_size"))
+      embedding_size = lib_ad.get("embedding_size").get<int>();
+    if (lib_ad.has("finetuning"))
+      _finetuning = lib_ad.get("finetuning").get<bool>();
+    if (lib_ad.has("freeze_traced"))
+      freeze_traced = lib_ad.get("freeze_traced").get<bool>();
+    if (lib_ad.has("loss"))
+      _loss = lib_ad.get("loss").get<std::string>();
+
+    _device = gpu ? torch::Device(DeviceType::CUDA, gpuid)
+                  : torch::Device(DeviceType::CPU);
+    _module._device = _device;
+
+    if (_template.find("recurrent") != std::string::npos)
+      {
+        // call caffe net generator before verything else
+        std::string dest_net
+            = this->_mlmodel._repo + '/' + _template + ".prototxt";
+        if (!fileops::file_exists(dest_net))
+          {
+            caffe::NetParameter net_param;
+            configure_recurrent_template(lib_ad, this->_inputc, net_param,
+                                         this->_logger);
+            torch_write_proto_to_text_file(net_param, dest_net);
+          }
+        else
+          {
+            this->_logger->info("prototxt net definition already present in "
+                                "repo : using old file");
+          }
+        this->_mlmodel._proto = dest_net;
+      }
+
+    // Create the model
+    if (this->_mlmodel._traced.empty() && this->_mlmodel._proto.empty())
+      throw MLLibInternalException(
+          "Use of libtorch backend needs either traced net or protofile");
+
+    this->_inputc._input_format = "bert";
+    if (_template == "bert")
+      {
+        if (_classification)
+          {
+            _module._classif = nn::Linear(embedding_size, _nclasses);
+            _module._classif->to(_device);
+            _module._hidden_states = true;
+            _module._classif_in = 1;
+          }
+        else if (!self_supervised.empty())
+          {
+            if (self_supervised != "mask")
+              {
+                throw MLLibBadParamException("self_supervised");
+              }
+            this->_logger->info("Masked Language model");
+            _masked_lm = true;
+            _seq_training = true;
+          }
+        else
+          {
+            throw MLLibBadParamException(
+                "BERT only supports self-supervised or classification");
+          }
+      }
+    else if (_template == "gpt2")
+      {
+        this->_inputc._input_format = "gpt2";
+        _seq_training = true;
+      }
+    else if (_template.find("recurrent") != std::string::npos)
+      {
+        _timeserie = true;
+      }
+    else if (!_template.empty())
+      {
+        throw MLLibBadParamException("template");
+      }
+
+    if (!this->_mlmodel._traced.empty())
+      this->_logger->info("Loading ml model from file {}.",
+                          this->_mlmodel._traced);
+    if (!this->_mlmodel._proto.empty())
+      this->_logger->info("Loading ml model from file {}.",
+                          this->_mlmodel._proto);
+    if (!this->_mlmodel._weights.empty())
+      this->_logger->info("Loading weights from file {}.",
+                          this->_mlmodel._weights);
+    _module.load(this->_mlmodel);
+    _module.freeze_traced(freeze_traced);
+
+    if (_classification)
+      this->_mltype = "classification";
+
+    _best_metrics = { "map", "meaniou",  "mlacc", "delta_score_0.1", "bacc",
+                      "f1",  "net_meas", "acc",   "L1_mean_error",   "eucll" };
+    _best_metric_value = std::numeric_limits<double>::infinity();
+  }
+
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void TorchLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+                TMLModel>::clear_mllib(const APIData &ad)
+  {
+    std::vector<std::string> extensions{ ".json", ".pt", ".ptw" };
+    fileops::remove_directory_files(this->_mlmodel._repo, extensions);
+    this->_logger->info("Torchlib service cleared");
+  }
+
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  bool TorchLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+                TMLModel>::is_better(double v1, double v2,
+                                     std::string metric_name)
+  {
+    if (metric_name == "eucll" || metric_name == "delta_score_0.1"
+        || metric_name == "L1_mean_error")
       return (v2 > v1);
     return (v1 > v2);
   }
 
-
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  int64_t TorchLib<TInputConnectorStrategy, TOutputConnectorStrategy, TMLModel>::save_if_best(APIData& meas_out, int64_t elapsed_it, optim::Optimizer& optimizer, int64_t best_to_remove)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  int64_t TorchLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+                   TMLModel>::save_if_best(APIData &meas_out,
+                                           int64_t elapsed_it,
+                                           optim::Optimizer &optimizer,
+                                           int64_t best_to_remove)
   {
     double cur_meas = std::numeric_limits<double>::infinity();
     std::string meas;
-    for (auto m: _best_metrics)
+    for (auto m : _best_metrics)
       {
         if (meas_out.has(m))
           {
@@ -416,11 +454,12 @@ namespace dd
     if (cur_meas == std::numeric_limits<double>::infinity())
       {
         // could not find value for measuring best
-        this->_logger->info("could not find any value for measuring best model");
+        this->_logger->info(
+            "could not find any value for measuring best model");
         return false;
       }
-    if (_best_metric_value == std::numeric_limits<double>::infinity() ||
-        is_better(cur_meas, _best_metric_value, meas))
+    if (_best_metric_value == std::numeric_limits<double>::infinity()
+        || is_better(cur_meas, _best_metric_value, meas))
       {
         if (best_to_remove != -1)
           {
@@ -431,13 +470,14 @@ namespace dd
         try
           {
             std::ofstream bestfile;
-            std::string bestfilename = this->_mlmodel._repo + this->_mlmodel._best_model_filename;
-            bestfile.open(bestfilename,std::ios::out);
-            bestfile << "iteration:" <<  elapsed_it << std::endl;
-            bestfile <<  meas << ":" << cur_meas << std::endl;
+            std::string bestfilename
+                = this->_mlmodel._repo + this->_mlmodel._best_model_filename;
+            bestfile.open(bestfilename, std::ios::out);
+            bestfile << "iteration:" << elapsed_it << std::endl;
+            bestfile << meas << ":" << cur_meas << std::endl;
             bestfile.close();
           }
-        catch(std::exception &e)
+        catch (std::exception &e)
           {
             this->_logger->error("could not write best model file");
           }
@@ -446,693 +486,743 @@ namespace dd
     return best_to_remove;
   }
 
-
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void TorchLib<TInputConnectorStrategy, TOutputConnectorStrategy, TMLModel>::remove_model(int64_t elapsed_it)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void TorchLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+                TMLModel>::remove_model(int64_t elapsed_it)
   {
     this->_logger->info("Deleting superseeded model {} ", elapsed_it);
-    std::remove((this->_mlmodel._repo+"/solver-" + std::to_string(elapsed_it) + ".pt").c_str());
-    std::remove((this->_mlmodel._repo+"/checkpoint-" + std::to_string(elapsed_it) + ".pt").c_str());
-    std::remove((this->_mlmodel._repo+"/checkpoint-" + std::to_string(elapsed_it) + ".ptw").c_str());
+    std::remove((this->_mlmodel._repo + "/solver-" + std::to_string(elapsed_it)
+                 + ".pt")
+                    .c_str());
+    std::remove((this->_mlmodel._repo + "/checkpoint-"
+                 + std::to_string(elapsed_it) + ".pt")
+                    .c_str());
+    std::remove((this->_mlmodel._repo + "/checkpoint-"
+                 + std::to_string(elapsed_it) + ".ptw")
+                    .c_str());
   }
 
-
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void TorchLib<TInputConnectorStrategy, TOutputConnectorStrategy, TMLModel>::snapshot(int64_t elapsed_it, optim::Optimizer& optimizer)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void TorchLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+                TMLModel>::snapshot(int64_t elapsed_it,
+                                    optim::Optimizer &optimizer)
   {
     this->_logger->info("Saving checkpoint after {} iterations", elapsed_it);
     this->_module.save_checkpoint(this->_mlmodel, std::to_string(elapsed_it));
     // Save optimizer
-    torch::save(optimizer, this->_mlmodel._repo + "/solver-" + std::to_string(elapsed_it) + ".pt");
-
+    torch::save(optimizer, this->_mlmodel._repo + "/solver-"
+                               + std::to_string(elapsed_it) + ".pt");
   }
 
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  int TorchLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+               TMLModel>::train(const APIData &ad, APIData &out)
+  {
+    this->_tjob_running.store(true);
 
-    template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-    int TorchLib<TInputConnectorStrategy, TOutputConnectorStrategy, TMLModel>::train(const APIData &ad, APIData &out)
-    {
-        this->_tjob_running.store(true);
+    TInputConnectorStrategy inputc(this->_inputc);
+    inputc._train = true;
+    inputc._finetuning = _finetuning;
 
-        TInputConnectorStrategy inputc(this->_inputc);
-        inputc._train = true;
-        inputc._finetuning = _finetuning;
+    APIData ad_input = ad.getobj("parameters").getobj("input");
+    if (ad_input.has("shuffle"))
+      inputc._dataset.set_shuffle(ad_input.get("shuffle").get<bool>());
 
-        APIData ad_input = ad.getobj("parameters").getobj("input");
-        if (ad_input.has("shuffle"))
-          inputc._dataset.set_shuffle(ad_input.get("shuffle").get<bool>());
-
-        try
-        {
-            inputc.transform(ad);
-			if (_module._native)
-			  {
-				auto batchoptional = inputc._dataset.get_batch({1});
-				TorchBatch batch = batchoptional.value();
-				torch::Tensor td = batch.data[0];
-				_module._native->finalize(td.sizes());
-                // reload params after finalize
-                if (!this->_mlmodel._traced.empty())
-                  torch::load(_module._native, this->_mlmodel._traced, _device);
-				_module._native->to(_device);
-			  }
-        }
-        catch (...)
-        {
-            throw;
-        }
-
-        APIData ad_mllib = ad.getobj("parameters").getobj("mllib");
-
-        // solver params
-        int64_t iterations = 1;
-        std::string solver_type = "SGD";
-        double base_lr = 0.0001;
-        int64_t batch_size = 1;
-        int64_t iter_size = 1;
-        int64_t test_batch_size = 1;
-        int64_t test_interval = 1;
-        int64_t save_period = 0;
-
-        Tensor class_weights = {};
-
-
-        // logging parameters
-        int64_t log_batch_period = 20;
-
-        if (ad_mllib.has("solver"))
-        {
-            APIData ad_solver = ad_mllib.getobj("solver");
-            if (ad_solver.has("iterations"))
-                iterations = ad_solver.get("iterations").get<int>();
-            if (ad_solver.has("solver_type"))
-                solver_type = ad_solver.get("solver_type").get<std::string>();
-            if (ad_solver.has("base_lr"))
-                base_lr = ad_solver.get("base_lr").get<double>();
-            if (ad_solver.has("test_interval"))
-                test_interval = ad_solver.get("test_interval").get<int>();
-            if (ad_solver.has("iter_size"))
-                iter_size = ad_solver.get("iter_size").get<int>();
-            if (ad_solver.has("snapshot"))
-                save_period = ad_solver.get("snapshot").get<int>();
-        }
-
-        if (ad_mllib.has("net"))
-        {
-            APIData ad_net = ad_mllib.getobj("net");
-            if (ad_net.has("batch_size"))
-                batch_size = ad_net.get("batch_size").get<int>();
-            if (ad_net.has("test_batch_size"))
-                test_batch_size = ad_net.get("test_batch_size").get<int>();
-        }
-
-        if (ad_mllib.has("class_weights"))
+    try
+      {
+        inputc.transform(ad);
+        if (_module._native)
           {
-            std::vector<double> cwv = ad_mllib.get("class_weights").get<std::vector<double>>();
-            if (cwv.size() != _nclasses)
+            auto batchoptional = inputc._dataset.get_batch({ 1 });
+            TorchBatch batch = batchoptional.value();
+            torch::Tensor td = batch.data[0];
+            _module._native->finalize(td.sizes());
+            // reload params after finalize
+            if (!this->_mlmodel._traced.empty())
+              torch::load(_module._native, this->_mlmodel._traced, _device);
+            _module._native->to(_device);
+          }
+      }
+    catch (...)
+      {
+        throw;
+      }
+
+    APIData ad_mllib = ad.getobj("parameters").getobj("mllib");
+
+    // solver params
+    int64_t iterations = 1;
+    std::string solver_type = "SGD";
+    double base_lr = 0.0001;
+    int64_t batch_size = 1;
+    int64_t iter_size = 1;
+    int64_t test_batch_size = 1;
+    int64_t test_interval = 1;
+    int64_t save_period = 0;
+
+    Tensor class_weights = {};
+
+    // logging parameters
+    int64_t log_batch_period = 20;
+
+    if (ad_mllib.has("solver"))
+      {
+        APIData ad_solver = ad_mllib.getobj("solver");
+        if (ad_solver.has("iterations"))
+          iterations = ad_solver.get("iterations").get<int>();
+        if (ad_solver.has("solver_type"))
+          solver_type = ad_solver.get("solver_type").get<std::string>();
+        if (ad_solver.has("base_lr"))
+          base_lr = ad_solver.get("base_lr").get<double>();
+        if (ad_solver.has("test_interval"))
+          test_interval = ad_solver.get("test_interval").get<int>();
+        if (ad_solver.has("iter_size"))
+          iter_size = ad_solver.get("iter_size").get<int>();
+        if (ad_solver.has("snapshot"))
+          save_period = ad_solver.get("snapshot").get<int>();
+      }
+
+    if (ad_mllib.has("net"))
+      {
+        APIData ad_net = ad_mllib.getobj("net");
+        if (ad_net.has("batch_size"))
+          batch_size = ad_net.get("batch_size").get<int>();
+        if (ad_net.has("test_batch_size"))
+          test_batch_size = ad_net.get("test_batch_size").get<int>();
+      }
+
+    if (ad_mllib.has("class_weights"))
+      {
+        std::vector<double> cwv
+            = ad_mllib.get("class_weights").get<std::vector<double>>();
+        if (cwv.size() != _nclasses)
+          {
+            this->_logger->error(
+                "class weights given, but number of weights {} do not match "
+                "number of classes {}, ignoring",
+                cwv.size(), _nclasses);
+          }
+        else
+          {
+            this->_logger->info("using class weights");
+            auto options = torch::TensorOptions().dtype(torch::kFloat64);
+            class_weights
+                = torch::from_blob(cwv.data(), { _nclasses }, options)
+                      .to(torch::kFloat32)
+                      .to(_device);
+          }
+      }
+
+    if (iter_size <= 0)
+      iter_size = 1;
+
+    // create dataset for evaluation during training
+    TorchDataset eval_dataset;
+    if (!inputc._test_dataset.empty())
+      {
+        eval_dataset = inputc._test_dataset; //.split(0, 0.1);
+      }
+
+    // create solver
+    std::unique_ptr<optim::Optimizer> optimizer;
+
+    if (solver_type == "ADAM")
+      optimizer = std::unique_ptr<optim::Optimizer>(
+          new optim::Adam(_module.parameters(), optim::AdamOptions(base_lr)));
+    else if (solver_type == "RMSPROP")
+      optimizer = std::unique_ptr<optim::Optimizer>(new optim::RMSprop(
+          _module.parameters(), optim::RMSpropOptions(base_lr)));
+    else if (solver_type == "ADAGRAD")
+      optimizer = std::unique_ptr<optim::Optimizer>(new optim::Adagrad(
+          _module.parameters(), optim::AdagradOptions(base_lr)));
+    else
+      {
+        if (solver_type != "SGD")
+          this->_logger->warn("Solver type {} not found, using SGD",
+                              solver_type);
+        optimizer = std::unique_ptr<optim::Optimizer>(
+            new optim::SGD(_module.parameters(), optim::SGDOptions(base_lr)));
+      }
+
+    int it = 0;
+    // reload solver and set it value accordingly
+    if (!this->_mlmodel._sstate.empty())
+      {
+        this->_logger->info("Reload solver from {}", this->_mlmodel._sstate);
+        size_t start = this->_mlmodel._sstate.rfind("-") + 1;
+        size_t end = this->_mlmodel._sstate.rfind(".");
+        it = std::stoi(this->_mlmodel._sstate.substr(start, end - start));
+        this->_logger->info("Restarting optimization from iter {}", it);
+        torch::load(*optimizer, this->_mlmodel._sstate);
+      }
+    optimizer->zero_grad();
+    _module.train();
+
+    // create dataloader
+    inputc._dataset.reset();
+    auto dataloader = torch::data::make_data_loader(
+        std::move(inputc._dataset), data::DataLoaderOptions(batch_size));
+
+    this->_logger->info("Training for {} iterations", iterations - it);
+    int batch_id = 0;
+    using namespace std::chrono;
+
+    int64_t best_to_remove = -1;
+
+    // it is the iteration count (not epoch)
+    while (it < iterations)
+      {
+        if (!this->_tjob_running.load())
+          {
+            break;
+          }
+
+        double train_loss = 0;
+        double avg_it_time = 0;
+
+        for (TorchBatch batch : *dataloader)
+          {
+            auto tstart = system_clock::now();
+            if (_masked_lm)
               {
-                this->_logger->error("class weights given, but number of weights {} do not match number of classes {}, ignoring", cwv.size(), _nclasses);
+                batch = inputc.generate_masked_lm_batch(batch);
+              }
+            std::vector<c10::IValue> in_vals;
+            for (Tensor tensor : batch.data)
+              {
+                in_vals.push_back(tensor.to(_device));
+              }
+            Tensor y = batch.target.at(0).to(_device);
+
+            Tensor y_pred;
+            try
+              {
+                y_pred = to_tensor_safe(_module.forward(in_vals));
+              }
+            catch (std::exception &e)
+              {
+                this->_logger->error(std::string("Libtorch error: ")
+                                     + e.what());
+                throw MLLibInternalException(std::string("Libtorch error: ")
+                                             + e.what());
+              }
+
+            // As CrossEntropy is not available (Libtorch 1.1) we use nllloss +
+            // log_softmax
+            Tensor loss;
+            if (_seq_training)
+              {
+                // Convert [n_batch, sequence_length, vocab_size] to [n_batch *
+                // sequence_length, vocab_size]
+                // + ignore non-masked tokens (== -1 in target)
+                loss = torch::nll_loss(
+                    torch::log_softmax(
+                        y_pred.view(IntList{ -1, y_pred.size(2) }), 1),
+                    y.view(IntList{ -1 }), class_weights, Reduction::Mean, -1);
+              }
+            else if (_timeserie)
+              {
+                if (_loss.empty() || _loss == "L1" || _loss == "l1")
+                  loss = torch::l1_loss(y_pred, y);
+                else if (_loss == "L2" || _loss == "l2" || _loss == "eucl")
+                  loss = torch::mse_loss(y_pred, y);
+                else
+                  throw MLLibBadParamException("unknown loss " + _loss);
               }
             else
               {
-                this->_logger->info("using class weights");
-                auto options = torch::TensorOptions().dtype(torch::kFloat64);
-                class_weights = torch::from_blob(cwv.data(),{_nclasses},options).to(torch::kFloat32).to(_device);
+                loss = torch::nll_loss(torch::log_softmax(y_pred, 1),
+                                       y.view(IntList{ -1 }), class_weights);
               }
-          }
+            if (iter_size > 1)
+              loss /= iter_size;
 
+            double loss_val = loss.item<double>();
+            train_loss += loss_val;
+            loss.backward();
+            auto tstop = system_clock::now();
+            avg_it_time += duration_cast<milliseconds>(tstop - tstart).count();
 
-        if (iter_size <= 0)
-            iter_size = 1;
-
-        // create dataset for evaluation during training
-        TorchDataset eval_dataset;
-        if (!inputc._test_dataset.empty())
-        {
-            eval_dataset = inputc._test_dataset; //.split(0, 0.1);
-        }
-
-        // create solver
-        std::unique_ptr<optim::Optimizer> optimizer;
-
-        if (solver_type == "ADAM")
-            optimizer = std::unique_ptr<optim::Optimizer>(
-                new optim::Adam(_module.parameters(), optim::AdamOptions(base_lr)));
-        else if (solver_type == "RMSPROP")
-            optimizer = std::unique_ptr<optim::Optimizer>(
-                new optim::RMSprop(_module.parameters(), optim::RMSpropOptions(base_lr)));
-        else if (solver_type == "ADAGRAD")
-            optimizer = std::unique_ptr<optim::Optimizer>(
-                new optim::Adagrad(_module.parameters(), optim::AdagradOptions(base_lr)));
-        else
-        {
-            if (solver_type != "SGD")
-                this->_logger->warn("Solver type {} not found, using SGD", solver_type);
-            optimizer = std::unique_ptr<optim::Optimizer>(
-                new optim::SGD(_module.parameters(), optim::SGDOptions(base_lr)));
-        }
-
-        int it = 0;
-        // reload solver and set it value accordingly
-        if (!this->_mlmodel._sstate.empty())
-        {
-            this->_logger->info("Reload solver from {}", this->_mlmodel._sstate);
-            size_t start = this->_mlmodel._sstate.rfind("-")+1;
-            size_t end = this->_mlmodel._sstate.rfind(".");
-            it = std::stoi(this->_mlmodel._sstate.substr(start,end-start));
-            this->_logger->info("Restarting optimization from iter {}", it);
-            torch::load(*optimizer, this->_mlmodel._sstate);
-        }
-        optimizer->zero_grad();
-        _module.train();
-
-        // create dataloader
-		inputc._dataset.reset();
-        auto dataloader = torch::data::make_data_loader(
-            std::move(inputc._dataset),
-            data::DataLoaderOptions(batch_size)
-        );
-
-        this->_logger->info("Training for {} iterations", iterations-it);
-        int batch_id = 0;
-        using namespace std::chrono;
-
-        int64_t best_to_remove = -1;
-
-        // it is the iteration count (not epoch)
-        while (it < iterations)
-        {
-            if (!this->_tjob_running.load())
-            {
-                break;
-            }
-
-            double train_loss = 0;
-            double avg_it_time = 0;
-
-            for (TorchBatch batch : *dataloader)
-            {
-                auto tstart = system_clock::now();
-                if (_masked_lm)
-                {
-                    batch = inputc.generate_masked_lm_batch(batch);
-                }
-                std::vector<c10::IValue> in_vals;
-                for (Tensor tensor : batch.data)
-				  {
-                    in_vals.push_back(tensor.to(_device));
-				  }
-                Tensor y = batch.target.at(0).to(_device);
-
-                Tensor y_pred;
-                try
-                {
-                    y_pred = to_tensor_safe(_module.forward(in_vals));
-                }
-                catch (std::exception &e)
-                {
-                  this->_logger->error(std::string("Libtorch error: ") + e.what());
-                  throw MLLibInternalException(std::string("Libtorch error: ") + e.what());
-                }
-
-                // As CrossEntropy is not available (Libtorch 1.1) we use nllloss + log_softmax
-                Tensor loss;
-                if (_seq_training)
-                {
-                    // Convert [n_batch, sequence_length, vocab_size] to [n_batch * sequence_length, vocab_size]
-                    // + ignore non-masked tokens (== -1 in target)
-                    loss = torch::nll_loss(
-                        torch::log_softmax(y_pred.view(IntList{-1, y_pred.size(2)}), 1),
-                        y.view(IntList{-1}),
-                        class_weights, Reduction::Mean, -1
-                    );
-                }
-				else if (_timeserie)
-					{
-						if (_loss.empty() || _loss == "L1" || _loss == "l1")
-							loss = torch::l1_loss(y_pred, y);
-						else if (_loss == "L2" || _loss == "l2" || _loss == "eucl")
-							loss= torch::mse_loss(y_pred, y);
-						else
-							throw MLLibBadParamException("unknown loss " + _loss);
-					}
-                else
-                {
-                  loss = torch::nll_loss(torch::log_softmax(y_pred, 1),
-                                         y.view(IntList{-1}),
-                                         class_weights);
-                }
-                if (iter_size > 1)
-                    loss /= iter_size;
-
-                double loss_val = loss.item<double>();
-                train_loss += loss_val;
-                loss.backward();
-                auto tstop = system_clock::now();
-                avg_it_time += duration_cast<milliseconds>(tstop - tstart).count();
-
-                if ((batch_id + 1) % iter_size == 0)
-                {
-                    if (!this->_tjob_running.load())
-                    {
-                        break;
-                    }
-                    try
-                      {
-                        optimizer->step();
-                        optimizer->zero_grad();
-                      }
-                    catch (std::exception &e)
-                      {
-                        this->_logger->error(std::string("Libtorch error: ") + e.what());
-                        throw MLLibInternalException(std::string("Libtorch error: ") + e.what());
-                      }
-
-                    avg_it_time /= iter_size;
-                    this->add_meas("learning_rate", base_lr);
-                    this->add_meas("iteration", it);
-                    this->add_meas("iter_time", avg_it_time);
-                    this->add_meas("remain_time", avg_it_time * iter_size * (iterations - it) / 1000.0);
-                    this->add_meas("train_loss", train_loss);
-                    this->add_meas_per_iter("learning_rate", base_lr);
-                    this->add_meas_per_iter("train_loss", train_loss);
-                    int64_t elapsed_it = it + 1;
-                    if (log_batch_period != 0 && elapsed_it % log_batch_period == 0)
-                    {
-                        this->_logger->info("Iteration {}/{}: loss is {}", elapsed_it, iterations, train_loss);
-                    }
-                    avg_it_time = 0;
-                    train_loss = 0;
-
-                    if (elapsed_it % test_interval == 0 && elapsed_it != iterations && !eval_dataset.empty())
-                    {
-                        // Free memory
-                        loss = torch::empty(1);
-                        y_pred = torch::empty(1);
-                        y = torch::empty(1);
-                        in_vals.clear();
-
-                        APIData meas_out;
-                        this->_logger->info("Start test");
-                        test(ad, inputc, eval_dataset, test_batch_size, meas_out);
-                        APIData meas_obj = meas_out.getobj("measure");
-                        std::vector<std::string> meas_names = meas_obj.list_keys();
-
-                        best_to_remove = save_if_best(meas_obj, elapsed_it, *optimizer, best_to_remove);
-
-                        for (auto name : meas_names)
-                        {
-                            if (name != "cmdiag" && name != "cmfull" && name != "labels")
-                            {
-                                double mval = meas_obj.get(name).get<double>();
-                                this->_logger->info("{}={}", name, mval);
-                                this->add_meas(name, mval);
-                                this->add_meas_per_iter(name, mval);
-                            }
-                            else if (name == "cmdiag")
-                            {
-                                std::vector<double> mdiag = meas_obj.get(name).get<std::vector<double>>();
-                                std::vector<std::string> cnames;
-                                std::string mdiag_str;
-                                for (size_t i=0; i<mdiag.size(); i++)
-                                {
-                                    mdiag_str += this->_mlmodel.get_hcorresp(i) + ":" + std::to_string(mdiag.at(i)) + " ";
-                                    this->add_meas_per_iter(name+'_'+this->_mlmodel.get_hcorresp(i), mdiag.at(i));
-                                    cnames.push_back(this->_mlmodel.get_hcorresp(i));
-                                }
-                                this->_logger->info("{}=[{}]", name, mdiag_str);
-                                this->add_meas(name, mdiag, cnames);
-                            }
-                        }
-                    }
-
-                    if ((save_period != 0 && elapsed_it % save_period == 0) || elapsed_it == iterations)
-                    {
-                      if (best_to_remove == elapsed_it)
-                        // current model already snapshoted as best model,
-                        // do not remove regular snapshot if it is  best model
-                        best_to_remove = -1;
-                      else
-                        snapshot(elapsed_it, *optimizer);
-                    }
-                    ++it;
-
-                    if (it >= iterations)
-                        break;
-                }
-
-                ++batch_id;
-            }
-        }
-
-        if (!this->_tjob_running.load())
-        {
-            this->_logger->info("Training job interrupted at iteration {}", it);
-            empty_cuda_cache();
-            return -1;
-        }
-
-        test(ad, inputc, inputc._test_dataset, test_batch_size, out);
-        empty_cuda_cache();
-
-        // Update model after training
-        this->_mlmodel.read_from_repository(this->_logger);
-        this->_mlmodel.read_corresp_file();
-
-        inputc.response_params(out);
-        this->_logger->info("Training done.");
-        return 0;
-    }
-
-    template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-    int TorchLib<TInputConnectorStrategy, TOutputConnectorStrategy, TMLModel>::predict(const APIData &ad, APIData &out)
-    {
-      int64_t predict_batch_size = 1;
-        APIData params = ad.getobj("parameters");
-        APIData output_params = params.getobj("output");
-        if (params.has("mllib"))
-          {
-            APIData ad_mllib = ad.getobj("parameters").getobj("mllib");
-            if (ad_mllib.has("net"))
+            if ((batch_id + 1) % iter_size == 0)
               {
-                APIData ad_net = ad_mllib.getobj("net");
-                if (ad_net.has("test_batch_size"))
-                  predict_batch_size = ad_net.get("test_batch_size").get<int>();
+                if (!this->_tjob_running.load())
+                  {
+                    break;
+                  }
+                try
+                  {
+                    optimizer->step();
+                    optimizer->zero_grad();
+                  }
+                catch (std::exception &e)
+                  {
+                    this->_logger->error(std::string("Libtorch error: ")
+                                         + e.what());
+                    throw MLLibInternalException(
+                        std::string("Libtorch error: ") + e.what());
+                  }
+
+                avg_it_time /= iter_size;
+                this->add_meas("learning_rate", base_lr);
+                this->add_meas("iteration", it);
+                this->add_meas("iter_time", avg_it_time);
+                this->add_meas("remain_time", avg_it_time * iter_size
+                                                  * (iterations - it)
+                                                  / 1000.0);
+                this->add_meas("train_loss", train_loss);
+                this->add_meas_per_iter("learning_rate", base_lr);
+                this->add_meas_per_iter("train_loss", train_loss);
+                int64_t elapsed_it = it + 1;
+                if (log_batch_period != 0
+                    && elapsed_it % log_batch_period == 0)
+                  {
+                    this->_logger->info("Iteration {}/{}: loss is {}",
+                                        elapsed_it, iterations, train_loss);
+                  }
+                avg_it_time = 0;
+                train_loss = 0;
+
+                if (elapsed_it % test_interval == 0 && elapsed_it != iterations
+                    && !eval_dataset.empty())
+                  {
+                    // Free memory
+                    loss = torch::empty(1);
+                    y_pred = torch::empty(1);
+                    y = torch::empty(1);
+                    in_vals.clear();
+
+                    APIData meas_out;
+                    this->_logger->info("Start test");
+                    test(ad, inputc, eval_dataset, test_batch_size, meas_out);
+                    APIData meas_obj = meas_out.getobj("measure");
+                    std::vector<std::string> meas_names = meas_obj.list_keys();
+
+                    best_to_remove = save_if_best(meas_obj, elapsed_it,
+                                                  *optimizer, best_to_remove);
+
+                    for (auto name : meas_names)
+                      {
+                        if (name != "cmdiag" && name != "cmfull"
+                            && name != "labels")
+                          {
+                            double mval = meas_obj.get(name).get<double>();
+                            this->_logger->info("{}={}", name, mval);
+                            this->add_meas(name, mval);
+                            this->add_meas_per_iter(name, mval);
+                          }
+                        else if (name == "cmdiag")
+                          {
+                            std::vector<double> mdiag
+                                = meas_obj.get(name)
+                                      .get<std::vector<double>>();
+                            std::vector<std::string> cnames;
+                            std::string mdiag_str;
+                            for (size_t i = 0; i < mdiag.size(); i++)
+                              {
+                                mdiag_str
+                                    += this->_mlmodel.get_hcorresp(i) + ":"
+                                       + std::to_string(mdiag.at(i)) + " ";
+                                this->add_meas_per_iter(
+                                    name + '_'
+                                        + this->_mlmodel.get_hcorresp(i),
+                                    mdiag.at(i));
+                                cnames.push_back(
+                                    this->_mlmodel.get_hcorresp(i));
+                              }
+                            this->_logger->info("{}=[{}]", name, mdiag_str);
+                            this->add_meas(name, mdiag, cnames);
+                          }
+                      }
+                  }
+
+                if ((save_period != 0 && elapsed_it % save_period == 0)
+                    || elapsed_it == iterations)
+                  {
+                    if (best_to_remove == elapsed_it)
+                      // current model already snapshoted as best model,
+                      // do not remove regular snapshot if it is  best model
+                      best_to_remove = -1;
+                    else
+                      snapshot(elapsed_it, *optimizer);
+                  }
+                ++it;
+
+                if (it >= iterations)
+                  break;
+              }
+
+            ++batch_id;
+          }
+      }
+
+    if (!this->_tjob_running.load())
+      {
+        this->_logger->info("Training job interrupted at iteration {}", it);
+        empty_cuda_cache();
+        return -1;
+      }
+
+    test(ad, inputc, inputc._test_dataset, test_batch_size, out);
+    empty_cuda_cache();
+
+    // Update model after training
+    this->_mlmodel.read_from_repository(this->_logger);
+    this->_mlmodel.read_corresp_file();
+
+    inputc.response_params(out);
+    this->_logger->info("Training done.");
+    return 0;
+  }
+
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  int TorchLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+               TMLModel>::predict(const APIData &ad, APIData &out)
+  {
+    int64_t predict_batch_size = 1;
+    APIData params = ad.getobj("parameters");
+    APIData output_params = params.getobj("output");
+    if (params.has("mllib"))
+      {
+        APIData ad_mllib = ad.getobj("parameters").getobj("mllib");
+        if (ad_mllib.has("net"))
+          {
+            APIData ad_net = ad_mllib.getobj("net");
+            if (ad_net.has("test_batch_size"))
+              predict_batch_size = ad_net.get("test_batch_size").get<int>();
+          }
+      }
+
+    bool lstm_continuation = false;
+    TInputConnectorStrategy inputc(this->_inputc);
+    TOutputConnectorStrategy outputc(this->_outputc);
+    ;
+    try
+      {
+        inputc.transform(ad);
+        if (_module._native)
+          {
+            auto batchoptional = inputc._dataset.get_batch({ 1 });
+            TorchBatch batch = batchoptional.value();
+            torch::Tensor td = batch.data[0];
+            _module._native->finalize(td.sizes());
+            // reload params after finalize
+            if (!this->_mlmodel._traced.empty())
+              torch::load(_module._native, this->_mlmodel._traced, _device);
+            _module._native->to(_device);
+
+            if (ad.getobj("parameters").getobj("input").has("continuation")
+                && ad.getobj("parameters")
+                       .getobj("input")
+                       .get("continuation")
+                       .get<bool>())
+              {
+                lstm_continuation = true;
+                _module._native->lstm_continues(true);
+              }
+            else
+              {
+                lstm_continuation = false;
+                _module._native->lstm_continues(false);
               }
           }
+      }
+    catch (...)
+      {
+        throw;
+      }
+    torch::Device cpu("cpu");
+    _module.eval();
 
+    if (output_params.has("measure"))
+      {
+        APIData meas_out;
+        test(ad, inputc, inputc._dataset, 1, meas_out);
+        meas_out.erase("iteration");
+        meas_out.erase("train_loss");
+        out.add("measure", meas_out.getobj("measure"));
+        empty_cuda_cache();
+        return 0;
+      }
 
-		bool lstm_continuation = false;
-        TInputConnectorStrategy inputc(this->_inputc);
-        TOutputConnectorStrategy outputc(this->_outputc);;
+    inputc._dataset.reset(false);
+
+    //		int batch_size = inputc._dataset.cache_size();
+    int batch_size = predict_batch_size;
+    if (lstm_continuation)
+      batch_size = 1;
+
+    auto dataloader = torch::data::make_data_loader(
+        std::move(inputc._dataset), data::DataLoaderOptions(batch_size));
+
+    std::vector<APIData> results_ads;
+    int nsample = 0;
+
+    for (TorchBatch batch : *dataloader)
+      {
+
+        std::vector<c10::IValue> in_vals;
+        for (Tensor tensor : batch.data)
+          {
+            in_vals.push_back(tensor.to(_device));
+          }
+        Tensor output;
         try
-		  {
-            inputc.transform(ad);
-			if (_module._native)
-			  {
-				auto batchoptional = inputc._dataset.get_batch({1});
-				TorchBatch batch = batchoptional.value();
-				torch::Tensor td = batch.data[0];
-                _module._native->finalize(td.sizes());
-                // reload params after finalize
-                if (!this->_mlmodel._traced.empty())
-                  torch::load(_module._native, this->_mlmodel._traced, _device);
-                _module._native->to(_device);
+          {
+            output = to_tensor_safe(_module.forward(in_vals));
+            if (_timeserie)
+              {
+                // DO NOTHING
+              }
+            else
+              {
+                if (_template == "gpt2")
+                  {
+                    // Keep only the prediction for the last token
+                    Tensor input_ids = batch.data[0];
+                    std::vector<Tensor> outputs;
+                    for (int i = 0; i < input_ids.size(0); ++i)
+                      {
+                        // output is (n_batch * sequence_length * vocab_size)
+                        // With gpt2, last token is endoftext so we need to
+                        // take the previous output.
+                        outputs.push_back(
+                            output[i][inputc._lengths.at(i) - 2]);
+                      }
+                    output = torch::stack(outputs);
+                  }
+                output = torch::softmax(output, 1).to(cpu);
+              }
+          }
+        catch (std::exception &e)
+          {
+            throw MLLibInternalException(std::string("Libtorch error:")
+                                         + e.what());
+          }
 
-				if (ad.getobj("parameters").getobj("input").has("continuation") &&
-					ad.getobj("parameters").getobj("input").get("continuation").get<bool>())
-				  {
-					lstm_continuation = true;
-					_module._native->lstm_continues(true);
-				  }
-				else
-				  {
-					lstm_continuation = false;
-					_module._native->lstm_continues(false);
-				  }
-			  }
-		  } catch (...) {
-		  throw;
-        }
-        torch::Device cpu("cpu");
-        _module.eval();
+        // Output
 
-        if (output_params.has("measure"))
-        {
-            APIData meas_out;
-            test(ad, inputc, inputc._dataset, 1, meas_out);
-            meas_out.erase("iteration");
-	        meas_out.erase("train_loss");
-            out.add("measure", meas_out.getobj("measure"));
-            empty_cuda_cache();
-            return 0;
-        }
+        if (output_params.has("best"))
+          {
+            const int best_count = output_params.get("best").get<int>();
+            std::tuple<Tensor, Tensor> sorted_output = output.sort(1, true);
+            auto probs_acc = std::get<0>(sorted_output).accessor<float, 2>();
+            auto indices_acc
+                = std::get<1>(sorted_output).accessor<int64_t, 2>();
 
-        inputc._dataset.reset(false);
+            for (int i = 0; i < output.size(0); ++i)
+              {
+                APIData results_ad;
+                std::vector<double> probs;
+                std::vector<std::string> cats;
 
-		//		int batch_size = inputc._dataset.cache_size();
-		int batch_size = predict_batch_size;
-		if (lstm_continuation)
-		  batch_size = 1;
+                for (int j = 0; j < best_count; ++j)
+                  {
+                    probs.push_back(probs_acc[i][j]);
+                    int index = indices_acc[i][j];
+                    if (_seq_training)
+                      {
+                        cats.push_back(inputc.get_word(index));
+                      }
+                    else
+                      {
+                        cats.push_back(this->_mlmodel.get_hcorresp(index));
+                      }
+                  }
 
-		 auto dataloader = torch::data::make_data_loader
-		   ( std::move(inputc._dataset),
-			 data::DataLoaderOptions(batch_size));
+                results_ad.add("uri", inputc._uris.at(results_ads.size()));
+                results_ad.add("loss", 0.0);
+                results_ad.add("cats", cats);
+                results_ad.add("probs", probs);
+                results_ad.add("nclasses", (int)_nclasses);
 
-		 std::vector<APIData> results_ads;
-		 int nsample = 0;
+                results_ads.push_back(results_ad);
+              }
+          }
+        else if (_timeserie)
+          {
+            output = output.to(cpu);
+            auto output_acc = output.accessor<float, 3>();
+            for (int j = 0; j < output.size(0); ++j)
+              {
+                std::vector<APIData> series;
+                for (int t = 0; t < output.size(1); ++t)
+                  {
+                    std::vector<double> preds;
+                    for (unsigned int k = 0; k < this->_inputc._ntargets; ++k)
+                      {
+                        preds.push_back(output_acc[j][t][k]);
+                      }
+                    APIData ts;
+                    ts.add("out", preds);
+                    series.push_back(ts);
+                  }
+                APIData result_ad;
+                if (!inputc._ids.empty())
+                  result_ad.add("uri", inputc._ids.at(nsample++));
+                else
+                  result_ad.add("uri", std::to_string(nsample++));
+                result_ad.add("series", series);
+                result_ad.add("probs",
+                              std::vector<double>(series.size(), 1.0));
+                result_ad.add("loss", 0.0);
+                results_ads.push_back(result_ad);
+              }
+          }
+      }
+    outputc.add_results(results_ads);
 
-		 for (TorchBatch batch : *dataloader)
-		  {
+    if (_timeserie)
+      out.add("timeseries", true);
+    outputc.finalize(output_params, out,
+                     static_cast<MLModel *>(&this->_mlmodel));
 
-			std::vector<c10::IValue> in_vals;
-			for (Tensor tensor : batch.data)
-			  {
-				in_vals.push_back(tensor.to(_device));
-			  }
-			Tensor output;
-			try
-			  {
-				output = to_tensor_safe(_module.forward(in_vals));
-				if (_timeserie)
-				  {
-					//DO NOTHING
-				  }
-				else
-				  {
-					if (_template == "gpt2")
-					  {
-						// Keep only the prediction for the last token
-						Tensor input_ids = batch.data[0];
-						std::vector<Tensor> outputs;
-						for (int i = 0; i < input_ids.size(0); ++i)
-						  {
-							// output is (n_batch * sequence_length * vocab_size)
-							// With gpt2, last token is endoftext so we need to take the previous output.
-							outputs.push_back(output[i][inputc._lengths.at(i) - 2]);
-						  }
-						output = torch::stack(outputs);
-					  }
-					output = torch::softmax(output, 1).to(cpu);
-				  }
-			  }
-			catch (std::exception &e)
-			  {
-				throw MLLibInternalException(std::string("Libtorch error:") + e.what());
-			  }
+    out.add("status", 0);
+    return 0;
+  }
 
-			// Output
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  int TorchLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+               TMLModel>::test(const APIData &ad,
+                               TInputConnectorStrategy &inputc,
+                               TorchDataset &dataset, int batch_size,
+                               APIData &out)
+  {
+    APIData ad_res;
+    APIData ad_out = ad.getobj("parameters").getobj("output");
+    int nclasses = _masked_lm ? inputc.vocab_size() : _nclasses;
 
-			if (output_params.has("best"))
-			  {
-				const int best_count = output_params.get("best").get<int>();
-				std::tuple<Tensor, Tensor> sorted_output = output.sort(1, true);
-				auto probs_acc = std::get<0>(sorted_output).accessor<float,2>();
-				auto indices_acc = std::get<1>(sorted_output).accessor<int64_t,2>();
+    // confusion matrix is irrelevant to masked_lm training
+    if (_masked_lm && ad_out.has("measure"))
+      {
+        auto meas = ad_out.get("measure").get<std::vector<std::string>>();
+        std::vector<std::string>::iterator it;
+        if ((it = std::find(meas.begin(), meas.end(), "cmfull")) != meas.end())
+          meas.erase(it);
+        if ((it = std::find(meas.begin(), meas.end(), "cmdiag")) != meas.end())
+          meas.erase(it);
+        ad_out.add("measure", meas);
+      }
 
-				for (int i = 0; i < output.size(0); ++i)
-				  {
-					APIData results_ad;
-					std::vector<double> probs;
-					std::vector<std::string> cats;
+    auto dataloader = torch::data::make_data_loader(
+        dataset, data::DataLoaderOptions(batch_size));
+    torch::Device cpu("cpu");
 
-					for (int j = 0; j < best_count; ++j)
-					  {
-						probs.push_back(probs_acc[i][j]);
-						int index = indices_acc[i][j];
-						if (_seq_training)
-						  {
-							cats.push_back(inputc.get_word(index));
-						  }
-						else
-						  {
-							cats.push_back(this->_mlmodel.get_hcorresp(index));
-						  }
-					  }
+    _module.eval();
+    int entry_id = 0;
+    for (TorchBatch batch : *dataloader)
+      {
+        if (_masked_lm)
+          {
+            batch = inputc.generate_masked_lm_batch(batch);
+          }
+        std::vector<c10::IValue> in_vals;
+        for (Tensor tensor : batch.data)
+          in_vals.push_back(tensor.to(_device));
 
-					results_ad.add("uri", inputc._uris.at(results_ads.size()));
-					results_ad.add("loss", 0.0);
-					results_ad.add("cats", cats);
-					results_ad.add("probs", probs);
-					results_ad.add("nclasses", (int)_nclasses);
+        Tensor output;
+        try
+          {
+            output = to_tensor_safe(_module.forward(in_vals));
+          }
+        catch (std::exception &e)
+          {
+            throw MLLibInternalException(std::string("Libtorch error: ")
+                                         + e.what());
+          }
 
-					results_ads.push_back(results_ad);
-				  }
-			  }
-			else if (_timeserie)
-			  {
-				output = output.to(cpu);
-				auto output_acc = output.accessor<float,3>();
-				for (int j=0; j<output.size(0); ++j)
-				  {
-					std::vector<APIData> series;
-					for (int t=0; t<output.size(1); ++t)
-					  {
-						std::vector<double> preds;
-						for (unsigned int k=0; k<this->_inputc._ntargets; ++k)
-						  {
-							preds.push_back(output_acc[j][t][k]);
-						  }
-						APIData ts;
-						ts.add("out", preds);
-						series.push_back(ts);
-					  }
-					APIData result_ad;
-					if (!inputc._ids.empty())
-					  result_ad.add("uri",inputc._ids.at(nsample++));
-					else result_ad.add("uri",std::to_string(nsample++));
-					result_ad.add("series", series);
-					result_ad.add("probs",std::vector<double>(series.size(),1.0));
-					result_ad.add("loss",0.0);
-					results_ads.push_back(result_ad);
-				  }
-			  }
-		  }
-		 outputc.add_results(results_ads);
+        if (batch.target.empty())
+          throw MLLibBadParamException("Missing label on data while testing");
+        Tensor labels;
+        if (_timeserie)
+          {
+            // iterate over data in batch
+            labels = batch.target[0];
+            output = output.to(cpu);
+            labels = labels.to(cpu);
+            auto output_acc = output.accessor<float, 3>();
+            auto target_acc = labels.accessor<float, 3>();
 
-		 if (_timeserie)
-		   out.add("timeseries",true);
-		 outputc.finalize(output_params, out, static_cast<MLModel*>(&this->_mlmodel));
-
-        out.add("status", 0);
-        return 0;
-    }
-
-    template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-    int TorchLib<TInputConnectorStrategy, TOutputConnectorStrategy, TMLModel>::test(const APIData &ad,
-                                                                                    TInputConnectorStrategy &inputc,
-                                                                                    TorchDataset &dataset,
-                                                                                    int batch_size,
-                                                                                    APIData &out)
-    {
-        APIData ad_res;
-        APIData ad_out = ad.getobj("parameters").getobj("output");
-        int nclasses = _masked_lm ? inputc.vocab_size() : _nclasses;
-
-        // confusion matrix is irrelevant to masked_lm training
-        if (_masked_lm && ad_out.has("measure"))
-        {
-            auto meas = ad_out.get("measure").get<std::vector<std::string>>();
-            std::vector<std::string>::iterator it;
-            if ((it = std::find(meas.begin(), meas.end(), "cmfull")) != meas.end())
-                meas.erase(it);
-            if ((it = std::find(meas.begin(), meas.end(), "cmdiag")) != meas.end())
-                meas.erase(it);
-            ad_out.add("measure", meas);
-        }
-
-        auto dataloader = torch::data::make_data_loader(
-            dataset,
-            data::DataLoaderOptions(batch_size)
-        );
-        torch::Device cpu("cpu");
-
-        _module.eval();
-        int entry_id = 0;
-        for (TorchBatch batch : *dataloader)
-        {
+            // tensors are test_batch_size x timesteps x ntargets
+            for (int j = 0; j < labels.size(0); ++j)
+              {
+                std::vector<double> targets;
+                std::vector<double> predictions;
+                for (int t = 0; t < labels.size(1); ++t)
+                  for (unsigned int k = 0; k < this->_inputc._ntargets; ++k)
+                    {
+                      targets.push_back(target_acc[j][t][k]);
+                      predictions.push_back(output_acc[j][t][k]);
+                    }
+                APIData bad;
+                bad.add("target", targets);
+                bad.add("pred", predictions);
+                ad_res.add(std::to_string(entry_id), bad);
+                ++entry_id;
+              }
+          }
+        else
+          {
+            labels = batch.target[0].view(IntList{ -1 });
             if (_masked_lm)
-            {
-                batch = inputc.generate_masked_lm_batch(batch);
-            }
-            std::vector<c10::IValue> in_vals;
-            for (Tensor tensor : batch.data)
-                in_vals.push_back(tensor.to(_device));
+              {
+                // Convert [n_batch, sequence_length, vocab_size] to [n_batch *
+                // sequence_length, vocab_size]
+                output = output.view(IntList{ -1, output.size(2) });
+              }
+            output = torch::softmax(output, 1).to(cpu);
+            auto output_acc = output.accessor<float, 2>();
+            auto labels_acc = labels.accessor<int64_t, 1>();
 
-            Tensor output;
-            try
-            {
-                output = to_tensor_safe(_module.forward(in_vals));
-            }
-            catch (std::exception &e)
-            {
-                throw MLLibInternalException(std::string("Libtorch error: ") + e.what());
-            }
+            for (int j = 0; j < labels.size(0); ++j)
+              {
+                if (_masked_lm && labels_acc[j] == -1)
+                  continue;
 
-            if (batch.target.empty())
-                throw MLLibBadParamException("Missing label on data while testing");
-            Tensor labels;
-			if (_timeserie)
-			  {
-				//iterate over data in batch
-				labels = batch.target[0];
-				output = output.to(cpu);
-				labels = labels.to(cpu);
-				auto output_acc = output.accessor<float,3>();
-				auto target_acc = labels.accessor<float,3>();
+                APIData bad;
+                std::vector<double> predictions;
+                for (int c = 0; c < nclasses; c++)
+                  {
+                    predictions.push_back(output_acc[j][c]);
+                  }
+                bad.add("target", static_cast<double>(labels_acc[j]));
+                bad.add("pred", predictions);
+                ad_res.add(std::to_string(entry_id), bad);
+                ++entry_id;
+              }
+          }
+        // this->_logger->info("Testing: {}/{} entries processed", entry_id,
+        // test_size);
+      }
 
-				// tensors are test_batch_size x timesteps x ntargets
-				for (int j=0; j<labels.size(0); ++j)
-				  {
-					std::vector<double> targets;
-					std::vector<double> predictions;
-					for (int t=0; t<labels.size(1); ++t)
-					  for (unsigned int k=0; k<this->_inputc._ntargets; ++k)
-						{
-						  targets.push_back(target_acc[j][t][k]);
-						  predictions.push_back(output_acc[j][t][k]);
-						}
-					APIData bad;
-					bad.add("target", targets);
-					bad.add("pred", predictions);
-					ad_res.add(std::to_string(entry_id), bad);
-					++entry_id;
-				  }
-			  }
-			else
-			  {
-				labels = batch.target[0].view(IntList{-1});
-				if (_masked_lm)
-				  {
-					// Convert [n_batch, sequence_length, vocab_size] to [n_batch * sequence_length, vocab_size]
-					output = output.view(IntList{-1, output.size(2)});
-				  }
-				output = torch::softmax(output, 1).to(cpu);
-				auto output_acc = output.accessor<float,2>();
-				auto labels_acc = labels.accessor<int64_t,1>();
+    ad_res.add("iteration", this->get_meas("iteration") + 1);
+    ad_res.add("train_loss", this->get_meas("train_loss"));
+    if (_timeserie)
+      {
+        ad_res.add("timeserie", true);
+        ad_res.add("timeseries", (int)this->_inputc._ntargets);
+      }
+    else
+      {
+        std::vector<std::string> clnames;
+        for (int i = 0; i < nclasses; i++)
+          clnames.push_back(this->_mlmodel.get_hcorresp(i));
+        ad_res.add("clnames", clnames);
+        ad_res.add("nclasses", nclasses);
+      }
+    ad_res.add("batch_size",
+               entry_id); // here batch_size = tested entries count
+    SupervisedOutput::measure(ad_res, ad_out, out);
+    _module.train();
+    return 0;
+  }
 
-				for (int j = 0; j < labels.size(0); ++j)
-				  {
-					if (_masked_lm && labels_acc[j] == -1)
-					  continue;
-
-					APIData bad;
-					std::vector<double> predictions;
-					for (int c = 0; c < nclasses; c++)
-					  {
-						predictions.push_back(output_acc[j][c]);
-					  }
-					bad.add("target", static_cast<double>(labels_acc[j]));
-					bad.add("pred", predictions);
-					ad_res.add(std::to_string(entry_id), bad);
-					++entry_id;
-				  }
-			  }
-            // this->_logger->info("Testing: {}/{} entries processed", entry_id, test_size);
-        }
-
-        ad_res.add("iteration",this->get_meas("iteration")+1);
-        ad_res.add("train_loss",this->get_meas("train_loss"));
-		if (_timeserie)
-		  {
-			ad_res.add("timeserie", true);
-			ad_res.add("timeseries", (int)this->_inputc._ntargets);
-		  }
-		else
-		  {
-			std::vector<std::string> clnames;
-			for (int i=0;i< nclasses;i++)
-			  clnames.push_back(this->_mlmodel.get_hcorresp(i));
-			ad_res.add("clnames", clnames);
-			ad_res.add("nclasses", nclasses);
-		  }
-        ad_res.add("batch_size", entry_id); // here batch_size = tested entries count
-        SupervisedOutput::measure(ad_res, ad_out, out);
-		_module.train();
-        return 0;
-    }
-
-
-    template class TorchLib<ImgTorchInputFileConn,SupervisedOutput,TorchModel>;
-    template class TorchLib<TxtTorchInputFileConn,SupervisedOutput,TorchModel>;
-    template class TorchLib<CSVTSTorchInputFileConn,SupervisedOutput,TorchModel>;
+  template class TorchLib<ImgTorchInputFileConn, SupervisedOutput, TorchModel>;
+  template class TorchLib<TxtTorchInputFileConn, SupervisedOutput, TorchModel>;
+  template class TorchLib<CSVTSTorchInputFileConn, SupervisedOutput,
+                          TorchModel>;
 }

--- a/src/backends/torch/torchmodel.cc
+++ b/src/backends/torch/torchmodel.cc
@@ -23,68 +23,82 @@
 
 namespace dd
 {
-    int TorchModel::read_from_repository(
-        const std::shared_ptr<spdlog::logger> &logger) {
+  int TorchModel::read_from_repository(
+      const std::shared_ptr<spdlog::logger> &logger)
+  {
 
-        const std::string weights = ".ptw";
-        const std::string traced = ".pt";
-        const std::string corresp = "corresp";
-		//solver. may lead to _solver.prototxt when generated from caffe generator
-		//we save solver states as solver-##.pt where ## is iteration number
-        const std::string sstate = "solver-";
-        const std::string proto = "proto";
+    const std::string weights = ".ptw";
+    const std::string traced = ".pt";
+    const std::string corresp = "corresp";
+    // solver. may lead to _solver.prototxt when generated from caffe generator
+    // we save solver states as solver-##.pt where ## is iteration number
+    const std::string sstate = "solver-";
+    const std::string proto = "proto";
 
-        std::unordered_set<std::string> files;
-        int err = fileops::list_directory(_repo, true, false, false, files);
+    std::unordered_set<std::string> files;
+    int err = fileops::list_directory(_repo, true, false, false, files);
 
-        if (err != 0) {
-            logger->error("Listing pytorch models failed");
-            return 1;
-        }
+    if (err != 0)
+      {
+        logger->error("Listing pytorch models failed");
+        return 1;
+      }
 
-        std::string tracedf,weightsf,correspf,sstatef,protof;
-        int traced_t = -1, weights_t = -1, corresp_t = -1, sstate_t = -1, proto_t = -1;
+    std::string tracedf, weightsf, correspf, sstatef, protof;
+    int traced_t = -1, weights_t = -1, corresp_t = -1, sstate_t = -1,
+        proto_t = -1;
 
-        for (const auto &file : files) {
-            long int lm = fileops::file_last_modif(file);
-            if (file.find(sstate) != std::string::npos) {
-                if (sstate_t < lm) {
-                    sstatef = file;
-                    sstate_t = lm;
-                }
-            }
-            else if (file.find(weights) != std::string::npos) {
-                if (weights_t < lm) {
-                    weightsf = file;
-                    weights_t = lm;
-                }
-            }
-            else if (file.find(traced) != std::string::npos) {
-                if (traced_t < lm) {
-                    tracedf = file;
-                    traced_t = lm;
-                }
-            }
-            else if (file.find(corresp) != std::string::npos) {
-                if (corresp_t < lm) {
-                    correspf = file;
-                    corresp_t = lm;
-                }
-            }
-            else if (file.find(proto) != std::string::npos) {
-              if (proto_t < lm) {
+    for (const auto &file : files)
+      {
+        long int lm = fileops::file_last_modif(file);
+        if (file.find(sstate) != std::string::npos)
+          {
+            if (sstate_t < lm)
+              {
+                sstatef = file;
+                sstate_t = lm;
+              }
+          }
+        else if (file.find(weights) != std::string::npos)
+          {
+            if (weights_t < lm)
+              {
+                weightsf = file;
+                weights_t = lm;
+              }
+          }
+        else if (file.find(traced) != std::string::npos)
+          {
+            if (traced_t < lm)
+              {
+                tracedf = file;
+                traced_t = lm;
+              }
+          }
+        else if (file.find(corresp) != std::string::npos)
+          {
+            if (corresp_t < lm)
+              {
+                correspf = file;
+                corresp_t = lm;
+              }
+          }
+        else if (file.find(proto) != std::string::npos)
+          {
+            if (proto_t < lm)
+              {
                 protof = file;
                 proto_t = lm;
               }
-            }
-        }
+          }
+      }
 
-        _traced = tracedf;
-        _weights = weightsf;
-        _corresp = correspf;
-        _sstate = sstatef;
-        _proto = protof;
+    _traced = tracedf;
+    _weights = weightsf;
+    _corresp = correspf;
+    _sstate = sstatef;
+    _proto = protof;
 
-        return 0;
-    }
+    return 0;
+  }
 }

--- a/src/backends/torch/torchmodel.h
+++ b/src/backends/torch/torchmodel.h
@@ -28,32 +28,38 @@
 
 namespace dd
 {
-    class TorchModel : public MLModel
+  class TorchModel : public MLModel
+  {
+  public:
+    TorchModel() : MLModel()
     {
-    public:
-        TorchModel() : MLModel() {}
+    }
 
-        TorchModel(const APIData &ad, APIData &adg,
-		    const std::shared_ptr<spdlog::logger> &logger)
-	        : MLModel(ad, adg, logger) {
+    TorchModel(const APIData &ad, APIData &adg,
+               const std::shared_ptr<spdlog::logger> &logger)
+        : MLModel(ad, adg, logger)
+    {
 
-	        read_from_repository(spdlog::get("api"));
-            read_corresp_file();
-        }
+      read_from_repository(spdlog::get("api"));
+      read_corresp_file();
+    }
 
-        TorchModel(const std::string &repo)
-            : MLModel(repo) {}
-        
-        ~TorchModel() {}
+    TorchModel(const std::string &repo) : MLModel(repo)
+    {
+    }
 
-        int read_from_repository(const std::shared_ptr<spdlog::logger> &logger);
+    ~TorchModel()
+    {
+    }
 
-    public:
-        std::string _traced;/**< path of the traced part of the net. */
-        std::string _weights;/**< path of the weights of the net. */
-        std::string _sstate;/**< current solver state to resume training */
-        std::string _proto;/**< prototxt file generated or read as graph */
-    };
+    int read_from_repository(const std::shared_ptr<spdlog::logger> &logger);
+
+  public:
+    std::string _traced;  /**< path of the traced part of the net. */
+    std::string _weights; /**< path of the weights of the net. */
+    std::string _sstate;  /**< current solver state to resume training */
+    std::string _proto;   /**< prototxt file generated or read as graph */
+  };
 }
 
 #endif // TORCHMODEL_H

--- a/src/backends/tsne/tsneinputconns.cc
+++ b/src/backends/tsne/tsneinputconns.cc
@@ -27,21 +27,21 @@ namespace dd
   {
     try
       {
-	CSVInputFileConn::transform(ad);
+        CSVInputFileConn::transform(ad);
       }
     catch (std::exception &e)
       {
-	throw;
+        throw;
       }
     _N = _csvdata.size();
     _D = _csvdata.at(0)._v.size();
-    _X = dMatR::Zero(_N,_D);
-    for (int i=0;i<_N;i++)
+    _X = dMatR::Zero(_N, _D);
+    for (int i = 0; i < _N; i++)
       {
-	for (int j=0;j<_D;j++)
-	  {
-	    _X(i,j) = _csvdata[i]._v[j];
-	  }
+        for (int j = 0; j < _D; j++)
+          {
+            _X(i, j) = _csvdata[i]._v[j];
+          }
       }
     _csvdata.clear();
   }
@@ -50,32 +50,32 @@ namespace dd
   {
     try
       {
-	TxtInputFileConn::transform(ad);
+        TxtInputFileConn::transform(ad);
       }
-    catch(std::exception &e)
+    catch (std::exception &e)
       {
-	throw;
+        throw;
       }
     _N = _txt.size();
     _D = _vocab.size();
-    _X = dMatR::Zero(_N,_D);
+    _X = dMatR::Zero(_N, _D);
     int i = 0;
     auto hit = _txt.begin();
-    while(hit!=_txt.end())
+    while (hit != _txt.end())
       {
-	TxtBowEntry *tbe = static_cast<TxtBowEntry*>((*hit));
-	std::unordered_map<std::string,Word>::const_iterator wit;
-	tbe->reset();
-	while(tbe->has_elt())
-	  {
-	    std::string key;
-	    double val;
-	    tbe->get_next_elt(key,val);
-	    if ((wit = _vocab.find(key))!=_vocab.end())
-	      _X(i,_vocab[key]._pos) = val;
-	  }
-	++i;
-	++hit;
+        TxtBowEntry *tbe = static_cast<TxtBowEntry *>((*hit));
+        std::unordered_map<std::string, Word>::const_iterator wit;
+        tbe->reset();
+        while (tbe->has_elt())
+          {
+            std::string key;
+            double val;
+            tbe->get_next_elt(key, val);
+            if ((wit = _vocab.find(key)) != _vocab.end())
+              _X(i, _vocab[key]._pos) = val;
+          }
+        ++i;
+        ++hit;
       }
   }
 }

--- a/src/backends/tsne/tsneinputconns.h
+++ b/src/backends/tsne/tsneinputconns.h
@@ -28,19 +28,26 @@
 
 namespace dd
 {
-  typedef Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic,Eigen::RowMajor> dMatR;
-  
+  typedef Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic,
+                        Eigen::RowMajor>
+      dMatR;
+
   class TSNEInputInterface
   {
   public:
-    TSNEInputInterface() {}
+    TSNEInputInterface()
+    {
+    }
     TSNEInputInterface(const TSNEInputInterface &tii)
-      :_X(tii._X),_D(tii._D),_N(tii._N) // XXX: avoid copying data ?
-      {
-      }
-    ~TSNEInputInterface() {}
+        : _X(tii._X), _D(tii._D), _N(tii._N) // XXX: avoid copying data ?
+    {
+    }
+    ~TSNEInputInterface()
+    {
+    }
+
   public:
-    dMatR _X; /**< data holder */
+    dMatR _X;    /**< data holder */
     int _D = -1; /**< problem dimensions */
     int _N = -1; /**< number of samples */
 
@@ -55,18 +62,24 @@ namespace dd
     {
       return -1;
     }
-    
-    //TODO: parameters, ids
+
+    // TODO: parameters, ids
   };
 
-  class CSVTSNEInputFileConn : public CSVInputFileConn, public TSNEInputInterface
+  class CSVTSNEInputFileConn : public CSVInputFileConn,
+                               public TSNEInputInterface
   {
   public:
-    CSVTSNEInputFileConn()
-      :CSVInputFileConn() {}
+    CSVTSNEInputFileConn() : CSVInputFileConn()
+    {
+    }
     CSVTSNEInputFileConn(const CSVTSNEInputFileConn &i)
-      :CSVInputFileConn(i),TSNEInputInterface(i) {}
-    ~CSVTSNEInputFileConn() {}
+        : CSVInputFileConn(i), TSNEInputInterface(i)
+    {
+    }
+    ~CSVTSNEInputFileConn()
+    {
+    }
 
     void init(const APIData &ad)
     {
@@ -76,14 +89,20 @@ namespace dd
     void transform(const APIData &ad);
   };
 
-  class TxtTSNEInputFileConn : public TxtInputFileConn, public TSNEInputInterface
+  class TxtTSNEInputFileConn : public TxtInputFileConn,
+                               public TSNEInputInterface
   {
   public:
-    TxtTSNEInputFileConn()
-      :TxtInputFileConn() {}
+    TxtTSNEInputFileConn() : TxtInputFileConn()
+    {
+    }
     TxtTSNEInputFileConn(const TxtTSNEInputFileConn &i)
-      :TxtInputFileConn(i),TSNEInputInterface(i) {}
-    ~TxtTSNEInputFileConn() {}
+        : TxtInputFileConn(i), TSNEInputInterface(i)
+    {
+    }
+    ~TxtTSNEInputFileConn()
+    {
+    }
 
     void init(const APIData &ad)
     {
@@ -92,7 +111,7 @@ namespace dd
 
     void transform(const APIData &ad);
   };
-  
+
 }
 
 #endif

--- a/src/backends/tsne/tsnelib.cc
+++ b/src/backends/tsne/tsnelib.cc
@@ -27,7 +27,7 @@
 
 namespace dd
 {
- 
+
   unsigned int hardware_concurrency()
   {
     unsigned int cores = std::thread::hardware_concurrency();
@@ -35,120 +35,135 @@ namespace dd
       cores = dd_utils::my_hardware_concurrency();
     return cores;
   }
-  
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  TSNELib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::TSNELib(const TSNEModel &cmodel)
-    :MLLib<TInputConnectorStrategy,TOutputConnectorStrategy,TSNEModel>(cmodel)
+
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  TSNELib<TInputConnectorStrategy, TOutputConnectorStrategy,
+          TMLModel>::TSNELib(const TSNEModel &cmodel)
+      : MLLib<TInputConnectorStrategy, TOutputConnectorStrategy, TSNEModel>(
+          cmodel)
   {
     this->_libname = "tsne";
   }
 
-    template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  TSNELib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::TSNELib(TSNELib &&cl) noexcept
-    :MLLib<TInputConnectorStrategy,TOutputConnectorStrategy,TSNEModel>(std::move(cl))
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  TSNELib<TInputConnectorStrategy, TOutputConnectorStrategy,
+          TMLModel>::TSNELib(TSNELib &&cl) noexcept
+      : MLLib<TInputConnectorStrategy, TOutputConnectorStrategy, TSNEModel>(
+          std::move(cl))
   {
     this->_libname = "tsne";
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  TSNELib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::~TSNELib()
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  TSNELib<TInputConnectorStrategy, TOutputConnectorStrategy,
+          TMLModel>::~TSNELib()
   {
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void TSNELib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::init_mllib(const APIData &ad)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void TSNELib<TInputConnectorStrategy, TOutputConnectorStrategy,
+               TMLModel>::init_mllib(const APIData &ad)
   {
     (void)ad;
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void TSNELib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::clear_mllib(const APIData &ad)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void TSNELib<TInputConnectorStrategy, TOutputConnectorStrategy,
+               TMLModel>::clear_mllib(const APIData &ad)
   {
     (void)ad;
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  int TSNELib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::train(const APIData &ad,
-										APIData &out)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  int TSNELib<TInputConnectorStrategy, TOutputConnectorStrategy,
+              TMLModel>::train(const APIData &ad, APIData &out)
   {
-    std::lock_guard<std::mutex> lock(_tsne_mutex); // locking per service training call
-    
+    std::lock_guard<std::mutex> lock(
+        _tsne_mutex); // locking per service training call
+
     TInputConnectorStrategy inputc(this->_inputc);
     inputc._train = true;
     APIData cad = ad;
     try
       {
-	inputc.transform(cad);
+        inputc.transform(cad);
       }
-    catch(...)
+    catch (...)
       {
-	throw;
+        throw;
       }
-    
+
     // parameters
     APIData ad_mllib = ad.getobj("parameters").getobj("mllib");
     if (ad_mllib.has("iterations"))
       _iterations = ad_mllib.get("iterations").get<int>();
     if (ad_mllib.has("perplexity"))
       _perplexity = ad_mllib.get("perplexity").get<int>();
-    
+
     // t-sne
     int N = -1;
     int D = -1;
     double *Y = nullptr;
     try
       {
-	N = inputc._N;
-	D = inputc._D;
-	std::cerr << "N=" << N << " / D=" << D << std::endl;
-	int num_threads = hardware_concurrency();
-	this->_logger->info("Detected {} cores", num_threads);
-	Y = new double[N*_no_dims]; // results
-	for (int i=0;i<N*_no_dims;i++)
-	  Y[i] = 0.0;
+        N = inputc._N;
+        D = inputc._D;
+        std::cerr << "N=" << N << " / D=" << D << std::endl;
+        int num_threads = hardware_concurrency();
+        this->_logger->info("Detected {} cores", num_threads);
+        Y = new double[N * _no_dims]; // results
+        for (int i = 0; i < N * _no_dims; i++)
+          Y[i] = 0.0;
 
-	TSNE tsne = TSNE(N,D,_perplexity,_theta);
-	tsne.step1(inputc._X.data(),Y,num_threads);
-	int test_iter = 50;
-	//time_t start = time(0);
-	double loss = 0.0;
-	for (int iter = 0; iter < _iterations; iter++) {
-	  tsne.step2_one_iter(Y,iter,loss,test_iter);
-	  this->add_meas("train_loss",loss);
-	  this->add_meas_per_iter("train_loss",loss);
-	  this->add_meas("iteration", iter);
-	}
-	
+        TSNE tsne = TSNE(N, D, _perplexity, _theta);
+        tsne.step1(inputc._X.data(), Y, num_threads);
+        int test_iter = 50;
+        // time_t start = time(0);
+        double loss = 0.0;
+        for (int iter = 0; iter < _iterations; iter++)
+          {
+            tsne.step2_one_iter(Y, iter, loss, test_iter);
+            this->add_meas("train_loss", loss);
+            this->add_meas_per_iter("train_loss", loss);
+            this->add_meas("iteration", iter);
+          }
       }
-    catch(std::exception &e)
+    catch (std::exception &e)
       {
-	this->_logger->error(e.what());
-	throw; //TODO: MLLib exception
+        this->_logger->error(e.what());
+        throw; // TODO: MLLib exception
       }
 
     // capture of results
     TOutputConnectorStrategy tout(this->_outputc);
     std::vector<APIData> vrad;
-    for (int i=0;i<N;i++)
+    for (int i = 0; i < N; i++)
       {
-	APIData rad;
-	rad.add("uri",std::to_string(i)); //TODO: ids
-	rad.add("loss",0.0); //TODO: useless ?
-	std::vector<double> vals;
-	for (int j=0;j<_no_dims;j++)
-	  {
-	    vals.push_back(Y[i*_no_dims+j]);
-	  }
-	rad.add("vals",vals);
-	vrad.push_back(rad);
+        APIData rad;
+        rad.add("uri", std::to_string(i)); // TODO: ids
+        rad.add("loss", 0.0);              // TODO: useless ?
+        std::vector<double> vals;
+        for (int j = 0; j < _no_dims; j++)
+          {
+            vals.push_back(Y[i * _no_dims + j]);
+          }
+        rad.add("vals", vals);
+        vrad.push_back(rad);
       }
     delete[] Y;
     tout.add_results(vrad);
-    tout.finalize(ad.getobj("parameters").getobj("output"),out,static_cast<MLModel*>(&this->_mlmodel));
-    out.add("status",0);
+    tout.finalize(ad.getobj("parameters").getobj("output"), out,
+                  static_cast<MLModel *>(&this->_mlmodel));
+    out.add("status", 0);
     return 0;
   }
 
-  template class TSNELib<CSVTSNEInputFileConn,UnsupervisedOutput,TSNEModel>;
-  template class TSNELib<TxtTSNEInputFileConn,UnsupervisedOutput,TSNEModel>;
+  template class TSNELib<CSVTSNEInputFileConn, UnsupervisedOutput, TSNEModel>;
+  template class TSNELib<TxtTSNEInputFileConn, UnsupervisedOutput, TSNEModel>;
 }

--- a/src/backends/tsne/tsnelib.h
+++ b/src/backends/tsne/tsnelib.h
@@ -31,10 +31,12 @@ namespace dd
   /**
    * Multicore TSNE wrapper
    */
-    template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel=TSNEModel>
-    class TSNELib : public MLLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>
-    {
-    public:
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel = TSNEModel>
+  class TSNELib : public MLLib<TInputConnectorStrategy,
+                               TOutputConnectorStrategy, TMLModel>
+  {
+  public:
     TSNELib(const TSNEModel &tmodel);
     TSNELib(TSNELib &&tl) noexcept;
     ~TSNELib();
@@ -54,13 +56,14 @@ namespace dd
       return 0;
     }
 
-    public:
+  public:
     int _iterations = 5000;
     int _perplexity = 30;
-    const int _no_dims = 2; /**< target dimensionality, backend lib only supports 2D */
+    const int _no_dims
+        = 2; /**< target dimensionality, backend lib only supports 2D */
     double _theta = 0.5; /**< angle */
     std::mutex _tsne_mutex;
-    };
+  };
 
 }
 

--- a/src/backends/tsne/tsnemodel.h
+++ b/src/backends/tsne/tsnemodel.h
@@ -32,21 +32,29 @@ namespace dd
   class TSNEModel : public MLModel
   {
   public:
-    TSNEModel():MLModel() {}
-  TSNEModel(const APIData &ad,APIData &adg,
-	    const std::shared_ptr<spdlog::logger> &logger)
-    :MLModel(ad,adg,logger)
-      {
-	if (ad.has("repository"))
-	  this->_repo = ad.get("repository").get<std::string>();
-	read_from_repository();	
-      }
-    TSNEModel(const std::string &repo)
-      :MLModel(repo) {}
-    ~TSNEModel() {}
+    TSNEModel() : MLModel()
+    {
+    }
+    TSNEModel(const APIData &ad, APIData &adg,
+              const std::shared_ptr<spdlog::logger> &logger)
+        : MLModel(ad, adg, logger)
+    {
+      if (ad.has("repository"))
+        this->_repo = ad.get("repository").get<std::string>();
+      read_from_repository();
+    }
+    TSNEModel(const std::string &repo) : MLModel(repo)
+    {
+    }
+    ~TSNEModel()
+    {
+    }
 
-    //TODO: load and save
-    int read_from_repository() { return 0; };
+    // TODO: load and save
+    int read_from_repository()
+    {
+      return 0;
+    };
   };
 }
 

--- a/src/backends/xgb/xgbinputconns.cc
+++ b/src/backends/xgb/xgbinputconns.cc
@@ -30,145 +30,167 @@ namespace dd
 
   // XXX: Adapted from XGBoost c_api.cc, pretty much sub-optimal memory wise,
   // and not very much adapted to large data...
-  xgboost::DMatrix* XGDMatrixSliceDMatrix(xgboost::DMatrix* handle,
-					  const int* idxset,
-					  unsigned long len)
+  xgboost::DMatrix *XGDMatrixSliceDMatrix(xgboost::DMatrix *handle,
+                                          const int *idxset, unsigned long len)
   {
-    std::unique_ptr<xgboost::data::SimpleCSRSource> source(new xgboost::data::SimpleCSRSource());
-    
+    std::unique_ptr<xgboost::data::SimpleCSRSource> source(
+        new xgboost::data::SimpleCSRSource());
+
     xgboost::data::SimpleCSRSource src;
     src.CopyFrom(handle);
-    xgboost::data::SimpleCSRSource& ret = *source;
-    
+    xgboost::data::SimpleCSRSource &ret = *source;
+
     CHECK_EQ(src.info.group_ptr_.size(), 0)
-      << "slice does not support group structure";
-    
+        << "slice does not support group structure";
+
     ret.Clear();
     ret.info.num_row_ = len;
     ret.info.num_col_ = src.info.num_col_;
-    
-    //dmlc::DataIter<xgboost::RowBatch>* iter = &src;
+
+    // dmlc::DataIter<xgboost::RowBatch>* iter = &src;
     auto iter = &src;
     iter->BeforeFirst();
     CHECK(iter->Next());
-    
-    //const xgboost::RowBatch& batch = iter->Value();
+
+    // const xgboost::RowBatch& batch = iter->Value();
     const auto batch = iter->Value();
-    for (unsigned long i = 0; i < len; ++i) {
-      const int ridx = idxset[i];
-      //xgboost::RowBatch::Inst inst = batch[ridx];
-      auto inst = batch[ridx];
-      CHECK_LT(static_cast<unsigned long>(ridx), batch.Size());
-      ret.page_.data.Resize(ret.page_.data.Size() + inst.size());
-      std::memcpy(dmlc::BeginPtr(ret.page_.data.HostVector()) + ret.page_.offset.HostVector().back(), inst.data(),
-		  sizeof(xgboost::Entry) * inst.size());
-      ret.page_.offset.HostVector().push_back(ret.page_.offset.HostVector().back() + inst.size());
-      ret.info.num_nonzero_ += inst.size();
-      
-      if (src.info.labels_.HostVector().size() != 0) {
-	ret.info.labels_.HostVector().push_back(src.info.labels_.HostVector()[ridx]);
+    for (unsigned long i = 0; i < len; ++i)
+      {
+        const int ridx = idxset[i];
+        // xgboost::RowBatch::Inst inst = batch[ridx];
+        auto inst = batch[ridx];
+        CHECK_LT(static_cast<unsigned long>(ridx), batch.Size());
+        ret.page_.data.Resize(ret.page_.data.Size() + inst.size());
+        std::memcpy(dmlc::BeginPtr(ret.page_.data.HostVector())
+                        + ret.page_.offset.HostVector().back(),
+                    inst.data(), sizeof(xgboost::Entry) * inst.size());
+        ret.page_.offset.HostVector().push_back(
+            ret.page_.offset.HostVector().back() + inst.size());
+        ret.info.num_nonzero_ += inst.size();
+
+        if (src.info.labels_.HostVector().size() != 0)
+          {
+            ret.info.labels_.HostVector().push_back(
+                src.info.labels_.HostVector()[ridx]);
+          }
+        if (src.info.weights_.HostVector().size() != 0)
+          {
+            ret.info.weights_.HostVector().push_back(
+                src.info.weights_.HostVector()[ridx]);
+          }
+        if (src.info.root_index_.size() != 0)
+          {
+            ret.info.root_index_.push_back(src.info.root_index_[ridx]);
+          }
       }
-      if (src.info.weights_.HostVector().size() != 0) {
-	ret.info.weights_.HostVector().push_back(src.info.weights_.HostVector()[ridx]);
-      }
-      if (src.info.root_index_.size() != 0) {
-	ret.info.root_index_.push_back(src.info.root_index_[ridx]);
-      }
-    }
     xgboost::DMatrix *out = xgboost::DMatrix::Create(std::move(source));
     return out;
   }
-  
-  xgboost::DMatrix* CSVXGBInputFileConn::create_from_mat(const std::vector<CSVline> &csvl)
+
+  xgboost::DMatrix *
+  CSVXGBInputFileConn::create_from_mat(const std::vector<CSVline> &csvl)
   {
     if (csvl.empty())
       return nullptr;
-    std::unique_ptr<xgboost::data::SimpleCSRSource> source(new xgboost::data::SimpleCSRSource());
-    xgboost::data::SimpleCSRSource& mat = *source;
+    std::unique_ptr<xgboost::data::SimpleCSRSource> source(
+        new xgboost::data::SimpleCSRSource());
+    xgboost::data::SimpleCSRSource &mat = *source;
     bool nan_missing = xgboost::common::CheckNAN(_missing);
     mat.info.num_row_ = csvl.size();
-    mat.info.num_col_ = feature_size()+1; // XXX: +1 otherwise there's a mismatch in xgboost's simple_dmatrix.cc:151
+    mat.info.num_col_
+        = feature_size() + 1; // XXX: +1 otherwise there's a mismatch in
+                              // xgboost's simple_dmatrix.cc:151
     auto hit = csvl.begin();
-    while(hit!=csvl.end())
+    while (hit != csvl.end())
       {
-	long nelem = 0;
-	auto lit = _columns.begin();
-	for (int i=0;i<(int)(*hit)._v.size();i++)
-	  {
-	    double v = (*hit)._v.at(i);
-	    if (xgboost::common::CheckNAN(v) && !nan_missing)
-	      throw InputConnectorBadParamException("NaN value in input data matrix, and missing != NaN");
-	    std::vector<int>::iterator ipos;
-	    if (!_label_pos.empty()
-		&& (ipos = std::find(_label_pos.begin(),_label_pos.end(),i))!=_label_pos.end())
-	      {
-		int pos = std::distance(_label_pos.begin(),ipos);
-		mat.info.labels_.HostVector().push_back(v+_label_offset[pos]);
-	      }
-	    else if (i == _id_pos)
-	      {
-		++lit;
-		continue;
-	      }
-	    else if (std::find(_label_pos.begin(),_label_pos.end(),i)==_label_pos.end())
-	      {
-		if (nan_missing || v != _missing)
-		  {
-		    mat.page_.data.HostVector().push_back(xgboost::Entry(i,v));
-		    ++nelem;
-		  }
-	      }
-	    ++lit;
-	  }
-	mat.page_.offset.HostVector().push_back(mat.page_.offset.HostVector().back()+nelem);
-	this->_ids.push_back((*hit)._str);
-	++hit;
+        long nelem = 0;
+        auto lit = _columns.begin();
+        for (int i = 0; i < (int)(*hit)._v.size(); i++)
+          {
+            double v = (*hit)._v.at(i);
+            if (xgboost::common::CheckNAN(v) && !nan_missing)
+              throw InputConnectorBadParamException(
+                  "NaN value in input data matrix, and missing != NaN");
+            std::vector<int>::iterator ipos;
+            if (!_label_pos.empty()
+                && (ipos = std::find(_label_pos.begin(), _label_pos.end(), i))
+                       != _label_pos.end())
+              {
+                int pos = std::distance(_label_pos.begin(), ipos);
+                mat.info.labels_.HostVector().push_back(v
+                                                        + _label_offset[pos]);
+              }
+            else if (i == _id_pos)
+              {
+                ++lit;
+                continue;
+              }
+            else if (std::find(_label_pos.begin(), _label_pos.end(), i)
+                     == _label_pos.end())
+              {
+                if (nan_missing || v != _missing)
+                  {
+                    mat.page_.data.HostVector().push_back(
+                        xgboost::Entry(i, v));
+                    ++nelem;
+                  }
+              }
+            ++lit;
+          }
+        mat.page_.offset.HostVector().push_back(
+            mat.page_.offset.HostVector().back() + nelem);
+        this->_ids.push_back((*hit)._str);
+        ++hit;
       }
     mat.info.num_nonzero_ = mat.page_.data.HostVector().size();
     xgboost::DMatrix *out = xgboost::DMatrix::Create(std::move(source));
     return out;
   }
-  
+
   void CSVXGBInputFileConn::transform(const APIData &ad)
   {
     try
       {
-	CSVInputFileConn::transform(ad);
+        CSVInputFileConn::transform(ad);
       }
     catch (std::exception &e)
       {
-	throw;
-      }    
+        throw;
+      }
 
     // feature map (useful for feature importance analysis)
     if (ad.has("model_repo"))
       {
-	std::ofstream fmap(ad.get("model_repo").get<std::string>()+"/model.fmap",std::ios::binary);
-	int nc = 0;
-	for (auto c: this->_columns)
-	  {
-	    fmap << nc << "\t" << c << "\tq\n";
-	    ++nc;
-	  }
+        std::ofstream fmap(ad.get("model_repo").get<std::string>()
+                               + "/model.fmap",
+                           std::ios::binary);
+        int nc = 0;
+        for (auto c : this->_columns)
+          {
+            fmap << nc << "\t" << c << "\tq\n";
+            ++nc;
+          }
       }
-      
+
     if (!_direct_csv)
       {
-	_m = std::shared_ptr<xgboost::DMatrix>(create_from_mat(_csvdata));
-	_csvdata.clear();
-	if (_m->Info().num_nonzero_ == 0)
-	  throw InputConnectorBadParamException("no data could be found processing XGBoost CSV input");
-	_mtest = std::shared_ptr<xgboost::DMatrix>(create_from_mat(_csvdata_test));
-	_csvdata_test.clear();
+        _m = std::shared_ptr<xgboost::DMatrix>(create_from_mat(_csvdata));
+        _csvdata.clear();
+        if (_m->Info().num_nonzero_ == 0)
+          throw InputConnectorBadParamException(
+              "no data could be found processing XGBoost CSV input");
+        _mtest = std::shared_ptr<xgboost::DMatrix>(
+            create_from_mat(_csvdata_test));
+        _csvdata_test.clear();
       }
     else
       {
-	// Not robust enough from within XGBoost
-	/*bool silent = false;
-	int dsplit = 2;
-	_m = xgboost::DMatrix::Load(_csv_fname,silent,dsplit==2);
-	if (!_csv_test_fname.empty())
-	_mtest = xgboost::DMatrix::Load(_csv_test_fname,silent,dsplit==2);*/
+        // Not robust enough from within XGBoost
+        /*bool silent = false;
+        int dsplit = 2;
+        _m = xgboost::DMatrix::Load(_csv_fname,silent,dsplit==2);
+        if (!_csv_test_fname.empty())
+        _mtest = xgboost::DMatrix::Load(_csv_test_fname,silent,dsplit==2);*/
       }
   }
 
@@ -176,64 +198,72 @@ namespace dd
   {
     //- get data
     InputConnectorStrategy::get_data(ad);
-    
+
     //- load lsvm file(s)
     bool silent = false;
     int dsplit = 2;
     if (_uris.size() == 1)
       {
-	//- shuffle & split matrix as required (read parameters -> fillup_parameters or init ?)
-	APIData ad_input = ad.getobj("parameters").getobj("input");
-	fillup_parameters(ad_input);
-	_logger->info("loading {}",_uris.at(0));
-	_m = std::shared_ptr<xgboost::DMatrix>(xgboost::DMatrix::Load(_uris.at(0),silent,dsplit));
-	size_t rsize = _m->Info().num_row_;
-	_logger->info("successfully read {} rows",rsize);
+        //- shuffle & split matrix as required (read parameters ->
+        // fillup_parameters or init ?)
+        APIData ad_input = ad.getobj("parameters").getobj("input");
+        fillup_parameters(ad_input);
+        _logger->info("loading {}", _uris.at(0));
+        _m = std::shared_ptr<xgboost::DMatrix>(
+            xgboost::DMatrix::Load(_uris.at(0), silent, dsplit));
+        size_t rsize = _m->Info().num_row_;
+        _logger->info("successfully read {} rows", rsize);
 
-	std::vector<int> rindex(rsize);
-	std::iota(std::begin(rindex),std::end(rindex),0);
-	if (_shuffle)
-	  {
-	    std::mt19937 g;
-	    if (_seed != -1)
-	      g = std::mt19937(_seed);
-	    else
-	      {
-		std::random_device rd;
-		g = std::mt19937(rd());
-	      }
-	    std::shuffle(rindex.begin(),rindex.end(),g);
-	  }
-	if (_test_split > 0.0)
-	  {
-	    // XXX: not optimal memory-wise, due to the XGDMatrixSlice op
-	    _logger->info("splitting dataset");
-	    int split_size = std::floor(rsize * (1.0-_test_split));
-	    std::vector<int> train_rindex(rindex.begin(),rindex.begin()+split_size);
-	    std::vector<int> test_rindex(rindex.begin()+split_size,rindex.end());
-	    rindex.clear();
-	    xgboost::DMatrix *mtrain = XGDMatrixSliceDMatrix(_m.get(),&train_rindex[0],train_rindex.size());
-	    _mtest = std::shared_ptr<xgboost::DMatrix>(XGDMatrixSliceDMatrix(_m.get(),&test_rindex[0],test_rindex.size()));
-	    _m = std::shared_ptr<xgboost::DMatrix>(mtrain);
-	    _logger->info("dataset successfully splitted");
-	  }
-	else
-	  {
-	    xgboost::DMatrix *mtrain = XGDMatrixSliceDMatrix(_m.get(),&rindex[0],rindex.size());
-	    _m = std::shared_ptr<xgboost::DMatrix>(mtrain);
-	    std::vector<int> ids(_m->Info().num_row_);
-	    std::iota(std::begin(ids),std::end(ids),0);
-	    for (int i: ids)
-	      this->_ids.push_back(std::to_string(i));
-	  }
-	
+        std::vector<int> rindex(rsize);
+        std::iota(std::begin(rindex), std::end(rindex), 0);
+        if (_shuffle)
+          {
+            std::mt19937 g;
+            if (_seed != -1)
+              g = std::mt19937(_seed);
+            else
+              {
+                std::random_device rd;
+                g = std::mt19937(rd());
+              }
+            std::shuffle(rindex.begin(), rindex.end(), g);
+          }
+        if (_test_split > 0.0)
+          {
+            // XXX: not optimal memory-wise, due to the XGDMatrixSlice op
+            _logger->info("splitting dataset");
+            int split_size = std::floor(rsize * (1.0 - _test_split));
+            std::vector<int> train_rindex(rindex.begin(),
+                                          rindex.begin() + split_size);
+            std::vector<int> test_rindex(rindex.begin() + split_size,
+                                         rindex.end());
+            rindex.clear();
+            xgboost::DMatrix *mtrain = XGDMatrixSliceDMatrix(
+                _m.get(), &train_rindex[0], train_rindex.size());
+            _mtest = std::shared_ptr<xgboost::DMatrix>(XGDMatrixSliceDMatrix(
+                _m.get(), &test_rindex[0], test_rindex.size()));
+            _m = std::shared_ptr<xgboost::DMatrix>(mtrain);
+            _logger->info("dataset successfully splitted");
+          }
+        else
+          {
+            xgboost::DMatrix *mtrain
+                = XGDMatrixSliceDMatrix(_m.get(), &rindex[0], rindex.size());
+            _m = std::shared_ptr<xgboost::DMatrix>(mtrain);
+            std::vector<int> ids(_m->Info().num_row_);
+            std::iota(std::begin(ids), std::end(ids), 0);
+            for (int i : ids)
+              this->_ids.push_back(std::to_string(i));
+          }
       }
     else if (_uris.size() == 2) // with test file
       {
-	_logger->info("reading train and test matrices");
-	_m = std::shared_ptr<xgboost::DMatrix>(xgboost::DMatrix::Load(_uris.at(0),silent,dsplit));
-	_mtest = std::shared_ptr<xgboost::DMatrix>(xgboost::DMatrix::Load(_uris.at(1),silent,dsplit));
-	_logger->info("successfully acquired data");
+        _logger->info("reading train and test matrices");
+        _m = std::shared_ptr<xgboost::DMatrix>(
+            xgboost::DMatrix::Load(_uris.at(0), silent, dsplit));
+        _mtest = std::shared_ptr<xgboost::DMatrix>(
+            xgboost::DMatrix::Load(_uris.at(1), silent, dsplit));
+        _logger->info("successfully acquired data");
       }
   }
 
@@ -241,69 +271,78 @@ namespace dd
   {
     try
       {
-	TxtInputFileConn::transform(ad);
+        TxtInputFileConn::transform(ad);
       }
     catch (std::exception &e)
       {
-	throw;
+        throw;
       }
 
     // fmap file
     if (ad.has("model_repo"))
       {
-	std::ofstream fmap(ad.get("model_repo").get<std::string>()+"/model.fmap",std::ios::binary);
-	int nc = 0;
-	auto vit = this->_vocab.begin();
-	while(vit!=this->_vocab.end())
-	  {
-	    fmap << nc << "\t" << (*vit).first << "\tq\n";
-	    ++vit;
-	    ++nc;
-	  }
+        std::ofstream fmap(ad.get("model_repo").get<std::string>()
+                               + "/model.fmap",
+                           std::ios::binary);
+        int nc = 0;
+        auto vit = this->_vocab.begin();
+        while (vit != this->_vocab.end())
+          {
+            fmap << nc << "\t" << (*vit).first << "\tq\n";
+            ++vit;
+            ++nc;
+          }
       }
-    
+
     _m = std::shared_ptr<xgboost::DMatrix>(create_from_mat(_txt));
     destroy_txt_entries(_txt);
     if (!_test_txt.empty())
       _mtest = std::shared_ptr<xgboost::DMatrix>(create_from_mat(_test_txt));
     destroy_txt_entries(_test_txt);
   }
-  
-  xgboost::DMatrix* TxtXGBInputFileConn::create_from_mat(const std::vector<TxtEntry<double>*> &txt)
+
+  xgboost::DMatrix *TxtXGBInputFileConn::create_from_mat(
+      const std::vector<TxtEntry<double> *> &txt)
   {
     if (txt.empty())
       return nullptr;
-    std::unique_ptr<xgboost::data::SimpleCSRSource> source(new xgboost::data::SimpleCSRSource());
-    xgboost::data::SimpleCSRSource& mat = *source;
+    std::unique_ptr<xgboost::data::SimpleCSRSource> source(
+        new xgboost::data::SimpleCSRSource());
+    xgboost::data::SimpleCSRSource &mat = *source;
     bool nan_missing = xgboost::common::CheckNAN(_missing);
     mat.info.num_row_ = txt.size();
-    mat.info.num_col_ = feature_size()+1; // XXX: +1 otherwise there's a mismatch in xgnoost's simple_dmatrix.cc:151
+    mat.info.num_col_
+        = feature_size() + 1; // XXX: +1 otherwise there's a mismatch in
+                              // xgnoost's simple_dmatrix.cc:151
     int nid = 0;
     auto hit = txt.begin();
-    while(hit!=txt.end())
+    while (hit != txt.end())
       {
-	long nelem = 0;
-	TxtBowEntry *tbe = static_cast<TxtBowEntry*>((*hit));
-	mat.info.labels_.HostVector().push_back(tbe->_target);
-	tbe->reset();
-	while(tbe->has_elt())
-	  {
-	    std::string key;
-	    double v;
-	    tbe->get_next_elt(key,v);
-	    if (xgboost::common::CheckNAN(v) && !nan_missing)
-	      throw InputConnectorBadParamException("NaN value in input data matrix, and missing != NaN");
-	    mat.page_.data.HostVector().push_back(xgboost::Entry(_vocab[key]._pos,v));
-	    ++nelem;
-	  }
-	mat.page_.offset.HostVector().push_back(mat.page_.offset.HostVector().back()+nelem);
-	this->_ids.push_back(std::to_string(nid));
-	++nid;
-	++hit;
+        long nelem = 0;
+        TxtBowEntry *tbe = static_cast<TxtBowEntry *>((*hit));
+        mat.info.labels_.HostVector().push_back(tbe->_target);
+        tbe->reset();
+        while (tbe->has_elt())
+          {
+            std::string key;
+            double v;
+            tbe->get_next_elt(key, v);
+            if (xgboost::common::CheckNAN(v) && !nan_missing)
+              throw InputConnectorBadParamException(
+                  "NaN value in input data matrix, and missing != NaN");
+            mat.page_.data.HostVector().push_back(
+                xgboost::Entry(_vocab[key]._pos, v));
+            ++nelem;
+          }
+        mat.page_.offset.HostVector().push_back(
+            mat.page_.offset.HostVector().back() + nelem);
+        this->_ids.push_back(std::to_string(nid));
+        ++nid;
+        ++hit;
       }
     mat.info.num_nonzero_ = mat.page_.data.HostVector().size();
     xgboost::DMatrix *out = xgboost::DMatrix::Create(std::move(source));
     return out;
   }
-  
+
 }

--- a/src/backends/xgb/xgbinputconns.h
+++ b/src/backends/xgb/xgbinputconns.h
@@ -26,7 +26,7 @@
 #include "txtinputfileconn.h"
 
 #define DMLC_THROW_EXCEPTION noexcept(false)
-#define DMLC_NO_EXCEPTION  noexcept(true)
+#define DMLC_NO_EXCEPTION noexcept(true)
 
 #include <dmlc/base.h>
 #include <dmlc/io.h>
@@ -39,15 +39,18 @@ namespace dd
   class XGBInputInterface
   {
   public:
-    XGBInputInterface() {}
-    XGBInputInterface(const XGBInputInterface &xii)
-      :_missing(xii._missing) {}
+    XGBInputInterface()
+    {
+    }
+    XGBInputInterface(const XGBInputInterface &xii) : _missing(xii._missing)
+    {
+    }
     ~XGBInputInterface()
-      {
-      }
+    {
+    }
 
   public:
-    std::shared_ptr<xgboost::DMatrix>_m;
+    std::shared_ptr<xgboost::DMatrix> _m;
     std::shared_ptr<xgboost::DMatrix> _mtest;
 
     // for API info only
@@ -61,61 +64,73 @@ namespace dd
     {
       return -1;
     }
-    
+
     // parameters
-    float _missing;// = std::NAN; /**< represents missing values. */
+    float _missing; // = std::NAN; /**< represents missing values. */
   };
-  
+
   class CSVXGBInputFileConn : public CSVInputFileConn, public XGBInputInterface
   {
   public:
-    CSVXGBInputFileConn()
-      :CSVInputFileConn() {}
+    CSVXGBInputFileConn() : CSVInputFileConn()
+    {
+    }
     CSVXGBInputFileConn(const CSVXGBInputFileConn &i)
-      :CSVInputFileConn(i),XGBInputInterface(i),_direct_csv(i._direct_csv) {}
-    ~CSVXGBInputFileConn() {}
-    
+        : CSVInputFileConn(i), XGBInputInterface(i), _direct_csv(i._direct_csv)
+    {
+    }
+    ~CSVXGBInputFileConn()
+    {
+    }
+
     void init(const APIData &ad)
     {
       if (ad.has("direct_csv") && ad.get("direct_csv").get<bool>())
-	_direct_csv = true;
+        _direct_csv = true;
       CSVInputFileConn::init(ad);
     }
 
     void transform(const APIData &ad);
 
-    xgboost::DMatrix* create_from_mat(const std::vector<CSVline> &csvl);
+    xgboost::DMatrix *create_from_mat(const std::vector<CSVline> &csvl);
 
   public:
-    bool _direct_csv = false; /**< whether to use the xgboost built-in CSV reader. */
+    bool _direct_csv
+        = false; /**< whether to use the xgboost built-in CSV reader. */
   };
 
-  class SVMXGBInputFileConn : public InputConnectorStrategy, public XGBInputInterface
+  class SVMXGBInputFileConn : public InputConnectorStrategy,
+                              public XGBInputInterface
   {
   public:
-    SVMXGBInputFileConn()
-      :InputConnectorStrategy() {}
+    SVMXGBInputFileConn() : InputConnectorStrategy()
+    {
+    }
     SVMXGBInputFileConn(const SVMXGBInputFileConn &i)
-      :InputConnectorStrategy(i),XGBInputInterface(i) {}
-    ~SVMXGBInputFileConn() {}
-    
+        : InputConnectorStrategy(i), XGBInputInterface(i)
+    {
+    }
+    ~SVMXGBInputFileConn()
+    {
+    }
+
     void fillup_parameters(const APIData &ad_input)
     {
       if (ad_input.has("shuffle"))
-	_shuffle = ad_input.get("shuffle").get<bool>();
+        _shuffle = ad_input.get("shuffle").get<bool>();
       if (ad_input.has("seed"))
-	_seed = ad_input.get("seed").get<int>();
+        _seed = ad_input.get("seed").get<int>();
       if (ad_input.has("test_split"))
-	_test_split = ad_input.get("test_split").get<double>();
+        _test_split = ad_input.get("test_split").get<double>();
     }
-    
+
     void init(const APIData &ad)
     {
       fillup_parameters(ad);
     }
-    
+
     void transform(const APIData &ad);
-    
+
   public:
     bool _shuffle = false;
     int _seed = -1;
@@ -125,11 +140,16 @@ namespace dd
   class TxtXGBInputFileConn : public TxtInputFileConn, public XGBInputInterface
   {
   public:
-    TxtXGBInputFileConn()
-      :TxtInputFileConn() {}
+    TxtXGBInputFileConn() : TxtInputFileConn()
+    {
+    }
     TxtXGBInputFileConn(const TxtXGBInputFileConn &i)
-      :TxtInputFileConn(i),XGBInputInterface(i) {}
-    ~TxtXGBInputFileConn() {}
+        : TxtInputFileConn(i), XGBInputInterface(i)
+    {
+    }
+    ~TxtXGBInputFileConn()
+    {
+    }
 
     void init(const APIData &ad)
     {
@@ -138,10 +158,10 @@ namespace dd
 
     void transform(const APIData &ad);
 
-    xgboost::DMatrix* create_from_mat(const std::vector<TxtEntry<double>*> &txt);
-    
+    xgboost::DMatrix *
+    create_from_mat(const std::vector<TxtEntry<double> *> &txt);
   };
-  
+
 }
 
 #endif

--- a/src/backends/xgb/xgblib.cc
+++ b/src/backends/xgb/xgblib.cc
@@ -28,16 +28,22 @@
 namespace dd
 {
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  XGBLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::XGBLib(const XGBModel &cmodel)
-    :MLLib<TInputConnectorStrategy,TOutputConnectorStrategy,XGBModel>(cmodel)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  XGBLib<TInputConnectorStrategy, TOutputConnectorStrategy, TMLModel>::XGBLib(
+      const XGBModel &cmodel)
+      : MLLib<TInputConnectorStrategy, TOutputConnectorStrategy, XGBModel>(
+          cmodel)
   {
     this->_libname = "xgboost";
   }
-  
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  XGBLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::XGBLib(XGBLib &&cl) noexcept
-    :MLLib<TInputConnectorStrategy,TOutputConnectorStrategy,XGBModel>(std::move(cl))
+
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  XGBLib<TInputConnectorStrategy, TOutputConnectorStrategy, TMLModel>::XGBLib(
+      XGBLib &&cl) noexcept
+      : MLLib<TInputConnectorStrategy, TOutputConnectorStrategy, XGBModel>(
+          std::move(cl))
   {
     this->_libname = "xgboost";
     _nclasses = cl._nclasses;
@@ -46,18 +52,23 @@ namespace dd
     _booster = cl._booster;
     if (_regression)
       this->_mltype = "regression";
-    else this->_mltype = "classification";
+    else
+      this->_mltype = "classification";
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  XGBLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::~XGBLib()
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  XGBLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+         TMLModel>::~XGBLib()
   {
     if (_learner)
       delete _learner;
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void XGBLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::init_mllib(const APIData &ad)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void XGBLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+              TMLModel>::init_mllib(const APIData &ad)
   {
 #ifndef CPU_ONLY
     if (ad.has("gpu"))
@@ -67,386 +78,430 @@ namespace dd
       _nclasses = ad.get("nclasses").get<int>();
     if (ad.has("regression") && ad.get("regression").get<bool>())
       {
-	_regression = true;
-	_nclasses = 1;
+        _regression = true;
+        _nclasses = 1;
       }
     if (ad.has("ntargets"))
       _ntargets = ad.get("ntargets").get<int>();
     if (_nclasses == 0)
-      throw MLLibBadParamException("number of classes is unknown (nclasses == 0)");
+      throw MLLibBadParamException(
+          "number of classes is unknown (nclasses == 0)");
     if (_regression && _ntargets == 0)
-      throw MLLibBadParamException("number of regression targets is unknown (ntargets == 0)");
+      throw MLLibBadParamException(
+          "number of regression targets is unknown (ntargets == 0)");
     this->_mlmodel.read_from_repository(this->_logger);
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void XGBLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::clear_mllib(const APIData &ad)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void XGBLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+              TMLModel>::clear_mllib(const APIData &ad)
   {
     (void)ad;
-    std::vector<std::string> extensions = {".model"};
-    fileops::remove_directory_files(this->_mlmodel._repo,extensions);
+    std::vector<std::string> extensions = { ".model" };
+    fileops::remove_directory_files(this->_mlmodel._repo, extensions);
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  int XGBLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::train(const APIData &ad,
-									       APIData &out)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  int XGBLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+             TMLModel>::train(const APIData &ad, APIData &out)
   {
     // any check on model here
     this->_mlmodel.read_from_repository(this->_logger);
-    
+
     // mutex if train and predict calls need to be isolated
     std::lock_guard<std::mutex> lock(_learner_mutex);
-    
+
     TInputConnectorStrategy inputc(this->_inputc);
-    inputc._train = true;    
+    inputc._train = true;
     APIData cad = ad;
-    cad.add("model_repo",this->_mlmodel._repo);
+    cad.add("model_repo", this->_mlmodel._repo);
     try
       {
-	inputc.transform(cad);
+        inputc.transform(cad);
       }
     catch (...)
       {
-	throw;
+        throw;
       }
-    
-      // parameters
-      int num_feature = 0; /**< feature dimension used in boosting, optional. */
-      _objective = "multi:softprob";
-      double base_score = 0.5;
-      std::string eval_metric = "merror";
-      int test_interval = 1;
-      int seed = 0;
-      
-      APIData ad_mllib = ad.getobj("parameters").getobj("mllib");
+
+    // parameters
+    int num_feature = 0; /**< feature dimension used in boosting, optional. */
+    _objective = "multi:softprob";
+    double base_score = 0.5;
+    std::string eval_metric = "merror";
+    int test_interval = 1;
+    int seed = 0;
+
+    APIData ad_mllib = ad.getobj("parameters").getobj("mllib");
 #ifndef CPU_ONLY
-      if (ad_mllib.has("gpu"))
-	_gpu = ad_mllib.get("gpu").get<bool>();
+    if (ad_mllib.has("gpu"))
+      _gpu = ad_mllib.get("gpu").get<bool>();
 #endif
-      if (ad_mllib.has("booster"))
-	_booster = ad_mllib.get("booster").get<std::string>();
-      if (ad_mllib.has("objective"))
-	_objective = ad_mllib.get("objective").get<std::string>();
-      if (ad_mllib.has("num_feature"))
-	num_feature = ad_mllib.get("num_feature").get<int>();
-      if (ad_mllib.has("base_score"))
-	base_score = ad_mllib.get("base_score").get<double>();
-      if (ad_mllib.has("eval_metric"))
-	eval_metric = ad_mllib.get("eval_metric").get<std::string>();
-      if (ad_mllib.has("seed"))
-	seed = ad_mllib.get("seed").get<int>();
-      if (ad_mllib.has("iterations"))
-	_params.num_round = ad_mllib.get("iterations").get<int>();
-      if (ad_mllib.has("test_interval"))
-	test_interval = ad_mllib.get("test_interval").get<int>();
-      if (ad_mllib.has("save_period"))
-	_params.save_period = ad_mllib.get("save_period").get<int>();
-      
-      _params.eval_train = false;
-      _params.eval_data_names.clear();
-      _params.eval_data_names.push_back("test");      
-      
-      add_cfg_param("booster",_booster);
-      add_cfg_param("objective",_objective);
-      add_cfg_param("num_feature",num_feature);
-      add_cfg_param("base_score",base_score);
-      add_cfg_param("eval_metric",eval_metric);
-      add_cfg_param("seed",seed);
-      if (_objective == "multi:softmax")
-	throw MLLibBadParamException("use multi:softprob objective instead of multi:softmax");
-      else if (_objective == "reg:linear" || _objective == "reg:logistic")
-	eval_metric = "rmse";
-      if (!_regression && _objective == "multi:softprob")
-	add_cfg_param("num_class",_nclasses);
-      
-      // booster parameters
-      double eta = 0.3;
-      double gamma = 0.0;
-      int max_depth = 6;
-      int min_child_weight = 1;
-      int max_delta_step = 0;
-      double subsample = 1.0;
-      double colsample = 1.0;
-      double lambda = 1.0;
-      double alpha = 0.0;
-      double lambda_bias = 0.0; // linear booster parameters
-      std::string tree_method = "auto";
-      double sketch_eps = 0.03;
-      double scale_pos_weight = 1.0;
-      std::string updater = ""; // was grow_colmaker,prune, now automatic;
-      bool refresh_leaf = true;
-      std::string process_type = "default";
-      std::string dart_sample_type = "uniform";
-      std::string dart_normalize_type = "tree";
-      double dart_rate_drop = 0.0;
-      bool dart_one_drop = false;
-      double dart_skip_drop = 0.0;
-      
-      APIData ad_booster = ad_mllib.getobj("booster_params");
-      if (ad_booster.size())
-	{
-	  if (ad_booster.has("eta"))
-	    eta = ad_booster.get("eta").get<double>();
-	  if (ad_booster.has("gamma"))
-	    gamma = ad_booster.get("gamma").get<double>();
-	  if (ad_booster.has("max_depth"))
-	    max_depth = ad_booster.get("max_depth").get<int>();
-	  if (ad_booster.has("min_child_weight"))
-	    min_child_weight = ad_booster.get("min_child_weight").get<int>();
-	  if (ad_booster.has("max_delta_step"))
-	    max_delta_step = ad_booster.get("max_delta_step").get<int>();
-	  if (ad_booster.has("subsample"))
-	    subsample = ad_booster.get("subsample").get<double>();
-	  if (ad_booster.has("colsample"))
-	    colsample = ad_booster.get("colsample").get<double>();
-	  if (ad_booster.has("lambda"))
-	    lambda = ad_booster.get("lambda").get<double>();
-	  if (ad_booster.has("alpha"))
-	    alpha = ad_booster.get("alpha").get<double>();
-	  if (ad_booster.has("lambda_bias"))
-	    lambda_bias = ad_booster.get("lambda_bias").get<double>();
-	  if (ad_booster.has("tree_method"))
-	    tree_method = ad_booster.get("tree_method").get<std::string>();
-	  if (ad_booster.has("sketch_eps"))
-	    sketch_eps = ad_booster.get("sketch_eps").get<double>();
-	  if (ad_booster.has("scale_pos_weight"))
-	    scale_pos_weight = ad_booster.get("scale_pos_weight").get<double>();
-	  if (ad_booster.has("updater"))
-	    updater = ad_booster.get("updater").get<std::string>();
-	  if (ad_booster.has("refresh_leaf"))
-	    refresh_leaf = ad_booster.get("refresh_leaf").get<bool>();
-	  if (ad_booster.has("process_type"))
-	    process_type = ad_booster.get("process_type").get<std::string>();
-	  if (ad_booster.has("sample_type"))
-	    dart_sample_type = ad_booster.get("sample_type").get<std::string>();
-	  if (ad_booster.has("normalize_type"))
-	    dart_normalize_type = ad_booster.get("normalize_type").get<std::string>();
-	  if (ad_booster.has("rate_drop"))
-	    dart_rate_drop = ad_booster.get("rate_drop").get<double>();
-	  if (ad_booster.has("one_drop"))
-	    dart_one_drop = ad_booster.get("one_drop").get<bool>();
-	  if (ad_booster.has("skip_drop"))
-	    dart_skip_drop = ad_booster.get("skip_drop").get<double>();
-	}
+    if (ad_mllib.has("booster"))
+      _booster = ad_mllib.get("booster").get<std::string>();
+    if (ad_mllib.has("objective"))
+      _objective = ad_mllib.get("objective").get<std::string>();
+    if (ad_mllib.has("num_feature"))
+      num_feature = ad_mllib.get("num_feature").get<int>();
+    if (ad_mllib.has("base_score"))
+      base_score = ad_mllib.get("base_score").get<double>();
+    if (ad_mllib.has("eval_metric"))
+      eval_metric = ad_mllib.get("eval_metric").get<std::string>();
+    if (ad_mllib.has("seed"))
+      seed = ad_mllib.get("seed").get<int>();
+    if (ad_mllib.has("iterations"))
+      _params.num_round = ad_mllib.get("iterations").get<int>();
+    if (ad_mllib.has("test_interval"))
+      test_interval = ad_mllib.get("test_interval").get<int>();
+    if (ad_mllib.has("save_period"))
+      _params.save_period = ad_mllib.get("save_period").get<int>();
+
+    _params.eval_train = false;
+    _params.eval_data_names.clear();
+    _params.eval_data_names.push_back("test");
+
+    add_cfg_param("booster", _booster);
+    add_cfg_param("objective", _objective);
+    add_cfg_param("num_feature", num_feature);
+    add_cfg_param("base_score", base_score);
+    add_cfg_param("eval_metric", eval_metric);
+    add_cfg_param("seed", seed);
+    if (_objective == "multi:softmax")
+      throw MLLibBadParamException(
+          "use multi:softprob objective instead of multi:softmax");
+    else if (_objective == "reg:linear" || _objective == "reg:logistic")
+      eval_metric = "rmse";
+    if (!_regression && _objective == "multi:softprob")
+      add_cfg_param("num_class", _nclasses);
+
+    // booster parameters
+    double eta = 0.3;
+    double gamma = 0.0;
+    int max_depth = 6;
+    int min_child_weight = 1;
+    int max_delta_step = 0;
+    double subsample = 1.0;
+    double colsample = 1.0;
+    double lambda = 1.0;
+    double alpha = 0.0;
+    double lambda_bias = 0.0; // linear booster parameters
+    std::string tree_method = "auto";
+    double sketch_eps = 0.03;
+    double scale_pos_weight = 1.0;
+    std::string updater = ""; // was grow_colmaker,prune, now automatic;
+    bool refresh_leaf = true;
+    std::string process_type = "default";
+    std::string dart_sample_type = "uniform";
+    std::string dart_normalize_type = "tree";
+    double dart_rate_drop = 0.0;
+    bool dart_one_drop = false;
+    double dart_skip_drop = 0.0;
+
+    APIData ad_booster = ad_mllib.getobj("booster_params");
+    if (ad_booster.size())
+      {
+        if (ad_booster.has("eta"))
+          eta = ad_booster.get("eta").get<double>();
+        if (ad_booster.has("gamma"))
+          gamma = ad_booster.get("gamma").get<double>();
+        if (ad_booster.has("max_depth"))
+          max_depth = ad_booster.get("max_depth").get<int>();
+        if (ad_booster.has("min_child_weight"))
+          min_child_weight = ad_booster.get("min_child_weight").get<int>();
+        if (ad_booster.has("max_delta_step"))
+          max_delta_step = ad_booster.get("max_delta_step").get<int>();
+        if (ad_booster.has("subsample"))
+          subsample = ad_booster.get("subsample").get<double>();
+        if (ad_booster.has("colsample"))
+          colsample = ad_booster.get("colsample").get<double>();
+        if (ad_booster.has("lambda"))
+          lambda = ad_booster.get("lambda").get<double>();
+        if (ad_booster.has("alpha"))
+          alpha = ad_booster.get("alpha").get<double>();
+        if (ad_booster.has("lambda_bias"))
+          lambda_bias = ad_booster.get("lambda_bias").get<double>();
+        if (ad_booster.has("tree_method"))
+          tree_method = ad_booster.get("tree_method").get<std::string>();
+        if (ad_booster.has("sketch_eps"))
+          sketch_eps = ad_booster.get("sketch_eps").get<double>();
+        if (ad_booster.has("scale_pos_weight"))
+          scale_pos_weight = ad_booster.get("scale_pos_weight").get<double>();
+        if (ad_booster.has("updater"))
+          updater = ad_booster.get("updater").get<std::string>();
+        if (ad_booster.has("refresh_leaf"))
+          refresh_leaf = ad_booster.get("refresh_leaf").get<bool>();
+        if (ad_booster.has("process_type"))
+          process_type = ad_booster.get("process_type").get<std::string>();
+        if (ad_booster.has("sample_type"))
+          dart_sample_type = ad_booster.get("sample_type").get<std::string>();
+        if (ad_booster.has("normalize_type"))
+          dart_normalize_type
+              = ad_booster.get("normalize_type").get<std::string>();
+        if (ad_booster.has("rate_drop"))
+          dart_rate_drop = ad_booster.get("rate_drop").get<double>();
+        if (ad_booster.has("one_drop"))
+          dart_one_drop = ad_booster.get("one_drop").get<bool>();
+        if (ad_booster.has("skip_drop"))
+          dart_skip_drop = ad_booster.get("skip_drop").get<double>();
+      }
 #ifndef CPU_ONLY
 #ifdef USE_XGBOOST_GPU
-      if (_gpu)
-	updater = "grow_gpu";
+    if (_gpu)
+      updater = "grow_gpu";
 #endif
 #endif
-      add_cfg_param("eta",eta);
-      add_cfg_param("gamma",gamma);
-      add_cfg_param("max_depth",max_depth);
-      add_cfg_param("min_child_weight",min_child_weight);
-      add_cfg_param("max_delta_step",max_delta_step);
-      add_cfg_param("subsample",subsample);
-      add_cfg_param("colsample",colsample);
-      add_cfg_param("lambda",lambda);
-      add_cfg_param("alpha",alpha);
-      add_cfg_param("lambda_bias",lambda_bias);
-      add_cfg_param("tree_method",tree_method);
-      add_cfg_param("sketch_eps",sketch_eps);
-      add_cfg_param("scale_pos_weight",scale_pos_weight);
-      if (!updater.empty())
-	add_cfg_param("updater",updater);
-      add_cfg_param("refresh_leaf",refresh_leaf);
-      add_cfg_param("process_type",process_type);
-      add_cfg_param("sample_type",dart_sample_type);
-      add_cfg_param("normalize_type",dart_normalize_type);
-      add_cfg_param("rate_drop",dart_rate_drop);
-      add_cfg_param("one_drop",dart_one_drop);
-      add_cfg_param("skip_drop",dart_skip_drop);
-      
-      // data setup
-      std::vector<std::shared_ptr<xgboost::DMatrix>> mats = { inputc._m };
-      std::shared_ptr<xgboost::DMatrix> dtrain(inputc._m);
-      std::vector<std::shared_ptr<xgboost::DMatrix>> deval;
-      std::vector<std::shared_ptr<xgboost::DMatrix>> eval_datasets;
-      for (size_t i = 0; i < _params.eval_data_names.size(); ++i) {
-	if (inputc._mtest)
-	  {
-	    deval.emplace_back(inputc._mtest);
-	    eval_datasets.push_back(deval.back());
-	    mats.push_back(deval.back());
-	  }
+    add_cfg_param("eta", eta);
+    add_cfg_param("gamma", gamma);
+    add_cfg_param("max_depth", max_depth);
+    add_cfg_param("min_child_weight", min_child_weight);
+    add_cfg_param("max_delta_step", max_delta_step);
+    add_cfg_param("subsample", subsample);
+    add_cfg_param("colsample", colsample);
+    add_cfg_param("lambda", lambda);
+    add_cfg_param("alpha", alpha);
+    add_cfg_param("lambda_bias", lambda_bias);
+    add_cfg_param("tree_method", tree_method);
+    add_cfg_param("sketch_eps", sketch_eps);
+    add_cfg_param("scale_pos_weight", scale_pos_weight);
+    if (!updater.empty())
+      add_cfg_param("updater", updater);
+    add_cfg_param("refresh_leaf", refresh_leaf);
+    add_cfg_param("process_type", process_type);
+    add_cfg_param("sample_type", dart_sample_type);
+    add_cfg_param("normalize_type", dart_normalize_type);
+    add_cfg_param("rate_drop", dart_rate_drop);
+    add_cfg_param("one_drop", dart_one_drop);
+    add_cfg_param("skip_drop", dart_skip_drop);
+
+    // data setup
+    std::vector<std::shared_ptr<xgboost::DMatrix>> mats = { inputc._m };
+    std::shared_ptr<xgboost::DMatrix> dtrain(inputc._m);
+    std::vector<std::shared_ptr<xgboost::DMatrix>> deval;
+    std::vector<std::shared_ptr<xgboost::DMatrix>> eval_datasets;
+    for (size_t i = 0; i < _params.eval_data_names.size(); ++i)
+      {
+        if (inputc._mtest)
+          {
+            deval.emplace_back(inputc._mtest);
+            eval_datasets.push_back(deval.back());
+            mats.push_back(deval.back());
+          }
       }
-      std::vector<std::string> eval_data_names = _params.eval_data_names;
-      //TODO: as needed, whether to report accuracy on training set
-      if (_params.eval_train) {
-	eval_datasets.push_back(dtrain);
-	eval_data_names.push_back(std::string("train"));
+    std::vector<std::string> eval_data_names = _params.eval_data_names;
+    // TODO: as needed, whether to report accuracy on training set
+    if (_params.eval_train)
+      {
+        eval_datasets.push_back(dtrain);
+        eval_data_names.push_back(std::string("train"));
       }
 
-      //initialize the learner
-      this->_tjob_running = true;
-      std::unique_ptr<xgboost::Learner> learner(xgboost::Learner::Create(mats));
-      learner->Configure(_params.cfg);
-      int version = rabit::LoadCheckPoint(learner.get());
-      if (version == 0) {
-	// initialize the model if needed.
-	if (_params.model_in != "NULL") { //TODO: if a model already exists
-	  std::unique_ptr<dmlc::Stream> fi(dmlc::Stream::Create(_params.model_in.c_str(), "r")); //TODO: update the model path (repo)
-	  learner->Load(fi.get());
-	} else {
-	  this->_logger->info("initializing model");
-	  learner->InitModel();
-	}
-      }    
-      
-      //start training
-      for (int i = version / 2; i < _params.num_round; ++i) {
-	if (!this->_tjob_running.load())
-	  break;
-	this->add_meas("iteration",i);
-	if (version % 2 == 0) {
-	  if (_params.silent == 0) {
-	    this->_logger->info("boosting round {}",i);
-	  }
-	  learner->UpdateOneIter(i, dtrain.get());
-	  if (learner->AllowLazyCheckPoint()) {
-	    rabit::LazyCheckPoint(learner.get());
-	  } else {
-	    rabit::CheckPoint(learner.get());
-	  }
-	  version += 1;
-	}
-	
-	// measures for dd
-	if (i > 0 && i % test_interval == 0 && !eval_datasets.empty())
-	  {
-	    APIData meas_out;
-	    test(ad,learner,eval_datasets.at(0).get(),meas_out);
-	    APIData meas_obj = meas_out.getobj("measure");
-	    std::vector<std::string> meas_str = meas_obj.list_keys();
-	    for (auto m: meas_str)
-	      {
-		if (m != "cmdiag" && m != "cmfull" && m != "labels") // do not report confusion matrix in server logs
-		  {
-		    double mval = meas_obj.get(m).get<double>();
-		    this->_logger->info("{}={}",m,mval);
-		    this->add_meas(m,mval);
-		    if (!std::isnan(mval)) // if testing occurs once before training even starts, loss is unknown and we don't add it to history.
-		      this->add_meas_per_iter(m,mval);
-		  }
-		else if (m == "cmdiag")
-		  {
-		    std::vector<double> mdiag = meas_obj.get(m).get<std::vector<double>>();
-		    std::string mdiag_str;
-		    for (size_t i=0;i<mdiag.size();i++)
-		      mdiag_str += std::to_string(i) + ":" + std::to_string(mdiag.at(i)) + " ";
-		    this->_logger->info("{}=[{}]",m,mdiag_str);
-		  }
-	      }
-	  }
-	
-	if (_params.save_period != 0 && (i + 1) % _params.save_period == 0) {
-	  this->_logger->info("model saving / repo={}",this->_mlmodel._repo);
-	  std::ostringstream os;
-	  os << this->_mlmodel._repo << '/'
-	     << std::setfill('0') << std::setw(4)
-	     << i + 1 << ".model";
-	  std::unique_ptr<dmlc::Stream> fo(dmlc::Stream::Create(os.str().c_str(), "w"));
-	  learner->Save(fo.get());
-	}
-	
-	if (learner->AllowLazyCheckPoint()) {
-	  rabit::LazyCheckPoint(learner.get());
-	} else {
-	  rabit::CheckPoint(learner.get());
-	}
-	version += 1;
-	//CHECK_EQ(version, rabit::VersionNumber());
-      }
-      
-      // always save final round
-      if ((!this->_tjob_running.load() || _params.save_period == 0 || _params.num_round % _params.save_period != 0)
-	  && _params.model_out != "NONE") {
-	std::ostringstream os;
-	if (_params.model_out == "NULL") {
-	  os << this->_mlmodel._repo << '/'
-	     << std::setfill('0') << std::setw(4)
-	     << _params.num_round << ".model";
-	} else {
-	  os << _params.model_out;
-	}
-	std::unique_ptr<dmlc::Stream> fo(dmlc::Stream::Create(os.str().c_str(), "w"));
-	learner->Save(fo.get());
+    // initialize the learner
+    this->_tjob_running = true;
+    std::unique_ptr<xgboost::Learner> learner(xgboost::Learner::Create(mats));
+    learner->Configure(_params.cfg);
+    int version = rabit::LoadCheckPoint(learner.get());
+    if (version == 0)
+      {
+        // initialize the model if needed.
+        if (_params.model_in != "NULL")
+          { // TODO: if a model already exists
+            std::unique_ptr<dmlc::Stream> fi(dmlc::Stream::Create(
+                _params.model_in.c_str(),
+                "r")); // TODO: update the model path (repo)
+            learner->Load(fi.get());
+          }
+        else
+          {
+            this->_logger->info("initializing model");
+            learner->InitModel();
+          }
       }
 
-      // bail on forced stop, i.e. not testing the model further.
-      if (!this->_tjob_running.load())
-	{
-	  return 0;
-	}
-      
-      // test
-      test(ad,learner,inputc._mtest.get(),out);
-      
-      // prepare model
-      this->_mlmodel.read_from_repository(this->_logger);
-      this->_mlmodel.read_corresp_file();
-      
-      // add whatever the input connector needs to transmit out
-      inputc.response_params(out);
-      
-      return 0;
+    // start training
+    for (int i = version / 2; i < _params.num_round; ++i)
+      {
+        if (!this->_tjob_running.load())
+          break;
+        this->add_meas("iteration", i);
+        if (version % 2 == 0)
+          {
+            if (_params.silent == 0)
+              {
+                this->_logger->info("boosting round {}", i);
+              }
+            learner->UpdateOneIter(i, dtrain.get());
+            if (learner->AllowLazyCheckPoint())
+              {
+                rabit::LazyCheckPoint(learner.get());
+              }
+            else
+              {
+                rabit::CheckPoint(learner.get());
+              }
+            version += 1;
+          }
+
+        // measures for dd
+        if (i > 0 && i % test_interval == 0 && !eval_datasets.empty())
+          {
+            APIData meas_out;
+            test(ad, learner, eval_datasets.at(0).get(), meas_out);
+            APIData meas_obj = meas_out.getobj("measure");
+            std::vector<std::string> meas_str = meas_obj.list_keys();
+            for (auto m : meas_str)
+              {
+                if (m != "cmdiag" && m != "cmfull"
+                    && m != "labels") // do not report confusion matrix in
+                                      // server logs
+                  {
+                    double mval = meas_obj.get(m).get<double>();
+                    this->_logger->info("{}={}", m, mval);
+                    this->add_meas(m, mval);
+                    if (!std::isnan(
+                            mval)) // if testing occurs once before training
+                                   // even starts, loss is unknown and we don't
+                                   // add it to history.
+                      this->add_meas_per_iter(m, mval);
+                  }
+                else if (m == "cmdiag")
+                  {
+                    std::vector<double> mdiag
+                        = meas_obj.get(m).get<std::vector<double>>();
+                    std::string mdiag_str;
+                    for (size_t i = 0; i < mdiag.size(); i++)
+                      mdiag_str += std::to_string(i) + ":"
+                                   + std::to_string(mdiag.at(i)) + " ";
+                    this->_logger->info("{}=[{}]", m, mdiag_str);
+                  }
+              }
+          }
+
+        if (_params.save_period != 0 && (i + 1) % _params.save_period == 0)
+          {
+            this->_logger->info("model saving / repo={}",
+                                this->_mlmodel._repo);
+            std::ostringstream os;
+            os << this->_mlmodel._repo << '/' << std::setfill('0')
+               << std::setw(4) << i + 1 << ".model";
+            std::unique_ptr<dmlc::Stream> fo(
+                dmlc::Stream::Create(os.str().c_str(), "w"));
+            learner->Save(fo.get());
+          }
+
+        if (learner->AllowLazyCheckPoint())
+          {
+            rabit::LazyCheckPoint(learner.get());
+          }
+        else
+          {
+            rabit::CheckPoint(learner.get());
+          }
+        version += 1;
+        // CHECK_EQ(version, rabit::VersionNumber());
+      }
+
+    // always save final round
+    if ((!this->_tjob_running.load() || _params.save_period == 0
+         || _params.num_round % _params.save_period != 0)
+        && _params.model_out != "NONE")
+      {
+        std::ostringstream os;
+        if (_params.model_out == "NULL")
+          {
+            os << this->_mlmodel._repo << '/' << std::setfill('0')
+               << std::setw(4) << _params.num_round << ".model";
+          }
+        else
+          {
+            os << _params.model_out;
+          }
+        std::unique_ptr<dmlc::Stream> fo(
+            dmlc::Stream::Create(os.str().c_str(), "w"));
+        learner->Save(fo.get());
+      }
+
+    // bail on forced stop, i.e. not testing the model further.
+    if (!this->_tjob_running.load())
+      {
+        return 0;
+      }
+
+    // test
+    test(ad, learner, inputc._mtest.get(), out);
+
+    // prepare model
+    this->_mlmodel.read_from_repository(this->_logger);
+    this->_mlmodel.read_corresp_file();
+
+    // add whatever the input connector needs to transmit out
+    inputc.response_params(out);
+
+    return 0;
   }
 
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  int XGBLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::predict(const APIData &ad,
-										   APIData &out)
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  int XGBLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+             TMLModel>::predict(const APIData &ad, APIData &out)
   {
     // mutex since using in-memory learner
     std::lock_guard<std::mutex> lock(_learner_mutex);
-    
+
     // data
     TInputConnectorStrategy inputc(this->_inputc);
     APIData cad = ad;
     try
       {
-	inputc.transform(cad);
+        inputc.transform(cad);
       }
     catch (...)
       {
-	throw;
+        throw;
       }
-    
+
     // load existing model as needed
     if (!_learner)
       {
-	_learner = xgboost::Learner::Create({});
-	std::string model_in = this->_mlmodel._weights;
-	this->_logger->info("loading XGBoost model file={}",model_in);
-	std::unique_ptr<dmlc::Stream> fi(dmlc::Stream::Create(model_in.c_str(),"r"));
-	_learner->Load(fi.get());
-	// we can't read the objective function string name from the xgboost in-memory model,
-	// so let's read it from file
-	_objective = this->_mlmodel.lookup_objective(model_in,this->_logger);
-	if (_objective == "")
-	  throw MLLibInternalException("failed to read the objective from XGBoost model file " + model_in);
+        _learner = xgboost::Learner::Create({});
+        std::string model_in = this->_mlmodel._weights;
+        this->_logger->info("loading XGBoost model file={}", model_in);
+        std::unique_ptr<dmlc::Stream> fi(
+            dmlc::Stream::Create(model_in.c_str(), "r"));
+        _learner->Load(fi.get());
+        // we can't read the objective function string name from the xgboost
+        // in-memory model, so let's read it from file
+        _objective = this->_mlmodel.lookup_objective(model_in, this->_logger);
+        if (_objective == "")
+          throw MLLibInternalException(
+              "failed to read the objective from XGBoost model file "
+              + model_in);
       }
 
     // test
     APIData ad_out = ad.getobj("parameters").getobj("output");
     if (ad_out.has("measure"))
       {
-	std::vector<std::shared_ptr<xgboost::DMatrix>> eval_datasets = { inputc._m };
-	APIData meas_out;
-	std::unique_ptr<xgboost::Learner> learner(_learner);
-	test(ad,learner,eval_datasets.at(0).get(),meas_out);
-	learner.release();
-	meas_out.erase("iteration");
-	out.add("measure",meas_out.getobj("measure"));
-	return 0;
+        std::vector<std::shared_ptr<xgboost::DMatrix>> eval_datasets
+            = { inputc._m };
+        APIData meas_out;
+        std::unique_ptr<xgboost::Learner> learner(_learner);
+        test(ad, learner, eval_datasets.at(0).get(), meas_out);
+        learner.release();
+        meas_out.erase("iteration");
+        out.add("measure", meas_out.getobj("measure"));
+        return 0;
       }
-    
+
     // predict
     xgboost::HostDeviceVector<float> preds;
     _learner->Configure(_params.cfg);
-    _learner->Predict(inputc._m.get(),_params.pred_margin,&preds,_params.ntree_limit);
+    _learner->Predict(inputc._m.get(), _params.pred_margin, &preds,
+                      _params.ntree_limit);
 
     // results
-    //float loss = 0.0; // XXX: how to acquire loss ?
+    // float loss = 0.0; // XXX: how to acquire loss ?
     int batch_size = preds.Size();
     int nclasses = _nclasses;
     if (_objective == "multi:softprob")
@@ -455,95 +510,101 @@ namespace dd
       nclasses--;
     TOutputConnectorStrategy tout(this->_outputc);
     std::vector<APIData> vrad;
-    for (int j=0;j<batch_size;j++)
+    for (int j = 0; j < batch_size; j++)
       {
-	APIData rad;
-	rad.add("uri",inputc._ids.at(j));
-	rad.add("loss",0.0); // XXX: truely, unreported.
-	std::vector<double> probs;
-	std::vector<std::string> cats;
-	for (int i=0;i<nclasses;i++)
-	  {
-	    probs.push_back(preds.HostVector().at(j*nclasses+i));
-	    cats.push_back(this->_mlmodel.get_hcorresp(i));
-	  }
-	if (_objective == "binary:logistic")
-	  {
-	    probs.insert(probs.begin(),1.0-probs.back());
-	    cats.insert(cats.begin(),this->_mlmodel.get_hcorresp(1));
-	  }
-	rad.add("probs",probs);
-	rad.add("cats",cats);
-	vrad.push_back(rad);
+        APIData rad;
+        rad.add("uri", inputc._ids.at(j));
+        rad.add("loss", 0.0); // XXX: truely, unreported.
+        std::vector<double> probs;
+        std::vector<std::string> cats;
+        for (int i = 0; i < nclasses; i++)
+          {
+            probs.push_back(preds.HostVector().at(j * nclasses + i));
+            cats.push_back(this->_mlmodel.get_hcorresp(i));
+          }
+        if (_objective == "binary:logistic")
+          {
+            probs.insert(probs.begin(), 1.0 - probs.back());
+            cats.insert(cats.begin(), this->_mlmodel.get_hcorresp(1));
+          }
+        rad.add("probs", probs);
+        rad.add("cats", cats);
+        vrad.push_back(rad);
       }
     tout.add_results(vrad);
     TOutputConnectorStrategy btout(this->_outputc);
     if (_regression)
       {
-	out.add("regression",true);
-	out.add("nclasses",nclasses);
+        out.add("regression", true);
+        out.add("nclasses", nclasses);
       }
-    out.add("nclasses",nclasses);
-    tout.finalize(ad.getobj("parameters").getobj("output"),out,static_cast<MLModel*>(&this->_mlmodel));
-    out.add("status",0);
+    out.add("nclasses", nclasses);
+    tout.finalize(ad.getobj("parameters").getobj("output"), out,
+                  static_cast<MLModel *>(&this->_mlmodel));
+    out.add("status", 0);
     return 0;
   }
-  
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-  void XGBLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::test(const APIData &ad,
-									       std::unique_ptr<xgboost::Learner> &learner,
-									       xgboost::DMatrix *dtest,
-									       APIData &out)
+
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  void
+  XGBLib<TInputConnectorStrategy, TOutputConnectorStrategy, TMLModel>::test(
+      const APIData &ad, std::unique_ptr<xgboost::Learner> &learner,
+      xgboost::DMatrix *dtest, APIData &out)
   {
     if (!dtest)
       return;
     APIData ad_res;
-    ad_res.add("iteration",this->get_meas("iteration"));
-    //ad_res.add("train_loss",this->get_meas("train_loss")); //TODO: can't acquire the loss yet.
+    ad_res.add("iteration", this->get_meas("iteration"));
+    // ad_res.add("train_loss",this->get_meas("train_loss")); //TODO: can't
+    // acquire the loss yet.
     APIData ad_out = ad.getobj("parameters").getobj("output");
     if (ad_out.has("measure"))
       {
-	int nout = _nclasses;
-	if (_regression && _ntargets > 1)
-	  nout = _ntargets;
-	ad_res.add("nclasses",_nclasses);
-	bool output_margin = false;
-	xgboost::HostDeviceVector<float> out_preds;
-	learner->Configure(_params.cfg);
-	learner->Predict(dtest,output_margin,&out_preds);
+        int nout = _nclasses;
+        if (_regression && _ntargets > 1)
+          nout = _ntargets;
+        ad_res.add("nclasses", _nclasses);
+        bool output_margin = false;
+        xgboost::HostDeviceVector<float> out_preds;
+        learner->Configure(_params.cfg);
+        learner->Predict(dtest, output_margin, &out_preds);
 
-	int nclasses = _nclasses;
-	int batch_size = out_preds.Size();
-	if (_objective == "multi:softprob")
-	  batch_size /= _nclasses;
-	else if (_objective == "binary:logistic")
-	  nclasses--;
-	for (int k=0;k<batch_size;k++)
-	  {
-	    APIData bad;
-	    std::vector<double> predictions;
-	    for (int c=0;c<nclasses;c++)
-	      {
-		predictions.push_back(out_preds.HostVector().at(k*nclasses+c));
-	      }
-	    if (_objective == "binary:logistic")
-	      predictions.insert(predictions.begin(),1.0-predictions.back());
-	    bad.add("target",static_cast<double>(dtest->Info().labels_.HostVector().at(k)));
-	    bad.add("pred",predictions);
-	    ad_res.add(std::to_string(k),bad);
-	  }
-	std::vector<std::string> clnames;
-	for (int i=0;i<nout;i++)
-	  clnames.push_back(std::to_string(i));
-	ad_res.add("clnames",clnames);
-	ad_res.add("batch_size",batch_size);
-	if (_regression)
-	  ad_res.add("regression",_regression);
+        int nclasses = _nclasses;
+        int batch_size = out_preds.Size();
+        if (_objective == "multi:softprob")
+          batch_size /= _nclasses;
+        else if (_objective == "binary:logistic")
+          nclasses--;
+        for (int k = 0; k < batch_size; k++)
+          {
+            APIData bad;
+            std::vector<double> predictions;
+            for (int c = 0; c < nclasses; c++)
+              {
+                predictions.push_back(
+                    out_preds.HostVector().at(k * nclasses + c));
+              }
+            if (_objective == "binary:logistic")
+              predictions.insert(predictions.begin(),
+                                 1.0 - predictions.back());
+            bad.add("target", static_cast<double>(
+                                  dtest->Info().labels_.HostVector().at(k)));
+            bad.add("pred", predictions);
+            ad_res.add(std::to_string(k), bad);
+          }
+        std::vector<std::string> clnames;
+        for (int i = 0; i < nout; i++)
+          clnames.push_back(std::to_string(i));
+        ad_res.add("clnames", clnames);
+        ad_res.add("batch_size", batch_size);
+        if (_regression)
+          ad_res.add("regression", _regression);
       }
-    SupervisedOutput::measure(ad_res,ad_out,out);
+    SupervisedOutput::measure(ad_res, ad_out, out);
   }
-  
-  template class XGBLib<CSVXGBInputFileConn,SupervisedOutput,XGBModel>;
-  template class XGBLib<SVMXGBInputFileConn,SupervisedOutput,XGBModel>;
-  template class XGBLib<TxtXGBInputFileConn,SupervisedOutput,XGBModel>;
+
+  template class XGBLib<CSVXGBInputFileConn, SupervisedOutput, XGBModel>;
+  template class XGBLib<SVMXGBInputFileConn, SupervisedOutput, XGBModel>;
+  template class XGBLib<TxtXGBInputFileConn, SupervisedOutput, XGBModel>;
 }

--- a/src/backends/xgb/xgblib.h
+++ b/src/backends/xgb/xgblib.h
@@ -29,14 +29,16 @@
 
 namespace xgboost
 {
-  struct CLIParam : public dmlc::Parameter<CLIParam> {
+  struct CLIParam : public dmlc::Parameter<CLIParam>
+  {
     /*! \brief whether silent */
     int silent = 0;
     /*! \brief whether evaluate training statistics */
     bool eval_train = false;
     /*! \brief number of boosting iterations */
     int num_round = 100;
-    /*! \brief the period to save the model, 0 means only save the final round model */
+    /*! \brief the period to save the model, 0 means only save the final round
+     * model */
     int save_period;
     /*! \brief the path of test model file, or file to restart training */
     std::string model_in = "NULL";
@@ -53,23 +55,21 @@ namespace xgboost
     /*! \brief the names of the evaluation data used in output log */
     std::vector<std::string> eval_data_names;
     /*! \brief all the configurations */
-    std::vector<std::pair<std::string, std::string> > cfg;
+    std::vector<std::pair<std::string, std::string>> cfg;
   };
 }
 
-template<typename T>
-void add_to_cfg(const std::string &key,
-		const T &val,
-		std::vector<std::pair<std::string,std::string>> &cfg)
+template <typename T>
+void add_to_cfg(const std::string &key, const T &val,
+                std::vector<std::pair<std::string, std::string>> &cfg)
 {
-  cfg.push_back(std::make_pair(key,std::to_string(val)));
+  cfg.push_back(std::make_pair(key, std::to_string(val)));
 }
-template<>
-inline void add_to_cfg(const std::string &key,
-		       const std::string &val,
-		       std::vector<std::pair<std::string,std::string>> &cfg)
+template <>
+inline void add_to_cfg(const std::string &key, const std::string &val,
+                       std::vector<std::pair<std::string, std::string>> &cfg)
 {
-  cfg.push_back(std::make_pair(key,val));
+  cfg.push_back(std::make_pair(key, val));
 }
 
 namespace dd
@@ -77,10 +77,12 @@ namespace dd
   /**
    * XGBoost library wrapper for deepdetect
    */
-  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel=XGBModel>
-    class XGBLib : public MLLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>
-    {
-    public:
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel = XGBModel>
+  class XGBLib : public MLLib<TInputConnectorStrategy,
+                              TOutputConnectorStrategy, TMLModel>
+  {
+  public:
     XGBLib(const XGBModel &xmodel);
     XGBLib(XGBLib &&xl) noexcept;
     ~XGBLib();
@@ -95,31 +97,30 @@ namespace dd
     int predict(const APIData &ad, APIData &out);
 
     /*- local functions -*/
-    void test(const APIData &ad,
-	      std::unique_ptr<xgboost::Learner> &learner,
-	      xgboost::DMatrix *dtest,
-	      APIData &out);
-    
-    template<typename T>
-    void add_cfg_param(const std::string &key,
-		       const T &val)
+    void test(const APIData &ad, std::unique_ptr<xgboost::Learner> &learner,
+              xgboost::DMatrix *dtest, APIData &out);
+
+    template <typename T>
+    void add_cfg_param(const std::string &key, const T &val)
     {
-      add_to_cfg(key,val,_params.cfg);
+      add_to_cfg(key, val, _params.cfg);
     }
 
-    public:
+  public:
     // general parameters
-    int _nclasses = 0; /**< required. */
+    int _nclasses = 0;        /**< required. */
     bool _regression = false; /**< whether the net acts as a regressor. */
     int _ntargets = 0; /**< number of classification or regression targets. */
-    std::string _booster = "gbtree"; /**< xgb booster, optional. */
+    std::string _booster = "gbtree";           /**< xgb booster, optional. */
     std::string _objective = "multi:softprob"; /**< xgb service objective. */
 
     bool _gpu = false; /**< whether to use GPU. */
     xgboost::CLIParam _params;
     xgboost::Learner *_learner = nullptr; /**< learner for prediction. */
-    std::mutex _learner_mutex; /**< mutex around the learner, e.g.. no concurrent predict calls as learner is not re-instantiated. Use batches instead. */
-    };
+    std::mutex _learner_mutex; /**< mutex around the learner, e.g.. no
+                                  concurrent predict calls as learner is not
+                                  re-instantiated. Use batches instead. */
+  };
 
 }
 

--- a/src/backends/xgb/xgbmodel.cc
+++ b/src/backends/xgb/xgbmodel.cc
@@ -26,8 +26,8 @@ namespace dd
 {
 
   XGBModel::XGBModel(const APIData &ad, APIData &adg,
-		     const std::shared_ptr<spdlog::logger> &logger)
-    :MLModel(ad,adg,logger)
+                     const std::shared_ptr<spdlog::logger> &logger)
+      : MLModel(ad, adg, logger)
   {
     if (ad.has("repository"))
       this->_repo = ad.get("repository").get<std::string>();
@@ -35,43 +35,46 @@ namespace dd
     read_corresp_file();
   }
 
-  int XGBModel::read_from_repository(const std::shared_ptr<spdlog::logger> &logger)
+  int XGBModel::read_from_repository(
+      const std::shared_ptr<spdlog::logger> &logger)
   {
     static std::string weights = ".model";
     static std::string corresp = "corresp";
     std::unordered_set<std::string> lfiles;
-    int e = fileops::list_directory(_repo,true,false,false,lfiles);
+    int e = fileops::list_directory(_repo, true, false, false, lfiles);
     if (e != 0)
       {
-	logger->error("error reading or listing XGBoost models in repository {}",_repo);
-	return 1;
+        logger->error(
+            "error reading or listing XGBoost models in repository {}", _repo);
+        return 1;
       }
-    std::string weightsf,correspf;
-    int weight_t=-1;
+    std::string weightsf, correspf;
+    int weight_t = -1;
     auto hit = lfiles.begin();
-    while(hit!=lfiles.end())
+    while (hit != lfiles.end())
       {
-	if ((*hit).find(weights)!=std::string::npos)
-	  {
-	    // stat file to pick the latest one
-	    long int wt = fileops::file_last_modif((*hit));
-	    if (wt > weight_t)
-	      {
-		weightsf = (*hit);
-		weight_t = wt;
-	      }
-	  }
-	else if ((*hit).find(corresp)!=std::string::npos)
-	  correspf = (*hit);
-	++hit;
+        if ((*hit).find(weights) != std::string::npos)
+          {
+            // stat file to pick the latest one
+            long int wt = fileops::file_last_modif((*hit));
+            if (wt > weight_t)
+              {
+                weightsf = (*hit);
+                weight_t = wt;
+              }
+          }
+        else if ((*hit).find(corresp) != std::string::npos)
+          correspf = (*hit);
+        ++hit;
       }
     _weights = weightsf;
     _corresp = correspf;
     return 0;
   }
 
-  std::string XGBModel::lookup_objective(const std::string &modelfile,
-					 const std::shared_ptr<spdlog::logger> &logger)
+  std::string
+  XGBModel::lookup_objective(const std::string &modelfile,
+                             const std::shared_ptr<spdlog::logger> &logger)
   {
     static std::string objective_softprob = "multi:softprob";
     static std::string objective_binary = "binary:logistic";
@@ -80,23 +83,24 @@ namespace dd
     std::ifstream ff(modelfile);
     if (!ff.is_open())
       {
-	logger->info("cannot open xgb model file {} for looking objective up",modelfile);
-	return "";
+        logger->info("cannot open xgb model file {} for looking objective up",
+                     modelfile);
+        return "";
       }
     std::string line;
-    while(!ff.eof())
+    while (!ff.eof())
       {
-	std::getline(ff,line);
-	if (line.find(objective_softprob,0)!=std::string::npos)
-	  return objective_softprob;
-	else if (line.find(objective_binary,0)!=std::string::npos)
-	  return objective_binary;
-	else if (line.find(objective_reg_linear,0)!=std::string::npos)
-	  return objective_reg_linear;
-	else if (line.find(objective_reg_logistic,0)!=std::string::npos)
-	  return objective_reg_logistic;
+        std::getline(ff, line);
+        if (line.find(objective_softprob, 0) != std::string::npos)
+          return objective_softprob;
+        else if (line.find(objective_binary, 0) != std::string::npos)
+          return objective_binary;
+        else if (line.find(objective_reg_linear, 0) != std::string::npos)
+          return objective_reg_linear;
+        else if (line.find(objective_reg_logistic, 0) != std::string::npos)
+          return objective_reg_logistic;
       }
     return "";
   }
-  
+
 }

--- a/src/backends/xgb/xgbmodel.h
+++ b/src/backends/xgb/xgbmodel.h
@@ -33,22 +33,28 @@ namespace dd
   class XGBModel : public MLModel
   {
   public:
-    XGBModel():MLModel() {}
+    XGBModel() : MLModel()
+    {
+    }
     XGBModel(const APIData &ad, APIData &adg,
-	     const std::shared_ptr<spdlog::logger> &logger);
-    XGBModel(const std::string &repo)
-      :MLModel(repo) {}
-    ~XGBModel() {}
+             const std::shared_ptr<spdlog::logger> &logger);
+    XGBModel(const std::string &repo) : MLModel(repo)
+    {
+    }
+    ~XGBModel()
+    {
+    }
 
     int read_from_repository(const std::shared_ptr<spdlog::logger> &logger);
 
-    std::string lookup_objective(const std::string &modelfile,
-				 const std::shared_ptr<spdlog::logger> &logger);
-    
-    //TODO
+    std::string
+    lookup_objective(const std::string &modelfile,
+                     const std::shared_ptr<spdlog::logger> &logger);
+
+    // TODO
     std::string _weights; /**< file with model weights. */
   };
-  
+
 }
 
 #endif

--- a/src/basegraph.cc
+++ b/src/basegraph.cc
@@ -28,347 +28,355 @@
 
 namespace dd
 {
-	BaseGraph::Vertex BaseGraph::create_var(std::string name)
-	{
-		_finalized = false;
-		_sorted = false;
-		BaseGraph::Vertex varVertex = boost::add_vertex(_graph);
-		_graph[varVertex].name = name;
-		_graph[varVertex].op = false;;
-		_varIndex[name] = varVertex;
-		return varVertex;
-	}
-
-	BaseGraph::Vertex BaseGraph::create_op(std::string name, std::string type)
-	{
-		_finalized = false;
-		_sorted = false;
-		BaseGraph::Vertex l = boost::add_vertex(_graph);
-		_graph[l].name = name;
-		_graph[l].type = type;
-		_graph[l].op = true;
-		_opIndex[name] = l;
-		return l;
-	}
-
-	void BaseGraph::set_input_dim(std::vector<int>& inputdim)
-	{
-		if (_graph[_input].dim == inputdim)
-			return;
-		_graph[_input].dim = inputdim;
-		_finalized = false;
-	}
-
-	BaseGraph::Vertex BaseGraph::set_input(std::string name, std::vector<int>& inputdim)
-	{
-		_inputname = name;
-		_finalized = false;
-		if (_varIndex.find(name) == _varIndex.end())
-			_input  = create_var(name);
-		else
-			_graph[_input].name = name;
-		_graph[_input].dim = inputdim;
-		return _input;
-	}
-
-	void BaseGraph::add_layer (std::string opname, std::string optype,
-						  std::vector<std::string>& inputs,
-						  std::vector<std::string>& outputs)
-	{
-		BaseGraph::Vertex v = add_layer(opname, optype);
-		add_inputs(v, inputs);
-		add_outputs(v, outputs);
-	}
-
-	BaseGraph::Vertex BaseGraph::add_layer(std::string opname, std::string optype)
-	{
-		return create_op(opname, optype);
-	}
-
-	std::vector<BaseGraph::Vertex> BaseGraph::add_outputs(std::string opname,
-														  std::vector<std::string>& outputs)
-	{
-		std::unordered_map<std::string, BaseGraph::Vertex>::iterator it = _opIndex.find(opname);
-		if (it == _opIndex.end())
-			{
-				std::cerr << "cannot add output to non existent layer " << opname << std::endl;
-				std::vector<BaseGraph::Vertex> ev;
-				return ev;
-			}
-		return add_outputs(it->second, outputs);
-	}
-
-	std::vector<BaseGraph::Vertex> BaseGraph::add_outputs(BaseGraph::Vertex v,
-														  std::vector<std::string>& outputs)
-	{
-		std::vector<BaseGraph::Vertex> outverts;
-		for (std::string output: outputs)
-			outverts.push_back(add_output(v, output));
-		return outverts;
-	}
-
-
-	BaseGraph::Vertex BaseGraph::add_output(std::string opname, std::string varname)
-	{
-		std::unordered_map<std::string, BaseGraph::Vertex>::iterator it = _opIndex.find(opname);
-		if (it == _opIndex.end())
-			{
-				std::cerr << "cannot add output to non existent layer " << opname << std::endl;
-				return LONG_MAX;
-			}
-		return add_output(it->second, varname);
-	}
-
-
-	BaseGraph::Vertex BaseGraph::add_output(BaseGraph::Vertex v, std::string varname)
-	{
-		std::unordered_map<std::string, BaseGraph::Vertex>::iterator it = _varIndex.find(varname);
-		BaseGraph::Vertex varVertex;
-		if (it == _varIndex.end())
-			varVertex = create_var(varname);
-		else
-			varVertex =  it->second;
-		if (boost::in_degree(varVertex, _graph) != 0)
-			std::cerr << "trying to add multiple producers for  var " <<
-				_graph[varVertex].name << std::endl;
-		else
-			{
-				boost::add_edge(v,varVertex, _graph);
-				_finalized =false;
-			}
-		return varVertex;
-	}
-
-
-	std::vector<BaseGraph::Vertex> BaseGraph::add_inputs(std::string opname,
-														 std::vector<std::string>& inputs)
-	{
-		std::unordered_map<std::string, BaseGraph::Vertex>::iterator it = _opIndex.find(opname);
-		if (it == _opIndex.end())
-			{
-				std::cerr << "cannot add inputs to non existent layer " << opname << std::endl;
-				std::vector<BaseGraph::Vertex> ev;
-				return ev;
-			}
-		return add_inputs(it->second, inputs);
-	}
-
-
-	std::vector<BaseGraph::Vertex> BaseGraph::add_inputs(BaseGraph::Vertex v,
-														 std::vector<std::string>& inputs)
-	{
-		std::vector<BaseGraph::Vertex> iv;
-		for (std::string input : inputs)
-			iv.push_back(add_input(v, input));
-		return iv;
-	}
-
-	BaseGraph::Vertex BaseGraph::add_input(std::string opname, std::string varname)
-	{
-		std::unordered_map<std::string, BaseGraph::Vertex>::iterator it = _opIndex.find(opname);
-		if (it == _opIndex.end())
-			{
-				std::cerr << "cannot add inputs to non existent layer " << opname << std::endl;
-				return LONG_MAX;
-			}
-		return add_input(it->second, varname);
-	}
-
-
-	BaseGraph::Vertex BaseGraph::add_input(BaseGraph::Vertex v, std::string varname)
-	{
-		std::unordered_map<std::string, BaseGraph::Vertex>::iterator it = _varIndex.find(varname);
-		BaseGraph::Vertex varVertex;
-		if (it == _varIndex.end())
-			varVertex = create_var(varname);
-		else
-			varVertex =  it->second;
-		_finalized = false;
-		boost::add_edge(varVertex, v, _graph);
-		return varVertex;
-	}
-
-
-
-	void BaseGraph::sort_all()
-	{
-		if (_sorted)
-			return;
-		_sortedOps.clear();
-		_sortedVars.clear();
-		boost::topological_sort(_graph, std::back_inserter(_sortedAll));
-		std::reverse(_sortedAll.begin(), _sortedAll.end());
-		for (BaseGraph::Vertex v: _sortedAll)
-			{
-				if (_graph[v].op)
-					_sortedOps.push_back(v);
-				else
-					_sortedVars.push_back(v);
-			}
-		_sorted = true;
-	}
-
-	void BaseGraph::finalize()
-	{
-		if (_finalized)
-			return;
-		//TODO :  some sanity checks,
-		// is there a path from input to ouput ?
-		// check if all necessary vars are produced
-		//
-		sort_all();
-		compute_blob_sizes();
-		_finalized = true;
-	}
-
-
-  std::tuple<std::vector<int>,std::vector<int>>
-  BaseGraph::compute_dims_from_producer(BaseGraph::Vertex producer)
-	{
-		std::vector<int> outputdim;
-		std::vector<int> inputdim;
-		std::vector<BaseGraph::Vertex> inputs;
-		auto es = boost::in_edges(producer,_graph);
-		for (auto eit = es.first; eit != es.second; ++eit)
-			inputs.push_back(boost::source(*eit,_graph));
-		outputdim.push_back(_graph[inputs[0]].dim[0]); // batchsize
-		for (int d: _graph[inputs[0]].dim)
-		  inputdim.push_back(d);
-		if (_graph[producer].type == "LSTM" || _graph[producer].type == "RNN")
-			{
-				outputdim.push_back(_graph[inputs[0]].dim[1]); // timesteps
-				outputdim.push_back(_graph[producer].num_output); //hidden_size
-			}
-		else if (_graph[producer].type == "InnerProduct")
-			{
-				unsigned int axis = (_graph[producer].axis == -1) ? 1 : _graph[producer].axis;
-				for (unsigned int i=1; i<axis; ++i)
-					outputdim.push_back(_graph[inputs[0]].dim[i]);
-				outputdim.push_back(_graph[producer].num_output);
-			}
-		return std::tie(inputdim,outputdim);
-	}
-
-	void BaseGraph::compute_dims(BaseGraph::Vertex v)
-	{
-		auto es = boost::in_edges(v,_graph);
-		auto eit = es.first;
-		BaseGraph::Vertex producer = boost::source(*eit,_graph);
-		auto newdims = compute_dims_from_producer(producer);
-		update_alloc_status(newdims, producer);
-		_graph[producer].dim = std::get<1>(newdims);
-		_graph[v].dim = std::get<1>(newdims);
-		_graph[producer].inputdim = std::get<0>(newdims);
-	}
-
-  void BaseGraph::update_alloc_status(std::tuple<std::vector<int>, std::vector<int>> newdims,
-									  BaseGraph::Vertex v)
+  BaseGraph::Vertex BaseGraph::create_var(std::string name)
   {
-	std::vector<int> old_outputdims = _graph[v].dim;
-	std::vector<int> old_inputdims = _graph[v].inputdim;
-	std::vector<int> new_outputdims = std::get<1>(newdims);
-	std::vector<int> new_inputdims = std::get<0>(newdims);
-	if (old_outputdims.size() != new_outputdims.size())
-	  {
-		_graph[v].alloc_needed = true;
-		return;
-	  }
-
-	if (old_inputdims.size() != new_inputdims.size())
-	  {
-		_graph[v].alloc_needed = true;
-		return;
-	  }
-
-
-	// for lstm, rnn layers, special case for timesteps => no realloc needed
-	if ((old_inputdims[1] != new_inputdims[1]))
-	  {
-		if (_graph[v].type != "LSTM" &&
-			_graph[v].type != "RNN" &&
-			(_graph[v].type != "InnerProduct" || _graph[v].axis <= 1))
-		  {
-			_graph[v].alloc_needed = true;
-			return;
-		  }
-	  }
-
-	// for every layer, if input dim > 2 , realloc needed
-	for (unsigned int i=2; i< new_inputdims.size(); ++i)
-	  if (old_inputdims[i] != new_inputdims[i])
-		{
-		  _graph[v].alloc_needed = true;
-		  return;
-		}
-
-	if ((old_outputdims[1] != new_outputdims[1]))
-	  {
-		if (_graph[v].type != "LSTM" &&
-			_graph[v].type != "RNN" &&
-			(_graph[v].type != "InnerProduct" || _graph[v].axis <= 1))
-		  {
-			_graph[v].alloc_needed = true;
-			return;
-		  }
-	  }
-	for (unsigned int i=2; i<old_outputdims.size(); ++i)
-	  if (old_outputdims[i] != new_outputdims[i])
-		{
-		  _graph[v].alloc_needed = true;
-		  return;
-		}
+    _finalized = false;
+    _sorted = false;
+    BaseGraph::Vertex varVertex = boost::add_vertex(_graph);
+    _graph[varVertex].name = name;
+    _graph[varVertex].op = false;
+    ;
+    _varIndex[name] = varVertex;
+    return varVertex;
   }
 
-	void BaseGraph::compute_blob_sizes()
-	{
-		for (BaseGraph::Vertex v: _sortedVars)
-			{
-				if (v == _input)
-					continue;
-				compute_dims(v);
-			}
-	}
+  BaseGraph::Vertex BaseGraph::create_op(std::string name, std::string type)
+  {
+    _finalized = false;
+    _sorted = false;
+    BaseGraph::Vertex l = boost::add_vertex(_graph);
+    _graph[l].name = name;
+    _graph[l].type = type;
+    _graph[l].op = true;
+    _opIndex[name] = l;
+    return l;
+  }
 
-	void BaseGraph::todot(std::ostream &out)
-	{
-		boost::write_graphviz(out, _graph,
-							  make_vertex_writer(boost::get(&VertexProperty::name,_graph),
-												 boost::get(&VertexProperty::op,_graph),
-												 boost::get(&VertexProperty::dim,_graph)));
-	}
+  void BaseGraph::set_input_dim(std::vector<int> &inputdim)
+  {
+    if (_graph[_input].dim == inputdim)
+      return;
+    _graph[_input].dim = inputdim;
+    _finalized = false;
+  }
 
-	std::vector<BaseGraph::Vertex> BaseGraph::inputs(BaseGraph::Vertex v)
-	{
-		std::vector<BaseGraph::Vertex> inputs;
-		NNGraph::in_edge_iterator eit,eend;
-		auto es = boost::in_edges(v,_graph);
-		for (auto eit = es.first; eit != es.second; ++eit)
-			inputs.push_back(boost::source(*eit,_graph));
-		return inputs;
-	}
+  BaseGraph::Vertex BaseGraph::set_input(std::string name,
+                                         std::vector<int> &inputdim)
+  {
+    _inputname = name;
+    _finalized = false;
+    if (_varIndex.find(name) == _varIndex.end())
+      _input = create_var(name);
+    else
+      _graph[_input].name = name;
+    _graph[_input].dim = inputdim;
+    return _input;
+  }
 
+  void BaseGraph::add_layer(std::string opname, std::string optype,
+                            std::vector<std::string> &inputs,
+                            std::vector<std::string> &outputs)
+  {
+    BaseGraph::Vertex v = add_layer(opname, optype);
+    add_inputs(v, inputs);
+    add_outputs(v, outputs);
+  }
 
-	std::vector<BaseGraph::Vertex> BaseGraph::outputs(BaseGraph::Vertex v)
-	{
-		std::vector<BaseGraph::Vertex> outputs;
-		NNGraph::out_edge_iterator eit,eend;
-		auto es = boost::out_edges(v,_graph);
-		for (auto eit = es.first; eit != es.second; ++eit)
-			outputs.push_back(boost::target(*eit,_graph));
-		return outputs;
-	}
+  BaseGraph::Vertex BaseGraph::add_layer(std::string opname,
+                                         std::string optype)
+  {
+    return create_op(opname, optype);
+  }
 
+  std::vector<BaseGraph::Vertex>
+  BaseGraph::add_outputs(std::string opname, std::vector<std::string> &outputs)
+  {
+    std::unordered_map<std::string, BaseGraph::Vertex>::iterator it
+        = _opIndex.find(opname);
+    if (it == _opIndex.end())
+      {
+        std::cerr << "cannot add output to non existent layer " << opname
+                  << std::endl;
+        std::vector<BaseGraph::Vertex> ev;
+        return ev;
+      }
+    return add_outputs(it->second, outputs);
+  }
 
-	int BaseGraph::dim(BaseGraph::Vertex v, int num_input, int ndim)
-	{
-		return _graph[inputs(v)[num_input]].dim[ndim];
-	}
+  std::vector<BaseGraph::Vertex>
+  BaseGraph::add_outputs(BaseGraph::Vertex v,
+                         std::vector<std::string> &outputs)
+  {
+    std::vector<BaseGraph::Vertex> outverts;
+    for (std::string output : outputs)
+      outverts.push_back(add_output(v, output));
+    return outverts;
+  }
+
+  BaseGraph::Vertex BaseGraph::add_output(std::string opname,
+                                          std::string varname)
+  {
+    std::unordered_map<std::string, BaseGraph::Vertex>::iterator it
+        = _opIndex.find(opname);
+    if (it == _opIndex.end())
+      {
+        std::cerr << "cannot add output to non existent layer " << opname
+                  << std::endl;
+        return LONG_MAX;
+      }
+    return add_output(it->second, varname);
+  }
+
+  BaseGraph::Vertex BaseGraph::add_output(BaseGraph::Vertex v,
+                                          std::string varname)
+  {
+    std::unordered_map<std::string, BaseGraph::Vertex>::iterator it
+        = _varIndex.find(varname);
+    BaseGraph::Vertex varVertex;
+    if (it == _varIndex.end())
+      varVertex = create_var(varname);
+    else
+      varVertex = it->second;
+    if (boost::in_degree(varVertex, _graph) != 0)
+      std::cerr << "trying to add multiple producers for  var "
+                << _graph[varVertex].name << std::endl;
+    else
+      {
+        boost::add_edge(v, varVertex, _graph);
+        _finalized = false;
+      }
+    return varVertex;
+  }
+
+  std::vector<BaseGraph::Vertex>
+  BaseGraph::add_inputs(std::string opname, std::vector<std::string> &inputs)
+  {
+    std::unordered_map<std::string, BaseGraph::Vertex>::iterator it
+        = _opIndex.find(opname);
+    if (it == _opIndex.end())
+      {
+        std::cerr << "cannot add inputs to non existent layer " << opname
+                  << std::endl;
+        std::vector<BaseGraph::Vertex> ev;
+        return ev;
+      }
+    return add_inputs(it->second, inputs);
+  }
+
+  std::vector<BaseGraph::Vertex>
+  BaseGraph::add_inputs(BaseGraph::Vertex v, std::vector<std::string> &inputs)
+  {
+    std::vector<BaseGraph::Vertex> iv;
+    for (std::string input : inputs)
+      iv.push_back(add_input(v, input));
+    return iv;
+  }
+
+  BaseGraph::Vertex BaseGraph::add_input(std::string opname,
+                                         std::string varname)
+  {
+    std::unordered_map<std::string, BaseGraph::Vertex>::iterator it
+        = _opIndex.find(opname);
+    if (it == _opIndex.end())
+      {
+        std::cerr << "cannot add inputs to non existent layer " << opname
+                  << std::endl;
+        return LONG_MAX;
+      }
+    return add_input(it->second, varname);
+  }
+
+  BaseGraph::Vertex BaseGraph::add_input(BaseGraph::Vertex v,
+                                         std::string varname)
+  {
+    std::unordered_map<std::string, BaseGraph::Vertex>::iterator it
+        = _varIndex.find(varname);
+    BaseGraph::Vertex varVertex;
+    if (it == _varIndex.end())
+      varVertex = create_var(varname);
+    else
+      varVertex = it->second;
+    _finalized = false;
+    boost::add_edge(varVertex, v, _graph);
+    return varVertex;
+  }
+
+  void BaseGraph::sort_all()
+  {
+    if (_sorted)
+      return;
+    _sortedOps.clear();
+    _sortedVars.clear();
+    boost::topological_sort(_graph, std::back_inserter(_sortedAll));
+    std::reverse(_sortedAll.begin(), _sortedAll.end());
+    for (BaseGraph::Vertex v : _sortedAll)
+      {
+        if (_graph[v].op)
+          _sortedOps.push_back(v);
+        else
+          _sortedVars.push_back(v);
+      }
+    _sorted = true;
+  }
+
+  void BaseGraph::finalize()
+  {
+    if (_finalized)
+      return;
+    // TODO :  some sanity checks,
+    // is there a path from input to ouput ?
+    // check if all necessary vars are produced
+    //
+    sort_all();
+    compute_blob_sizes();
+    _finalized = true;
+  }
+
+  std::tuple<std::vector<int>, std::vector<int>>
+  BaseGraph::compute_dims_from_producer(BaseGraph::Vertex producer)
+  {
+    std::vector<int> outputdim;
+    std::vector<int> inputdim;
+    std::vector<BaseGraph::Vertex> inputs;
+    auto es = boost::in_edges(producer, _graph);
+    for (auto eit = es.first; eit != es.second; ++eit)
+      inputs.push_back(boost::source(*eit, _graph));
+    outputdim.push_back(_graph[inputs[0]].dim[0]); // batchsize
+    for (int d : _graph[inputs[0]].dim)
+      inputdim.push_back(d);
+    if (_graph[producer].type == "LSTM" || _graph[producer].type == "RNN")
+      {
+        outputdim.push_back(_graph[inputs[0]].dim[1]);    // timesteps
+        outputdim.push_back(_graph[producer].num_output); // hidden_size
+      }
+    else if (_graph[producer].type == "InnerProduct")
+      {
+        unsigned int axis
+            = (_graph[producer].axis == -1) ? 1 : _graph[producer].axis;
+        for (unsigned int i = 1; i < axis; ++i)
+          outputdim.push_back(_graph[inputs[0]].dim[i]);
+        outputdim.push_back(_graph[producer].num_output);
+      }
+    return std::tie(inputdim, outputdim);
+  }
+
+  void BaseGraph::compute_dims(BaseGraph::Vertex v)
+  {
+    auto es = boost::in_edges(v, _graph);
+    auto eit = es.first;
+    BaseGraph::Vertex producer = boost::source(*eit, _graph);
+    auto newdims = compute_dims_from_producer(producer);
+    update_alloc_status(newdims, producer);
+    _graph[producer].dim = std::get<1>(newdims);
+    _graph[v].dim = std::get<1>(newdims);
+    _graph[producer].inputdim = std::get<0>(newdims);
+  }
+
+  void BaseGraph::update_alloc_status(
+      std::tuple<std::vector<int>, std::vector<int>> newdims,
+      BaseGraph::Vertex v)
+  {
+    std::vector<int> old_outputdims = _graph[v].dim;
+    std::vector<int> old_inputdims = _graph[v].inputdim;
+    std::vector<int> new_outputdims = std::get<1>(newdims);
+    std::vector<int> new_inputdims = std::get<0>(newdims);
+    if (old_outputdims.size() != new_outputdims.size())
+      {
+        _graph[v].alloc_needed = true;
+        return;
+      }
+
+    if (old_inputdims.size() != new_inputdims.size())
+      {
+        _graph[v].alloc_needed = true;
+        return;
+      }
+
+    // for lstm, rnn layers, special case for timesteps => no realloc needed
+    if ((old_inputdims[1] != new_inputdims[1]))
+      {
+        if (_graph[v].type != "LSTM" && _graph[v].type != "RNN"
+            && (_graph[v].type != "InnerProduct" || _graph[v].axis <= 1))
+          {
+            _graph[v].alloc_needed = true;
+            return;
+          }
+      }
+
+    // for every layer, if input dim > 2 , realloc needed
+    for (unsigned int i = 2; i < new_inputdims.size(); ++i)
+      if (old_inputdims[i] != new_inputdims[i])
+        {
+          _graph[v].alloc_needed = true;
+          return;
+        }
+
+    if ((old_outputdims[1] != new_outputdims[1]))
+      {
+        if (_graph[v].type != "LSTM" && _graph[v].type != "RNN"
+            && (_graph[v].type != "InnerProduct" || _graph[v].axis <= 1))
+          {
+            _graph[v].alloc_needed = true;
+            return;
+          }
+      }
+    for (unsigned int i = 2; i < old_outputdims.size(); ++i)
+      if (old_outputdims[i] != new_outputdims[i])
+        {
+          _graph[v].alloc_needed = true;
+          return;
+        }
+  }
+
+  void BaseGraph::compute_blob_sizes()
+  {
+    for (BaseGraph::Vertex v : _sortedVars)
+      {
+        if (v == _input)
+          continue;
+        compute_dims(v);
+      }
+  }
+
+  void BaseGraph::todot(std::ostream &out)
+  {
+    boost::write_graphviz(
+        out, _graph,
+        make_vertex_writer(boost::get(&VertexProperty::name, _graph),
+                           boost::get(&VertexProperty::op, _graph),
+                           boost::get(&VertexProperty::dim, _graph)));
+  }
+
+  std::vector<BaseGraph::Vertex> BaseGraph::inputs(BaseGraph::Vertex v)
+  {
+    std::vector<BaseGraph::Vertex> inputs;
+    NNGraph::in_edge_iterator eit, eend;
+    auto es = boost::in_edges(v, _graph);
+    for (auto eit = es.first; eit != es.second; ++eit)
+      inputs.push_back(boost::source(*eit, _graph));
+    return inputs;
+  }
+
+  std::vector<BaseGraph::Vertex> BaseGraph::outputs(BaseGraph::Vertex v)
+  {
+    std::vector<BaseGraph::Vertex> outputs;
+    NNGraph::out_edge_iterator eit, eend;
+    auto es = boost::out_edges(v, _graph);
+    for (auto eit = es.first; eit != es.second; ++eit)
+      outputs.push_back(boost::target(*eit, _graph));
+    return outputs;
+  }
+
+  int BaseGraph::dim(BaseGraph::Vertex v, int num_input, int ndim)
+  {
+    return _graph[inputs(v)[num_input]].dim[ndim];
+  }
 
   bool BaseGraph::allocated()
   {
-	for (BaseGraph::Vertex v: _sortedOps)
-	  if (_graph[v].alloc_needed)
-		return false;
-	return true;
+    for (BaseGraph::Vertex v : _sortedOps)
+      if (_graph[v].alloc_needed)
+        return false;
+    return true;
   }
 }

--- a/src/basegraph.h
+++ b/src/basegraph.h
@@ -29,323 +29,353 @@ namespace dd
 {
 
   /**
-   * base graph is the high level representation of the neural net and soon other ops (chains/ data aug)
+   * base graph is the high level representation of the neural net and soon
+   * other ops (chains/ data aug)
    *
    */
   class BaseGraph
   {
 
   public:
+    /**
+     *  a vertex contains info about the operator on the computation flow
+     *  a vertex is also used for data blobs, in that case op is set to false
+     */
+    struct VertexProperty
+    {
+      bool op; /**< false if this vertex is data only (used for split / dup
+                  nodes) */
+      std::string name; /**< name of the operator / data tensor */
+      std::string type; /**< type of the operator  */
+      std::vector<int>
+          dim; /**< output dim for operators, data dim for data blobs */
+      std::vector<int> inputdim; /**< input dims for operators, needed to see
+                                    if some change has occured */
+      bool alloc_needed = true;  /**< true if some dimensions have changed */
+      int num_output = -1; /**< number of output for some operator types */
+      int axis = -1; /**< axis parameters for innerproduct operator type */
+    };
 
-	/**
-	 *  a vertex contains info about the operator on the computation flow
-	 *  a vertex is also used for data blobs, in that case op is set to false
-	 */
-	struct VertexProperty
-	{
-	  bool op; /**< false if this vertex is data only (used for split / dup nodes) */
-	  std::string name;	 /**< name of the operator / data tensor */
-	  std::string type; /**< type of the operator  */
-	  std::vector<int> dim;  /**< output dim for operators, data dim for data blobs */
-	  std::vector<int> inputdim; /**< input dims for operators, needed to see if some change has occured */
-	  bool alloc_needed = true; /**< true if some dimensions have changed */
-	  int num_output = -1;		/**< number of output for some operator types */
-	  int axis = -1;			/**< axis parameters for innerproduct operator type */
-	};
+    /**
+     * \brief edge property holder : nothing atm
+     *
+     */
+    struct EdgeProperty
+    {
+    };
 
-	/**
-	 * \brief edge property holder : nothing atm
-	 *
-	 */
-	struct EdgeProperty
-	{
-	};
+    /**
+     * \brief highly templated functor for having a string representation of a
+     * vertex
+     *
+     */
+    template <class NameMap, class OpMap, class DimMap> class vertex_writer
+    {
+    public:
+      vertex_writer(NameMap n, OpMap t, DimMap d) : name(n), op(t), dim(d)
+      {
+      }
+      template <class Vertex>
+      void operator()(std::ostream &out, const Vertex &v) const
+      {
+        if (op[v])
+          out << "[label=\"" << name[v] << "\", shape=box]";
+        else
+          {
+            std::string ds = "{ ";
+            std::vector<int> dims = dim[v];
+            ds += std::to_string(dims[0]);
+            for (unsigned int i = 1; i < dims.size(); ++i)
+              ds += " , " + std::to_string(dims[i]);
+            ds += " }";
+            out << "[label=\"" << name[v] << " " << ds << "\", shape=ellipse]";
+          }
+      }
 
-	/**
-	 * \brief highly templated functor for having a string representation of a vertex
-	 *
-	 */
-	template <class NameMap, class OpMap, class DimMap>
-	class vertex_writer {
-	public:
-	  vertex_writer(NameMap n, OpMap t, DimMap d) : name(n), op(t), dim(d) {}
-	  template <class Vertex>
-	  void operator()(std::ostream &out, const Vertex& v) const {
-		if (op[v])
-		  out << "[label=\"" << name[v] << "\", shape=box]";
-		else
-		  {
-			std::string ds = "{ ";
-			std::vector<int> dims = dim[v];
-			ds += std::to_string(dims[0]);
-			for (unsigned int i = 1; i<dims.size(); ++i)
-			  ds += " , " + std::to_string(dims[i]);
-			ds+= " }";
-			out << "[label=\"" << name[v] << " " << ds << "\", shape=ellipse]";
-		  }
-	  }
-	private:
-	  NameMap name;
-	  OpMap op;
-	  DimMap dim;
-	};
+    private:
+      NameMap name;
+      OpMap op;
+      DimMap dim;
+    };
 
-	/**
-	 * factory functor for debug, or something like this
-	 */
-	template <class NameMap, class OpMap, class DimMap>
-	inline vertex_writer<NameMap, OpMap, DimMap> make_vertex_writer(NameMap n, OpMap t, DimMap d) {
-	  return vertex_writer<NameMap, OpMap, DimMap>(n,t,d);
-	}
+    /**
+     * factory functor for debug, or something like this
+     */
+    template <class NameMap, class OpMap, class DimMap>
+    inline vertex_writer<NameMap, OpMap, DimMap>
+    make_vertex_writer(NameMap n, OpMap t, DimMap d)
+    {
+      return vertex_writer<NameMap, OpMap, DimMap>(n, t, d);
+    }
 
+    typedef boost::adjacency_list<boost::vecS, boost::vecS,
+                                  boost::bidirectionalS, VertexProperty,
+                                  EdgeProperty>
+        NNGraph; /**< the graph itself */
+    typedef boost::graph_traits<NNGraph>::vertex_descriptor
+        Vertex; /**< append vertex info */
+    typedef boost::graph_traits<NNGraph>::edge_descriptor
+        Edge; /**< append edge info (nothing atm) */
 
+    /**
+     * \brief add layer / operator to the computational graph
+     *
+     * @param opname name of the layer
+     * @param optype type of the layer
+     * @param inputs name of inputs to connect
+     * @param outputs name of outputs
+     */
+    void add_layer(std::string opname, std::string optype,
+                   std::vector<std::string> &inputs,
+                   std::vector<std::string> &outputs);
 
-	typedef boost::adjacency_list<boost::vecS, boost::vecS, boost::bidirectionalS, VertexProperty, EdgeProperty> NNGraph; /**< the graph itself */
-	typedef boost::graph_traits<NNGraph>::vertex_descriptor Vertex; /**< append vertex info */
-	typedef boost::graph_traits<NNGraph>::edge_descriptor Edge; /**< append edge info (nothing atm) */
+    /**
+     * \brief add layer / operator to the computational graph, reduced version
+     * @param opname name of the layer
+     * @param optype type of the layer
+     * @return  added vertex
+     */
+    Vertex add_layer(std::string opname, std::string optype);
 
+    /**
+     * \brief set general input
+     * @param name name of input data/blob
+     * @param inputdim dimensions of the blob
+     * @return the added vertex
+     */
+    Vertex set_input(std::string name, std::vector<int> &inputdim);
 
-	/**
-	 * \brief add layer / operator to the computational graph
-	 *
-	 * @param opname name of the layer
-	 * @param optype type of the layer
-	 * @param inputs name of inputs to connect
-	 * @param outputs name of outputs
-	 */
-	void add_layer(std::string opname, std::string optype,
-				   std::vector<std::string>& inputs,
-				   std::vector<std::string>& outputs);
+    /**
+     * \brief add/bind some inputs to a vertex
+     * if they already exist, they are bound, if not they are allocated
+     * @param v vertex to add inputs to
+     * @param inputs name of inputs
+     * @return list of data inputs
+     */
+    std::vector<Vertex> add_inputs(Vertex v, std::vector<std::string> &inputs);
 
-	/**
-	 * \brief add layer / operator to the computational graph, reduced version
-	 * @param opname name of the layer
-	 * @param optype type of the layer
-	 * @return  added vertex
-	 */
-	Vertex add_layer(std::string opname, std::string optype);
+    /**
+     * \brief add/bind some inputs to a vertex
+     * if they already exist, they are bound, if not they are allocated
+     * @param opname name of operator to add inputs to
+     * @param inputs name of inputs
+     * @return list of data inputs
+     */
+    std::vector<Vertex> add_inputs(std::string opname,
+                                   std::vector<std::string> &inputs);
 
-	/**
-	 * \brief set general input
-	 * @param name name of input data/blob
-	 * @param inputdim dimensions of the blob
-	 * @return the added vertex
-	 */
-	Vertex set_input(std::string name, std::vector<int>& inputdim);
+    /**
+     * \brief add single input to a vertex, allocate data vertex if needed
+     * @param v vertex to add input to
+     * @param input name of data input
+     * @return input vertex
+     */
+    Vertex add_input(Vertex v, std::string input);
 
-	/**
-	 * \brief add/bind some inputs to a vertex
-	 * if they already exist, they are bound, if not they are allocated
-	 * @param v vertex to add inputs to
-	 * @param inputs name of inputs
-	 * @return list of data inputs
-	 */
-	std::vector<Vertex> add_inputs(Vertex v, std::vector<std::string>& inputs);
+    /**
+     * \brief add single input to a vertex, allocate data vertex if needed
+     * @param opname operator to add input to
+     * @param input name of data input
+     * @return input vertex
+     */
+    Vertex add_input(std::string opname, std::string inputs);
 
-	/**
-	 * \brief add/bind some inputs to a vertex
-	 * if they already exist, they are bound, if not they are allocated
-	 * @param opname name of operator to add inputs to
-	 * @param inputs name of inputs
-	 * @return list of data inputs
-	 */
-	std::vector<Vertex> add_inputs(std::string opname, std::vector<std::string>& inputs);
+    /**
+     * \brief add outputs to an operator vertex, allocates outputs if needed
+     * @param v vertex to add ouput to
+     * @param outputs name of data outputs
+     * @return vector of data vertices
+     */
+    std::vector<Vertex> add_outputs(Vertex v,
+                                    std::vector<std::string> &outputs);
 
-	/**
-	 * \brief add single input to a vertex, allocate data vertex if needed
-	 * @param v vertex to add input to
-	 * @param input name of data input
-	 * @return input vertex
-	 */
-	Vertex add_input(Vertex v, std::string input);
+    /**
+     * \brief add outputs to an operator , allocates outputs if needed
+     * @param opname name of operator to add ouput to
+     * @param outputs name of data outputs
+     * @return vector of data vertices
+     */
+    std::vector<Vertex> add_outputs(std::string opname,
+                                    std::vector<std::string> &outputs);
 
+    /**
+     * \brief add output to an operator vertex, allocates output if needed
+     * @param v vertex to add ouput to
+     * @param varname name of data output
+     * @return data vertex
+     */
+    Vertex add_output(Vertex v, std::string varname);
 
-	/**
-	 * \brief add single input to a vertex, allocate data vertex if needed
-	 * @param opname operator to add input to
-	 * @param input name of data input
-	 * @return input vertex
-	 */
-	Vertex add_input(std::string opname, std::string inputs);
+    /**
+     * \brief add output to an operator , allocates output if needed
+     * @param opnameto add ouput to
+     * @param varname name of data output
+     * @return data vertex
+     */
+    Vertex add_output(std::string opname, std::string varname);
 
-	/**
-	 * \brief add outputs to an operator vertex, allocates outputs if needed
-	 * @param v vertex to add ouput to
-	 * @param outputs name of data outputs
-	 * @return vector of data vertices
-	 */
-	std::vector<Vertex> add_outputs(Vertex v, std::vector<std::string>& outputs);
+    /**
+     * \brief set loss to be used at learning
+     * @param name  loss name
+     */
+    void set_loss(std::string name)
+    {
+      _loss = name;
+    }
 
+    /**
+     * topological_sort of vertices
+     */
+    void sort_all();
 
-	/**
-	 * \brief add outputs to an operator , allocates outputs if needed
-	 * @param opname name of operator to add ouput to
-	 * @param outputs name of data outputs
-	 * @return vector of data vertices
-	 */
-	std::vector<Vertex> add_outputs(std::string opname, std::vector<std::string>& outputs);
+    /**
+     * \brief gives a dot reprensention of the graph, for debgging purposes
+     * @param out ostream to put text to
+     */
+    void todot(std::ostream &out);
 
+    /**
+     * \brief check, sort, do some computations on blob sizes
+     */
+    void finalize();
 
-	/**
-	 * \brief add output to an operator vertex, allocates output if needed
-	 * @param v vertex to add ouput to
-	 * @param varname name of data output
-	 * @return data vertex
-	 */
-	Vertex add_output(Vertex v, std::string varname);
+    /**
+     * \brief set input data dimensions
+     * @param inputdim
+     */
+    void set_input_dim(std::vector<int> &inputdim);
 
-	/**
-	 * \brief add output to an operator , allocates output if needed
-	 * @param opnameto add ouput to
-	 * @param varname name of data output
-	 * @return data vertex
-	 */
-	Vertex add_output(std::string opname, std::string varname);
+    /**
+     * \brief set ouput  data name
+     * @param output : data blob name
+     */
+    void set_output_name(std::string output)
+    {
+      _outputname = output;
+    }
 
-	/**
-	 * \brief set loss to be used at learning
-	 * @param name  loss name
-	 */
-	void set_loss(std::string name) {_loss= name;}
+    /**
+     * \brief get input vertices
+     * @param Vertex from which inputs are needed
+     * @return all inpit vertices
+     */
+    std::vector<Vertex> inputs(Vertex);
 
-	/**
-	 * topological_sort of vertices
-	 */
-	void sort_all();
+    /**
+     * \brief get output vertices
+     * @param Vertex from which outputs are needed
+     * @return all output vertices
+     */
+    std::vector<Vertex> outputs(Vertex);
 
-	/**
-	 * \brief gives a dot reprensention of the graph, for debgging purposes
-	 * @param out ostream to put text to
-	 */
-	void todot(std::ostream &out);
+    /**
+     * \brief get some precise dimension of some inpit of a vertex
+     *
+     * @param v vertex from which some input dimension is needed
+     * @param num_input number of the input (generally 0 for first input)
+     * @param ndim number of dimension needed
+     *
+     * @return the dimension
+     */
+    int dim(Vertex v, int num_input, int ndim);
 
-	/**
-	 * \brief check, sort, do some computations on blob sizes
-	 */
-	void finalize();
+    /**
+     * \brief gives number of outputs of a vertex
+     */
+    int num_output(Vertex v) const
+    {
+      return _graph[v].num_output;
+    }
 
-	/**
-	 * \brief set input data dimensions
-	 * @param inputdim
-	 */
-	void set_input_dim(std::vector<int>& inputdim);
+    /**
+     * \brief accessor for an operator vertex name
+     */
+    std::string opname(Vertex v) const
+    {
+      return _graph[v].name;
+    }
 
+    /**
+     * \brief accessor for a varaible vertex name
+     */
+    std::string varname(Vertex v) const
+    {
+      return _graph[v].name;
+    }
 
-	/**
-	 * \brief set ouput  data name
-	 * @param output : data blob name
-	 */
-	void set_output_name(std::string output) {_outputname = output;}
-
-	/**
-	 * \brief get input vertices
-	 * @param Vertex from which inputs are needed
-	 * @return all inpit vertices
-	 */
-	std::vector<Vertex> inputs(Vertex);
-
-	/**
-	 * \brief get output vertices
-	 * @param Vertex from which outputs are needed
-	 * @return all output vertices
-	 */
-	std::vector<Vertex> outputs(Vertex);
-
-	/**
-	 * \brief get some precise dimension of some inpit of a vertex
-	 *
-	 * @param v vertex from which some input dimension is needed
-	 * @param num_input number of the input (generally 0 for first input)
-	 * @param ndim number of dimension needed
-	 *
-	 * @return the dimension
-	 */
-	int dim(Vertex v, int num_input, int ndim);
-
-	/**
-	 * \brief gives number of outputs of a vertex
-	 */
-	int num_output(Vertex v) const {return _graph[v].num_output;}
-
-	/**
-	 * \brief accessor for an operator vertex name
-	 */
-	std::string opname(Vertex v) const {return _graph[v].name;}
-
-	/**
-	 * \brief accessor for a varaible vertex name
-	 */
-	std::string varname(Vertex v) const {return _graph[v].name;}
-
-	/**
-	 * \brief accessor for an operator vertex type
-	 */
-	std::string optype(Vertex v) const {return _graph[v].type;}
-
+    /**
+     * \brief accessor for an operator vertex type
+     */
+    std::string optype(Vertex v) const
+    {
+      return _graph[v].type;
+    }
 
   protected:
-	NNGraph _graph;				/**< the graph is here !  */
-	Vertex _input;				/**<  root input vertex */
-	std::string _inputname; /**<  root input name */
-	std::string _outputname; /**<  ouput name */
-	std::string _loss;			/**< loss name */
+    NNGraph _graph;          /**< the graph is here !  */
+    Vertex _input;           /**<  root input vertex */
+    std::string _inputname;  /**<  root input name */
+    std::string _outputname; /**<  ouput name */
+    std::string _loss;       /**< loss name */
 
-	std::unordered_map<std::string, Vertex> _varIndex; /**< to get a data vertex from its name */
-	std::unordered_map<std::string, Vertex> _opIndex; /**< to get an operator vertex from its name */
+    std::unordered_map<std::string, Vertex>
+        _varIndex; /**< to get a data vertex from its name */
+    std::unordered_map<std::string, Vertex>
+        _opIndex; /**< to get an operator vertex from its name */
 
-	/**
-	 * \brief helper to create a data vertex
-	 * @param name
-	 */
-	Vertex create_var(std::string name);
+    /**
+     * \brief helper to create a data vertex
+     * @param name
+     */
+    Vertex create_var(std::string name);
 
-	/**
-	 * hleper to create an operator vertex
-	 * @param name
-	 * @param type
-	 * @return
-	 */
-	Vertex create_op(std::string name, std::string type);
+    /**
+     * hleper to create an operator vertex
+     * @param name
+     * @param type
+     * @return
+     */
+    Vertex create_op(std::string name, std::string type);
 
-	std::vector<Vertex> _sortedAll; /**< all vertices, sorted  */
-	std::vector<Vertex> _sortedOps; /**< all operators, sorted */
-	std::vector<Vertex> _sortedVars; /**< all data blobs, sorted */
+    std::vector<Vertex> _sortedAll;  /**< all vertices, sorted  */
+    std::vector<Vertex> _sortedOps;  /**< all operators, sorted */
+    std::vector<Vertex> _sortedVars; /**< all data blobs, sorted */
 
-	bool _finalized =false;		/**< is laready finalized?  */
-	bool _sorted = false;		/**< is already sorted?  */
+    bool _finalized = false; /**< is laready finalized?  */
+    bool _sorted = false;    /**< is already sorted?  */
 
-	/**
-	 * \brief compute input/output dims of a data vertex, given is producer,
-	 * @param producer
-	 * @return input dim of producer, output dims of producer == dims of var
-	 */
-	std::tuple<std::vector<int>,std::vector<int>> compute_dims_from_producer(Vertex producer);
+    /**
+     * \brief compute input/output dims of a data vertex, given is producer,
+     * @param producer
+     * @return input dim of producer, output dims of producer == dims of var
+     */
+    std::tuple<std::vector<int>, std::vector<int>>
+    compute_dims_from_producer(Vertex producer);
 
-	/**
-	 * \brief compute dims of a data vertex
-	 * @param v
-	 */
-	void compute_dims(Vertex v);
+    /**
+     * \brief compute dims of a data vertex
+     * @param v
+     */
+    void compute_dims(Vertex v);
 
-	/**
-	 * compute all data vertices sizes
-	 */
-	void compute_blob_sizes();
+    /**
+     * compute all data vertices sizes
+     */
+    void compute_blob_sizes();
 
-	/**
-	 * \brief check if realloc is needed, in case of change of input/ouput dims
-	 */
-	void update_alloc_status(std::tuple<std::vector<int>, std::vector<int>> newdims,
-							 Vertex v);
+    /**
+     * \brief check if realloc is needed, in case of change of input/ouput dims
+     */
+    void
+    update_alloc_status(std::tuple<std::vector<int>, std::vector<int>> newdims,
+                        Vertex v);
 
-	/**
-	 * check if everything is correclty allocated, ie do no need reallocation
-	 * @return
-	 */
-	bool allocated();
+    /**
+     * check if everything is correclty allocated, ie do no need reallocation
+     * @return
+     */
+    bool allocated();
   };
 }
-
-
 
 #endif

--- a/src/caffegraphinput.h
+++ b/src/caffegraphinput.h
@@ -22,54 +22,56 @@
 #ifndef CAFFE_GRAPH_INPUT_H
 #define CAFFE_GRAPH_INPUT_H
 
-
 #include <google/protobuf/text_format.h>
 #include "src/caffe.pb.h"
 
 #include "basegraph.h"
 
-
 namespace dd
 {
 
   /**
-   *  this class add from_proto trait to basegraph, ie allows to build a base graph from a prototxt file
+   *  this class add from_proto trait to basegraph, ie allows to build a base
+   * graph from a prototxt file
    */
   class CaffeGraphInput : public virtual BaseGraph
   {
   public:
+    /**
+     *  simple contructor to build a basegraph from a prototxt
+     */
+    CaffeGraphInput(std::string filename)
+    {
+      from_proto(filename);
+    }
 
-	/**
-	 *  simple contructor to build a basegraph from a prototxt
-	 */
-	CaffeGraphInput(std::string filename) {from_proto(filename);}
   private:
+    /**
+     * create basegraph from proto
+     */
+    int from_proto(std::string filename);
 
-	/**
-	 * create basegraph from proto
-	 */
-	int from_proto(std::string filename);
+    /**
+     * read protofile
+     */
+    bool read_proto(std::string filename, google::protobuf::Message *proto);
 
-	/**
-	 * read protofile
-	 */
-	bool read_proto(std::string filename, google::protobuf::Message* proto);
+    /**
+     * check if we are in all permute / ssplit / concat stuff needed by caffe
+     * before lstm
+     * @return
+     */
+    bool lstm_preparation(caffe::NetParameter &net, int i);
 
-	/**
-	 * check if we are in all permute / ssplit / concat stuff needed by caffe before lstm
-	 * @return
-	 */
-	bool lstm_preparation(caffe::NetParameter& net, int i);
+    /**
+     * check if protofile is an lstm definition created by dede
+     */
+    bool is_simple_lstm(caffe::NetParameter &net);
 
-	/**
-	 * check if protofile is an lstm definition created by dede
-	 */
-	bool is_simple_lstm(caffe::NetParameter &net);
-
-	/**
-	 * create basegraph from lstm protofile created by dede
-	 */
-	bool parse_simple_lstm(caffe::NetParameter &net);
+    /**
+     * create basegraph from lstm protofile created by dede
+     */
+    bool parse_simple_lstm(caffe::NetParameter &net);
   };
 }
 #endif

--- a/src/chain.cc
+++ b/src/chain.cc
@@ -28,64 +28,65 @@ namespace dd
   {
     (void)ad;
   }
-  
+
   void visitor_nested::operator()(const std::vector<APIData> &vad)
   {
-    std::unordered_map<std::string,APIData>::iterator rhit;
-    for (size_t i=0;i<vad.size();i++)
+    std::unordered_map<std::string, APIData>::iterator rhit;
+    for (size_t i = 0; i < vad.size(); i++)
       {
-	APIData ad = vad.at(i);
-	APIData adc = ad;
-	auto hit = ad._data.begin();
-	while(hit!=ad._data.end())
-	  {
-	    std::string ad_key = (*hit).first;
-	    auto rhit_range = _replacements->equal_range(ad_key);
-	    int rcount = std::distance(rhit_range.first,rhit_range.second);
-	    if (rcount > 0)
-	      {
-		for (auto rhit=rhit_range.first; rhit!=rhit_range.second; ++rhit)
-		  {
-		    std::string nested_chain = (*rhit).second.list_keys().at(0);
-		    
-		    // recursive replacements for chains with > 2 models
-		    bool recursive_changes = false;
-		    visitor_nested vn(_replacements);
-		    APIData nested_ad = (*rhit).second.getobj(nested_chain);
-		    auto nhit = nested_ad._data.begin();
-		    while(nhit!=nested_ad._data.end())
-		      {
-			mapbox::util::apply_visitor(vn,(*nhit).second);
-			if (!vn._vad.empty())
-			  {
-			    adc.add(nested_chain,vn._vad);
-			    recursive_changes = true;
-			  }
-			++nhit;
-		      }
-		    
-		    if (!recursive_changes)
-		      adc.add(nested_chain,
-			      (*rhit).second.getobj(nested_chain));
-		    
-		  }
-		// we erase the chainid, and add up the model object
-		adc._data.erase(ad_key);
-		_vad.push_back(adc);
-	      }
-	    else
-	      {
-		APIData vis_ad_out;
-		visitor_nested vn(_replacements);
-		mapbox::util::apply_visitor(vn,(*hit).second);
-		if (!vn._vad.empty())
-		  {
-		    vis_ad_out.add((*hit).first,vn._vad);
-		    _vad.push_back(vis_ad_out);
-		  }
-	      }
-	    ++hit;
-	  }
+        APIData ad = vad.at(i);
+        APIData adc = ad;
+        auto hit = ad._data.begin();
+        while (hit != ad._data.end())
+          {
+            std::string ad_key = (*hit).first;
+            auto rhit_range = _replacements->equal_range(ad_key);
+            int rcount = std::distance(rhit_range.first, rhit_range.second);
+            if (rcount > 0)
+              {
+                for (auto rhit = rhit_range.first; rhit != rhit_range.second;
+                     ++rhit)
+                  {
+                    std::string nested_chain
+                        = (*rhit).second.list_keys().at(0);
+
+                    // recursive replacements for chains with > 2 models
+                    bool recursive_changes = false;
+                    visitor_nested vn(_replacements);
+                    APIData nested_ad = (*rhit).second.getobj(nested_chain);
+                    auto nhit = nested_ad._data.begin();
+                    while (nhit != nested_ad._data.end())
+                      {
+                        mapbox::util::apply_visitor(vn, (*nhit).second);
+                        if (!vn._vad.empty())
+                          {
+                            adc.add(nested_chain, vn._vad);
+                            recursive_changes = true;
+                          }
+                        ++nhit;
+                      }
+
+                    if (!recursive_changes)
+                      adc.add(nested_chain,
+                              (*rhit).second.getobj(nested_chain));
+                  }
+                // we erase the chainid, and add up the model object
+                adc._data.erase(ad_key);
+                _vad.push_back(adc);
+              }
+            else
+              {
+                APIData vis_ad_out;
+                visitor_nested vn(_replacements);
+                mapbox::util::apply_visitor(vn, (*hit).second);
+                if (!vn._vad.empty())
+                  {
+                    vis_ad_out.add((*hit).first, vn._vad);
+                    _vad.push_back(vis_ad_out);
+                  }
+              }
+            ++hit;
+          }
       }
   }
 
@@ -94,79 +95,81 @@ namespace dd
     //  pre-compile models != first model
     std::vector<std::string> uris;
     APIData first_model_out;
-    std::unordered_multimap<std::string,APIData> other_models_out;
-    std::unordered_map<std::string,APIData>::const_iterator hit = _model_data.begin();
-    while(hit!=_model_data.end())
+    std::unordered_multimap<std::string, APIData> other_models_out;
+    std::unordered_map<std::string, APIData>::const_iterator hit
+        = _model_data.begin();
+    while (hit != _model_data.end())
       {
-	std::string model_id = (*hit).first;
-	std::string model_name = get_model_sname(model_id);
-	if (model_id == _first_id)
-	  {
-	    first_model_out = (*hit).second;
-	    std::vector<APIData> predictions = first_model_out.getv("predictions");
-	    for (auto v: predictions)
-	      {
-		uris.push_back(v.get("uri").get<std::string>());
-	      }
-	  }
-	else
-	  {
-	    // predictions/classes or predictions/vals
-	    std::vector<APIData> preds = (*hit).second.getv("predictions");
-	    for (auto p: preds)
-	      {
-		if (p.has("classes"))
-		  {
-		    APIData clout;
-		    APIData cls;
-		    cls.add("classes",p.getv("classes"));
-		    clout.add(model_name,cls);
-		    other_models_out.insert(std::pair<std::string,APIData>(p.get("uri").get<std::string>(),
-									   clout));
-		  }
-		else if (p.has("vals"))
-		  {
-		    APIData vout;
-		    APIData vals;
-		    vals.add("vals",p.get("vals").get<std::vector<double>>());
-		    if (p.has("nns"))
-		      vals.add("nns",p.getv("nns"));
-		    vout.add(model_name,vals);
-		    other_models_out.insert(std::pair<std::string,APIData>(p.get("uri").get<std::string>(),
-									   vout));
-		  }
-		else if (p.has("vector"))
-		  {
-		    APIData clout;
-		    APIData cls;
-		    cls.add("vector",p.getv("vector"));
-		    clout.add(model_name,cls);
-		    other_models_out.insert(std::pair<std::string,APIData>(p.get("uri").get<std::string>(),
-									   clout));
-		  }
-	      }
-	  }
-	++hit;
+        std::string model_id = (*hit).first;
+        std::string model_name = get_model_sname(model_id);
+        if (model_id == _first_id)
+          {
+            first_model_out = (*hit).second;
+            std::vector<APIData> predictions
+                = first_model_out.getv("predictions");
+            for (auto v : predictions)
+              {
+                uris.push_back(v.get("uri").get<std::string>());
+              }
+          }
+        else
+          {
+            // predictions/classes or predictions/vals
+            std::vector<APIData> preds = (*hit).second.getv("predictions");
+            for (auto p : preds)
+              {
+                if (p.has("classes"))
+                  {
+                    APIData clout;
+                    APIData cls;
+                    cls.add("classes", p.getv("classes"));
+                    clout.add(model_name, cls);
+                    other_models_out.insert(std::pair<std::string, APIData>(
+                        p.get("uri").get<std::string>(), clout));
+                  }
+                else if (p.has("vals"))
+                  {
+                    APIData vout;
+                    APIData vals;
+                    vals.add("vals", p.get("vals").get<std::vector<double>>());
+                    if (p.has("nns"))
+                      vals.add("nns", p.getv("nns"));
+                    vout.add(model_name, vals);
+                    other_models_out.insert(std::pair<std::string, APIData>(
+                        p.get("uri").get<std::string>(), vout));
+                  }
+                else if (p.has("vector"))
+                  {
+                    APIData clout;
+                    APIData cls;
+                    cls.add("vector", p.getv("vector"));
+                    clout.add(model_name, cls);
+                    other_models_out.insert(std::pair<std::string, APIData>(
+                        p.get("uri").get<std::string>(), clout));
+                  }
+              }
+          }
+        ++hit;
       }
 
     // call on nested visitor
     APIData vis_ad_out;
     visitor_nested vn(&other_models_out);
     auto vhit = first_model_out._data.begin();
-    while(vhit!=first_model_out._data.end())
+    while (vhit != first_model_out._data.end())
       {
-	mapbox::util::apply_visitor(vn,(*vhit).second);
-	if (!vn._vad.empty())
-	  {
-	    vis_ad_out.add((*vhit).first,vn._vad);
-	  }
-	++vhit;
+        mapbox::util::apply_visitor(vn, (*vhit).second);
+        if (!vn._vad.empty())
+          {
+            vis_ad_out.add((*vhit).first, vn._vad);
+          }
+        ++vhit;
       }
     std::vector<APIData> predictions = vis_ad_out.getv("predictions");
-    for (size_t i=0;i<predictions.size();i++)
-      predictions.at(i).add("uri",uris.at(i));
-    vis_ad_out.add("predictions",predictions);
+    for (size_t i = 0; i < predictions.size(); i++)
+      predictions.at(i).add("uri", uris.at(i));
+    vis_ad_out.add("predictions", predictions);
     return vis_ad_out;
   }
-  
+
 }

--- a/src/chain.h
+++ b/src/chain.h
@@ -34,67 +34,69 @@ namespace dd
   class ChainData
   {
   public:
-    ChainData() {}
-    ~ChainData() {}
-
-    void add_model_data(const std::string &id,
-			const APIData &out)
+    ChainData()
     {
-      std::unordered_map<std::string,APIData>::iterator hit;
-      if ((hit=_model_data.find(id))!=_model_data.end())
-	_model_data.erase(hit);
-      _model_data.insert(std::pair<std::string,APIData>(id,out));
+    }
+    ~ChainData()
+    {
+    }
+
+    void add_model_data(const std::string &id, const APIData &out)
+    {
+      std::unordered_map<std::string, APIData>::iterator hit;
+      if ((hit = _model_data.find(id)) != _model_data.end())
+        _model_data.erase(hit);
+      _model_data.insert(std::pair<std::string, APIData>(id, out));
     }
 
     APIData get_model_data(const std::string &id) const
     {
-      std::unordered_map<std::string,APIData>::const_iterator hit;
-      if ((hit=_model_data.find(id))!=_model_data.end())
-	return (*hit).second;
+      std::unordered_map<std::string, APIData>::const_iterator hit;
+      if ((hit = _model_data.find(id)) != _model_data.end())
+        return (*hit).second;
       else
-	return APIData();
+        return APIData();
     }
 
-    void add_action_data(const std::string &id,
-			 const APIData &out)
+    void add_action_data(const std::string &id, const APIData &out)
     {
-      std::unordered_map<std::string,APIData>::iterator hit;
-      if ((hit=_action_data.find(id))!=_action_data.end())
-	_action_data.erase(hit);
-      _action_data.insert(std::pair<std::string,APIData>(id,out));
+      std::unordered_map<std::string, APIData>::iterator hit;
+      if ((hit = _action_data.find(id)) != _action_data.end())
+        _action_data.erase(hit);
+      _action_data.insert(std::pair<std::string, APIData>(id, out));
     }
 
     APIData get_action_data(const std::string &id) const
     {
-      std::unordered_map<std::string,APIData>::const_iterator hit;
-      if ((hit=_action_data.find(id))!=_action_data.end())
-	return (*hit).second;
+      std::unordered_map<std::string, APIData>::const_iterator hit;
+      if ((hit = _action_data.find(id)) != _action_data.end())
+        return (*hit).second;
       else
-	return APIData();
+        return APIData();
     }
 
-    void add_model_sname(const std::string &id,
-			 const std::string &sname)
+    void add_model_sname(const std::string &id, const std::string &sname)
     {
-      std::unordered_map<std::string,std::string>::iterator hit;
-      if ((hit=_id_sname.find(id))==_id_sname.end())
-	_id_sname.insert(std::pair<std::string,std::string>(id,sname));
+      std::unordered_map<std::string, std::string>::iterator hit;
+      if ((hit = _id_sname.find(id)) == _id_sname.end())
+        _id_sname.insert(std::pair<std::string, std::string>(id, sname));
     }
 
     std::string get_model_sname(const std::string &id)
     {
-      std::unordered_map<std::string,std::string>::const_iterator hit;
-      if ((hit=_id_sname.find(id))!=_id_sname.end())
-	return (*hit).second;
-      else return std::string();
+      std::unordered_map<std::string, std::string>::const_iterator hit;
+      if ((hit = _id_sname.find(id)) != _id_sname.end())
+        return (*hit).second;
+      else
+        return std::string();
     }
-    
+
     APIData nested_chain_output();
 
-    std::unordered_map<std::string,APIData> _model_data;
-    std::unordered_map<std::string,APIData> _action_data;
-    std::unordered_map<std::string,std::string> _id_sname;
-    //std::string _first_sname;
+    std::unordered_map<std::string, APIData> _model_data;
+    std::unordered_map<std::string, APIData> _action_data;
+    std::unordered_map<std::string, std::string> _id_sname;
+    // std::string _first_sname;
     std::string _first_id;
   };
 
@@ -104,29 +106,69 @@ namespace dd
   class visitor_nested
   {
   public:
-    visitor_nested(std::unordered_multimap<std::string,APIData> *r)
-      :_replacements(r) {}
-    ~visitor_nested() {}
-    
-    void operator()(const std::string &str) { (void)str; }
-    void operator()(const double &d) { (void)d; }
-    void operator()(const int &i) { (void)i; }
-    void operator()(const long int &i) { (void)i; }
-    void operator()(const long long int &i) { (void)i; }
-    void operator()(const bool &b) { (void)b; }
-    void operator()(const std::vector<double> &vd) { (void)vd; }
-    void operator()(const std::vector<int> &vd) { (void)vd; }
-    void operator()(const std::vector<bool> &vd) { (void)vd; }
-    void operator()(const std::vector<std::string> &vs) { (void)vs; }
-    void operator()(const std::vector<cv::Mat> &vcv) { (void)vcv; }
-    void operator()(const std::vector<std::pair<int,int>> &vpi) { (void)vpi; }
+    visitor_nested(std::unordered_multimap<std::string, APIData> *r)
+        : _replacements(r)
+    {
+    }
+    ~visitor_nested()
+    {
+    }
+
+    void operator()(const std::string &str)
+    {
+      (void)str;
+    }
+    void operator()(const double &d)
+    {
+      (void)d;
+    }
+    void operator()(const int &i)
+    {
+      (void)i;
+    }
+    void operator()(const long int &i)
+    {
+      (void)i;
+    }
+    void operator()(const long long int &i)
+    {
+      (void)i;
+    }
+    void operator()(const bool &b)
+    {
+      (void)b;
+    }
+    void operator()(const std::vector<double> &vd)
+    {
+      (void)vd;
+    }
+    void operator()(const std::vector<int> &vd)
+    {
+      (void)vd;
+    }
+    void operator()(const std::vector<bool> &vd)
+    {
+      (void)vd;
+    }
+    void operator()(const std::vector<std::string> &vs)
+    {
+      (void)vs;
+    }
+    void operator()(const std::vector<cv::Mat> &vcv)
+    {
+      (void)vcv;
+    }
+    void operator()(const std::vector<std::pair<int, int>> &vpi)
+    {
+      (void)vpi;
+    }
     void operator()(const APIData &ad);
     void operator()(const std::vector<APIData> &vad);
-    
-    std::unordered_multimap<std::string,APIData> *_replacements = nullptr;
+
+    std::unordered_multimap<std::string, APIData> *_replacements = nullptr;
     std::vector<APIData> _vad;
   };
-  
+
 }
 
 #endif

--- a/src/chain_actions.cc
+++ b/src/chain_actions.cc
@@ -30,109 +30,125 @@
 
 namespace dd
 {
-  void ImgsCropAction::apply(APIData &model_out,
-			     ChainData &cdata)
-    {
-      std::vector<APIData> vad = model_out.getv("predictions");
-      std::vector<cv::Mat> imgs = model_out.getobj("input").get("imgs").get<std::vector<cv::Mat>>();
-      std::vector<std::pair<int,int>> imgs_size = model_out.getobj("input").get("imgs_size").get<std::vector<std::pair<int,int>>>();
-      std::vector<cv::Mat> cropped_imgs;
-      std::vector<std::string> bbox_ids;
+  void ImgsCropAction::apply(APIData &model_out, ChainData &cdata)
+  {
+    std::vector<APIData> vad = model_out.getv("predictions");
+    std::vector<cv::Mat> imgs
+        = model_out.getobj("input").get("imgs").get<std::vector<cv::Mat>>();
+    std::vector<std::pair<int, int>> imgs_size
+        = model_out.getobj("input")
+              .get("imgs_size")
+              .get<std::vector<std::pair<int, int>>>();
+    std::vector<cv::Mat> cropped_imgs;
+    std::vector<std::string> bbox_ids;
 
-      // check for action parameters
-      double bratio = 0.0;
-      if (_params.has("padding_ratio"))
-	bratio = _params.get("padding_ratio").get<double>(); // e.g. 0.055
-      std::vector<APIData> cvad;
+    // check for action parameters
+    double bratio = 0.0;
+    if (_params.has("padding_ratio"))
+      bratio = _params.get("padding_ratio").get<double>(); // e.g. 0.055
+    std::vector<APIData> cvad;
 
-      bool save_crops = false;
-      if (_params.has("save_crops"))
-	save_crops = _params.get("save_crops").get<bool>();
+    bool save_crops = false;
+    if (_params.has("save_crops"))
+      save_crops = _params.get("save_crops").get<bool>();
 
-      std::string save_path;
-      if (_params.has("save_path"))
-	save_path = _params.get("save_path").get<std::string>() + "/";
-      
-      // iterate image batch
-      for (size_t i=0;i<vad.size();i++)
-	{
-	  std::string uri = vad.at(i).get("uri").get<std::string>();
-	  
-	  cv::Mat img = imgs.at(i);
-	  int orig_cols = imgs_size.at(i).second;
-	  int orig_rows = imgs_size.at(i).first;
+    std::string save_path;
+    if (_params.has("save_path"))
+      save_path = _params.get("save_path").get<std::string>() + "/";
 
-	  std::vector<APIData> ad_cls = vad.at(i).getv("classes");
-	  std::vector<APIData> cad_cls;
-	  
-	  // iterate bboxes per image
-	  for (size_t j=0;j<ad_cls.size();j++)
-	    {
-	      APIData bbox = ad_cls.at(j).getobj("bbox");
-	      if (bbox.empty())
-		throw ActionBadParamException("crop action cannot find bbox object for uri " + uri);
+    // iterate image batch
+    for (size_t i = 0; i < vad.size(); i++)
+      {
+        std::string uri = vad.at(i).get("uri").get<std::string>();
 
-	      double xmin = bbox.get("xmin").get<double>() / orig_cols * img.cols;
-	      double ymin = bbox.get("ymin").get<double>() / orig_rows * img.rows;
-	      double xmax = bbox.get("xmax").get<double>() / orig_cols * img.cols;
-	      double ymax = bbox.get("ymax").get<double>() / orig_rows * img.rows;
-	      
-	      double deltax = bratio * (xmax - xmin);
-	      double deltay = bratio * (ymax - ymin);
+        cv::Mat img = imgs.at(i);
+        int orig_cols = imgs_size.at(i).second;
+        int orig_rows = imgs_size.at(i).first;
 
-	      double cxmin = std::max(0.0,xmin-deltax);
-	      double cxmax = std::min(static_cast<double>(img.cols),xmax+deltax);
-	      double cymin = std::max(0.0,ymin-deltay);
-	      double cymax = std::min(static_cast<double>(img.rows),ymax+deltay);
+        std::vector<APIData> ad_cls = vad.at(i).getv("classes");
+        std::vector<APIData> cad_cls;
 
-	      if (cxmin > img.cols || cymin > img.rows || cxmax < 0 || cymax < 0)
-		{
-		  _chain_logger->warn("bounding box does not intersect image, skipping crop action");
-		  continue;
-		}
+        // iterate bboxes per image
+        for (size_t j = 0; j < ad_cls.size(); j++)
+          {
+            APIData bbox = ad_cls.at(j).getobj("bbox");
+            if (bbox.empty())
+              throw ActionBadParamException(
+                  "crop action cannot find bbox object for uri " + uri);
 
-	      cv::Rect roi(cxmin,cymin,cxmax-cxmin,cymax-cymin);
-	      cv::Mat cropped_img = img(roi);
+            double xmin
+                = bbox.get("xmin").get<double>() / orig_cols * img.cols;
+            double ymin
+                = bbox.get("ymin").get<double>() / orig_rows * img.rows;
+            double xmax
+                = bbox.get("xmax").get<double>() / orig_cols * img.cols;
+            double ymax
+                = bbox.get("ymax").get<double>() / orig_rows * img.rows;
 
-	      // adding bbox id
-	      std::string bbox_id = genid(uri,"bbox"+std::to_string(j));
-	      bbox_ids.push_back(bbox_id);
-	      APIData ad_cid;
-	      ad_cls.at(j).add(bbox_id,ad_cid);
-	      cad_cls.push_back(ad_cls.at(j));
-	      
-	      // save crops if requested
-	      if (save_crops)
-		{
-		  std::string puri = dd_utils::split(uri,'/').back();
-		  cv::imwrite(save_path + "crop_" + puri + "_" + std::to_string(j) + ".png",cropped_img);
-		}
-	      cropped_imgs.push_back(std::move(cropped_img));
-	    }
-	  APIData ccls;
-	  ccls.add("uri",uri);
-	  if (vad.at(i).has("index_uri"))
-	    ccls.add("index_uri",vad.at(i).get("index_uri").get<std::string>());
-	  ccls.add("classes",cad_cls);
-	  cvad.push_back(ccls);
-	}
-      // store crops into action output store
-      APIData action_out;
-      action_out.add("data_raw_img",cropped_imgs);
-      action_out.add("cids",bbox_ids);
-      cdata.add_action_data(_action_id,action_out);      
-      
-      // updated model data with chain ids
-      model_out.add("predictions",cvad);
-    }
+            double deltax = bratio * (xmax - xmin);
+            double deltay = bratio * (ymax - ymin);
 
-  void ImgsRotateAction::apply(APIData &model_out,
-			       ChainData &cdata)
+            double cxmin = std::max(0.0, xmin - deltax);
+            double cxmax
+                = std::min(static_cast<double>(img.cols), xmax + deltax);
+            double cymin = std::max(0.0, ymin - deltay);
+            double cymax
+                = std::min(static_cast<double>(img.rows), ymax + deltay);
+
+            if (cxmin > img.cols || cymin > img.rows || cxmax < 0 || cymax < 0)
+              {
+                _chain_logger->warn("bounding box does not intersect image, "
+                                    "skipping crop action");
+                continue;
+              }
+
+            cv::Rect roi(cxmin, cymin, cxmax - cxmin, cymax - cymin);
+            cv::Mat cropped_img = img(roi);
+
+            // adding bbox id
+            std::string bbox_id = genid(uri, "bbox" + std::to_string(j));
+            bbox_ids.push_back(bbox_id);
+            APIData ad_cid;
+            ad_cls.at(j).add(bbox_id, ad_cid);
+            cad_cls.push_back(ad_cls.at(j));
+
+            // save crops if requested
+            if (save_crops)
+              {
+                std::string puri = dd_utils::split(uri, '/').back();
+                cv::imwrite(save_path + "crop_" + puri + "_"
+                                + std::to_string(j) + ".png",
+                            cropped_img);
+              }
+            cropped_imgs.push_back(std::move(cropped_img));
+          }
+        APIData ccls;
+        ccls.add("uri", uri);
+        if (vad.at(i).has("index_uri"))
+          ccls.add("index_uri", vad.at(i).get("index_uri").get<std::string>());
+        ccls.add("classes", cad_cls);
+        cvad.push_back(ccls);
+      }
+    // store crops into action output store
+    APIData action_out;
+    action_out.add("data_raw_img", cropped_imgs);
+    action_out.add("cids", bbox_ids);
+    cdata.add_action_data(_action_id, action_out);
+
+    // updated model data with chain ids
+    model_out.add("predictions", cvad);
+  }
+
+  void ImgsRotateAction::apply(APIData &model_out, ChainData &cdata)
   {
     // get label
     std::vector<APIData> vad = model_out.getv("predictions");
-    std::vector<cv::Mat> imgs = model_out.getobj("input").get("imgs").get<std::vector<cv::Mat>>();
-    std::vector<std::pair<int,int>> imgs_size = model_out.getobj("input").get("imgs_size").get<std::vector<std::pair<int,int>>>();
+    std::vector<cv::Mat> imgs
+        = model_out.getobj("input").get("imgs").get<std::vector<cv::Mat>>();
+    std::vector<std::pair<int, int>> imgs_size
+        = model_out.getobj("input")
+              .get("imgs_size")
+              .get<std::vector<std::pair<int, int>>>();
     std::vector<cv::Mat> rimgs;
     std::vector<std::string> uris;
 
@@ -148,118 +164,120 @@ namespace dd
     std::string save_path;
     if (_params.has("save_path"))
       save_path = _params.get("save_path").get<std::string>() + "/";
-    
-    for (size_t i=0;i<vad.size();i++) // iterate predictions
-      {
-	std::string uri = vad.at(i).get("uri").get<std::string>();
-	cv::Mat img = imgs.at(i);
-	std::vector<APIData> ad_cls = vad.at(i).getv("classes");
-	std::vector<APIData> cad_cls;
-	
-	// rotate and make image available to next service
-	if (ad_cls.size() > 0)
-	  {
-	    uris.push_back(uri);
-	    std::string cat1 = ad_cls.at(0).get("cat").get<std::string>();
-	    cv::Mat rimg, timg;
-	    if (cat1 == "0")  // all tests in absolute orientation
-	      {
-		rimg = img;
-	      }
-	    else if (cat1 == "90")
-	      {
-		cv::transpose(img,timg);
-		int orient = 1;
-		if (orientation == "relative")
-		  orient = 0; // 270
-		cv::flip(timg,rimg,orient);
-	      }
-	    else if (cat1 == "180")
-	      {
-		cv::flip(img,rimg,-1);
-	      }
-	    else if (cat1 == "270")
-	      {
-		cv::transpose(img,timg);
-		int orient = 0;
-		if (orientation == "relative")
-		  orient = 1; // 90
-		cv::flip(timg,rimg,orient);
-	      }
-	    if (!rimg.empty())
-	      {
-		rimgs.push_back(rimg);
 
-		// save image if requested
-		if (save_img)
-		  {
-		    std::string puri = dd_utils::split(uri,'/').back();
-		    cv::imwrite(save_path + "rot_" + puri + "_" + cat1 + ".png",rimg);
-		  }
-	      }
-	  }
+    for (size_t i = 0; i < vad.size(); i++) // iterate predictions
+      {
+        std::string uri = vad.at(i).get("uri").get<std::string>();
+        cv::Mat img = imgs.at(i);
+        std::vector<APIData> ad_cls = vad.at(i).getv("classes");
+        std::vector<APIData> cad_cls;
+
+        // rotate and make image available to next service
+        if (ad_cls.size() > 0)
+          {
+            uris.push_back(uri);
+            std::string cat1 = ad_cls.at(0).get("cat").get<std::string>();
+            cv::Mat rimg, timg;
+            if (cat1 == "0") // all tests in absolute orientation
+              {
+                rimg = img;
+              }
+            else if (cat1 == "90")
+              {
+                cv::transpose(img, timg);
+                int orient = 1;
+                if (orientation == "relative")
+                  orient = 0; // 270
+                cv::flip(timg, rimg, orient);
+              }
+            else if (cat1 == "180")
+              {
+                cv::flip(img, rimg, -1);
+              }
+            else if (cat1 == "270")
+              {
+                cv::transpose(img, timg);
+                int orient = 0;
+                if (orientation == "relative")
+                  orient = 1; // 90
+                cv::flip(timg, rimg, orient);
+              }
+            if (!rimg.empty())
+              {
+                rimgs.push_back(rimg);
+
+                // save image if requested
+                if (save_img)
+                  {
+                    std::string puri = dd_utils::split(uri, '/').back();
+                    cv::imwrite(
+                        save_path + "rot_" + puri + "_" + cat1 + ".png", rimg);
+                  }
+              }
+          }
       }
     // store rotated images into action output store
     APIData action_out;
-    action_out.add("data_raw_img",rimgs);
-    action_out.add("cids",uris);
-    cdata.add_action_data(_action_id,action_out);
+    action_out.add("data_raw_img", rimgs);
+    action_out.add("cids", uris);
+    cdata.add_action_data(_action_id, action_out);
   }
-  
-  void ClassFilter::apply(APIData &model_out,
-			  ChainData &cdata)
+
+  void ClassFilter::apply(APIData &model_out, ChainData &cdata)
   {
     if (!_params.has("classes"))
       {
-	throw ActionBadParamException("filter action is missing classes parameter");
+        throw ActionBadParamException(
+            "filter action is missing classes parameter");
       }
-    std::vector<std::string> on_classes = _params.get("classes").get<std::vector<std::string>>();
+    std::vector<std::string> on_classes
+        = _params.get("classes").get<std::vector<std::string>>();
     std::unordered_set<std::string> on_classes_us;
-    for (auto s: on_classes)
+    for (auto s : on_classes)
       on_classes_us.insert(s);
     std::unordered_set<std::string>::const_iterator usit;
-    
+
     std::vector<APIData> vad = model_out.getv("predictions");
     std::vector<APIData> cvad;
-    
-    for (size_t i=0;i<vad.size();i++)
-      {
-	std::vector<APIData> ad_cls = vad.at(i).getv("classes");
-	std::vector<APIData> cad_cls;
 
-	for (size_t j=0;j<ad_cls.size();j++)
-	  {
-	    std::string cat = ad_cls.at(j).get("cat").get<std::string>();
-	    if ((usit=on_classes_us.find(cat))!=on_classes_us.end())
-	      {
-		cad_cls.push_back(ad_cls.at(j));
-	      }
-	  }
-	APIData ccls;
-	ccls.add("classes",cad_cls);
-	if (vad.at(i).has("index_uri"))
-	  ccls.add("index_uri",vad.at(i).get("index_uri").get<std::string>());
-	ccls.add("uri",vad.at(i).get("uri").get<std::string>());
-	cvad.push_back(ccls);
+    for (size_t i = 0; i < vad.size(); i++)
+      {
+        std::vector<APIData> ad_cls = vad.at(i).getv("classes");
+        std::vector<APIData> cad_cls;
+
+        for (size_t j = 0; j < ad_cls.size(); j++)
+          {
+            std::string cat = ad_cls.at(j).get("cat").get<std::string>();
+            if ((usit = on_classes_us.find(cat)) != on_classes_us.end())
+              {
+                cad_cls.push_back(ad_cls.at(j));
+              }
+          }
+        APIData ccls;
+        ccls.add("classes", cad_cls);
+        if (vad.at(i).has("index_uri"))
+          ccls.add("index_uri", vad.at(i).get("index_uri").get<std::string>());
+        ccls.add("uri", vad.at(i).get("uri").get<std::string>());
+        cvad.push_back(ccls);
       }
 
     // empty action data
-    cdata.add_action_data(_action_id,APIData());
-    //actions_data.push_back(APIData());
-    
+    cdata.add_action_data(_action_id, APIData());
+    // actions_data.push_back(APIData());
+
     // updated model data
-    model_out.add("predictions",cvad);
+    model_out.add("predictions", cvad);
   }
 
-  void ChainActionFactory::apply_action(const std::string &action_type,
-					APIData &model_out,
-					ChainData &cdata,
-					const std::shared_ptr<spdlog::logger> &chain_logger)
+  void ChainActionFactory::apply_action(
+      const std::string &action_type, APIData &model_out, ChainData &cdata,
+      const std::shared_ptr<spdlog::logger> &chain_logger)
   {
     std::string action_id;
     if (_adc.has("id"))
-        action_id = _adc.get("id").get<std::string>();
-    else action_id = std::to_string(cdata._action_data.size());
+      action_id = _adc.get("id").get<std::string>();
+    else
+      action_id = std::to_string(cdata._action_data.size());
     if (action_type == "crop")
       {
         ImgsCropAction act(_adc, action_id, action_type, chain_logger);
@@ -267,8 +285,8 @@ namespace dd
       }
     else if (action_type == "rotate")
       {
-	ImgsRotateAction act(_adc, action_id,action_type, chain_logger);
-	act.apply(model_out, cdata);
+        ImgsRotateAction act(_adc, action_id, action_type, chain_logger);
+        act.apply(model_out, cdata);
       }
     else if (action_type == "filter")
       {
@@ -276,15 +294,16 @@ namespace dd
         act.apply(model_out, cdata);
       }
 #ifdef USE_DLIB
-      else if (action_type == "dlib_align_crop")
-   {
-       DlibAlignCropAction act(_adc,action_id,action_type, chain_logger);
-       act.apply(model_out,cdata);
-   }
+    else if (action_type == "dlib_align_crop")
+      {
+        DlibAlignCropAction act(_adc, action_id, action_type, chain_logger);
+        act.apply(model_out, cdata);
+      }
 #endif
-    else {
+    else
+      {
         throw ActionBadParamException("unknown action " + action_type);
-    }
+      }
   }
 
 } // end of namespace

--- a/src/chain_actions.h
+++ b/src/chain_actions.h
@@ -33,10 +33,17 @@ namespace dd
   class ActionBadParamException : public std::exception
   {
   public:
-    ActionBadParamException(const std::string &s)
-      :_s(s) {}
-    ~ActionBadParamException() {}
-    const char* what() const noexcept { return _s.c_str(); }
+    ActionBadParamException(const std::string &s) : _s(s)
+    {
+    }
+    ~ActionBadParamException()
+    {
+    }
+    const char *what() const noexcept
+    {
+      return _s.c_str();
+    }
+
   private:
     std::string _s;
   };
@@ -44,38 +51,45 @@ namespace dd
   class ActionInternalException : public std::exception
   {
   public:
-    ActionInternalException(const std::string &s)
-      :_s(s) {}
-    ~ActionInternalException() {}
-    const char* what() const noexcept { return _s.c_str(); }
+    ActionInternalException(const std::string &s) : _s(s)
+    {
+    }
+    ~ActionInternalException()
+    {
+    }
+    const char *what() const noexcept
+    {
+      return _s.c_str();
+    }
+
   private:
     std::string _s;
   };
-  
+
   class ChainAction
   {
   public:
-  ChainAction(const APIData &adc,
-	      const std::string &action_id,
-	      const std::string &action_type,
-	      const std::shared_ptr<spdlog::logger> chain_logger)
-    :_action_id(action_id),_action_type(action_type),_chain_logger(chain_logger)
+    ChainAction(const APIData &adc, const std::string &action_id,
+                const std::string &action_type,
+                const std::shared_ptr<spdlog::logger> chain_logger)
+        : _action_id(action_id), _action_type(action_type),
+          _chain_logger(chain_logger)
     {
       APIData action_adc = adc.getobj("action");
       _params = action_adc.getobj("parameters");
     }
 
-    ~ChainAction() {}
+    ~ChainAction()
+    {
+    }
 
-    std::string genid(const std::string &uri,
-		      const std::string &local_id)
-      {
-	std::string str = uri+local_id;
-	return std::to_string(std::hash<std::string>{}(str));
-      }
-    
-    void apply(APIData &model_out,
-	       ChainData &cdata);
+    std::string genid(const std::string &uri, const std::string &local_id)
+    {
+      std::string str = uri + local_id;
+      return std::to_string(std::hash<std::string>{}(str));
+    }
+
+    void apply(APIData &model_out, ChainData &cdata);
 
     std::string _action_id;
     std::string _action_type;
@@ -87,62 +101,71 @@ namespace dd
   class ImgsCropAction : public ChainAction
   {
   public:
-    ImgsCropAction(const APIData &adc,
-		   const std::string &action_id,
-		   const std::string &action_type,
-		   const std::shared_ptr<spdlog::logger> chain_logger)
-      :ChainAction(adc,action_id,action_type,chain_logger) {}
+    ImgsCropAction(const APIData &adc, const std::string &action_id,
+                   const std::string &action_type,
+                   const std::shared_ptr<spdlog::logger> chain_logger)
+        : ChainAction(adc, action_id, action_type, chain_logger)
+    {
+    }
 
-    ~ImgsCropAction() {}
-    
-    void apply(APIData &model_out,
-	       ChainData &cdata);
+    ~ImgsCropAction()
+    {
+    }
+
+    void apply(APIData &model_out, ChainData &cdata);
   };
 
   class ImgsRotateAction : public ChainAction
   {
   public:
-    ImgsRotateAction(const APIData &adc,
-		     const std::string &action_id,
-		     const std::string &action_type,
-		     const std::shared_ptr<spdlog::logger> chain_logger)
-      :ChainAction(adc,action_id,action_type,chain_logger) {}
+    ImgsRotateAction(const APIData &adc, const std::string &action_id,
+                     const std::string &action_type,
+                     const std::shared_ptr<spdlog::logger> chain_logger)
+        : ChainAction(adc, action_id, action_type, chain_logger)
+    {
+    }
 
-    ~ImgsRotateAction() {}
-    
-    void apply(APIData &model_out,
-	       ChainData &cdata);
+    ~ImgsRotateAction()
+    {
+    }
+
+    void apply(APIData &model_out, ChainData &cdata);
   };
-  
+
   class ClassFilter : public ChainAction
   {
   public:
-    ClassFilter(const APIData &adc,
-		const std::string &action_id,
-		const std::string &action_type,
-		const std::shared_ptr<spdlog::logger> chain_logger)
-      :ChainAction(adc,action_id,action_type,chain_logger) {_in_place = true;}
-    ~ClassFilter() {}
+    ClassFilter(const APIData &adc, const std::string &action_id,
+                const std::string &action_type,
+                const std::shared_ptr<spdlog::logger> chain_logger)
+        : ChainAction(adc, action_id, action_type, chain_logger)
+    {
+      _in_place = true;
+    }
+    ~ClassFilter()
+    {
+    }
 
-    void apply(APIData &model_out,
-	       ChainData &cdata);
+    void apply(APIData &model_out, ChainData &cdata);
   };
 
   class ChainActionFactory
   {
   public:
-    ChainActionFactory(const APIData &adc)
-      :_adc(adc) {}
-    ~ChainActionFactory() {}
+    ChainActionFactory(const APIData &adc) : _adc(adc)
+    {
+    }
+    ~ChainActionFactory()
+    {
+    }
 
-    void apply_action(const std::string &action_type,
-		      APIData &model_out,
-		      ChainData &cdata,
-		      const std::shared_ptr<spdlog::logger> &chain_logger);
+    void apply_action(const std::string &action_type, APIData &model_out,
+                      ChainData &cdata,
+                      const std::shared_ptr<spdlog::logger> &chain_logger);
 
     APIData _adc; /**< action ad object. */
   };
-  
+
 } // end of namespace
 
 #endif

--- a/src/commandlineapi.cc
+++ b/src/commandlineapi.cc
@@ -23,17 +23,16 @@
 #include <gflags/gflags.h>
 #include <iostream>
 
-DEFINE_string(service,"","service string (e.g. caffe)");
-DEFINE_bool(predict,false,"run service in predict mode");
-DEFINE_bool(train,false,"run service in train mode");
-DEFINE_string(model_repo,"","model repository");
-DEFINE_string(imgfname,"","image file name");
+DEFINE_string(service, "", "service string (e.g. caffe)");
+DEFINE_bool(predict, false, "run service in predict mode");
+DEFINE_bool(train, false, "run service in train mode");
+DEFINE_string(model_repo, "", "model repository");
+DEFINE_string(imgfname, "", "image file name");
 
 namespace dd
 {
 
-  CommandLineAPI::CommandLineAPI()
-    :APIStrategy()
+  CommandLineAPI::CommandLineAPI() : APIStrategy()
   {
   }
 
@@ -44,63 +43,79 @@ namespace dd
   int CommandLineAPI::boot(int argc, char *argv[])
   {
     google::ParseCommandLineFlags(&argc, &argv, true);
-    
+
     // create service.
     if (FLAGS_service.empty())
       {
-	std::cout << "service required\n";
-	return 1;
+        std::cout << "service required\n";
+        return 1;
       }
 
     if (FLAGS_predict)
       {
-	if (FLAGS_service == "caffe")
-	  {
-	    APIData model_ad;
-	    model_ad.add("repository",FLAGS_model_repo);
-	    APIData adg;
-	    CaffeModel cmodel(model_ad);
-	    add_service(FLAGS_service,std::move(MLService<CaffeLib,ImgCaffeInputFileConn,SupervisedOutput,CaffeModel>(FLAGS_service,cmodel)));
-	  }
-	if (!FLAGS_imgfname.empty())
-	  {
-	    std::cout << FLAGS_imgfname << std::endl;
-	    APIData ad;
-	    //ad.add("imgfname",FLAGS_imgfname);
-	    std::vector<std::string> vdata = { FLAGS_imgfname };
-	    ad.add("data",vdata);
-	    APIData out;
-	    predict(ad,0,out);
-	    //std::cout << "witness=\n" << out.to_str() << std::endl;
-	    //std::string tpl = "status={{status}}\n{{cat0}} --> {{prob0}}\n{{cat1}} --> {{prob1}}\n{{cat2}} --> {{prob2}}\n";
-	    std::string tpl = "status={{status}}\n{{# predictions}}loss={{loss}}\n{{# classes}}{{cat}} --> {{prob}}\n{{/classes}}{{/predictions}}\n";
-	    //std::string tpl = "{{# predictions}}\nloss --> {{loss}}\n{{/ predictions}}\n";
-	    std::cout << "response=\n" << out.render_template(tpl) << std::endl;//,"predictions") << std::endl;
-	    //APIData pred = out.get("predictions").get<std::vector<APIData>>().at(0);
-	    //std::cout << "response=\n" << pred.render_template(tpl) << std::endl;
-	    APIData adr;
-	    remove_service(FLAGS_service,adr);
-	  }
+        if (FLAGS_service == "caffe")
+          {
+            APIData model_ad;
+            model_ad.add("repository", FLAGS_model_repo);
+            APIData adg;
+            CaffeModel cmodel(model_ad);
+            add_service(FLAGS_service,
+                        std::move(MLService<CaffeLib, ImgCaffeInputFileConn,
+                                            SupervisedOutput, CaffeModel>(
+                            FLAGS_service, cmodel)));
+          }
+        if (!FLAGS_imgfname.empty())
+          {
+            std::cout << FLAGS_imgfname << std::endl;
+            APIData ad;
+            // ad.add("imgfname",FLAGS_imgfname);
+            std::vector<std::string> vdata = { FLAGS_imgfname };
+            ad.add("data", vdata);
+            APIData out;
+            predict(ad, 0, out);
+            // std::cout << "witness=\n" << out.to_str() << std::endl;
+            // std::string tpl = "status={{status}}\n{{cat0}} -->
+            // {{prob0}}\n{{cat1}} --> {{prob1}}\n{{cat2}} --> {{prob2}}\n";
+            std::string tpl
+                = "status={{status}}\n{{# predictions}}loss={{loss}}\n{{# "
+                  "classes}}{{cat}} --> "
+                  "{{prob}}\n{{/classes}}{{/predictions}}\n";
+            // std::string tpl = "{{# predictions}}\nloss --> {{loss}}\n{{/
+            // predictions}}\n";
+            std::cout << "response=\n"
+                      << out.render_template(tpl)
+                      << std::endl; //,"predictions") << std::endl;
+            // APIData pred =
+            // out.get("predictions").get<std::vector<APIData>>().at(0);
+            // std::cout << "response=\n" << pred.render_template(tpl) <<
+            // std::endl;
+            APIData adr;
+            remove_service(FLAGS_service, adr);
+          }
       }
     else if (FLAGS_train)
       {
-	if (FLAGS_service == "caffe")
-	  {
-	    APIData model_ad;
-	    model_ad.add("repository",FLAGS_model_repo);
-	    APIData adg;
-	    CaffeModel cmodel(model_ad);
-	    add_service(FLAGS_service,std::move(MLService<CaffeLib,ImgCaffeInputFileConn,SupervisedOutput,CaffeModel>(FLAGS_service,cmodel)));
-	    APIData ad, out;
-	    train(ad,0,out);
-	    std::string tpl = "status={{status}}\n";
-	    std::cout << "response=\n" << out.render_template(tpl) << std::endl;
-	    APIData adr;
-	    remove_service(FLAGS_service,adr);
-	  }
+        if (FLAGS_service == "caffe")
+          {
+            APIData model_ad;
+            model_ad.add("repository", FLAGS_model_repo);
+            APIData adg;
+            CaffeModel cmodel(model_ad);
+            add_service(FLAGS_service,
+                        std::move(MLService<CaffeLib, ImgCaffeInputFileConn,
+                                            SupervisedOutput, CaffeModel>(
+                            FLAGS_service, cmodel)));
+            APIData ad, out;
+            train(ad, 0, out);
+            std::string tpl = "status={{status}}\n";
+            std::cout << "response=\n"
+                      << out.render_template(tpl) << std::endl;
+            APIData adr;
+            remove_service(FLAGS_service, adr);
+          }
       }
 
     return 0;
   }
-  
+
 }

--- a/src/commandlineapi.h
+++ b/src/commandlineapi.h
@@ -27,14 +27,14 @@
 namespace dd
 {
   class CommandLineAPI : public APIStrategy
-    {
-    public:
-      CommandLineAPI();
-      ~CommandLineAPI();
-      
-      int boot(int argc, char *argv[]);
-    };
-  
+  {
+  public:
+    CommandLineAPI();
+    ~CommandLineAPI();
+
+    int boot(int argc, char *argv[]);
+  };
+
 }
 
 #endif

--- a/src/commandlinejsonapi.cc
+++ b/src/commandlinejsonapi.cc
@@ -23,20 +23,21 @@
 #include <gflags/gflags.h>
 #include <iostream>
 
-DEFINE_bool(info,false,"/info JSON call");
-DEFINE_string(service_create,"","/service/service_name call JSON string");
-DEFINE_string(service_name,"","service name string for JSON call /service/service_name");
-DEFINE_string(service_delete,"","/service/service_name DELETE call JSON string");
-DEFINE_string(service_predict,"","/predict POST call JSON string");
-DEFINE_string(service_train,"","/train POST call JSON string");
-DEFINE_string(service_train_status,"","/train GET call JSON string");
-DEFINE_string(service_train_delete,"","/train DELETE call JSON string");
+DEFINE_bool(info, false, "/info JSON call");
+DEFINE_string(service_create, "", "/service/service_name call JSON string");
+DEFINE_string(service_name, "",
+              "service name string for JSON call /service/service_name");
+DEFINE_string(service_delete, "",
+              "/service/service_name DELETE call JSON string");
+DEFINE_string(service_predict, "", "/predict POST call JSON string");
+DEFINE_string(service_train, "", "/train POST call JSON string");
+DEFINE_string(service_train_status, "", "/train GET call JSON string");
+DEFINE_string(service_train_delete, "", "/train DELETE call JSON string");
 
 namespace dd
 {
 
-  CommandLineJsonAPI::CommandLineJsonAPI()
-    :JsonAPI()
+  CommandLineJsonAPI::CommandLineJsonAPI() : JsonAPI()
   {
   }
 
@@ -47,57 +48,60 @@ namespace dd
   int CommandLineJsonAPI::boot(int argc, char *argv[])
   {
     google::ParseCommandLineFlags(&argc, &argv, true);
-    
+
     if (!FLAGS_service_create.empty())
       {
-	if (FLAGS_service_name.empty())
-	  {
-	    std::string janswer = jrender(dd_not_found_404());
-	    std::cout << janswer << std::endl;
-	  }
-	std::string janswer = jrender(service_create(FLAGS_service_name,FLAGS_service_create));
-	std::cout << janswer << std::endl;
+        if (FLAGS_service_name.empty())
+          {
+            std::string janswer = jrender(dd_not_found_404());
+            std::cout << janswer << std::endl;
+          }
+        std::string janswer = jrender(
+            service_create(FLAGS_service_name, FLAGS_service_create));
+        std::cout << janswer << std::endl;
       }
     if (FLAGS_info)
       {
-	std::string janswer = jrender(info(""));
-	std::cout << janswer << std::endl;
+        std::string janswer = jrender(info(""));
+        std::cout << janswer << std::endl;
       }
     if (!FLAGS_service_name.empty())
       {
-	std::string janswer = jrender(service_status(FLAGS_service_name));
-	std::cout << janswer << std::endl;
+        std::string janswer = jrender(service_status(FLAGS_service_name));
+        std::cout << janswer << std::endl;
       }
     if (!FLAGS_service_train.empty())
       {
-	std::string janswer = jrender(service_train(FLAGS_service_train));
-	std::cout << janswer << std::endl;
+        std::string janswer = jrender(service_train(FLAGS_service_train));
+        std::cout << janswer << std::endl;
       }
     if (!FLAGS_service_train_status.empty())
       {
-	std::string janswer = jrender(service_train_status(FLAGS_service_train_status));
-	std::cout << janswer << std::endl;
+        std::string janswer
+            = jrender(service_train_status(FLAGS_service_train_status));
+        std::cout << janswer << std::endl;
       }
     if (!FLAGS_service_train_delete.empty())
       {
-	std::string janswer = jrender(service_train_delete(FLAGS_service_train_delete));
-	std::cout << janswer << std::endl;
+        std::string janswer
+            = jrender(service_train_delete(FLAGS_service_train_delete));
+        std::cout << janswer << std::endl;
       }
     if (!FLAGS_service_predict.empty())
       {
-	std::string janswer = jrender(service_predict(FLAGS_service_predict));
-	std::cout << janswer << std::endl;
+        std::string janswer = jrender(service_predict(FLAGS_service_predict));
+        std::cout << janswer << std::endl;
       }
     if (!FLAGS_service_delete.empty())
       {
-	std::string janswer = jrender(service_delete(FLAGS_service_name,
-						     FLAGS_service_delete));
-	std::cout << janswer << std::endl;
+        std::string janswer = jrender(
+            service_delete(FLAGS_service_name, FLAGS_service_delete));
+        std::cout << janswer << std::endl;
       }
     if (!FLAGS_service_name.empty())
       {
-	std::string janswer = jrender(service_status(FLAGS_service_name));
-	std::cout << janswer << std::endl;
+        std::string janswer = jrender(service_status(FLAGS_service_name));
+        std::cout << janswer << std::endl;
       }
     return 0;
   }

--- a/src/commandlinejsonapi.h
+++ b/src/commandlinejsonapi.h
@@ -27,14 +27,14 @@
 namespace dd
 {
   class CommandLineJsonAPI : public JsonAPI
-    {
-    public:
-      CommandLineJsonAPI();
-      ~CommandLineJsonAPI();
-      
-      int boot(int argc, char *argv[]);
-    };
-  
+  {
+  public:
+    CommandLineJsonAPI();
+    ~CommandLineJsonAPI();
+
+    int boot(int argc, char *argv[]);
+  };
+
 }
 
 #endif

--- a/src/csvinputfileconn.cc
+++ b/src/csvinputfileconn.cc
@@ -30,9 +30,10 @@ namespace dd
     if (_cifc)
       {
         _cifc->read_csv(fname);
-	return 0;
+        return 0;
       }
-    else return -1;
+    else
+      return -1;
   }
 
   int DDCsv::read_db(const std::string &fname)
@@ -40,7 +41,7 @@ namespace dd
     _cifc->_db_fname = fname;
     return 0;
   }
-  
+
   int DDCsv::read_mem(const std::string &content)
   {
     if (!_cifc)
@@ -48,40 +49,45 @@ namespace dd
     std::stringstream sh(content);
     std::string line;
     int l = 0;
-    while(std::getline(sh,line))
+    while (std::getline(sh, line))
       {
-	if (_cifc->_columns.empty() && _cifc->_train && l == 0)
-	  {
-	    _cifc->read_header(line);
-	    ++l;
-	    continue;
-	  }
-	
-	std::vector<double> vals;
-	std::string cid;
-	int nlines = 0;
-	_cifc->read_csv_line(line,_cifc->_delim,vals,cid,nlines);
-	if (_cifc->_scale)
-	  {
-	    if (!_cifc->_train) // in prediction mode, on-the-fly scaling
-	      {
-		_cifc->scale_vals(vals);
-	      }
-	    else // in training mode, collect bounds, then scale in another pass over the data
-	      {
-		if (_cifc->_min_vals.empty() && _cifc->_max_vals.empty())
-		  _cifc->_min_vals = _cifc->_max_vals = vals;
-		for (size_t j=0;j<vals.size();j++)
-		  {
-		    _cifc->_min_vals.at(j) = std::min(vals.at(j),_cifc->_min_vals.at(j));
-		    _cifc->_max_vals.at(j) = std::max(vals.at(j),_cifc->_max_vals.at(j));
-		  }
-	      }
-	  }
-	if (!cid.empty())
-	  _cifc->add_train_csvline(cid,vals);
-	else _cifc->add_train_csvline(std::to_string(_cifc->_csvdata.size()+1),vals);
-	++l;
+        if (_cifc->_columns.empty() && _cifc->_train && l == 0)
+          {
+            _cifc->read_header(line);
+            ++l;
+            continue;
+          }
+
+        std::vector<double> vals;
+        std::string cid;
+        int nlines = 0;
+        _cifc->read_csv_line(line, _cifc->_delim, vals, cid, nlines);
+        if (_cifc->_scale)
+          {
+            if (!_cifc->_train) // in prediction mode, on-the-fly scaling
+              {
+                _cifc->scale_vals(vals);
+              }
+            else // in training mode, collect bounds, then scale in another
+                 // pass over the data
+              {
+                if (_cifc->_min_vals.empty() && _cifc->_max_vals.empty())
+                  _cifc->_min_vals = _cifc->_max_vals = vals;
+                for (size_t j = 0; j < vals.size(); j++)
+                  {
+                    _cifc->_min_vals.at(j)
+                        = std::min(vals.at(j), _cifc->_min_vals.at(j));
+                    _cifc->_max_vals.at(j)
+                        = std::max(vals.at(j), _cifc->_max_vals.at(j));
+                  }
+              }
+          }
+        if (!cid.empty())
+          _cifc->add_train_csvline(cid, vals);
+        else
+          _cifc->add_train_csvline(std::to_string(_cifc->_csvdata.size() + 1),
+                                   vals);
+        ++l;
       }
     _cifc->update_columns();
     return 0;
@@ -89,340 +95,364 @@ namespace dd
 
   /*- CSVInputFileConn -*/
   void CSVInputFileConn::update_category(const std::string &c,
-					 const std::string &val)
+                                         const std::string &val)
   {
-    std::unordered_map<std::string,CCategorical>::iterator hit;
-    if ((hit=_categoricals.find(c))!=_categoricals.end())
+    std::unordered_map<std::string, CCategorical>::iterator hit;
+    if ((hit = _categoricals.find(c)) != _categoricals.end())
       (*hit).second.add_cat(val);
   }
 
   void CSVInputFileConn::update_columns()
   {
-    std::unordered_map<std::string,CCategorical>::iterator chit;
+    std::unordered_map<std::string, CCategorical>::iterator chit;
     auto lit = _columns.begin();
     std::list<std::string> ncolumns = _columns;
     auto nlit = ncolumns.begin();
-    while(lit!=_columns.end())
+    while (lit != _columns.end())
       {
-	if (is_category((*lit)))
-	  {
-	    chit = _categoricals.find((*lit));
-	    auto hit = (*chit).second._vals.begin();
-	    while(hit!=(*chit).second._vals.end())
-	      {
-		std::string ncolname = (*lit) + "_" + (*hit).first;
-		auto nlit2 = nlit;
-		nlit = ncolumns.insert(nlit,ncolname);
-		if (hit == (*chit).second._vals.begin())
-		  ncolumns.erase(nlit2);
-		++hit;
-	      }
-	  }
-	++lit;
-	++nlit;
+        if (is_category((*lit)))
+          {
+            chit = _categoricals.find((*lit));
+            auto hit = (*chit).second._vals.begin();
+            while (hit != (*chit).second._vals.end())
+              {
+                std::string ncolname = (*lit) + "_" + (*hit).first;
+                auto nlit2 = nlit;
+                nlit = ncolumns.insert(nlit, ncolname);
+                if (hit == (*chit).second._vals.begin())
+                  ncolumns.erase(nlit2);
+                ++hit;
+              }
+          }
+        ++lit;
+        ++nlit;
       }
     _columns = ncolumns;
 
     // update label_pos and id_pos
     int i = 0;
     lit = _columns.begin();
-    while(lit!=_columns.end())
+    while (lit != _columns.end())
       {
-	if ((*lit) == _id)
-	  _id_pos = i;
-  else
-         for (unsigned int j=0; j< _label.size(); ++j)
-           if ((*lit) == _label[j])
-             _label_pos[j] = i;
-	++i;
-	++lit;
+        if ((*lit) == _id)
+          _id_pos = i;
+        else
+          for (unsigned int j = 0; j < _label.size(); ++j)
+            if ((*lit) == _label[j])
+              _label_pos[j] = i;
+        ++i;
+        ++lit;
       }
 
-    //debug
+    // debug
     /*std::cerr << "number of new columns=" << _columns.size() << std::endl;
     std::cerr << "new CSV columns:\n";
     std::copy(_columns.begin(),_columns.end(),
-	      std::ostream_iterator<std::string>(std::cout," "));
-	      std::cerr << std::endl;*/
-    //debug
+              std::ostream_iterator<std::string>(std::cout," "));
+              std::cerr << std::endl;*/
+    // debug
   }
-  
-  void CSVInputFileConn::read_csv_line(const std::string &hline,
-				       const std::string &delim,
-				       std::vector<double> &vals,
-				       std::string &column_id,
-				       int &nlines)
-    {
-      std::string col;
-      std::unordered_set<int>::const_iterator hit;
-      std::stringstream sh(hline);
-      int c = -1;
-      auto lit = _columns.begin();
-      while(std::getline(sh,col,delim[0]))
-	{
-	  ++c;
-	  std::string col_name;
 
-	  // detect strings by looking for characters and for quotes
-	  // convert to float unless it is string (ignore strings, aka categorical fields, for now)
-	  if (!_columns.empty()) // in prediction mode, columns from header are not mandatory
-	    {
-	      if ((hit=_ignored_columns_pos.find(c))!=_ignored_columns_pos.end())
-		{
-		  continue;
-		}
-	      col_name = (*lit);
-	      if (_id_pos == c)
-		{
-		  column_id = col;
-		}
-	    }
-	  try
-	    {
-	      double val = 0.0;
-	      if (!col.empty())
-		{
-		  // one-hot vector encoding as required
-		  if (!_columns.empty() && is_category(col_name))
-		    {
-		      // - look up category
-		      std::unordered_map<std::string,CCategorical>::const_iterator chit
-			= _categoricals.find(col_name);
-		      int cnum = (*chit).second.get_cat_num(col);
-		      if (cnum < 0)
-			{
-			  throw InputConnectorBadParamException("unknown category " + col + " for variable " + col_name);
-			}
-		      
-		      // - create one-hot vector
-		      int csize = (*chit).second._vals.size();
-		      std::vector<double> ohv = one_hot_vector(cnum,csize);
-		      vals.insert(vals.end(),ohv.begin(),ohv.end());
-		    }
-		  else
-		    {
-		      val = std::stod(col);
-		      vals.push_back(val);
-		    }
-		}
-	    }
-	  catch (std::invalid_argument &e)
-	    {
-	      // not a number, skip for now
-	      if (column_id == col) // if id is string, replace with number / TODO: better scheme
-		vals.push_back(c);
-	      else
-		{
-		  _logger->error("line {}: skipping column {} / not a number",nlines,col_name);
-		  _logger->error(hline);
-		  throw InputConnectorBadParamException("column " + col_name + " is not a number, use categoricals or ignore parameters instead");
-		}
-	    }
-	  ++lit;
-	}
-      ++nlines;
-    }
+  void CSVInputFileConn::read_csv_line(const std::string &hline,
+                                       const std::string &delim,
+                                       std::vector<double> &vals,
+                                       std::string &column_id, int &nlines)
+  {
+    std::string col;
+    std::unordered_set<int>::const_iterator hit;
+    std::stringstream sh(hline);
+    int c = -1;
+    auto lit = _columns.begin();
+    while (std::getline(sh, col, delim[0]))
+      {
+        ++c;
+        std::string col_name;
+
+        // detect strings by looking for characters and for quotes
+        // convert to float unless it is string (ignore strings, aka
+        // categorical fields, for now)
+        if (!_columns.empty()) // in prediction mode, columns from header are
+                               // not mandatory
+          {
+            if ((hit = _ignored_columns_pos.find(c))
+                != _ignored_columns_pos.end())
+              {
+                continue;
+              }
+            col_name = (*lit);
+            if (_id_pos == c)
+              {
+                column_id = col;
+              }
+          }
+        try
+          {
+            double val = 0.0;
+            if (!col.empty())
+              {
+                // one-hot vector encoding as required
+                if (!_columns.empty() && is_category(col_name))
+                  {
+                    // - look up category
+                    std::unordered_map<std::string,
+                                       CCategorical>::const_iterator chit
+                        = _categoricals.find(col_name);
+                    int cnum = (*chit).second.get_cat_num(col);
+                    if (cnum < 0)
+                      {
+                        throw InputConnectorBadParamException(
+                            "unknown category " + col + " for variable "
+                            + col_name);
+                      }
+
+                    // - create one-hot vector
+                    int csize = (*chit).second._vals.size();
+                    std::vector<double> ohv = one_hot_vector(cnum, csize);
+                    vals.insert(vals.end(), ohv.begin(), ohv.end());
+                  }
+                else
+                  {
+                    val = std::stod(col);
+                    vals.push_back(val);
+                  }
+              }
+          }
+        catch (std::invalid_argument &e)
+          {
+            // not a number, skip for now
+            if (column_id == col) // if id is string, replace with number /
+                                  // TODO: better scheme
+              vals.push_back(c);
+            else
+              {
+                _logger->error("line {}: skipping column {} / not a number",
+                               nlines, col_name);
+                _logger->error(hline);
+                throw InputConnectorBadParamException(
+                    "column " + col_name
+                    + " is not a number, use categoricals or ignore "
+                      "parameters instead");
+              }
+          }
+        ++lit;
+      }
+    ++nlines;
+  }
 
   void CSVInputFileConn::read_header(std::string &hline)
   {
-    hline.erase(std::remove(hline.begin(),hline.end(),'\r'),hline.end()); // remove ^M if any
+    hline.erase(std::remove(hline.begin(), hline.end(), '\r'),
+                hline.end()); // remove ^M if any
     std::stringstream sg(hline);
     std::string col;
-    
+
     // read header
     std::unordered_set<std::string>::const_iterator hit;
-    std::unordered_map<std::string,int>::const_iterator hit2;
+    std::unordered_map<std::string, int>::const_iterator hit2;
     int i = 0;
     bool has_id = false;
-    while(std::getline(sg,col,_delim[0]))
+    while (std::getline(sg, col, _delim[0]))
       {
-	if ((hit=_ignored_columns.find(col))!=_ignored_columns.end())
-	  {
-	    _ignored_columns_pos.insert(i);
-	    ++i;
-	    continue;
-	  }
-	else _columns.push_back(col);
-	
-	if ((hit2=_label_set.find(col))!=_label_set.end())
-	  _label_pos.at((*hit2).second) = i;
-	if (!has_id && !_id.empty() && col == _id)
-	  {
-	    _id_pos = i;
-	    has_id = true;
-	  }
-	++i;
+        if ((hit = _ignored_columns.find(col)) != _ignored_columns.end())
+          {
+            _ignored_columns_pos.insert(i);
+            ++i;
+            continue;
+          }
+        else
+          _columns.push_back(col);
+
+        if ((hit2 = _label_set.find(col)) != _label_set.end())
+          _label_pos.at((*hit2).second) = i;
+        if (!has_id && !_id.empty() && col == _id)
+          {
+            _id_pos = i;
+            has_id = true;
+          }
+        ++i;
       }
     _detect_cols = i;
-    for (size_t j=0;j<_label_pos.size();j++)
+    for (size_t j = 0; j < _label_pos.size(); j++)
       if (_label_pos.at(j) < 0 && _train)
-	throw InputConnectorBadParamException("cannot find label column " + _label[j]);
+        throw InputConnectorBadParamException("cannot find label column "
+                                              + _label[j]);
     if (!_id.empty() && !has_id)
       throw InputConnectorBadParamException("cannot find id column " + _id);
   }
-
 
   void CSVInputFileConn::find_min_max(std::ifstream &csv_file)
   {
     int nlines = 0;
     std::string hline;
-    while(std::getline(csv_file,hline))
+    while (std::getline(csv_file, hline))
       {
-        hline.erase(std::remove(hline.begin(),hline.end(),'\r'),hline.end());
+        hline.erase(std::remove(hline.begin(), hline.end(), '\r'),
+                    hline.end());
         std::vector<double> vals;
         std::string cid;
-        read_csv_line(hline,_delim,vals,cid,nlines);
+        read_csv_line(hline, _delim, vals, cid, nlines);
         if (nlines == 1)
           _min_vals = _max_vals = vals;
         else
           {
-            for (size_t j=0;j<vals.size();j++)
+            for (size_t j = 0; j < vals.size(); j++)
               {
-                _min_vals.at(j) = std::min(vals.at(j),_min_vals.at(j));
-                _max_vals.at(j) = std::max(vals.at(j),_max_vals.at(j));
+                _min_vals.at(j) = std::min(vals.at(j), _min_vals.at(j));
+                _max_vals.at(j) = std::max(vals.at(j), _max_vals.at(j));
               }
           }
       }
     csv_file.clear();
-    csv_file.seekg(0,std::ios::beg);
-    std::getline(csv_file,hline); // skip header line
+    csv_file.seekg(0, std::ios::beg);
+    std::getline(csv_file, hline); // skip header line
   }
-  
-  void CSVInputFileConn::read_csv(const std::string &fname, const bool forbid_shuffle)
+
+  void CSVInputFileConn::read_csv(const std::string &fname,
+                                  const bool forbid_shuffle)
   {
-      std::ifstream csv_file(fname,std::ios::binary);
-      _logger->info("fname={} / open={}",fname,csv_file.is_open());
-      if (!csv_file.is_open())
-	throw InputConnectorBadParamException("cannot open file " + fname);
-      std::string hline;
-      std::getline(csv_file,hline);
-      read_header(hline);
-      
-      //debug
-      /*std::cerr << "found " << _detect_cols << " columns\n";
-      std::cerr << "label size=" << _label.size() << " / label_pos size=" << _label_pos.size() << std::endl;
-      std::cout << "CSV columns:\n";
-      std::copy(_columns.begin(),_columns.end(),
-		std::ostream_iterator<std::string>(std::cout," "));
-		std::cout << std::endl;*/
-      //debug
+    std::ifstream csv_file(fname, std::ios::binary);
+    _logger->info("fname={} / open={}", fname, csv_file.is_open());
+    if (!csv_file.is_open())
+      throw InputConnectorBadParamException("cannot open file " + fname);
+    std::string hline;
+    std::getline(csv_file, hline);
+    read_header(hline);
 
-      // categorical variables
-      if (_train && !_categoricals.empty())
-	{
-	  int l = 0;
-	  while(std::getline(csv_file,hline))
-	    {
-	      hline.erase(std::remove(hline.begin(),hline.end(),'\r'),hline.end());
-	      std::vector<double> vals;
-	      std::string cid;
-	      std::string col;
-	      auto hit = _columns.begin();
-	      std::unordered_set<int>::const_iterator igit;
-	      std::stringstream sh(hline);
-	      int cu = 0;
-	      while(std::getline(sh,col,_delim[0]))
-		{
-		  if (cu >= _detect_cols)
-		    {
-		      _logger->error("line {} has more columns than headers",l);
-		      _logger->error(hline);
-		      throw InputConnectorBadParamException("line has more columns than headers");
-		    }
-		  if ((igit=_ignored_columns_pos.find(cu))!=_ignored_columns_pos.end())
-		    {
-		      ++cu;
-		      continue;
-		    }
-		  update_category((*hit),col);
-		  ++hit;
-		  ++cu;
-		}
-	      ++l;
-	    }
-	  csv_file.clear();
-	  csv_file.seekg(0,std::ios::beg);
-	  std::getline(csv_file,hline); // skip header line
-	}
+    // debug
+    /*std::cerr << "found " << _detect_cols << " columns\n";
+    std::cerr << "label size=" << _label.size() << " / label_pos size=" <<
+    _label_pos.size() << std::endl; std::cout << "CSV columns:\n";
+    std::copy(_columns.begin(),_columns.end(),
+              std::ostream_iterator<std::string>(std::cout," "));
+              std::cout << std::endl;*/
+    // debug
 
-      // scaling to [0,1]
-      int nlines = 0;
-      if (_scale && (_min_vals.empty() || _max_vals.empty()))
-	{
-         find_min_max(csv_file);
-	}
+    // categorical variables
+    if (_train && !_categoricals.empty())
+      {
+        int l = 0;
+        while (std::getline(csv_file, hline))
+          {
+            hline.erase(std::remove(hline.begin(), hline.end(), '\r'),
+                        hline.end());
+            std::vector<double> vals;
+            std::string cid;
+            std::string col;
+            auto hit = _columns.begin();
+            std::unordered_set<int>::const_iterator igit;
+            std::stringstream sh(hline);
+            int cu = 0;
+            while (std::getline(sh, col, _delim[0]))
+              {
+                if (cu >= _detect_cols)
+                  {
+                    _logger->error("line {} has more columns than headers", l);
+                    _logger->error(hline);
+                    throw InputConnectorBadParamException(
+                        "line has more columns than headers");
+                  }
+                if ((igit = _ignored_columns_pos.find(cu))
+                    != _ignored_columns_pos.end())
+                  {
+                    ++cu;
+                    continue;
+                  }
+                update_category((*hit), col);
+                ++hit;
+                ++cu;
+              }
+            ++l;
+          }
+        csv_file.clear();
+        csv_file.seekg(0, std::ios::beg);
+        std::getline(csv_file, hline); // skip header line
+      }
 
-      // read data
-      while(std::getline(csv_file,hline))
-	{
-	  hline.erase(std::remove(hline.begin(),hline.end(),'\r'),hline.end());
-	  std::vector<double> vals;
-	  std::string cid;
-	  read_csv_line(hline,_delim,vals,cid,nlines);
-	  if (_scale)
-	    {
-	      scale_vals(vals);
-	    }
-	  if (!_id.empty())
-	    {
-	      add_train_csvline(cid,vals);
-	    }
-	  else add_train_csvline(std::to_string(nlines),vals); 
-	  
-	  //debug
-	  /*std::cout << "csv data line #" << nlines << "= " << vals.size() << std::endl;
-	    std::copy(vals.begin(),vals.end(),std::ostream_iterator<double>(std::cout," "));
-	    std::cout << std::endl;*/
-	  //debug
-	}
-      _logger->info("read {} lines from {}",nlines,fname);
-      csv_file.close();
-      
-      // test file, if any.
-      if (!_csv_test_fname.empty())
-	{
-	  nlines = 0;
-	  std::ifstream csv_test_file(_csv_test_fname,std::ios::binary);
-	  if (!csv_test_file.is_open())
-	    throw InputConnectorBadParamException("cannot open test file " + fname);
-	  std::getline(csv_test_file,hline); // skip header line
-	  while(std::getline(csv_test_file,hline))
-	    {
-	      hline.erase(std::remove(hline.begin(),hline.end(),'\r'),hline.end());
-	      std::vector<double> vals;
-	      std::string cid;
-	      read_csv_line(hline,_delim,vals,cid,nlines);
-	      if (_scale)
-		{
-		  scale_vals(vals);
-		}
-	      if (!_id.empty())
-		add_test_csvline(cid,vals);
-	      //_csvdata_test.emplace_back(cid,vals);
-	      else add_test_csvline(std::to_string(nlines),vals);
-	      //_csvdata_test.emplace_back(std::to_string(nlines),vals);
-	      
-	      //debug
-	      /*std::cout << "csv test data line=";
-		std::copy(vals.begin(),vals.end(),std::ostream_iterator<double>(std::cout," "));
-		std::cout << std::endl;*/
-	      //debug
-	    }
-	  _logger->info("read {} lines from {}", nlines, _csv_test_fname);
-	  csv_test_file.close();
-	}
+    // scaling to [0,1]
+    int nlines = 0;
+    if (_scale && (_min_vals.empty() || _max_vals.empty()))
+      {
+        find_min_max(csv_file);
+      }
 
-      // shuffle before possible test data selection.
-      if (!forbid_shuffle)
-        shuffle_data(_csvdata);
-      
-      if (_csv_test_fname.empty() && _test_split > 0)
-	{
-	  split_data(_csvdata, _csvdata_test);
-	  _logger->info("data split test size={} / remaining data size={}",_csvdata_test.size(),_csvdata.size());
-	}
-      if (!_ignored_columns.empty() || !_categoricals.empty())
-        update_columns();
+    // read data
+    while (std::getline(csv_file, hline))
+      {
+        hline.erase(std::remove(hline.begin(), hline.end(), '\r'),
+                    hline.end());
+        std::vector<double> vals;
+        std::string cid;
+        read_csv_line(hline, _delim, vals, cid, nlines);
+        if (_scale)
+          {
+            scale_vals(vals);
+          }
+        if (!_id.empty())
+          {
+            add_train_csvline(cid, vals);
+          }
+        else
+          add_train_csvline(std::to_string(nlines), vals);
+
+        // debug
+        /*std::cout << "csv data line #" << nlines << "= " << vals.size() <<
+          std::endl;
+          std::copy(vals.begin(),vals.end(),std::ostream_iterator<double>(std::cout,"
+          ")); std::cout << std::endl;*/
+        // debug
+      }
+    _logger->info("read {} lines from {}", nlines, fname);
+    csv_file.close();
+
+    // test file, if any.
+    if (!_csv_test_fname.empty())
+      {
+        nlines = 0;
+        std::ifstream csv_test_file(_csv_test_fname, std::ios::binary);
+        if (!csv_test_file.is_open())
+          throw InputConnectorBadParamException("cannot open test file "
+                                                + fname);
+        std::getline(csv_test_file, hline); // skip header line
+        while (std::getline(csv_test_file, hline))
+          {
+            hline.erase(std::remove(hline.begin(), hline.end(), '\r'),
+                        hline.end());
+            std::vector<double> vals;
+            std::string cid;
+            read_csv_line(hline, _delim, vals, cid, nlines);
+            if (_scale)
+              {
+                scale_vals(vals);
+              }
+            if (!_id.empty())
+              add_test_csvline(cid, vals);
+            //_csvdata_test.emplace_back(cid,vals);
+            else
+              add_test_csvline(std::to_string(nlines), vals);
+            //_csvdata_test.emplace_back(std::to_string(nlines),vals);
+
+            // debug
+            /*std::cout << "csv test data line=";
+              std::copy(vals.begin(),vals.end(),std::ostream_iterator<double>(std::cout,"
+              ")); std::cout << std::endl;*/
+            // debug
+          }
+        _logger->info("read {} lines from {}", nlines, _csv_test_fname);
+        csv_test_file.close();
+      }
+
+    // shuffle before possible test data selection.
+    if (!forbid_shuffle)
+      shuffle_data(_csvdata);
+
+    if (_csv_test_fname.empty() && _test_split > 0)
+      {
+        split_data(_csvdata, _csvdata_test);
+        _logger->info("data split test size={} / remaining data size={}",
+                      _csvdata_test.size(), _csvdata.size());
+      }
+    if (!_ignored_columns.empty() || !_categoricals.empty())
+      update_columns();
   }
-  
+
 }

--- a/src/csvinputfileconn.h
+++ b/src/csvinputfileconn.h
@@ -32,74 +32,89 @@
 namespace dd
 {
   class CSVInputFileConn;
-  
+
   class DDCsv
   {
   public:
-    DDCsv() {}
-    ~DDCsv() {}
+    DDCsv()
+    {
+    }
+    ~DDCsv()
+    {
+    }
 
     int read_file(const std::string &fname);
     int read_db(const std::string &fname);
     int read_mem(const std::string &content);
     int read_dir(const std::string &dir)
     {
-      throw InputConnectorBadParamException("uri " + dir + " is a directory, requires a CSV file");
+      throw InputConnectorBadParamException(
+          "uri " + dir + " is a directory, requires a CSV file");
     }
-    
+
     CSVInputFileConn *_cifc = nullptr;
     APIData _adconf;
     std::shared_ptr<spdlog::logger> _logger;
   };
-  
+
   class CSVline
   {
   public:
-    CSVline(const std::string &str,
-	    const std::vector<double> &v)
-      :_str(str),_v(v) {}
-    ~CSVline() {}
-    std::string _str; /**< csv line id */
+    CSVline(const std::string &str, const std::vector<double> &v)
+        : _str(str), _v(v)
+    {
+    }
+    ~CSVline()
+    {
+    }
+    std::string _str;       /**< csv line id */
     std::vector<double> _v; /**< csv line data */
   };
 
   class CCategorical
   {
   public:
-    CCategorical() {}
-    ~CCategorical() {}
-
-    void add_cat(const std::string &v,
-		 const int &val)
+    CCategorical()
     {
-      std::unordered_map<std::string,int>::iterator hit;
-      if ((hit=_vals.find(v))==_vals.end())
-	_vals.insert(std::pair<std::string,int>(v,val));
+    }
+    ~CCategorical()
+    {
+    }
+
+    void add_cat(const std::string &v, const int &val)
+    {
+      std::unordered_map<std::string, int>::iterator hit;
+      if ((hit = _vals.find(v)) == _vals.end())
+        _vals.insert(std::pair<std::string, int>(v, val));
     }
 
     void add_cat(const std::string &v)
     {
-      add_cat(v,_vals.size());
+      add_cat(v, _vals.size());
     }
-    
+
     int get_cat_num(const std::string &v) const
     {
-      std::unordered_map<std::string,int>::const_iterator hit;
-      if ((hit=_vals.find(v))!=_vals.end())
-	return (*hit).second;
+      std::unordered_map<std::string, int>::const_iterator hit;
+      if ((hit = _vals.find(v)) != _vals.end())
+        return (*hit).second;
       return -1;
     }
-    
-    std::unordered_map<std::string,int> _vals; /**< categorical value mapping. */
+
+    std::unordered_map<std::string, int>
+        _vals; /**< categorical value mapping. */
   };
-  
+
   class CSVInputFileConn : public InputConnectorStrategy
   {
   public:
-    CSVInputFileConn()
-      :InputConnectorStrategy() {}
-    ~CSVInputFileConn() {}
-  
+    CSVInputFileConn() : InputConnectorStrategy()
+    {
+    }
+    ~CSVInputFileConn()
+    {
+    }
+
     void init(const APIData &ad)
     {
       fillup_parameters(ad);
@@ -123,92 +138,100 @@ namespace dd
         }
 
       if (ad_input.has("id"))
-	_id = ad_input.get("id").get<std::string>();
+        _id = ad_input.get("id").get<std::string>();
       if (ad_input.has("separator"))
-	_delim = ad_input.get("separator").get<std::string>();
+        _delim = ad_input.get("separator").get<std::string>();
 
       if (ad_input.has("ignore"))
-	{
-	  std::vector<std::string> vignore = ad_input.get("ignore").get<std::vector<std::string>>();
-	  for (std::string s: vignore)
-	    _ignored_columns.insert(s);
-	}
+        {
+          std::vector<std::string> vignore
+              = ad_input.get("ignore").get<std::vector<std::string>>();
+          for (std::string s : vignore)
+            _ignored_columns.insert(s);
+        }
 
       if (ad_input.has("test_split"))
-	_test_split = ad_input.get("test_split").get<double>();
-      
+        _test_split = ad_input.get("test_split").get<double>();
+
       // read categorical mapping, if any
       read_categoricals(ad_input);
-      
+
       // read scaling parameters, if any
       read_scale_vals(ad_input);
 
       if (ad_input.has("label"))
-	{
-	  try
-	    {
-	      std::string label = ad_input.get("label").get<std::string>();
-		  // weird stuff may happen if label is given as single string (not vector) both at service
-		  // creation and at train (mutiple calls may be possible
-		  // due to csvts fillup parameters everywhere it can)
-		  bool already_in_labels = false;
-		  for (std::string l : _label)
-			{
-			  if (l == label)
-				{
-				  already_in_labels = true;
-				  break;
-				}
-			}
-		  if (!already_in_labels)
-			_label.push_back(label);
-	    }
-	  catch(std::exception &e)
-	    {
-	      try
-		{
-		  _label = ad_input.get("label").get<std::vector<std::string>>();
-		}
-	      catch(std::exception &e)
-		{
-		  throw InputConnectorBadParamException("wrong type for label parameter");
-		}
-	    }
-	  _label_pos.clear();
-	  for (size_t l=0;l<_label.size();l++)
-	    {
-	      _label_pos.push_back(-1);
-	      _label_set.insert(std::pair<std::string,int>(_label.at(l),l));
-	    }
-	}
-      //TODO: array
+        {
+          try
+            {
+              std::string label = ad_input.get("label").get<std::string>();
+              // weird stuff may happen if label is given as single string (not
+              // vector) both at service creation and at train (mutiple calls
+              // may be possible due to csvts fillup parameters everywhere it
+              // can)
+              bool already_in_labels = false;
+              for (std::string l : _label)
+                {
+                  if (l == label)
+                    {
+                      already_in_labels = true;
+                      break;
+                    }
+                }
+              if (!already_in_labels)
+                _label.push_back(label);
+            }
+          catch (std::exception &e)
+            {
+              try
+                {
+                  _label
+                      = ad_input.get("label").get<std::vector<std::string>>();
+                }
+              catch (std::exception &e)
+                {
+                  throw InputConnectorBadParamException(
+                      "wrong type for label parameter");
+                }
+            }
+          _label_pos.clear();
+          for (size_t l = 0; l < _label.size(); l++)
+            {
+              _label_pos.push_back(-1);
+              _label_set.insert(std::pair<std::string, int>(_label.at(l), l));
+            }
+        }
+      // TODO: array
       if (ad_input.has("label_offset"))
-	{
-	  try
-	    {
-	      int label_offset = ad_input.get("label_offset").get<int>();
-	      _label_offset.push_back(label_offset);
-	    }
-	  catch(std::exception &e)
-	    {
-	      try
-		{
-		  _label_offset = ad_input.get("label_offset").get<std::vector<int>>();
-		}
-	      catch(std::exception &e)
-		{
-		  throw InputConnectorBadParamException("wrong type for label_offset parameter");
-		}
-	    }
-	}
-      else _label_offset = std::vector<int>(_label.size(),0);
+        {
+          try
+            {
+              int label_offset = ad_input.get("label_offset").get<int>();
+              _label_offset.push_back(label_offset);
+            }
+          catch (std::exception &e)
+            {
+              try
+                {
+                  _label_offset
+                      = ad_input.get("label_offset").get<std::vector<int>>();
+                }
+              catch (std::exception &e)
+                {
+                  throw InputConnectorBadParamException(
+                      "wrong type for label_offset parameter");
+                }
+            }
+        }
+      else
+        _label_offset = std::vector<int>(_label.size(), 0);
 
       if (ad_input.has("categoricals"))
-	{
-	  std::vector<std::string> vcats = ad_input.get("categoricals").get<std::vector<std::string>>();
-	  for (std::string v: vcats)
-	    _categoricals.emplace(std::make_pair(v,CCategorical()));
-	}
+        {
+          std::vector<std::string> vcats
+              = ad_input.get("categoricals").get<std::vector<std::string>>();
+          for (std::string v : vcats)
+            _categoricals.emplace(std::make_pair(v, CCategorical()));
+        }
 
       // timeout
       this->set_timeout(ad_input);
@@ -217,30 +240,31 @@ namespace dd
     void read_categoricals(const APIData &ad_input)
     {
       if (ad_input.has("categoricals_mapping"))
-	{
-	  APIData ad_cats = ad_input.getobj("categoricals_mapping");
-	  std::vector<std::string> vcats = ad_cats.list_keys();
-	  for (std::string c: vcats)
-	    {
-	      APIData ad_cat = ad_cats.getobj(c);
-	      CCategorical cc;
-	      _categoricals.insert(std::make_pair(c,cc));
-	      auto chit = _categoricals.find(c);
-	      std::vector<std::string> vcvals = ad_cat.list_keys();
-	      for (std::string v: vcvals)
-		{
-		  (*chit).second.add_cat(v,ad_cat.get(v).get<int>());
-		}
-	    }
-	}
+        {
+          APIData ad_cats = ad_input.getobj("categoricals_mapping");
+          std::vector<std::string> vcats = ad_cats.list_keys();
+          for (std::string c : vcats)
+            {
+              APIData ad_cat = ad_cats.getobj(c);
+              CCategorical cc;
+              _categoricals.insert(std::make_pair(c, cc));
+              auto chit = _categoricals.find(c);
+              std::vector<std::string> vcvals = ad_cat.list_keys();
+              for (std::string v : vcvals)
+                {
+                  (*chit).second.add_cat(v, ad_cat.get(v).get<int>());
+                }
+            }
+        }
     }
-    
+
     void scale_vals(std::vector<double> &vals)
     {
       auto lit = _columns.begin();
-      for (int j=0;j<(int)vals.size();j++)
+      for (int j = 0; j < (int)vals.size(); j++)
         {
-          bool j_is_id = (_columns.empty() || _id.empty()) ? false : (*lit) == _id;
+          bool j_is_id
+              = (_columns.empty() || _id.empty()) ? false : (*lit) == _id;
           if (j_is_id)
             {
               ++lit;
@@ -255,7 +279,9 @@ namespace dd
           if (_dont_scale_labels)
             {
               bool j_is_label = false;
-              if (!_columns.empty() && std::find(_label_pos.begin(),_label_pos.end(),j)!=_label_pos.end())
+              if (!_columns.empty()
+                  && std::find(_label_pos.begin(), _label_pos.end(), j)
+                         != _label_pos.end())
                 j_is_label = true;
               if (j_is_label)
                 {
@@ -263,9 +289,10 @@ namespace dd
                   continue;
                 }
             }
-          vals.at(j) = (vals.at(j) - _min_vals.at(j)) / (_max_vals.at(j) - _min_vals.at(j));
+          vals.at(j) = (vals.at(j) - _min_vals.at(j))
+                       / (_max_vals.at(j) - _min_vals.at(j));
           if (_scale_between_minus1_and_1)
-            vals.at(j) = vals.at(j)-0.5;
+            vals.at(j) = vals.at(j) - 0.5;
           ++lit;
         }
     }
@@ -273,85 +300,92 @@ namespace dd
     void read_scale_vals(const APIData &ad_input)
     {
       if (ad_input.has("scale") && ad_input.get("scale").get<bool>())
-	{
-	  _scale = true;
-	  if (ad_input.has("min_vals"))
-	    {
-	      try
-		{
-		  _min_vals = ad_input.get("min_vals").get<std::vector<double>>();
-		}
-	      catch(...)
-		{
-		  std::vector<int> vi = ad_input.get("min_vals").get<std::vector<int>>();
-		  _min_vals = std::vector<double>(vi.begin(),vi.end());
-		}
-	    }
-	  if (ad_input.has("max_vals"))
-	    {
-	      try
-		{
-		  _max_vals = ad_input.get("max_vals").get<std::vector<double>>();
-		}
-	      catch(...)
-		{
-		  std::vector<int> vi = ad_input.get("max_vals").get<std::vector<int>>();
-		  _max_vals = std::vector<double>(vi.begin(),vi.end());
-		}
-	    }
-	  
-	  //debug
-	  /*std::cout << "loaded min/max scales:\n";
-	  std::copy(_min_vals.begin(),_min_vals.end(),std::ostream_iterator<double>(std::cout," "));
-	  std::cout << std::endl;
-	  std::copy(_max_vals.begin(),_max_vals.end(),std::ostream_iterator<double>(std::cout," "));
-	  std::cout << std::endl;*/
-	  //debug
+        {
+          _scale = true;
+          if (ad_input.has("min_vals"))
+            {
+              try
+                {
+                  _min_vals
+                      = ad_input.get("min_vals").get<std::vector<double>>();
+                }
+              catch (...)
+                {
+                  std::vector<int> vi
+                      = ad_input.get("min_vals").get<std::vector<int>>();
+                  _min_vals = std::vector<double>(vi.begin(), vi.end());
+                }
+            }
+          if (ad_input.has("max_vals"))
+            {
+              try
+                {
+                  _max_vals
+                      = ad_input.get("max_vals").get<std::vector<double>>();
+                }
+              catch (...)
+                {
+                  std::vector<int> vi
+                      = ad_input.get("max_vals").get<std::vector<int>>();
+                  _max_vals = std::vector<double>(vi.begin(), vi.end());
+                }
+            }
 
-	  if (!_train && (_max_vals.empty() || _min_vals.empty()))
-	    throw InputConnectorBadParamException("predict: failed acquiring scaling min_vals or max_vals");
-	}
+          // debug
+          /*std::cout << "loaded min/max scales:\n";
+          std::copy(_min_vals.begin(),_min_vals.end(),std::ostream_iterator<double>(std::cout,"
+          ")); std::cout << std::endl;
+          std::copy(_max_vals.begin(),_max_vals.end(),std::ostream_iterator<double>(std::cout,"
+          ")); std::cout << std::endl;*/
+          // debug
+
+          if (!_train && (_max_vals.empty() || _min_vals.empty()))
+            throw InputConnectorBadParamException(
+                "predict: failed acquiring scaling min_vals or max_vals");
+        }
     }
 
     void shuffle_data(std::vector<CSVline> &csvdata)
     {
       if (_shuffle)
-        std::shuffle(csvdata.begin(),csvdata.end(),_g);
+        std::shuffle(csvdata.begin(), csvdata.end(), _g);
     }
 
-    void split_data(std::vector<CSVline> &csvdata, std::vector<CSVline> &csvdata_test)
+    void split_data(std::vector<CSVline> &csvdata,
+                    std::vector<CSVline> &csvdata_test)
     {
       if (_test_split > 0.0)
-	{
-	  int split_size = std::floor(csvdata.size() * (1.0-_test_split));
-	  auto chit = csvdata.begin();
-	  auto dchit = chit;
-	  int cpos = 0;
-	  while(chit!=csvdata.end())
-	    {
-	      if (cpos == split_size)
-		{
-		  if (dchit == csvdata.begin())
-		    dchit = chit;
-		  csvdata_test.push_back((*chit));
-		}
-	      else ++cpos;
-	      ++chit;
-	    }
-	  csvdata.erase(dchit,csvdata.end());
-	}
+        {
+          int split_size = std::floor(csvdata.size() * (1.0 - _test_split));
+          auto chit = csvdata.begin();
+          auto dchit = chit;
+          int cpos = 0;
+          while (chit != csvdata.end())
+            {
+              if (cpos == split_size)
+                {
+                  if (dchit == csvdata.begin())
+                    dchit = chit;
+                  csvdata_test.push_back((*chit));
+                }
+              else
+                ++cpos;
+              ++chit;
+            }
+          csvdata.erase(dchit, csvdata.end());
+        }
     }
-    
+
     virtual void add_train_csvline(const std::string &id,
-				   std::vector<double> &vals)
+                                   std::vector<double> &vals)
     {
-      _csvdata.emplace_back(id,std::move(vals));
+      _csvdata.emplace_back(id, std::move(vals));
     }
 
     virtual void add_test_csvline(const std::string &id,
-				  std::vector<double> &vals)
+                                  std::vector<double> &vals)
     {
-      _csvdata_test.emplace_back(id,std::move(vals));
+      _csvdata_test.emplace_back(id, std::move(vals));
     }
 
     void transform(const APIData &ad)
@@ -364,83 +398,94 @@ namespace dd
        * Training from either file or memory.
        */
       if (_train)
-	{
-	  int uri_offset = 0;
-	  if (fileops::file_exists(_uris.at(0))) // training from file
-	    {
-	      _csv_fname = _uris.at(0);
-	      if (_uris.size() > 1)
-		_csv_test_fname = _uris.at(1);
-	    }
-	  else // training from memory
-	    {
-	    }
+        {
+          int uri_offset = 0;
+          if (fileops::file_exists(_uris.at(0))) // training from file
+            {
+              _csv_fname = _uris.at(0);
+              if (_uris.size() > 1)
+                _csv_test_fname = _uris.at(1);
+            }
+          else // training from memory
+            {
+            }
 
-	  // check on common and required parameters
-	  bool autoencoder = ad_input.has("autoencoder") && ad_input.get("autoencoder").get<bool>();
-	  if (!ad_input.has("label") && _train && _label.empty() && !autoencoder)
-	    throw InputConnectorBadParamException("missing label column parameter");
-	  
-	  if (!_csv_fname.empty()) // when training from file
-	    {
-	      DataEl<DDCsv> ddcsv(this->_input_timeout);
-	      ddcsv._ctype._cifc = this;
-	      ddcsv._ctype._adconf = ad_input;
-	      ddcsv.read_element(_csv_fname,this->_logger);
-	    }
-	  else // training from posted data (in-memory)
-	    {
-	      for (size_t i=uri_offset;i<_uris.size();i++)
-		{
-		  DataEl<DDCsv> ddcsv(this->_input_timeout);
-		  ddcsv._ctype._cifc = this;
-		  ddcsv._ctype._adconf = ad_input;
-		  ddcsv.read_element(_uris.at(i),this->_logger);
-		}
-	      if (_scale)
-		{
-		  for (size_t j=0;j<_csvdata.size();j++)
-		    {
-		      scale_vals(_csvdata.at(j)._v);
-		    }
-		}
-	      shuffle_data(_csvdata);
-	      if (_test_split > 0.0)
-               split_data(_csvdata, _csvdata_test);
-	      //std::cerr << "data split test size=" << _csvdata_test.size() << " / remaining data size=" << _csvdata.size() << std::endl;
-	      if (!_ignored_columns.empty() || !_categoricals.empty())
-		update_columns();
-	    }
-	}
+          // check on common and required parameters
+          bool autoencoder = ad_input.has("autoencoder")
+                             && ad_input.get("autoencoder").get<bool>();
+          if (!ad_input.has("label") && _train && _label.empty()
+              && !autoencoder)
+            throw InputConnectorBadParamException(
+                "missing label column parameter");
+
+          if (!_csv_fname.empty()) // when training from file
+            {
+              DataEl<DDCsv> ddcsv(this->_input_timeout);
+              ddcsv._ctype._cifc = this;
+              ddcsv._ctype._adconf = ad_input;
+              ddcsv.read_element(_csv_fname, this->_logger);
+            }
+          else // training from posted data (in-memory)
+            {
+              for (size_t i = uri_offset; i < _uris.size(); i++)
+                {
+                  DataEl<DDCsv> ddcsv(this->_input_timeout);
+                  ddcsv._ctype._cifc = this;
+                  ddcsv._ctype._adconf = ad_input;
+                  ddcsv.read_element(_uris.at(i), this->_logger);
+                }
+              if (_scale)
+                {
+                  for (size_t j = 0; j < _csvdata.size(); j++)
+                    {
+                      scale_vals(_csvdata.at(j)._v);
+                    }
+                }
+              shuffle_data(_csvdata);
+              if (_test_split > 0.0)
+                split_data(_csvdata, _csvdata_test);
+              // std::cerr << "data split test size=" << _csvdata_test.size()
+              // << " / remaining data size=" << _csvdata.size() << std::endl;
+              if (!_ignored_columns.empty() || !_categoricals.empty())
+                update_columns();
+            }
+        }
       else // prediction mode
-	{
-	  for (size_t i=0;i<_uris.size();i++)
-	    {
-	      if (i ==0 && !fileops::file_exists(_uris.at(0)) && (!_categoricals.empty() || (ad_input.size() && !_id.empty() && _uris.at(0).find(_delim)!=std::string::npos))) // first line might be the header if we have some options to consider //TODO: prevents reading from CSV file
-		{
-		  read_header(_uris.at(0));
-		  continue;
-		}
-	      /*else if (!_categoricals.empty())
-		throw InputConnectorBadParamException("use of categoricals_mapping requires a CSV header");*/
-	      DataEl<DDCsv> ddcsv(this->_input_timeout);
-	      ddcsv._ctype._cifc = this;
-	      ddcsv._ctype._adconf = ad_input;
-	      ddcsv.read_element(_uris.at(i),this->_logger);
-	    }
-	}
+        {
+          for (size_t i = 0; i < _uris.size(); i++)
+            {
+              if (i == 0 && !fileops::file_exists(_uris.at(0))
+                  && (!_categoricals.empty()
+                      || (ad_input.size() && !_id.empty()
+                          && _uris.at(0).find(_delim)
+                                 != std::string::
+                                     npos))) // first line might be the header
+                                             // if we have some options to
+                                             // consider //TODO: prevents
+                                             // reading from CSV file
+                {
+                  read_header(_uris.at(0));
+                  continue;
+                }
+              /*else if (!_categoricals.empty())
+                throw InputConnectorBadParamException("use of
+                categoricals_mapping requires a CSV header");*/
+              DataEl<DDCsv> ddcsv(this->_input_timeout);
+              ddcsv._ctype._cifc = this;
+              ddcsv._ctype._adconf = ad_input;
+              ddcsv.read_element(_uris.at(i), this->_logger);
+            }
+        }
       if (_csvdata.empty() && _db_fname.empty())
-	throw InputConnectorBadParamException("no data could be found");
+        throw InputConnectorBadParamException("no data could be found");
     }
 
     void read_header(std::string &hline);
-      
-    void read_csv_line(const std::string &hline,
-		       const std::string &delim,
-		       std::vector<double> &vals,
-		       std::string &column_id,
-		       int &nlines);
-    
+
+    void read_csv_line(const std::string &hline, const std::string &delim,
+                       std::vector<double> &vals, std::string &column_id,
+                       int &nlines);
+
     void read_csv(const std::string &fname, const bool forbid_shuffle = false);
 
     int batch_size() const
@@ -456,82 +501,82 @@ namespace dd
     int feature_size() const
     {
       if (!_id.empty())
-	return _columns.size() - 1 - _label.size(); // minus label and id
-      else return _columns.size() - _label.size(); // minus label
+        return _columns.size() - 1 - _label.size(); // minus label and id
+      else
+        return _columns.size() - _label.size(); // minus label
     }
 
     void response_params(APIData &out)
     {
       APIData adparams;
       if (_scale || !_categoricals.empty())
-	{
-	  if (out.has("parameters"))
-	    {
-	      adparams = out.getobj("parameters");
-	    }
-	  if (!adparams.has("input"))
-	    {
-	      APIData adinput;
-	      adinput.add("connector",std::string("csv"));
-	      adparams.add("input",adinput);
-	    }
-	}
+        {
+          if (out.has("parameters"))
+            {
+              adparams = out.getobj("parameters");
+            }
+          if (!adparams.has("input"))
+            {
+              APIData adinput;
+              adinput.add("connector", std::string("csv"));
+              adparams.add("input", adinput);
+            }
+        }
       APIData adinput = adparams.getobj("input");
       if (_scale)
-	{
-	  adinput.add("min_vals",_min_vals);
-	  adinput.add("max_vals",_max_vals);
-	}
+        {
+          adinput.add("min_vals", _min_vals);
+          adinput.add("max_vals", _max_vals);
+        }
       if (!_categoricals.empty())
-	{
-	  APIData cats;
-	  auto hit = _categoricals.begin();
-	  while(hit!=_categoricals.end())
-	    {
-	      APIData adcat;
-	      auto chit = (*hit).second._vals.begin();
-	      while(chit!=(*hit).second._vals.end())
-		{
-		  adcat.add((*chit).first,(*chit).second);
-		  ++chit;
-		}
-	      cats.add((*hit).first,adcat);
-	      ++hit;
-	    }
-	  adinput.add("categoricals_mapping",cats);
-	}
-      adparams.add("input",adinput);
-      out.add("parameters",adparams);
+        {
+          APIData cats;
+          auto hit = _categoricals.begin();
+          while (hit != _categoricals.end())
+            {
+              APIData adcat;
+              auto chit = (*hit).second._vals.begin();
+              while (chit != (*hit).second._vals.end())
+                {
+                  adcat.add((*chit).first, (*chit).second);
+                  ++chit;
+                }
+              cats.add((*hit).first, adcat);
+              ++hit;
+            }
+          adinput.add("categoricals_mapping", cats);
+        }
+      adparams.add("input", adinput);
+      out.add("parameters", adparams);
     }
 
     bool is_category(const std::string &c)
     {
-      std::unordered_map<std::string,CCategorical>::const_iterator hit;
-      if ((hit=_categoricals.find(c))!=_categoricals.end())
-	return true;
+      std::unordered_map<std::string, CCategorical>::const_iterator hit;
+      if ((hit = _categoricals.find(c)) != _categoricals.end())
+        return true;
       return false;
     }
 
-    void update_category(const std::string &c,
-			 const std::string &val);
+    void update_category(const std::string &c, const std::string &val);
 
     void update_columns();
 
-
     // below helpers for csvts
-    std::pair<std::vector<double>,std::vector<double>> get_min_max_vals(std::string& fname)
-      {
-        clear_min_max();
-        find_min_max(fname);
-        return get_min_max_vals();
-      }
+    std::pair<std::vector<double>, std::vector<double>>
+    get_min_max_vals(std::string &fname)
+    {
+      clear_min_max();
+      find_min_max(fname);
+      return get_min_max_vals();
+    }
 
     void find_min_max(std::string &fname)
     {
-      std::ifstream csv_file(fname,std::ios::binary);
+      std::ifstream csv_file(fname, std::ios::binary);
       // discard header
       std::string hline;
-      std::getline(csv_file,hline);
+      std::getline(csv_file, hline);
       if (_columns.empty())
         {
           read_header(hline);
@@ -547,20 +592,18 @@ namespace dd
       _min_vals.clear();
       _max_vals.clear();
     }
-    std::pair<std::vector<double>,std::vector<double>> get_min_max_vals()
-      {
-        return std::pair<std::vector<double>,std::vector<double>>(_min_vals,_max_vals);
-      }
+    std::pair<std::vector<double>, std::vector<double>> get_min_max_vals()
+    {
+      return std::pair<std::vector<double>, std::vector<double>>(_min_vals,
+                                                                 _max_vals);
+    }
 
-
-    
-    std::vector<double> one_hot_vector(const int &cnum,
-				       const int &size)
-      {
-	std::vector<double> v(size,0.0);
-	v.at(cnum) = 1.0;
-	return v;
-      }
+    std::vector<double> one_hot_vector(const int &cnum, const int &size)
+    {
+      std::vector<double> v(size, 0.0);
+      v.at(cnum) = 1.0;
+      return v;
+    }
 
     // options
     bool _shuffle = false;
@@ -569,23 +612,29 @@ namespace dd
     std::string _csv_test_fname;
     std::list<std::string> _columns;
     std::vector<std::string> _label;
-    std::unordered_map<std::string,int> _label_set;
+    std::unordered_map<std::string, int> _label_set;
     std::string _delim = ",";
     int _id_pos = -1;
     std::vector<int> _label_pos;
-    std::vector<int> _label_offset; /**< negative offset so that labels range from 0 onward */
+    std::vector<int> _label_offset; /**< negative offset so that labels range
+                                       from 0 onward */
     std::unordered_set<std::string> _ignored_columns;
     std::unordered_set<int> _ignored_columns_pos;
     std::string _id;
     bool _scale = false; /**< whether to scale all data between 0 and 1 */
-    bool _dont_scale_labels = true; // original csv input conn do not scale labels, while it is needed for csv timeseries
+    bool _dont_scale_labels
+        = true; // original csv input conn do not scale labels, while it is
+                // needed for csv timeseries
     bool _scale_between_minus1_and_1 = false;
-    std::vector<double> _min_vals; /**< upper bound used for auto-scaling data */
-    std::vector<double> _max_vals; /**< lower bound used for auto-scaling data */
-    std::unordered_map<std::string,CCategorical> _categoricals; /**< auto-converted categorical variables */
+    std::vector<double>
+        _min_vals; /**< upper bound used for auto-scaling data */
+    std::vector<double>
+        _max_vals; /**< lower bound used for auto-scaling data */
+    std::unordered_map<std::string, CCategorical>
+        _categoricals; /**< auto-converted categorical variables */
     double _test_split = -1;
     int _detect_cols = -1;
-    
+
     // data
     std::vector<CSVline> _csvdata;
     std::vector<CSVline> _csvdata_test;

--- a/src/csvtsinputfileconn.cc
+++ b/src/csvtsinputfileconn.cc
@@ -33,13 +33,14 @@ namespace dd
         _cifc->_columns.clear();
         std::string testfname = _cifc->_csv_test_fname;
         _cifc->_csv_test_fname = "";
-        _cifc->read_csv(fname,true);
+        _cifc->read_csv(fname, true);
         _cifc->_csv_test_fname = testfname;
         _cifc->push_csv_to_csvts(is_test_data);
         _cifc->_fnames.push_back(fname);
         return 0;
       }
-    else return -1;
+    else
+      return -1;
   }
 
   int DDCsvTS::read_db(const std::string &fname)
@@ -48,34 +49,34 @@ namespace dd
     return 0;
   }
 
-
   int DDCsvTS::read_mem(const std::string &content)
   {
     if (_cifc)
       {
         // tokenize on END_OF_SEQ  markers
-        std::string delim="END_OF_SEQ";
+        std::string delim = "END_OF_SEQ";
         size_t start = 0;
         size_t next = 0;
         while ((next = content.find(delim, start)) != std::string::npos)
           {
-            std::string csvfile = content.substr(start, next-start);
+            std::string csvfile = content.substr(start, next - start);
             _ddcsv._cifc = _cifc;
             _ddcsv.read_mem(csvfile);
             _cifc->push_csv_to_csvts();
             start = next + delim.length();
           }
-        std::string csvfile = content.substr(start, next-start);
+        std::string csvfile = content.substr(start, next - start);
         _ddcsv._cifc = _cifc;
         _ddcsv.read_mem(csvfile);
         _cifc->push_csv_to_csvts();
         return 0;
       }
-    else return -1;
+    else
+      return -1;
   }
 
-  int DDCsvTS::read_dir(const std::string &dir, bool is_test_data, bool allow_read_test,
-                        bool update_bounds)
+  int DDCsvTS::read_dir(const std::string &dir, bool is_test_data,
+                        bool allow_read_test, bool update_bounds)
   {
     // first recursive list csv files
     std::unordered_set<std::string> allfiles;
@@ -86,34 +87,37 @@ namespace dd
     if (!_cifc)
       return -1;
 
-    if (update_bounds && _cifc->_scale && (_cifc->_min_vals.empty() || _cifc->_max_vals.empty()))
+    if (update_bounds && _cifc->_scale
+        && (_cifc->_min_vals.empty() || _cifc->_max_vals.empty()))
       {
         std::unordered_set<std::string> reallyallfiles;
         if (allow_read_test)
-          ret = fileops::list_directory(_cifc->_csv_test_fname, true, false, true, reallyallfiles);
+          ret = fileops::list_directory(_cifc->_csv_test_fname, true, false,
+                                        true, reallyallfiles);
         reallyallfiles.insert(allfiles.begin(), allfiles.end());
 
         std::vector<double> min_vals(_cifc->_min_vals);
         std::vector<double> max_vals(_cifc->_max_vals);
         for (auto fname : reallyallfiles)
           {
-            std::pair<std::vector<double>,std::vector<double>> mm = _cifc->get_min_max_vals(fname);
+            std::pair<std::vector<double>, std::vector<double>> mm
+                = _cifc->get_min_max_vals(fname);
             if (min_vals.empty())
               {
-                for (size_t j=0;j<mm.first.size();j++)
+                for (size_t j = 0; j < mm.first.size(); j++)
                   min_vals.push_back(mm.first.at(j));
               }
             else
               {
-                for (size_t j=0;j<mm.first.size();j++)
-                  min_vals.at(j) = std::min(mm.first.at(j),min_vals.at(j));
+                for (size_t j = 0; j < mm.first.size(); j++)
+                  min_vals.at(j) = std::min(mm.first.at(j), min_vals.at(j));
               }
             if (max_vals.empty())
-              for (size_t j=0;j<mm.first.size();j++)
+              for (size_t j = 0; j < mm.first.size(); j++)
                 max_vals.push_back(mm.second.at(j));
             else
-              for (size_t j=0;j<mm.first.size();j++)
-                max_vals.at(j) = std::max(mm.second.at(j),max_vals.at(j));
+              for (size_t j = 0; j < mm.first.size(); j++)
+                max_vals.at(j) = std::max(mm.second.at(j), max_vals.at(j));
           }
         _cifc->_min_vals = min_vals;
         _cifc->_max_vals = max_vals;
@@ -125,10 +129,9 @@ namespace dd
 
     _cifc->shuffle_data_if_needed();
     if (allow_read_test)
-      read_dir(_cifc->_csv_test_fname, true,false,false);
+      read_dir(_cifc->_csv_test_fname, true, false, false);
     return 0;
   }
-
 
   void CSVTSInputFileConn::shuffle_data_if_needed()
   {
@@ -136,22 +139,23 @@ namespace dd
       shuffle_data(_csvtsdata);
   }
 
-  void CSVTSInputFileConn::shuffle_data(std::vector<std::vector<CSVline>> csvtsdata)
+  void
+  CSVTSInputFileConn::shuffle_data(std::vector<std::vector<CSVline>> csvtsdata)
   {
-    std::shuffle(csvtsdata.begin(),csvtsdata.end(),_g);
+    std::shuffle(csvtsdata.begin(), csvtsdata.end(), _g);
   }
 
-
-  void CSVTSInputFileConn::split_data(std::vector<std::vector<CSVline>> csvtsdata,
-                  std::vector<std::vector<CSVline>> csvtsdata_test)
+  void CSVTSInputFileConn::split_data(
+      std::vector<std::vector<CSVline>> csvtsdata,
+      std::vector<std::vector<CSVline>> csvtsdata_test)
   {
     if (_test_split > 0.0)
       {
-        int split_size = std::floor(csvtsdata.size() * (1.0-_test_split));
+        int split_size = std::floor(csvtsdata.size() * (1.0 - _test_split));
         auto chit = csvtsdata.begin();
         auto dchit = chit;
         int cpos = 0;
-        while(chit!=csvtsdata.end())
+        while (chit != csvtsdata.end())
           {
             if (cpos == split_size)
               {
@@ -159,13 +163,13 @@ namespace dd
                   dchit = chit;
                 csvtsdata_test.push_back((*chit));
               }
-            else ++cpos;
+            else
+              ++cpos;
             ++chit;
           }
-        csvtsdata.erase(dchit,csvtsdata.end());
+        csvtsdata.erase(dchit, csvtsdata.end());
       }
   }
-
 
   void CSVTSInputFileConn::transform(const APIData &ad)
   {
@@ -174,78 +178,85 @@ namespace dd
     APIData ad_input = ad.getobj("parameters").getobj("input");
     fillup_parameters(ad_input);
 
-      /**
-       * Training from either file or memory.
-       */
-      if (_train)
-        {
-          int uri_offset = 0;
-          if (fileops::file_exists(_uris.at(0))) // training from dir
-            {
-              _csv_fname = _uris.at(0);
-              if (_uris.size() > 1)
-                _csv_test_fname = _uris.at(1);
-            }
-          else // training from memory
-            {
-            }
-
-          if (!_csv_fname.empty()) // when training from file
-            {
-              DataEl<DDCsvTS> ddcsvts(this->_input_timeout);
-              ddcsvts._ctype._cifc = this;
-              ddcsvts._ctype._adconf = ad_input;
-              ddcsvts.read_element(_csv_fname,this->_logger);
-              // this read element will call read csvts_dir and scale and shuffle
-            }
-          else
+    /**
+     * Training from either file or memory.
+     */
+    if (_train)
+      {
+        int uri_offset = 0;
+        if (fileops::file_exists(_uris.at(0))) // training from dir
           {
-            for (size_t i=uri_offset;i<_uris.size();i++)
-		{
-		  DataEl<DDCsvTS> ddcsvts(this->_input_timeout);
-		  ddcsvts._ctype._cifc = this;
-		  ddcsvts._ctype._adconf = ad_input;
-		  ddcsvts.read_element(_uris.at(i),this->_logger);
-		}
+            _csv_fname = _uris.at(0);
+            if (_uris.size() > 1)
+              _csv_test_fname = _uris.at(1);
+          }
+        else // training from memory
+          {
+          }
+
+        if (!_csv_fname.empty()) // when training from file
+          {
+            DataEl<DDCsvTS> ddcsvts(this->_input_timeout);
+            ddcsvts._ctype._cifc = this;
+            ddcsvts._ctype._adconf = ad_input;
+            ddcsvts.read_element(_csv_fname, this->_logger);
+            // this read element will call read csvts_dir and scale and shuffle
+          }
+        else
+          {
+            for (size_t i = uri_offset; i < _uris.size(); i++)
+              {
+                DataEl<DDCsvTS> ddcsvts(this->_input_timeout);
+                ddcsvts._ctype._cifc = this;
+                ddcsvts._ctype._adconf = ad_input;
+                ddcsvts.read_element(_uris.at(i), this->_logger);
+              }
             if (_scale)
-		{
-		  for (size_t j=0;j<_csvtsdata.size();j++)
-		    {
-                    for (size_t k=0;k<_csvtsdata.at(j).size();k++)
+              {
+                for (size_t j = 0; j < _csvtsdata.size(); j++)
+                  {
+                    for (size_t k = 0; k < _csvtsdata.at(j).size(); k++)
                       scale_vals(_csvtsdata.at(j).at(k)._v);
-		    }
-		}
+                  }
+              }
             shuffle_data(_csvtsdata);
             if (_test_split > 0.0)
               {
                 split_data(_csvtsdata, _csvtsdata_test);
-                std::cerr << "data split test size=" << _csvdata_test.size() << " / remaining data size=" << _csvdata.size() << std::endl;
+                std::cerr << "data split test size=" << _csvdata_test.size()
+                          << " / remaining data size=" << _csvdata.size()
+                          << std::endl;
               }
           }
-        }
-      else // prediction mode
-        {
+      }
+    else // prediction mode
+      {
 
-
-          for (size_t i=0;i<_uris.size();i++)
-            {
-              if (i ==0 && !fileops::file_exists(_uris.at(0)) && (ad_input.size() && _uris.at(0).find(_delim)!=std::string::npos)) // first line might be the header if we have some options to consider //TODO: prevents reading from CSV file
-                {
-                  read_header(_uris.at(0));
-                  continue;
-                }
-              /*else if (!_categoricals.empty())
-                throw InputConnectorBadParamException("use of categoricals_mapping requires a CSV header");*/
-              DataEl<DDCsvTS> ddcsvts(this->_input_timeout);
-              ddcsvts._ctype._cifc = this;
-              ddcsvts._ctype._adconf = ad_input;
-              ddcsvts.read_element(_uris.at(i),this->_logger);
-            }
-        }
-      if (_csvtsdata.empty() && _db_fname.empty())
-        throw InputConnectorBadParamException("no data could be found");
-
-    }
+        for (size_t i = 0; i < _uris.size(); i++)
+          {
+            if (i == 0 && !fileops::file_exists(_uris.at(0))
+                && (ad_input.size()
+                    && _uris.at(0).find(_delim)
+                           != std::string::
+                               npos)) // first line might be the header if we
+                                      // have some options to consider //TODO:
+                                      // prevents reading from CSV file
+              {
+                read_header(_uris.at(0));
+                continue;
+              }
+            /*else if (!_categoricals.empty())
+              throw InputConnectorBadParamException("use of
+              categoricals_mapping requires a CSV header");*/
+            DataEl<DDCsvTS> ddcsvts(this->_input_timeout);
+            ddcsvts._ctype._cifc = this;
+            ddcsvts._ctype._adconf = ad_input;
+            ddcsvts.read_element(_uris.at(i), this->_logger);
+          }
+      }
+    if (_csvtsdata.empty() && _db_fname.empty())
+      throw InputConnectorBadParamException("no data could be found");
+  }
 
   void CSVTSInputFileConn::response_params(APIData &out)
   {
@@ -259,22 +270,19 @@ namespace dd
         if (!adparams.has("input"))
           {
             APIData adinput;
-            adinput.add("connector",std::string("csvts"));
-            adparams.add("input",adinput);
+            adinput.add("connector", std::string("csvts"));
+            adparams.add("input", adinput);
           }
       }
     APIData adinput = adparams.getobj("input");
     if (_scale)
       {
-        adinput.add("min_vals",_min_vals);
-        adinput.add("max_vals",_max_vals);
+        adinput.add("min_vals", _min_vals);
+        adinput.add("max_vals", _max_vals);
       }
-    adparams.add("input",adinput);
-    out.add("parameters",adparams);
+    adparams.add("input", adinput);
+    out.add("parameters", adparams);
   }
-
-
-
 
   void CSVTSInputFileConn::push_csv_to_csvts(bool is_test_data)
   {
@@ -311,7 +319,8 @@ namespace dd
     in.open(boundsfname);
     if (!in.is_open())
       {
-        _logger->warn("bounds file {} detected but cannot be opened", boundsfname);
+        _logger->warn("bounds file {} detected but cannot be opened",
+                      boundsfname);
         return false;
       }
     std::string line;
@@ -319,9 +328,9 @@ namespace dd
     int ncols = -1;
     int nlabels = -1;
 
-    while (getline(in,line))
+    while (getline(in, line))
       {
-        tokens = dd_utils::split(line,':');
+        tokens = dd_utils::split(line, ':');
         if (tokens.empty())
           continue;
         std::string key = tokens.at(0);
@@ -333,20 +342,20 @@ namespace dd
         else if (key == "label_pos")
           {
             _label_pos.clear();
-            for (int i=0;i<nlabels; ++i)
-              _label_pos.push_back(std::atoi(tokens.at(i+1).c_str()));
+            for (int i = 0; i < nlabels; ++i)
+              _label_pos.push_back(std::atoi(tokens.at(i + 1).c_str()));
           }
         else if (key == "min_vals")
           {
             _min_vals.clear();
-            for (int i=0;i<ncols; ++i)
-              _min_vals.push_back(std::atof(tokens.at(i+1).c_str()));
+            for (int i = 0; i < ncols; ++i)
+              _min_vals.push_back(std::atof(tokens.at(i + 1).c_str()));
           }
         else if (key == "max_vals")
           {
             _max_vals.clear();
-            for (int i=0;i<ncols; ++i)
-              _max_vals.push_back(std::atof(tokens.at(i+1).c_str()));
+            for (int i = 0; i < ncols; ++i)
+              _max_vals.push_back(std::atof(tokens.at(i + 1).c_str()));
           }
       }
     this->_logger->info("bounds loaded");
@@ -357,26 +366,31 @@ namespace dd
   void CSVTSInputFileConn::serialize_bounds()
   {
     std::string boundsfname = _model_repo + "/" + _boundsfname;
-    std::string delim=":";
+    std::string delim = ":";
     std::ofstream out;
     out.open(boundsfname);
     if (!out.is_open())
-      throw InputConnectorBadParamException("failed opening for writing bounds file " + boundsfname);
+      throw InputConnectorBadParamException(
+          "failed opening for writing bounds file " + boundsfname);
 
     out << "ncols: " << _min_vals.size() << std::endl;
     out << "nlabels: " << _label_pos.size() << std::endl;
-    out<<"label_pos: ";
-    for (unsigned int i = 0; i< _label_pos.size() -1; ++i)
-      out<< " " << _label_pos[i] << " " << delim;
-    out << " " <<_label_pos[_label_pos.size()-1] << std::endl;
-    out << "min_vals: " ;
-    for (unsigned int i = 0; i< _min_vals.size() -1; ++i)
-      out << " " << std::setprecision(_boundsprecision) <<  _min_vals[i] << " " << delim;
-    out << " " << std::setprecision(_boundsprecision) << _min_vals[_min_vals.size() -1] << std::endl;
-    out << "max_vals: " ;
-    for (unsigned int i = 0; i< _max_vals.size() -1; ++i)
-      out << " " << std::setprecision(_boundsprecision) << _max_vals[i] << " " << delim;
-    out << " " << std::setprecision(_boundsprecision) << _max_vals[_max_vals.size() -1] << std::endl;
+    out << "label_pos: ";
+    for (unsigned int i = 0; i < _label_pos.size() - 1; ++i)
+      out << " " << _label_pos[i] << " " << delim;
+    out << " " << _label_pos[_label_pos.size() - 1] << std::endl;
+    out << "min_vals: ";
+    for (unsigned int i = 0; i < _min_vals.size() - 1; ++i)
+      out << " " << std::setprecision(_boundsprecision) << _min_vals[i] << " "
+          << delim;
+    out << " " << std::setprecision(_boundsprecision)
+        << _min_vals[_min_vals.size() - 1] << std::endl;
+    out << "max_vals: ";
+    for (unsigned int i = 0; i < _max_vals.size() - 1; ++i)
+      out << " " << std::setprecision(_boundsprecision) << _max_vals[i] << " "
+          << delim;
+    out << " " << std::setprecision(_boundsprecision)
+        << _max_vals[_max_vals.size() - 1] << std::endl;
 
     out.close();
     deserialize_bounds(true);

--- a/src/csvtsinputfileconn.h
+++ b/src/csvtsinputfileconn.h
@@ -37,14 +37,18 @@ namespace dd
   class DDCsvTS
   {
   public:
-  DDCsvTS(): _ddcsv()  {}
-    ~DDCsvTS() {}
+    DDCsvTS() : _ddcsv()
+    {
+    }
+    ~DDCsvTS()
+    {
+    }
 
     int read_file(const std::string &fname, bool is_test_data = false);
     int read_db(const std::string &fname);
     int read_mem(const std::string &content);
-    int read_dir(const std::string &dir, bool is_test_data = false, bool allow_read_test = true,
-                 bool update_bounds = true);
+    int read_dir(const std::string &dir, bool is_test_data = false,
+                 bool allow_read_test = true, bool update_bounds = true);
 
     DDCsv _ddcsv;
     CSVTSInputFileConn *_cifc = nullptr;
@@ -52,33 +56,30 @@ namespace dd
     std::shared_ptr<spdlog::logger> _logger;
   };
 
-
   class CSVTSInputFileConn : public CSVInputFileConn
   {
   public:
+    CSVTSInputFileConn() : CSVInputFileConn()
+    {
+      this->_dont_scale_labels = false;
+      this->_scale_between_minus1_and_1 = true;
+      this->_timeserie = true;
+    }
 
+    ~CSVTSInputFileConn()
+    {
+    }
 
-
-  CSVTSInputFileConn()
-    :CSVInputFileConn()
-      {
-        this->_dont_scale_labels = false;
-        this->_scale_between_minus1_and_1 = true;
-        this->_timeserie = true;
-      }
-
-    ~CSVTSInputFileConn() {}
-
-  CSVTSInputFileConn(const CSVTSInputFileConn &i)
-    : CSVInputFileConn(i), _csvtsdata(i._csvtsdata),
-      _csvtsdata_test(i._csvtsdata_test)
-        {
-          this->_scale_between_minus1_and_1 = i._scale_between_minus1_and_1;
-          this->_dont_scale_labels = i._dont_scale_labels;
-          this->_min_vals = i._min_vals;
-          this->_max_vals = i._max_vals;
-          this->_timeserie = true;
-        }
+    CSVTSInputFileConn(const CSVTSInputFileConn &i)
+        : CSVInputFileConn(i), _csvtsdata(i._csvtsdata),
+          _csvtsdata_test(i._csvtsdata_test)
+    {
+      this->_scale_between_minus1_and_1 = i._scale_between_minus1_and_1;
+      this->_dont_scale_labels = i._dont_scale_labels;
+      this->_min_vals = i._min_vals;
+      this->_max_vals = i._max_vals;
+      this->_timeserie = true;
+    }
 
     void init(const APIData &ad)
     {
@@ -100,7 +101,6 @@ namespace dd
 
     void shuffle_data(std::vector<std::vector<CSVline>> cvstsdata);
     void shuffle_data_if_needed();
-
 
     void split_data(std::vector<std::vector<CSVline>> cvstsdata,
                     std::vector<std::vector<CSVline>> cvstsdata_test);
@@ -130,9 +130,8 @@ namespace dd
 
     void response_params(APIData &out);
 
-
     void push_csv_to_csvts(DDCsv &ddcsv);
-    void push_csv_to_csvts(bool is_test_data=false);
+    void push_csv_to_csvts(bool is_test_data = false);
 
     std::string _boundsfname = "bounds.dat";
 

--- a/src/deepdetect.cc
+++ b/src/deepdetect.cc
@@ -31,7 +31,8 @@
 #if defined(USE_HTTP_SERVER) && defined(USE_JSON_API)
 #include "httpjsonapi.h"
 #endif // USE_HTTP_SERVER && USE_JSON_API
-#if defined(USE_JSON_API) && !defined(USE_HTTP_SERVER) && !defined(USE_COMMAND_LINE)
+#if defined(USE_JSON_API) && !defined(USE_HTTP_SERVER)                        \
+    && !defined(USE_COMMAND_LINE)
 #include "jsonapi.h"
 #endif
 #include "dd_config.h"
@@ -39,17 +40,16 @@
 
 namespace dd
 {
-  template<class TAPIStrategy>
+  template <class TAPIStrategy>
   std::string DeepDetect<TAPIStrategy>::_commit_version = GIT_COMMIT_HASH;
 
-  template<class TAPIStrategy>
-  DeepDetect<TAPIStrategy>::DeepDetect()
+  template <class TAPIStrategy> DeepDetect<TAPIStrategy>::DeepDetect()
   {
-    std::cout << "DeepDetect [ commit " << DeepDetect::_commit_version << " ]\n";
+    std::cout << "DeepDetect [ commit " << DeepDetect::_commit_version
+              << " ]\n";
   }
 
-  template<class TAPIStrategy>
-  DeepDetect<TAPIStrategy>::~DeepDetect()
+  template <class TAPIStrategy> DeepDetect<TAPIStrategy>::~DeepDetect()
   {
   }
 
@@ -66,10 +66,9 @@ namespace dd
 #ifdef USE_HTTP_SERVER
   template class DeepDetect<HttpJsonAPI>;
 #endif
-  #if !defined(USE_COMMAND_LINE) && !defined(USE_HTTP)
-    template class DeepDetect<JsonAPI>;
-  #endif
+#if !defined(USE_COMMAND_LINE) && !defined(USE_HTTP)
+  template class DeepDetect<JsonAPI>;
 #endif
-
+#endif
 
 }

--- a/src/deepdetect.h
+++ b/src/deepdetect.h
@@ -31,16 +31,16 @@ namespace dd
   /**
    * \brief main deepdetect class, deriving API
    */
-  template <class TAPIStrategy>
-    class DeepDetect : public TAPIStrategy
-    {
-    public:
-      DeepDetect();
-      ~DeepDetect();
+  template <class TAPIStrategy> class DeepDetect : public TAPIStrategy
+  {
+  public:
+    DeepDetect();
+    ~DeepDetect();
 
-      static std::string _commit_version; /**< stores the current commit version */
-    };
-  
+    static std::string
+        _commit_version; /**< stores the current commit version */
+  };
+
 }
 
 #endif

--- a/src/generators/net_caffe.cc
+++ b/src/generators/net_caffe.cc
@@ -28,12 +28,12 @@ namespace dd
 {
 
   /*- CaffeCommon -*/
-  caffe::LayerParameter* CaffeCommon::add_layer(caffe::NetParameter *net_param,
-						const std::string &bottom,
-						const std::string &top,
-						const std::string &name,
-						const std::string &type,
-						const std::string &label)
+  caffe::LayerParameter *CaffeCommon::add_layer(caffe::NetParameter *net_param,
+                                                const std::string &bottom,
+                                                const std::string &top,
+                                                const std::string &name,
+                                                const std::string &type,
+                                                const std::string &label)
   {
     caffe::LayerParameter *lparam = net_param->add_layer();
     if (!bottom.empty())
@@ -53,33 +53,33 @@ namespace dd
     std::string activation = "ReLU"; // default
     if (ad_mllib.has("activation"))
       {
-	activation = ad_mllib.get("activation").get<std::string>();
-	if (dd_utils::iequals(activation,"relu"))
-	  activation = "ReLU";
-	else if (dd_utils::iequals(activation,"prelu"))
-	  activation = "PReLU";
-	else if (dd_utils::iequals(activation,"elu"))
-	  activation = "ELU";
-	else if (dd_utils::iequals(activation,"sigmoid"))
-	  activation = "Sigmoid";
-	else if (dd_utils::iequals(activation,"tanh"))
-	  activation = "TanH";
-	else if (dd_utils::iequals(activation,"swish"))
-	  activation = "Swish";
+        activation = ad_mllib.get("activation").get<std::string>();
+        if (dd_utils::iequals(activation, "relu"))
+          activation = "ReLU";
+        else if (dd_utils::iequals(activation, "prelu"))
+          activation = "PReLU";
+        else if (dd_utils::iequals(activation, "elu"))
+          activation = "ELU";
+        else if (dd_utils::iequals(activation, "sigmoid"))
+          activation = "Sigmoid";
+        else if (dd_utils::iequals(activation, "tanh"))
+          activation = "TanH";
+        else if (dd_utils::iequals(activation, "swish"))
+          activation = "Swish";
       }
     return activation;
   }
-  
+
   /*- NetInputCaffe -*/
   template <class TInputCaffe>
   void NetInputCaffe<TInputCaffe>::configure_inputs(const APIData &ad_mllib,
-						    const TInputCaffe &inputc)
+                                                    const TInputCaffe &inputc)
   {
     int ntargets = -1;
     if (ad_mllib.has("ntargets"))
       ntargets = ad_mllib.get("ntargets").get<int>();
     bool db = false;
-    if (ad_mllib.has("db")) //TODO: if Caffe + image, db is true
+    if (ad_mllib.has("db")) // TODO: if Caffe + image, db is true
       db = ad_mllib.get("db").get<bool>();
     bool autoencoder = false;
     if (ad_mllib.has("autoencoder"))
@@ -88,105 +88,123 @@ namespace dd
     int height = inputc.height() > 0 ? inputc.height() : 1;
     int channels = inputc.channels() > 0 ? inputc.channels() : 1;
     int batch_size = inputc.batch_size() > 0 ? inputc.batch_size() : 1;
-    bool flat1dconv = inputc._flat1dconv; // whether the model uses 1d-conv (e.g. character-level convnet for text)
-    
+    bool flat1dconv
+        = inputc._flat1dconv; // whether the model uses 1d-conv (e.g.
+                              // character-level convnet for text)
+
     // train net
     std::string top = "data";
     std::string label = "label";
     if (ntargets > 1)
       {
-	top = "fulldata";
-	label = "fake_label";
+        top = "fulldata";
+        label = "fake_label";
       }
 
     // train layer
-    caffe::LayerParameter *lparam = CaffeCommon::add_layer(this->_net_params,"",top,"inputl","",label);
+    caffe::LayerParameter *lparam = CaffeCommon::add_layer(
+        this->_net_params, "", top, "inputl", "", label);
     caffe::NetStateRule *nsr = lparam->add_include();
     nsr->set_phase(caffe::TRAIN);
-    
+
     // deploy net
-    caffe::LayerParameter *dlparam = CaffeCommon::add_layer(this->_dnet_params,"",top,"inputl","",label);
-    
+    caffe::LayerParameter *dlparam = CaffeCommon::add_layer(
+        this->_dnet_params, "", top, "inputl", "", label);
+
     // sources
     if (db)
       {
-	if (inputc._sparse)
-	  lparam->set_type("SparseData");
-	else lparam->set_type("Data");
-	caffe::DataParameter *dparam = lparam->mutable_data_param();
-	dparam->set_source("train.lmdb");
-	dparam->set_batch_size(32); // dummy value, updated before training
-	dparam->set_backend(caffe::DataParameter_DB_LMDB);
-	if (!flat1dconv)
-	  {
-	    bool has_mirror = false;
-	    if (ad_mllib.has("mirror"))
-	      {
-		has_mirror = ad_mllib.get("mirror").get<bool>();
-		lparam->mutable_transform_param()->set_mirror(has_mirror);
-	      }
-	    bool has_rotate = false;
-	    if (ad_mllib.has("rotate"))
-	      {
-		has_rotate = ad_mllib.get("rotate").get<bool>();
-		lparam->mutable_transform_param()->set_rotate(has_rotate);
-	      }
-	    //TODO
-	    /*std::string mf = "mean.binaryproto";
-	      lparam->mutable_transform_param()->set_mean_file(mf.c_str());*/
-	    bool has_noise = false;
-	    bool has_distort = false;
-	    if (ad_mllib.has("noise"))
-	      {
-		has_noise = true;
-		APIData ad_noise = ad_mllib.getobj("noise");
-		caffe::LayerParameter *lparam = this->_net_params->mutable_layer(0); // data input layer
-		caffe::TransformationParameter *trparam = lparam->mutable_transform_param();
-		caffe::NoiseParameter *nparam = trparam->mutable_noise_param();
-		nparam->set_all_effects(true); // all effects true is default
-	      }
-	    if (ad_mllib.has("distort"))
-	      {
-		has_distort = true;
-		APIData ad_noise = ad_mllib.getobj("noise");
-		caffe::LayerParameter *lparam = this->_net_params->mutable_layer(0); // data input layer
-		caffe::TransformationParameter *trparam = lparam->mutable_transform_param();
-		caffe::NoiseParameter *nparam = trparam->mutable_noise_param();
-		nparam->set_all_effects(true); // all effects true is default
-	      }
-	    if (autoencoder && (has_noise || has_distort || has_rotate))
-	      {
-		this->_net_params->mutable_layer(0)->add_top("orig_data"); // unchanged data top
-		this->_net_params->mutable_layer(0)->mutable_transform_param()->set_untransformed_top(true);
-	      }
-	  }
-	
-	// test
-	/*lparam = this->_net_params->add_layer(); // test layer
-	lparam->set_type("Data");
-	dparam = lparam->mutable_data_param();
-	dparam->set_source("test.lmdb");
-	dparam->set_batch_size(32); // dummy value, updated before training
-	dparam->set_backend(caffe::DataParameter_DB_LMDB);
-	caffe::NetStateRule *nsr = lparam->add_include();
-	nsr->set_phase(caffe::TEST);*/
+        if (inputc._sparse)
+          lparam->set_type("SparseData");
+        else
+          lparam->set_type("Data");
+        caffe::DataParameter *dparam = lparam->mutable_data_param();
+        dparam->set_source("train.lmdb");
+        dparam->set_batch_size(32); // dummy value, updated before training
+        dparam->set_backend(caffe::DataParameter_DB_LMDB);
+        if (!flat1dconv)
+          {
+            bool has_mirror = false;
+            if (ad_mllib.has("mirror"))
+              {
+                has_mirror = ad_mllib.get("mirror").get<bool>();
+                lparam->mutable_transform_param()->set_mirror(has_mirror);
+              }
+            bool has_rotate = false;
+            if (ad_mllib.has("rotate"))
+              {
+                has_rotate = ad_mllib.get("rotate").get<bool>();
+                lparam->mutable_transform_param()->set_rotate(has_rotate);
+              }
+            // TODO
+            /*std::string mf = "mean.binaryproto";
+              lparam->mutable_transform_param()->set_mean_file(mf.c_str());*/
+            bool has_noise = false;
+            bool has_distort = false;
+            if (ad_mllib.has("noise"))
+              {
+                has_noise = true;
+                APIData ad_noise = ad_mllib.getobj("noise");
+                caffe::LayerParameter *lparam
+                    = this->_net_params->mutable_layer(0); // data input layer
+                caffe::TransformationParameter *trparam
+                    = lparam->mutable_transform_param();
+                caffe::NoiseParameter *nparam = trparam->mutable_noise_param();
+                nparam->set_all_effects(true); // all effects true is default
+              }
+            if (ad_mllib.has("distort"))
+              {
+                has_distort = true;
+                APIData ad_noise = ad_mllib.getobj("noise");
+                caffe::LayerParameter *lparam
+                    = this->_net_params->mutable_layer(0); // data input layer
+                caffe::TransformationParameter *trparam
+                    = lparam->mutable_transform_param();
+                caffe::NoiseParameter *nparam = trparam->mutable_noise_param();
+                nparam->set_all_effects(true); // all effects true is default
+              }
+            if (autoencoder && (has_noise || has_distort || has_rotate))
+              {
+                this->_net_params->mutable_layer(0)->add_top(
+                    "orig_data"); // unchanged data top
+                this->_net_params->mutable_layer(0)
+                    ->mutable_transform_param()
+                    ->set_untransformed_top(true);
+              }
+          }
+
+        // test
+        /*lparam = this->_net_params->add_layer(); // test layer
+        lparam->set_type("Data");
+        dparam = lparam->mutable_data_param();
+        dparam->set_source("test.lmdb");
+        dparam->set_batch_size(32); // dummy value, updated before training
+        dparam->set_backend(caffe::DataParameter_DB_LMDB);
+        caffe::NetStateRule *nsr = lparam->add_include();
+        nsr->set_phase(caffe::TEST);*/
       }
     else
       {
-	if (inputc._sparse)
-	  lparam->set_type("MemorySparseData");
-	else lparam->set_type("MemoryData");
-	caffe::MemoryDataParameter *mdparam = lparam->mutable_memory_data_param();
-	mdparam->set_batch_size(batch_size); // dummy value, updated before training
-	mdparam->set_channels(channels);
-	mdparam->set_height(height);
-	mdparam->set_width(width);
+        if (inputc._sparse)
+          lparam->set_type("MemorySparseData");
+        else
+          lparam->set_type("MemoryData");
+        caffe::MemoryDataParameter *mdparam
+            = lparam->mutable_memory_data_param();
+        mdparam->set_batch_size(
+            batch_size); // dummy value, updated before training
+        mdparam->set_channels(channels);
+        mdparam->set_height(height);
+        mdparam->set_width(width);
       }
-    
-    lparam = CaffeCommon::add_layer(this->_net_params,"",top,"inputl",
-				    inputc._sparse ? "MemorySparseData" : "MemoryData",label); // test layer
+
+    lparam = CaffeCommon::add_layer(this->_net_params, "", top, "inputl",
+                                    inputc._sparse ? "MemorySparseData"
+                                                   : "MemoryData",
+                                    label); // test layer
     caffe::MemoryDataParameter *mdparam = lparam->mutable_memory_data_param();
-    mdparam->set_batch_size(batch_size); // dummy value, updated before training
+    mdparam->set_batch_size(
+        batch_size); // dummy value, updated before training
     mdparam->set_channels(channels);
     mdparam->set_height(height);
     mdparam->set_width(width);
@@ -196,156 +214,156 @@ namespace dd
     // deploy
     if (inputc._sparse)
       dlparam->set_type("MemorySparseData");
-    else dlparam->set_type("MemoryData");
+    else
+      dlparam->set_type("MemoryData");
     mdparam = dlparam->mutable_memory_data_param();
     mdparam->set_batch_size(1);
     mdparam->set_channels(channels);
     mdparam->set_height(height);
     mdparam->set_width(width);
-    
+
     if (ntargets > 1) // regression
       {
-	lparam = CaffeCommon::add_layer(this->_net_params,top,"data");
-	lparam->add_top("label");
-	lparam->set_type("Slice");
-	lparam->set_name("slice_labels");
-	caffe::SliceParameter *sparam = lparam->mutable_slice_param();
-	sparam->set_slice_dim(1);
-	sparam->add_slice_point(1);
+        lparam = CaffeCommon::add_layer(this->_net_params, top, "data");
+        lparam->add_top("label");
+        lparam->set_type("Slice");
+        lparam->set_name("slice_labels");
+        caffe::SliceParameter *sparam = lparam->mutable_slice_param();
+        sparam->set_slice_dim(1);
+        sparam->add_slice_point(1);
 
-	dlparam = CaffeCommon::add_layer(this->_dnet_params,top,"data");
-	dlparam->add_top("label");
-	dlparam->set_type("Slice");
-	dlparam->set_name("slice_labels");
-	sparam = dlparam->mutable_slice_param();
-	sparam->set_slice_dim(1);
-	sparam->add_slice_point(1);
+        dlparam = CaffeCommon::add_layer(this->_dnet_params, top, "data");
+        dlparam->add_top("label");
+        dlparam->set_type("Slice");
+        dlparam->set_name("slice_labels");
+        sparam = dlparam->mutable_slice_param();
+        sparam->set_slice_dim(1);
+        sparam->add_slice_point(1);
       }
     if (inputc._embed)
       {
-	/*lparam = CaffeCommon::add_layer(this->_net_params,top,"embed");
-	  lparam->set_type("Embed")*/
-	int input_dim = 69;
-	int num_output = 16;
-	add_embed(this->_net_params,top,"embed",input_dim,num_output);
-	add_embed(this->_dnet_params,top,"embed",input_dim,num_output);
+        /*lparam = CaffeCommon::add_layer(this->_net_params,top,"embed");
+          lparam->set_type("Embed")*/
+        int input_dim = 69;
+        int num_output = 16;
+        add_embed(this->_net_params, top, "embed", input_dim, num_output);
+        add_embed(this->_dnet_params, top, "embed", input_dim, num_output);
       }
   }
 
-	template <>
-	void NetInputCaffe<ImgTorchInputFileConn>::configure_inputs(const APIData &ad_mllib,
-																  const ImgTorchInputFileConn &inputc)
-	{
-	}
+  template <>
+  void NetInputCaffe<ImgTorchInputFileConn>::configure_inputs(
+      const APIData &ad_mllib, const ImgTorchInputFileConn &inputc)
+  {
+  }
 
-	template <>
-	void NetInputCaffe<TxtTorchInputFileConn>::configure_inputs(const APIData &ad_mllib,
-																  const TxtTorchInputFileConn &inputc)
-	{
-	}
+  template <>
+  void NetInputCaffe<TxtTorchInputFileConn>::configure_inputs(
+      const APIData &ad_mllib, const TxtTorchInputFileConn &inputc)
+  {
+  }
 
-	/*- NetInputCaffe for proto/torch backend => only lstm for now  -*/
-	template <>
-	void NetInputCaffe<CSVTSTorchInputFileConn>::configure_inputs(const APIData &ad_mllib,
-													  const CSVTSTorchInputFileConn &inputc)
-	{
-		int width = inputc.width() > 0 ? inputc.width() : 1;
-		int height = inputc.height() > 0 ? inputc.height() : 1;
-		int channels = inputc.channels() > 0 ? inputc.channels() : 1;
-		int batch_size = inputc.batch_size() > 0 ? inputc.batch_size() : 1;
-		std::string top = "data";
-		std::string label = "label";
-		caffe::LayerParameter *lparam = CaffeCommon::add_layer(this->_net_params,"",top,"inputl","",label);
-		lparam->set_type("MemoryData");
-		caffe::MemoryDataParameter *mdparam = lparam->mutable_memory_data_param();
-		mdparam->set_batch_size(batch_size); // dummy value, updated before training
-		mdparam->set_channels(channels);
-		mdparam->set_height(height);
-		mdparam->set_width(width);
-	}
-
-
+  /*- NetInputCaffe for proto/torch backend => only lstm for now  -*/
+  template <>
+  void NetInputCaffe<CSVTSTorchInputFileConn>::configure_inputs(
+      const APIData &ad_mllib, const CSVTSTorchInputFileConn &inputc)
+  {
+    int width = inputc.width() > 0 ? inputc.width() : 1;
+    int height = inputc.height() > 0 ? inputc.height() : 1;
+    int channels = inputc.channels() > 0 ? inputc.channels() : 1;
+    int batch_size = inputc.batch_size() > 0 ? inputc.batch_size() : 1;
+    std::string top = "data";
+    std::string label = "label";
+    caffe::LayerParameter *lparam = CaffeCommon::add_layer(
+        this->_net_params, "", top, "inputl", "", label);
+    lparam->set_type("MemoryData");
+    caffe::MemoryDataParameter *mdparam = lparam->mutable_memory_data_param();
+    mdparam->set_batch_size(
+        batch_size); // dummy value, updated before training
+    mdparam->set_channels(channels);
+    mdparam->set_height(height);
+    mdparam->set_width(width);
+  }
 
   template <class TInputCaffe>
   void NetInputCaffe<TInputCaffe>::add_embed(caffe::NetParameter *net_param,
-					     const std::string &bottom,
-					     const std::string &top,
-					     const int &input_dim,
-					     const int &num_output)
+                                             const std::string &bottom,
+                                             const std::string &top,
+                                             const int &input_dim,
+                                             const int &num_output)
   {
-    caffe::LayerParameter *lparam = CaffeCommon::add_layer(net_param,bottom,top,"embed_"+top,"Embed");
+    caffe::LayerParameter *lparam = CaffeCommon::add_layer(
+        net_param, bottom, top, "embed_" + top, "Embed");
     lparam->mutable_embed_param()->set_input_dim(input_dim);
     lparam->mutable_embed_param()->set_num_output(num_output);
   }
 
   /*- NetLayersCaffe -*/
   void NetLayersCaffe::add_fc(caffe::NetParameter *net_param,
-			      const std::string &bottom,
-			      const std::string &top,
-			      const int &num_output)
+                              const std::string &bottom,
+                              const std::string &top, const int &num_output)
   {
-    caffe::LayerParameter *lparam = CaffeCommon::add_layer(net_param,bottom,top,"fc_"+bottom,"InnerProduct");
-    caffe::InnerProductParameter *iparam = lparam->mutable_inner_product_param();
+    caffe::LayerParameter *lparam = CaffeCommon::add_layer(
+        net_param, bottom, top, "fc_" + bottom, "InnerProduct");
+    caffe::InnerProductParameter *iparam
+        = lparam->mutable_inner_product_param();
     iparam->set_num_output(num_output);
-    iparam->mutable_weight_filler()->set_type("xavier"); //TODO: option
+    iparam->mutable_weight_filler()->set_type("xavier"); // TODO: option
     caffe::FillerParameter *fparam = iparam->mutable_bias_filler();
     fparam->set_type("constant");
-    fparam->set_value(0.0); //TODO: option
+    fparam->set_value(0.0); // TODO: option
   }
 
   void NetLayersCaffe::add_sparse_fc(caffe::NetParameter *net_param,
-				     const std::string &bottom,
-				     const std::string &top,
-				     const int &num_output)
+                                     const std::string &bottom,
+                                     const std::string &top,
+                                     const int &num_output)
   {
-    caffe::LayerParameter *lparam = CaffeCommon::add_layer(net_param,bottom,top,"fc_"+bottom,"SparseInnerProduct");
-    caffe::InnerProductParameter *iparam = lparam->mutable_inner_product_param();
+    caffe::LayerParameter *lparam = CaffeCommon::add_layer(
+        net_param, bottom, top, "fc_" + bottom, "SparseInnerProduct");
+    caffe::InnerProductParameter *iparam
+        = lparam->mutable_inner_product_param();
     iparam->set_num_output(num_output);
-    iparam->mutable_weight_filler()->set_type("xavier"); //TODO: option
+    iparam->mutable_weight_filler()->set_type("xavier"); // TODO: option
     caffe::FillerParameter *fparam = iparam->mutable_bias_filler();
     fparam->set_type("constant");
-    fparam->set_value(0.0); //TODO: option
+    fparam->set_value(0.0); // TODO: option
   }
-  
+
   void NetLayersCaffe::add_conv(caffe::NetParameter *net_param,
-				const std::string &bottom,
-				const std::string &top,
-				const int &num_output,
-				const int &kernel_size,
-				const int &pad,
-				const int &stride,
-				const int &kernel_w,
-				const int &kernel_h,
-				const int &pad_w,
-				const int &pad_h,
-				const std::string &name,
-				const std::string &init)
+                                const std::string &bottom,
+                                const std::string &top, const int &num_output,
+                                const int &kernel_size, const int &pad,
+                                const int &stride, const int &kernel_w,
+                                const int &kernel_h, const int &pad_w,
+                                const int &pad_h, const std::string &name,
+                                const std::string &init)
   {
-    caffe::LayerParameter *lparam = CaffeCommon::add_layer(net_param,bottom,top,name.empty()?"conv_"+bottom:name,"Convolution");
+    caffe::LayerParameter *lparam = CaffeCommon::add_layer(
+        net_param, bottom, top, name.empty() ? "conv_" + bottom : name,
+        "Convolution");
     caffe::ConvolutionParameter *cparam = lparam->mutable_convolution_param();
     cparam->set_num_output(num_output);
     if (kernel_w == 0 && kernel_h == 0)
       cparam->add_kernel_size(kernel_size);
     else
       {
-	cparam->set_kernel_w(kernel_w);
-	cparam->set_kernel_h(kernel_h);
-      }	
+        cparam->set_kernel_w(kernel_w);
+        cparam->set_kernel_h(kernel_h);
+      }
     if (pad_w == 0 && pad_h == 0)
       cparam->add_pad(pad);
     else
       {
-	cparam->set_pad_w(pad_w);
-	cparam->set_pad_h(pad_h);
+        cparam->set_pad_w(pad_w);
+        cparam->set_pad_h(pad_h);
       }
     cparam->add_stride(stride);
     cparam->mutable_weight_filler()->set_type(init);
     caffe::FillerParameter *fparam = cparam->mutable_bias_filler();
     fparam->set_type("constant");
-    //fparam->set_value(0.2); //TODO: option
+    // fparam->set_value(0.2); //TODO: option
   }
-
-
 
   void NetLayersCaffe::add_lstm(caffe::NetParameter *net_param,
                                 const std::string &seq,
@@ -361,8 +379,7 @@ namespace dd
   }
 
   void NetLayersCaffe::add_rnn(caffe::NetParameter *net_param,
-                               const std::string &seq,
-                               const std::string &cont,
+                               const std::string &seq, const std::string &cont,
                                const std::string &name)
   {
     caffe::LayerParameter *lparam = net_param->add_layer();
@@ -373,94 +390,83 @@ namespace dd
     lparam->set_type("RNN");
   }
 
-
-
-  void NetLayersCaffe::add_deconv(caffe::NetParameter *net_param,
-				  const std::string &bottom,
-				  const std::string &top,
-				  const int &num_output,
-				  const int &kernel_size,
-				  const int &pad,
-				  const int &stride,
-				  const int &kernel_w,
-				  const int &kernel_h,
-				  const int &pad_w,
-				  const int &pad_h,
-				  const std::string &name,
-				  const std::string &init)
+  void NetLayersCaffe::add_deconv(
+      caffe::NetParameter *net_param, const std::string &bottom,
+      const std::string &top, const int &num_output, const int &kernel_size,
+      const int &pad, const int &stride, const int &kernel_w,
+      const int &kernel_h, const int &pad_w, const int &pad_h,
+      const std::string &name, const std::string &init)
   {
-    caffe::LayerParameter *lparam = CaffeCommon::add_layer(net_param,bottom,top,name.empty()?"deconv_"+bottom:name,"Deconvolution");
+    caffe::LayerParameter *lparam = CaffeCommon::add_layer(
+        net_param, bottom, top, name.empty() ? "deconv_" + bottom : name,
+        "Deconvolution");
     caffe::ConvolutionParameter *cparam = lparam->mutable_convolution_param();
     cparam->set_num_output(num_output);
     if (kernel_w == 0 && kernel_h == 0)
       cparam->add_kernel_size(kernel_size);
     else
       {
-	cparam->set_kernel_w(kernel_w);
-	cparam->set_kernel_h(kernel_h);
-      }	
+        cparam->set_kernel_w(kernel_w);
+        cparam->set_kernel_h(kernel_h);
+      }
     if (pad_w == 0 && pad_h == 0)
       cparam->add_pad(pad);
     else
       {
-	cparam->set_pad_w(pad_w);
-	cparam->set_pad_h(pad_h);
+        cparam->set_pad_w(pad_w);
+        cparam->set_pad_h(pad_h);
       }
     cparam->add_stride(stride);
     cparam->mutable_weight_filler()->set_type(init);
     caffe::FillerParameter *fparam = cparam->mutable_bias_filler();
     fparam->set_type("constant");
-    //fparam->set_value(0.2); //TODO: option
+    // fparam->set_value(0.2); //TODO: option
   }
 
-
   void NetLayersCaffe::add_act(caffe::NetParameter *net_param,
-			       const std::string &bottom,
-			       const std::string &activation,
-			       const double &elu_alpha,
-			       const double &negative_slope,
-			       const bool &test)
+                               const std::string &bottom,
+                               const std::string &activation,
+                               const double &elu_alpha,
+                               const double &negative_slope, const bool &test)
   {
-    caffe::LayerParameter *lparam = CaffeCommon::add_layer(net_param,bottom,bottom,
-							   "act_" + activation + "_" + bottom,activation);
+    caffe::LayerParameter *lparam = CaffeCommon::add_layer(
+        net_param, bottom, bottom, "act_" + activation + "_" + bottom,
+        activation);
     if (activation == "ELU" && elu_alpha != 1.0)
       lparam->mutable_elu_param()->set_alpha(elu_alpha);
     if (activation == "ReLU" && negative_slope != 0.0)
       lparam->mutable_relu_param()->set_negative_slope(negative_slope);
     if (test)
       {
-	caffe::NetStateRule *nsr = lparam->add_include();
-	nsr->set_phase(caffe::TEST);
+        caffe::NetStateRule *nsr = lparam->add_include();
+        nsr->set_phase(caffe::TEST);
       }
   }
 
-
   void NetLayersCaffe::add_pooling(caffe::NetParameter *net_param,
-				   const std::string &bottom,
-				   const std::string &top,
-				   const int &kernel_size,
-				   const int &stride,
-				   const std::string &type,
-				   const int &kernel_w,
-				   const int &kernel_h,
-				   const int &stride_w,
-				   const int &stride_h)
+                                   const std::string &bottom,
+                                   const std::string &top,
+                                   const int &kernel_size, const int &stride,
+                                   const std::string &type,
+                                   const int &kernel_w, const int &kernel_h,
+                                   const int &stride_w, const int &stride_h)
   {
-    caffe::LayerParameter *lparam = CaffeCommon::add_layer(net_param,bottom,top,"pool_"+bottom,"Pooling");
+    caffe::LayerParameter *lparam = CaffeCommon::add_layer(
+        net_param, bottom, top, "pool_" + bottom, "Pooling");
     caffe::PoolingParameter *pparam = lparam->mutable_pooling_param();
     if (kernel_w == 0 && kernel_h == 0)
       pparam->set_kernel_size(kernel_size);
     else
       {
-	pparam->set_kernel_w(kernel_w);
-	pparam->set_kernel_h(kernel_h);
+        pparam->set_kernel_w(kernel_w);
+        pparam->set_kernel_h(kernel_h);
       }
     if (stride_w == 0 && stride_h == 0)
       pparam->set_stride(stride);
     else
       {
-	pparam->set_stride_w(stride_w);
-	pparam->set_stride_h(stride_h);
+        pparam->set_stride_w(stride_w);
+        pparam->set_stride_h(stride_h);
       }
     if (type == "MAX")
       pparam->set_pool(caffe::PoolingParameter::MAX);
@@ -471,156 +477,159 @@ namespace dd
   }
 
   void NetLayersCaffe::add_dropout(caffe::NetParameter *net_param,
-				   const std::string &bottom,
-				   const double &ratio)
+                                   const std::string &bottom,
+                                   const double &ratio)
   {
-    caffe::LayerParameter *lparam = CaffeCommon::add_layer(net_param,bottom,bottom,
-							   "drop_"+bottom,"Dropout");
+    caffe::LayerParameter *lparam = CaffeCommon::add_layer(
+        net_param, bottom, bottom, "drop_" + bottom, "Dropout");
     lparam->mutable_dropout_param()->set_dropout_ratio(ratio);
   }
-  
+
   void NetLayersCaffe::add_bn(caffe::NetParameter *net_param,
-			      const std::string &bottom,
-			      const std::string &top)
+                              const std::string &bottom,
+                              const std::string &top)
   {
-    caffe::LayerParameter *lparam = CaffeCommon::add_layer(net_param,bottom,top.empty()?bottom:top,
-							   "bn_"+bottom,"BatchNorm");
-    lparam = CaffeCommon::add_layer(net_param,top.empty()?bottom:top,top.empty()?bottom:top,
-				    "scale_"+bottom,"Scale"); //TODO: add scale
+    caffe::LayerParameter *lparam
+        = CaffeCommon::add_layer(net_param, bottom, top.empty() ? bottom : top,
+                                 "bn_" + bottom, "BatchNorm");
+    lparam = CaffeCommon::add_layer(
+        net_param, top.empty() ? bottom : top, top.empty() ? bottom : top,
+        "scale_" + bottom, "Scale"); // TODO: add scale
     lparam->mutable_scale_param()->set_bias_term(true);
   }
 
   void NetLayersCaffe::add_eltwise(caffe::NetParameter *net_param,
-				   const std::string &bottom1,
-				   const std::string &bottom2,
-				   const std::string &top)
+                                   const std::string &bottom1,
+                                   const std::string &bottom2,
+                                   const std::string &top)
   {
-    caffe::LayerParameter *lparam = CaffeCommon::add_layer(net_param,bottom1,top,"elt_"+top,"Eltwise");
+    caffe::LayerParameter *lparam = CaffeCommon::add_layer(
+        net_param, bottom1, top, "elt_" + top, "Eltwise");
     lparam->add_bottom(bottom2);
   }
 
   void NetLayersCaffe::add_reshape(caffe::NetParameter *net_param,
-				   const std::string &bottom,
-				   const std::string &top,
-				   const caffe::ReshapeParameter &r_param)
+                                   const std::string &bottom,
+                                   const std::string &top,
+                                   const caffe::ReshapeParameter &r_param)
   {
-    //TODO
-    caffe::LayerParameter *lparam = CaffeCommon::add_layer(net_param,bottom,top,"reshape_"+top,"Reshape");
+    // TODO
+    caffe::LayerParameter *lparam = CaffeCommon::add_layer(
+        net_param, bottom, top, "reshape_" + top, "Reshape");
     lparam->mutable_reshape_param()->CopyFrom(r_param);
   }
 
   void NetLayersCaffe::add_softmax(caffe::NetParameter *net_param,
-				   const std::string &bottom,
-				   const std::string &label,
-				   const std::string &top,
-				   const int &num_output,
-				   const bool &deploy)
+                                   const std::string &bottom,
+                                   const std::string &label,
+                                   const std::string &top,
+                                   const int &num_output, const bool &deploy)
   {
     std::string ln_tmp = "ip_" + top;
-    add_fc(net_param,bottom,ln_tmp,num_output);
+    add_fc(net_param, bottom, ln_tmp, num_output);
 
     if (!deploy)
       {
-	caffe::LayerParameter *lparam = CaffeCommon::add_layer(net_param,ln_tmp,top,
-							       "prob","SoftmaxWithLoss"); // train
-	lparam->add_bottom(label);
-	caffe::NetStateRule *nsr = lparam->add_include();
-	nsr->set_phase(caffe::TRAIN);
-	
-	lparam = CaffeCommon::add_layer(net_param,ln_tmp,top,
-					"probt","Softmax"); // test
-	nsr = lparam->add_include();
-	nsr->set_phase(caffe::TEST);
+        caffe::LayerParameter *lparam = CaffeCommon::add_layer(
+            net_param, ln_tmp, top, "prob", "SoftmaxWithLoss"); // train
+        lparam->add_bottom(label);
+        caffe::NetStateRule *nsr = lparam->add_include();
+        nsr->set_phase(caffe::TRAIN);
+
+        lparam = CaffeCommon::add_layer(net_param, ln_tmp, top, "probt",
+                                        "Softmax"); // test
+        nsr = lparam->add_include();
+        nsr->set_phase(caffe::TEST);
       }
     else
       {
-	CaffeCommon::add_layer(net_param,ln_tmp,top,
-			       "prob","Softmax"); // deploy
+        CaffeCommon::add_layer(net_param, ln_tmp, top, "prob",
+                               "Softmax"); // deploy
       }
   }
 
   void NetLayersCaffe::add_euclidean_loss(caffe::NetParameter *net_param,
-					  const std::string &bottom,
-					  const std::string &label,
-					  const std::string &top,
-					  const int &num_output,
-					  const bool &deploy)
+                                          const std::string &bottom,
+                                          const std::string &label,
+                                          const std::string &top,
+                                          const int &num_output,
+                                          const bool &deploy)
   {
     std::string ln_tmp = "ip_" + top;
-    add_fc(net_param,bottom,ln_tmp,num_output);
-
+    add_fc(net_param, bottom, ln_tmp, num_output);
 
     if (!deploy)
       {
-	caffe::LayerParameter *lparam = CaffeCommon::add_layer(net_param,ln_tmp,top,
-							       "loss","EuclideanLoss"); // train
-	lparam->add_bottom(label);
-	caffe::NetStateRule *nsr = lparam->add_include();
-	nsr->set_phase(caffe::TRAIN);
+        caffe::LayerParameter *lparam = CaffeCommon::add_layer(
+            net_param, ln_tmp, top, "loss", "EuclideanLoss"); // train
+        lparam->add_bottom(label);
+        caffe::NetStateRule *nsr = lparam->add_include();
+        nsr->set_phase(caffe::TRAIN);
       }
   }
 
-  void NetLayersCaffe::add_sigmoid_crossentropy_loss(caffe::NetParameter *net_param,
-						     const std::string &bottom,
-						     const std::string &label,
-						     const std::string &top,
-						     const int &num_output,
-						     const bool &deploy,
-						     const bool &fc)
+  void NetLayersCaffe::add_sigmoid_crossentropy_loss(
+      caffe::NetParameter *net_param, const std::string &bottom,
+      const std::string &label, const std::string &top, const int &num_output,
+      const bool &deploy, const bool &fc)
   {
     std::string ln_tmp = "ip_" + top;
     if (fc)
-      add_fc(net_param,bottom,ln_tmp,num_output);
-    else add_conv(net_param,bottom,ln_tmp,num_output,1,0,1);
-    
+      add_fc(net_param, bottom, ln_tmp, num_output);
+    else
+      add_conv(net_param, bottom, ln_tmp, num_output, 1, 0, 1);
+
     if (!deploy)
       {
-	caffe::LayerParameter *lparam = CaffeCommon::add_layer(net_param,ln_tmp,top,
-							       "loss","SigmoidCrossEntropyLoss"); // train
-	lparam->add_bottom(label);
-	caffe::NetStateRule *nsr = lparam->add_include();
-	nsr->set_phase(caffe::TRAIN);
-	caffe::LossParameter *nlp = lparam->mutable_loss_param();
-	nlp->set_normalization((caffe::LossParameter_NormalizationMode)0); // FULL
-	add_flatten(net_param,ln_tmp,"conv_flatten",true);
-	add_act(net_param,"conv_flatten","Sigmoid",1.0,0.0,true); // test
+        caffe::LayerParameter *lparam
+            = CaffeCommon::add_layer(net_param, ln_tmp, top, "loss",
+                                     "SigmoidCrossEntropyLoss"); // train
+        lparam->add_bottom(label);
+        caffe::NetStateRule *nsr = lparam->add_include();
+        nsr->set_phase(caffe::TRAIN);
+        caffe::LossParameter *nlp = lparam->mutable_loss_param();
+        nlp->set_normalization(
+            (caffe::LossParameter_NormalizationMode)0); // FULL
+        add_flatten(net_param, ln_tmp, "conv_flatten", true);
+        add_act(net_param, "conv_flatten", "Sigmoid", 1.0, 0.0, true); // test
       }
   }
 
   void NetLayersCaffe::add_interp(caffe::NetParameter *net_param,
-				  const std::string &bottom,
-				  const std::string &top,
-				  const int &interp_width,
-				  const int &interp_height)
+                                  const std::string &bottom,
+                                  const std::string &top,
+                                  const int &interp_width,
+                                  const int &interp_height)
   {
-    caffe::LayerParameter *lparam = CaffeCommon::add_layer(net_param,bottom,top,"interp_"+bottom,"Interp");
+    caffe::LayerParameter *lparam = CaffeCommon::add_layer(
+        net_param, bottom, top, "interp_" + bottom, "Interp");
     lparam->mutable_interp_param()->set_width(interp_width);
     lparam->mutable_interp_param()->set_height(interp_height);
   }
 
   void NetLayersCaffe::add_flatten(caffe::NetParameter *net_param,
-				   const std::string &bottom,
-				   const std::string &top,
-				   const bool &test)
+                                   const std::string &bottom,
+                                   const std::string &top, const bool &test)
   {
-    caffe::LayerParameter *lparam = CaffeCommon::add_layer(net_param,bottom,top,"flatten_"+bottom,"Flatten");
+    caffe::LayerParameter *lparam = CaffeCommon::add_layer(
+        net_param, bottom, top, "flatten_" + bottom, "Flatten");
     if (test)
       {
-	caffe::NetStateRule *nsr = lparam->add_include();
-	nsr->set_phase(caffe::TEST);
+        caffe::NetStateRule *nsr = lparam->add_include();
+        nsr->set_phase(caffe::TEST);
       }
   }
-  
+
   /*- NetLossCaffe -*/
 
   /*- NetCaffe -*/
   /*template<class TNetInputCaffe, class TNetLayersCaffe, class TNetLossCaffe>
-  NetCaffe<TNetInputCaffe,TNetLayersCaffe,TNetLossCaffe>::NetCaffe(caffe::NetParameter *net_params,
-								   caffe::NetParameter *dnet_params)
+  NetCaffe<TNetInputCaffe,TNetLayersCaffe,TNetLossCaffe>::NetCaffe(caffe::NetParameter
+  *net_params, caffe::NetParameter *dnet_params)
     :_net_params(net_params),_dnet_params(dnet_params),
      _nic(net_params,dnet_params),_nlac(net_params,dnet_params)//,_nloc(net_params,dnet_params)
   {
-    
+
   }*/
 
 #ifdef USE_CAFFE
@@ -635,6 +644,5 @@ namespace dd
   template class NetInputCaffe<ImgTorchInputFileConn>;
   template class NetInputCaffe<TxtTorchInputFileConn>;
 #endif
-
 
 }

--- a/src/generators/net_caffe.h
+++ b/src/generators/net_caffe.h
@@ -32,174 +32,136 @@ namespace dd
   class CaffeCommon
   {
   public:
-    static caffe::LayerParameter* add_layer(caffe::NetParameter *net_param,
-					    const std::string &bottom,
-					    const std::string &top,
-					    const std::string &name="",
-					    const std::string &type="",
-					    const std::string &label="");
-    
+    static caffe::LayerParameter *
+    add_layer(caffe::NetParameter *net_param, const std::string &bottom,
+              const std::string &top, const std::string &name = "",
+              const std::string &type = "", const std::string &label = "");
+
     static std::string set_activation(const APIData &ad_mllib);
-    
   };
-  
+
   template <class TInputCaffe>
-  class NetInputCaffe: public NetInput<TInputCaffe>
+  class NetInputCaffe : public NetInput<TInputCaffe>
   {
   public:
-  NetInputCaffe(caffe::NetParameter *net_params,
-		caffe::NetParameter *dnet_params)
-    :NetInput<TInputCaffe>(),_net_params(net_params),_dnet_params(dnet_params)
+    NetInputCaffe(caffe::NetParameter *net_params,
+                  caffe::NetParameter *dnet_params)
+        : NetInput<TInputCaffe>(), _net_params(net_params),
+          _dnet_params(dnet_params)
     {
       _net_params->set_name("net");
       _dnet_params->set_name("dnet");
     }
-    ~NetInputCaffe() {}
-    
-    void configure_inputs(const APIData &ad_mllib,
-			  const TInputCaffe &inputc);
-    
-    void add_embed(caffe::NetParameter *net_param,
-		   const std::string &bottom,
-		   const std::string &top,
-		   const int &input_dim,
-		   const int &num_output);
+    ~NetInputCaffe()
+    {
+    }
+
+    void configure_inputs(const APIData &ad_mllib, const TInputCaffe &inputc);
+
+    void add_embed(caffe::NetParameter *net_param, const std::string &bottom,
+                   const std::string &top, const int &input_dim,
+                   const int &num_output);
 
     caffe::NetParameter *_net_params;
     caffe::NetParameter *_dnet_params;
   };
 
-  class NetLayersCaffe: public NetLayers
+  class NetLayersCaffe : public NetLayers
   {
   public:
     NetLayersCaffe(caffe::NetParameter *net_params,
-		   caffe::NetParameter *dnet_params,
-		   std::shared_ptr<spdlog::logger> &logger)
-      :NetLayers(),_net_params(net_params),_dnet_params(dnet_params),_logger(logger) {}
-    
-    //void add_basic_block() {}
-    void configure_net(const APIData &ad) { (void)ad; }
-    
+                   caffe::NetParameter *dnet_params,
+                   std::shared_ptr<spdlog::logger> &logger)
+        : NetLayers(), _net_params(net_params), _dnet_params(dnet_params),
+          _logger(logger)
+    {
+    }
+
+    // void add_basic_block() {}
+    void configure_net(const APIData &ad)
+    {
+      (void)ad;
+    }
+
     // common layers
-    void add_fc(caffe::NetParameter *net_param,
-		const std::string &bottom,
-		const std::string &top,
-		const int &num_output);
+    void add_fc(caffe::NetParameter *net_param, const std::string &bottom,
+                const std::string &top, const int &num_output);
 
     void add_sparse_fc(caffe::NetParameter *net_param,
-		       const std::string &bottom,
-		       const std::string &top,
-		       const int &num_output);
-    
-    void add_conv(caffe::NetParameter *net_param,
-		  const std::string &bottom,
-		  const std::string &top,
-		  const int &num_output,
-		  const int &kernel_size,
-		  const int &pad,
-		  const int &stride,
-		  const int &kernel_w=0,
-		  const int &kernel_h=0,
-		  const int &pad_w=0,
-		  const int &pad_h=0,
-		  const std::string &name="",
-		  const std::string &init="msra");
+                       const std::string &bottom, const std::string &top,
+                       const int &num_output);
 
-    void add_deconv(caffe::NetParameter *net_param,
-		    const std::string &bottom,
-		    const std::string &top,
-		    const int &num_output,
-		    const int &kernel_size,
-		    const int &pad,
-		    const int &stride,
-		    const int &kernel_w=0,
-		    const int &kernel_h=0,
-		    const int &pad_w=0,
-		    const int &pad_h=0,
-		    const std::string &name="",
-		    const std::string &init="msra");
+    void add_conv(caffe::NetParameter *net_param, const std::string &bottom,
+                  const std::string &top, const int &num_output,
+                  const int &kernel_size, const int &pad, const int &stride,
+                  const int &kernel_w = 0, const int &kernel_h = 0,
+                  const int &pad_w = 0, const int &pad_h = 0,
+                  const std::string &name = "",
+                  const std::string &init = "msra");
 
-    void add_act(caffe::NetParameter *net_param,
-		 const std::string &bottom,
-		 const std::string &activation,
-		 const double &elu_alpha=1.0,
-		 const double &negative_slope=0.0,
-		 const bool &test=false);
+    void add_deconv(caffe::NetParameter *net_param, const std::string &bottom,
+                    const std::string &top, const int &num_output,
+                    const int &kernel_size, const int &pad, const int &stride,
+                    const int &kernel_w = 0, const int &kernel_h = 0,
+                    const int &pad_w = 0, const int &pad_h = 0,
+                    const std::string &name = "",
+                    const std::string &init = "msra");
 
-    void add_pooling(caffe::NetParameter *net_param,
-		     const std::string &bottom,
-		     const std::string &top,
-		     const int &kernel_size,
-		     const int &stride,
-		     const std::string &type,
-		     const int &kernel_w=0,
-		     const int &kernel_h=0,
-		     const int &stride_w=0,
-		     const int &stride_h=0);
+    void add_act(caffe::NetParameter *net_param, const std::string &bottom,
+                 const std::string &activation, const double &elu_alpha = 1.0,
+                 const double &negative_slope = 0.0, const bool &test = false);
 
-    void add_dropout(caffe::NetParameter *net_param,
-		     const std::string &bottom,
-		     const double &ratio);
+    void add_pooling(caffe::NetParameter *net_param, const std::string &bottom,
+                     const std::string &top, const int &kernel_size,
+                     const int &stride, const std::string &type,
+                     const int &kernel_w = 0, const int &kernel_h = 0,
+                     const int &stride_w = 0, const int &stride_h = 0);
 
-    void add_lstm(caffe::NetParameter *net_param,
-                  const std::string &seq,
-                  const std::string &cont,
-                  const std::string &name);
+    void add_dropout(caffe::NetParameter *net_param, const std::string &bottom,
+                     const double &ratio);
 
-    void add_rnn(caffe::NetParameter *net_param,
-                 const std::string &seq,
-                 const std::string &cont,
-                 const std::string &name);
+    void add_lstm(caffe::NetParameter *net_param, const std::string &seq,
+                  const std::string &cont, const std::string &name);
 
+    void add_rnn(caffe::NetParameter *net_param, const std::string &seq,
+                 const std::string &cont, const std::string &name);
 
-    void add_bn(caffe::NetParameter *net_param,
-		const std::string &bottom,
-		const std::string &top="");
+    void add_bn(caffe::NetParameter *net_param, const std::string &bottom,
+                const std::string &top = "");
 
     void add_eltwise(caffe::NetParameter *net_param,
-		     const std::string &bottom1,
-		     const std::string &bottom2,
-		     const std::string &top);
+                     const std::string &bottom1, const std::string &bottom2,
+                     const std::string &top);
 
-    void add_reshape(caffe::NetParameter *net_param,
-		     const std::string &bottom,
-		     const std::string &top,
-		     const caffe::ReshapeParameter &r_param); //TODO
+    void add_reshape(caffe::NetParameter *net_param, const std::string &bottom,
+                     const std::string &top,
+                     const caffe::ReshapeParameter &r_param); // TODO
 
     // requires a fully connected layer (all losses ?)
-    void add_softmax(caffe::NetParameter *net_param,
-		     const std::string &bottom,
-		     const std::string &label,
-		     const std::string &top,
-		     const int &num_output,
-		     const bool &deploy=false);
+    void add_softmax(caffe::NetParameter *net_param, const std::string &bottom,
+                     const std::string &label, const std::string &top,
+                     const int &num_output, const bool &deploy = false);
 
     void add_euclidean_loss(caffe::NetParameter *net_param,
-			    const std::string &bottom,
-			    const std::string &label,
-			    const std::string &top,
-			    const int &num_output,
-			    const bool &deploy=false);
+                            const std::string &bottom,
+                            const std::string &label, const std::string &top,
+                            const int &num_output, const bool &deploy = false);
 
     void add_sigmoid_crossentropy_loss(caffe::NetParameter *net_param,
-				       const std::string &bottom,
-				       const std::string &label,
-				       const std::string &top,
-				       const int &num_output,
-				       const bool &deploy=false,
-				       const bool &fc=true);
+                                       const std::string &bottom,
+                                       const std::string &label,
+                                       const std::string &top,
+                                       const int &num_output,
+                                       const bool &deploy = false,
+                                       const bool &fc = true);
 
-    void add_interp(caffe::NetParameter *net_param,
-		    const std::string &bottom,
-		    const std::string &top,
-		    const int &interp_width,
-		    const int &interp_height);
+    void add_interp(caffe::NetParameter *net_param, const std::string &bottom,
+                    const std::string &top, const int &interp_width,
+                    const int &interp_height);
 
-    void add_flatten(caffe::NetParameter *net_param,
-		     const std::string &bottom,
-		     const std::string &top,
-		     const bool &test=false);
-    
+    void add_flatten(caffe::NetParameter *net_param, const std::string &bottom,
+                     const std::string &top, const bool &test = false);
+
     caffe::NetParameter *_net_params;
     caffe::NetParameter *_dnet_params;
     std::shared_ptr<spdlog::logger> _logger;
@@ -208,30 +170,34 @@ namespace dd
   class NetLossCaffe
   {
   public:
-    
   };
-  
+
   template <class TNetInputCaffe, class TNetLayersCaffe, class TNetLossCaffe>
-    class NetCaffe : public NetGenerator<TNetInputCaffe,TNetLayersCaffe,TNetLossCaffe>
+  class NetCaffe
+      : public NetGenerator<TNetInputCaffe, TNetLayersCaffe, TNetLossCaffe>
+  {
+  public:
+    NetCaffe(caffe::NetParameter *net_params, caffe::NetParameter *dnet_params,
+             std::shared_ptr<spdlog::logger> &logger)
+        : _net_params(net_params), _dnet_params(dnet_params),
+          _nic(net_params, dnet_params),
+          _nlac(net_params, dnet_params, logger), _logger(logger)
     {
-    public:
-      NetCaffe(caffe::NetParameter *net_params,
-	       caffe::NetParameter *dnet_params,
-	       std::shared_ptr<spdlog::logger> &logger)
-	:_net_params(net_params),_dnet_params(dnet_params),
-	_nic(net_params,dnet_params),_nlac(net_params,dnet_params,logger),_logger(logger) {}
-      ~NetCaffe() {}
+    }
+    ~NetCaffe()
+    {
+    }
 
-    public:
-      caffe::NetParameter* _net_params; /**< training net definition. */
-      caffe::NetParameter* _dnet_params; /**< deploy net definition. */
+  public:
+    caffe::NetParameter *_net_params;  /**< training net definition. */
+    caffe::NetParameter *_dnet_params; /**< deploy net definition. */
 
-      TNetInputCaffe _nic;
-      TNetLayersCaffe _nlac;
-      //TNetLossCaffe _nloc
-      std::shared_ptr<spdlog::logger> _logger;
-    };
-  
+    TNetInputCaffe _nic;
+    TNetLayersCaffe _nlac;
+    // TNetLossCaffe _nloc
+    std::shared_ptr<spdlog::logger> _logger;
+  };
+
 }
 
 #endif

--- a/src/generators/net_caffe_convnet.cc
+++ b/src/generators/net_caffe_convnet.cc
@@ -27,94 +27,89 @@ namespace dd
 {
 
   /*- NetLayersCaffeConvnet -*/
-  void NetLayersCaffeConvnet::parse_conv_layers(const std::vector<std::string> &layers,
-						std::vector<ConvBlock> &cr_layers,
-						std::vector<int> &fc_layers)
+  void NetLayersCaffeConvnet::parse_conv_layers(
+      const std::vector<std::string> &layers,
+      std::vector<ConvBlock> &cr_layers, std::vector<int> &fc_layers)
   {
     const std::string cr_str = "CR";
     const std::string d_str = "DR";
     const std::string u_str = "UR";
-    for (auto s: layers)
+    for (auto s : layers)
       {
-	size_t pos = 0;
-	if ((pos=s.find(cr_str))!=std::string::npos)
-	  {
-	    std::string ncr = s.substr(0,pos);
-	    std::string crs = s.substr(pos+cr_str.size());
-	    cr_layers.push_back(ConvBlock(cr_str,std::atoi(ncr.c_str()),std::atoi(crs.c_str())));
-	  }
-	else if ((pos=s.find(d_str))!=std::string::npos)
-	  {
-	    std::string crs = s.substr(pos+cr_str.size());
-	    cr_layers.push_back(ConvBlock(d_str,1,std::atoi(crs.c_str())));
-	  }
-	else if ((pos=s.find(u_str))!=std::string::npos)
-	  {
-	    std::string crs = s.substr(pos+cr_str.size());
-	    cr_layers.push_back(ConvBlock(u_str,1,std::atoi(crs.c_str())));
-	  }
-	else
-	  {
-	    try
-	      {
-		fc_layers.push_back(std::atoi(s.c_str()));
-	      }
-	    catch(std::exception &e)
-	      {
-		//TODO
-		throw MLLibBadParamException("convnet template requires fully connected layers size to be specified as a string");
-	      }
-	  }
+        size_t pos = 0;
+        if ((pos = s.find(cr_str)) != std::string::npos)
+          {
+            std::string ncr = s.substr(0, pos);
+            std::string crs = s.substr(pos + cr_str.size());
+            cr_layers.push_back(ConvBlock(cr_str, std::atoi(ncr.c_str()),
+                                          std::atoi(crs.c_str())));
+          }
+        else if ((pos = s.find(d_str)) != std::string::npos)
+          {
+            std::string crs = s.substr(pos + cr_str.size());
+            cr_layers.push_back(ConvBlock(d_str, 1, std::atoi(crs.c_str())));
+          }
+        else if ((pos = s.find(u_str)) != std::string::npos)
+          {
+            std::string crs = s.substr(pos + cr_str.size());
+            cr_layers.push_back(ConvBlock(u_str, 1, std::atoi(crs.c_str())));
+          }
+        else
+          {
+            try
+              {
+                fc_layers.push_back(std::atoi(s.c_str()));
+              }
+            catch (std::exception &e)
+              {
+                // TODO
+                throw MLLibBadParamException(
+                    "convnet template requires fully connected layers size to "
+                    "be specified as a string");
+              }
+          }
       }
   }
 
-  std::string NetLayersCaffeConvnet::add_basic_block(caffe::NetParameter *net_param,
-					      const std::string &bottom,
-					      const std::string &top,
-					      const int &nconv,
-					      const int &num_output,
-					      const int &kernel_size,
-					      const int &pad,
-					      const int &stride,
-					      const std::string &activation,
-					      const double &dropout_ratio,
-					      const bool &bn,
-					      const int &pl_kernel_size,
-					      const int &pl_stride,
-					      const std::string &pl_type,
-					      const int &kernel_w,
-					      const int &kernel_h,
-					      const int &pl_kernel_w,
-					      const int &pl_kernel_h,
-					      const int &pl_stride_w,
-					      const int &pl_stride_h)
+  std::string NetLayersCaffeConvnet::add_basic_block(
+      caffe::NetParameter *net_param, const std::string &bottom,
+      const std::string &top, const int &nconv, const int &num_output,
+      const int &kernel_size, const int &pad, const int &stride,
+      const std::string &activation, const double &dropout_ratio,
+      const bool &bn, const int &pl_kernel_size, const int &pl_stride,
+      const std::string &pl_type, const int &kernel_w, const int &kernel_h,
+      const int &pl_kernel_w, const int &pl_kernel_h, const int &pl_stride_w,
+      const int &pl_stride_h)
   {
     std::string top_conv;
     std::string bottom_conv = bottom;
-    for (int c=0;c<nconv;c++)
+    for (int c = 0; c < nconv; c++)
       {
-	top_conv = top + "_conv_" + std::to_string(c);
-	add_conv(net_param,bottom_conv,top_conv,num_output,kernel_size,pad,stride,kernel_w,kernel_h,0,0,top_conv);
-	if (bn)
-	  {
-	    add_bn(net_param,top_conv);
-	    if (activation != "none")
-	      add_act(net_param,top_conv,activation);
-	  }
-	else if (dropout_ratio > 0.0) // though in general, no dropout between convolutions
-	  {
-	    if (activation != "none")
-	      add_act(net_param,top_conv,activation);
-	    if (c != nconv-1)
-	      add_dropout(net_param,top_conv,dropout_ratio);
-	  }
-	else if (activation != "none")
-	  add_act(net_param,top_conv,activation);
-	bottom_conv = top_conv;
+        top_conv = top + "_conv_" + std::to_string(c);
+        add_conv(net_param, bottom_conv, top_conv, num_output, kernel_size,
+                 pad, stride, kernel_w, kernel_h, 0, 0, top_conv);
+        if (bn)
+          {
+            add_bn(net_param, top_conv);
+            if (activation != "none")
+              add_act(net_param, top_conv, activation);
+          }
+        else if (dropout_ratio
+                 > 0.0) // though in general, no dropout between convolutions
+          {
+            if (activation != "none")
+              add_act(net_param, top_conv, activation);
+            if (c != nconv - 1)
+              add_dropout(net_param, top_conv, dropout_ratio);
+          }
+        else if (activation != "none")
+          add_act(net_param, top_conv, activation);
+        bottom_conv = top_conv;
       }
     // pooling
     if (pl_type != "NONE")
-      add_pooling(net_param,top_conv,top,pl_kernel_size,pl_stride,pl_type,pl_kernel_w,pl_kernel_h,pl_stride_w,pl_stride_h);
+      add_pooling(net_param, top_conv, top, pl_kernel_size, pl_stride, pl_type,
+                  pl_kernel_w, pl_kernel_h, pl_stride_w, pl_stride_h);
     /*if (dropout_ratio > 0.0 && !bn)
       add_dropout(net_param,top,dropout_ratio);*/
     return top_conv;
@@ -137,17 +132,16 @@ namespace dd
     bool flat1dconv = false;
     if (ad_mllib.has("flat1dconv"))
       flat1dconv = ad_mllib.get("flat1dconv").get<bool>();
-    
-    
+
     std::vector<std::string> layers;
     std::string activation = CaffeCommon::set_activation(ad_mllib);
     double dropout = 0.5;
     if (ad_mllib.has("layers"))
       layers = ad_mllib.get("layers").get<std::vector<std::string>>();
-    //TODO: else raise exception
+    // TODO: else raise exception
     std::vector<ConvBlock> cr_layers;
     std::vector<int> fc_layers;
-    parse_conv_layers(layers,cr_layers,fc_layers);
+    parse_conv_layers(layers, cr_layers, fc_layers);
     if (ad_mllib.has("dropout"))
       dropout = ad_mllib.get("dropout").get<double>();
     bool bn = false;
@@ -160,104 +154,139 @@ namespace dd
     int width = -1;
     int height = -1;
     if (flat1dconv)
-      width = this->_net_params->mutable_layer(1)->mutable_memory_data_param()->width();
+      width = this->_net_params->mutable_layer(1)
+                  ->mutable_memory_data_param()
+                  ->width();
     if (autoencoder)
       {
-	width = ad_mllib.get("width").get<int>();
-	height = ad_mllib.get("height").get<int>();
+        width = ad_mllib.get("width").get<int>();
+        height = ad_mllib.get("height").get<int>();
       }
     std::string top_conv;
-    //TODO: support for embed layer in inputs
-    for (size_t l=0;l<cr_layers.size();l++)
+    // TODO: support for embed layer in inputs
+    for (size_t l = 0; l < cr_layers.size(); l++)
       {
-	std::string top = "ip" + std::to_string(l);
-	if (cr_layers.at(l)._layer == "CR")
-	  {
-	    if (!flat1dconv)
-	      {
-		int conv_pad = 0;
-		if (has_deconv)
-		  conv_pad = 1;
-		if (has_deconv && l == cr_layers.size()-1)
-		  {
-		    top_conv = add_basic_block(this->_net_params,bottom,top,cr_layers.at(l)._nconv,cr_layers.at(l)._num_output,
-					     conv_kernel_size,conv_pad,1,"none",0.0,bn,1,1,"NONE");
-		    top_conv = add_basic_block(this->_dnet_params,bottom,top,cr_layers.at(l)._nconv,cr_layers.at(l)._num_output,
-					     conv_kernel_size,conv_pad,1,"none",0.0,bn,1,1,"NONE");
-		  }
-		else
-		  {
-		    top_conv = add_basic_block(this->_net_params,bottom,top,cr_layers.at(l)._nconv,cr_layers.at(l)._num_output,
-					       conv_kernel_size,conv_pad,1,activation,0.0,bn,2,2,has_deconv?"NONE":"MAX");
-		    top_conv = add_basic_block(this->_dnet_params,bottom,top,cr_layers.at(l)._nconv,cr_layers.at(l)._num_output,
-					       conv_kernel_size,conv_pad,1,activation,0.0,bn,2,2,has_deconv?"NONE":"MAX");
-		  }
-	      }
-	    else
-	      {
-		top_conv = add_basic_block(this->_net_params,bottom,top,cr_layers.at(l)._nconv,cr_layers.at(l)._num_output,
-					   0,0,1,activation,0.0,bn,0,0,"MAX",bottom=="data"?width:1,l<2?conv1d_early_kernel_size:conv_kernel_size,1,3,1,3);
-		top_conv = add_basic_block(this->_dnet_params,bottom,top,cr_layers.at(l)._nconv,cr_layers.at(l)._num_output,
-					   0,0,1,activation,0.0,bn,0,0,"MAX",bottom=="data"?width:1,l<2?conv1d_early_kernel_size:conv_kernel_size,1,3,1,3);
-	      }
-	  }
-	else if (cr_layers.at(l)._layer == "DR")
-	  {
-	    add_deconv(this->_net_params,top_conv,top,cr_layers.at(l)._num_output,2,0,2);
-	    add_act(this->_net_params,top,activation);
-	    add_deconv(this->_dnet_params,top_conv,top,cr_layers.at(l)._num_output,2,0,2);
-	    add_act(this->_dnet_params,top,activation);
-	    has_deconv = true;
-	  }
-	//TODO: upsampling UR
-	bottom = top;
+        std::string top = "ip" + std::to_string(l);
+        if (cr_layers.at(l)._layer == "CR")
+          {
+            if (!flat1dconv)
+              {
+                int conv_pad = 0;
+                if (has_deconv)
+                  conv_pad = 1;
+                if (has_deconv && l == cr_layers.size() - 1)
+                  {
+                    top_conv = add_basic_block(
+                        this->_net_params, bottom, top, cr_layers.at(l)._nconv,
+                        cr_layers.at(l)._num_output, conv_kernel_size,
+                        conv_pad, 1, "none", 0.0, bn, 1, 1, "NONE");
+                    top_conv = add_basic_block(this->_dnet_params, bottom, top,
+                                               cr_layers.at(l)._nconv,
+                                               cr_layers.at(l)._num_output,
+                                               conv_kernel_size, conv_pad, 1,
+                                               "none", 0.0, bn, 1, 1, "NONE");
+                  }
+                else
+                  {
+                    top_conv = add_basic_block(
+                        this->_net_params, bottom, top, cr_layers.at(l)._nconv,
+                        cr_layers.at(l)._num_output, conv_kernel_size,
+                        conv_pad, 1, activation, 0.0, bn, 2, 2,
+                        has_deconv ? "NONE" : "MAX");
+                    top_conv = add_basic_block(
+                        this->_dnet_params, bottom, top,
+                        cr_layers.at(l)._nconv, cr_layers.at(l)._num_output,
+                        conv_kernel_size, conv_pad, 1, activation, 0.0, bn, 2,
+                        2, has_deconv ? "NONE" : "MAX");
+                  }
+              }
+            else
+              {
+                top_conv = add_basic_block(
+                    this->_net_params, bottom, top, cr_layers.at(l)._nconv,
+                    cr_layers.at(l)._num_output, 0, 0, 1, activation, 0.0, bn,
+                    0, 0, "MAX", bottom == "data" ? width : 1,
+                    l < 2 ? conv1d_early_kernel_size : conv_kernel_size, 1, 3,
+                    1, 3);
+                top_conv = add_basic_block(
+                    this->_dnet_params, bottom, top, cr_layers.at(l)._nconv,
+                    cr_layers.at(l)._num_output, 0, 0, 1, activation, 0.0, bn,
+                    0, 0, "MAX", bottom == "data" ? width : 1,
+                    l < 2 ? conv1d_early_kernel_size : conv_kernel_size, 1, 3,
+                    1, 3);
+              }
+          }
+        else if (cr_layers.at(l)._layer == "DR")
+          {
+            add_deconv(this->_net_params, top_conv, top,
+                       cr_layers.at(l)._num_output, 2, 0, 2);
+            add_act(this->_net_params, top, activation);
+            add_deconv(this->_dnet_params, top_conv, top,
+                       cr_layers.at(l)._num_output, 2, 0, 2);
+            add_act(this->_dnet_params, top, activation);
+            has_deconv = true;
+          }
+        // TODO: upsampling UR
+        bottom = top;
       }
     if (flat1dconv)
       {
-	std::string top = "reshape0";
-	caffe::ReshapeParameter r_param;
-	r_param.mutable_shape()->add_dim(0);
-	r_param.mutable_shape()->add_dim(-1);
-	add_reshape(this->_net_params,bottom,top,r_param);
-	add_reshape(this->_dnet_params,bottom,top,r_param);
-	bottom = top;
+        std::string top = "reshape0";
+        caffe::ReshapeParameter r_param;
+        r_param.mutable_shape()->add_dim(0);
+        r_param.mutable_shape()->add_dim(-1);
+        add_reshape(this->_net_params, bottom, top, r_param);
+        add_reshape(this->_dnet_params, bottom, top, r_param);
+        bottom = top;
       }
     bottom = top_conv;
     int l = 0;
-    for (auto fc: fc_layers)
+    for (auto fc : fc_layers)
       {
-	std::string top = "fc" + std::to_string(fc) + "_" + std::to_string(l);
-	NetLayersCaffeMLP::add_basic_block(this->_net_params,bottom,top,fc,activation,dropout,bn,false);
-	NetLayersCaffeMLP::add_basic_block(this->_dnet_params,bottom,top,fc,activation,0.0,bn,false);
-	bottom = top;
-	++l;
+        std::string top = "fc" + std::to_string(fc) + "_" + std::to_string(l);
+        NetLayersCaffeMLP::add_basic_block(this->_net_params, bottom, top, fc,
+                                           activation, dropout, bn, false);
+        NetLayersCaffeMLP::add_basic_block(this->_dnet_params, bottom, top, fc,
+                                           activation, 0.0, bn, false);
+        bottom = top;
+        ++l;
       }
     if (regression)
       {
-	add_euclidean_loss(this->_net_params,bottom,"label","losst",ntargets);
-	add_euclidean_loss(this->_net_params,bottom,"","loss",ntargets,true);
+        add_euclidean_loss(this->_net_params, bottom, "label", "losst",
+                           ntargets);
+        add_euclidean_loss(this->_net_params, bottom, "", "loss", ntargets,
+                           true);
       }
     else if (autoencoder)
       {
-	std::string data = "data";
-	if (this->_net_params->mutable_layer(0)->top_size() == 3)
-	  data = "orig_data";
-	add_interp(this->_net_params,bottom,"final_interp",width,height);
-	add_sigmoid_crossentropy_loss(this->_net_params,"final_interp",data,"losst",ntargets,false,false);
-	add_interp(this->_dnet_params,bottom,"final_interp",width,height);
-	add_conv(this->_dnet_params,"final_interp","conv_prob",ntargets,1,0,1);
-	add_flatten(this->_dnet_params,"conv_prob","conv_flatten");
-	add_act(this->_dnet_params,"conv_flatten","Sigmoid");
+        std::string data = "data";
+        if (this->_net_params->mutable_layer(0)->top_size() == 3)
+          data = "orig_data";
+        add_interp(this->_net_params, bottom, "final_interp", width, height);
+        add_sigmoid_crossentropy_loss(this->_net_params, "final_interp", data,
+                                      "losst", ntargets, false, false);
+        add_interp(this->_dnet_params, bottom, "final_interp", width, height);
+        add_conv(this->_dnet_params, "final_interp", "conv_prob", ntargets, 1,
+                 0, 1);
+        add_flatten(this->_dnet_params, "conv_prob", "conv_flatten");
+        add_act(this->_dnet_params, "conv_flatten", "Sigmoid");
       }
     else
       {
-	add_softmax(this->_net_params,bottom,"label","losst",nclasses > 0 ? nclasses : ntargets);
-	add_softmax(this->_dnet_params,bottom,"","loss",nclasses > 0 ? nclasses : ntargets,true);
+        add_softmax(this->_net_params, bottom, "label", "losst",
+                    nclasses > 0 ? nclasses : ntargets);
+        add_softmax(this->_dnet_params, bottom, "", "loss",
+                    nclasses > 0 ? nclasses : ntargets, true);
       }
   }
 
-  template class NetCaffe<NetInputCaffe<ImgCaffeInputFileConn>,NetLayersCaffeConvnet,NetLossCaffe>;
-  template class NetCaffe<NetInputCaffe<CSVCaffeInputFileConn>,NetLayersCaffeConvnet,NetLossCaffe>;
-  template class NetCaffe<NetInputCaffe<TxtCaffeInputFileConn>,NetLayersCaffeConvnet,NetLossCaffe>;
-  template class NetCaffe<NetInputCaffe<SVMCaffeInputFileConn>,NetLayersCaffeConvnet,NetLossCaffe>;
+  template class NetCaffe<NetInputCaffe<ImgCaffeInputFileConn>,
+                          NetLayersCaffeConvnet, NetLossCaffe>;
+  template class NetCaffe<NetInputCaffe<CSVCaffeInputFileConn>,
+                          NetLayersCaffeConvnet, NetLossCaffe>;
+  template class NetCaffe<NetInputCaffe<TxtCaffeInputFileConn>,
+                          NetLayersCaffeConvnet, NetLossCaffe>;
+  template class NetCaffe<NetInputCaffe<SVMCaffeInputFileConn>,
+                          NetLayersCaffeConvnet, NetLossCaffe>;
 }

--- a/src/generators/net_caffe_convnet.h
+++ b/src/generators/net_caffe_convnet.h
@@ -30,54 +30,51 @@ namespace dd
   class ConvBlock
   {
   public:
-    ConvBlock(const std::string &layer,
-	      const int &nconv,
-	      const int &num_output)
-      :_layer(layer),_nconv(nconv),_num_output(num_output) {}
-    ~ConvBlock() {}
+    ConvBlock(const std::string &layer, const int &nconv,
+              const int &num_output)
+        : _layer(layer), _nconv(nconv), _num_output(num_output)
+    {
+    }
+    ~ConvBlock()
+    {
+    }
     std::string _layer; // from C: conv, D: deconv, U: upsample
     int _nconv;
     int _num_output;
   };
-  
-  class NetLayersCaffeConvnet: public NetLayersCaffeMLP
+
+  class NetLayersCaffeConvnet : public NetLayersCaffeMLP
   {
   public:
-  NetLayersCaffeConvnet(caffe::NetParameter *net_params,
-			caffe::NetParameter *dnet_params,
-			std::shared_ptr<spdlog::logger> &logger)
-    :NetLayersCaffeMLP(net_params,dnet_params,logger) 
-      {
-	net_params->set_name("convnet");
-	dnet_params->set_name("convnet");
-      }
-    ~NetLayersCaffeConvnet() {}
+    NetLayersCaffeConvnet(caffe::NetParameter *net_params,
+                          caffe::NetParameter *dnet_params,
+                          std::shared_ptr<spdlog::logger> &logger)
+        : NetLayersCaffeMLP(net_params, dnet_params, logger)
+    {
+      net_params->set_name("convnet");
+      dnet_params->set_name("convnet");
+    }
+    ~NetLayersCaffeConvnet()
+    {
+    }
 
   protected:
     void parse_conv_layers(const std::vector<std::string> &layers,
-			   std::vector<ConvBlock> &cr_layers,
-			   std::vector<int> &fc_layers);
+                           std::vector<ConvBlock> &cr_layers,
+                           std::vector<int> &fc_layers);
+
   private:
-    std::string add_basic_block(caffe::NetParameter *net_param,
-			 const std::string &bottom,
-			 const std::string &top,
-			 const int &nconv,
-			 const int &num_output,
-			 const int &kernel_size,
-			 const int &pad,
-			 const int &stride,
-			 const std::string &activation,
-			 const double &dropout_ratio,
-			 const bool &bn,
-			 const int &pl_kernel_size,
-			 const int &pl_stride,
-			 const std::string &pl_type,
-			 const int &kernel_w=0,
-			 const int &kernel_h=0,
-			 const int &pl_kernel_w=0,
-			 const int &pl_kernel_h=0,
-			 const int &pl_stride_w=0,
-			 const int &pl_stride_h=0); //TODO: class of convolution parameters ? use caffe proto ?
+    std::string add_basic_block(
+        caffe::NetParameter *net_param, const std::string &bottom,
+        const std::string &top, const int &nconv, const int &num_output,
+        const int &kernel_size, const int &pad, const int &stride,
+        const std::string &activation, const double &dropout_ratio,
+        const bool &bn, const int &pl_kernel_size, const int &pl_stride,
+        const std::string &pl_type, const int &kernel_w = 0,
+        const int &kernel_h = 0, const int &pl_kernel_w = 0,
+        const int &pl_kernel_h = 0, const int &pl_stride_w = 0,
+        const int &pl_stride_h
+        = 0); // TODO: class of convolution parameters ? use caffe proto ?
 
   public:
     void configure_net(const APIData &ad_mllib);

--- a/src/generators/net_caffe_mlp.cc
+++ b/src/generators/net_caffe_mlp.cc
@@ -27,33 +27,34 @@ namespace dd
 
   /*- NetLayersCaffeMLP -*/
   void NetLayersCaffeMLP::add_basic_block(caffe::NetParameter *net_param,
-					  const std::string &bottom,
-					  const std::string &top,
-					  const int &num_output,
-					  const std::string &activation,
-					  const double &dropout_ratio,
-					  const bool &bn,
-					  const bool &sparse)
+                                          const std::string &bottom,
+                                          const std::string &top,
+                                          const int &num_output,
+                                          const std::string &activation,
+                                          const double &dropout_ratio,
+                                          const bool &bn, const bool &sparse)
   {
     if (sparse)
-      add_sparse_fc(net_param,bottom,top,num_output);
-    else add_fc(net_param,bottom,top,num_output);
+      add_sparse_fc(net_param, bottom, top, num_output);
+    else
+      add_fc(net_param, bottom, top, num_output);
     if (bn)
       {
-	add_bn(net_param,top);
-	add_act(net_param,top,activation);
+        add_bn(net_param, top);
+        add_act(net_param, top, activation);
       }
     else if (dropout_ratio > 0.0)
       {
-	add_act(net_param,top,activation);
-	add_dropout(net_param,top,dropout_ratio);
+        add_act(net_param, top, activation);
+        add_dropout(net_param, top, dropout_ratio);
       }
-    else add_act(net_param,top,activation);
+    else
+      add_act(net_param, top, activation);
   }
 
   void NetLayersCaffeMLP::configure_net(const APIData &ad_mllib)
   {
-    std::vector<int> layers = {50}; // default
+    std::vector<int> layers = { 50 }; // default
     std::string activation = CaffeCommon::set_activation(ad_mllib);
     double dropout = 0.0; // default
     if (ad_mllib.has("layers"))
@@ -79,33 +80,47 @@ namespace dd
     if (ad_mllib.has("autoencoder"))
       autoencoder = ad_mllib.get("autoencoder").get<bool>();
     std::string bottom = "data";
-    for (size_t l=0;l<layers.size();l++)
+    for (size_t l = 0; l < layers.size(); l++)
       {
-	std::string top = "ip" + std::to_string(l);
-	add_basic_block(this->_net_params,bottom,top,layers.at(l),activation,dropout,bn,sparse&&l==0?sparse:false);
-	add_basic_block(this->_dnet_params,bottom,top,layers.at(l),activation,0.0,bn,sparse&&l==0?sparse:false);
-	bottom = top;
+        std::string top = "ip" + std::to_string(l);
+        add_basic_block(this->_net_params, bottom, top, layers.at(l),
+                        activation, dropout, bn,
+                        sparse && l == 0 ? sparse : false);
+        add_basic_block(this->_dnet_params, bottom, top, layers.at(l),
+                        activation, 0.0, bn,
+                        sparse && l == 0 ? sparse : false);
+        bottom = top;
       }
-    //TODO: to loss ?
+    // TODO: to loss ?
     if (regression)
       {
-	add_euclidean_loss(this->_net_params,bottom,"label","losst",ntargets);
-	add_euclidean_loss(this->_dnet_params,bottom,"","loss",ntargets,true);
+        add_euclidean_loss(this->_net_params, bottom, "label", "losst",
+                           ntargets);
+        add_euclidean_loss(this->_dnet_params, bottom, "", "loss", ntargets,
+                           true);
       }
-    else if (autoencoder) //TODO: sigmoid crossentropy would be only for integer-type targets...
+    else if (autoencoder) // TODO: sigmoid crossentropy would be only for
+                          // integer-type targets...
       {
-	add_sigmoid_crossentropy_loss(this->_net_params,bottom,"data","losst",ntargets);
-	add_act(this->_dnet_params,bottom,"sigmoid");
+        add_sigmoid_crossentropy_loss(this->_net_params, bottom, "data",
+                                      "losst", ntargets);
+        add_act(this->_dnet_params, bottom, "sigmoid");
       }
     else
       {
-	add_softmax(this->_net_params,bottom,"label","losst",nclasses > 0 ? nclasses : ntargets);
-	add_softmax(this->_dnet_params,bottom,"","loss",nclasses > 0 ? nclasses : ntargets,true);
+        add_softmax(this->_net_params, bottom, "label", "losst",
+                    nclasses > 0 ? nclasses : ntargets);
+        add_softmax(this->_dnet_params, bottom, "", "loss",
+                    nclasses > 0 ? nclasses : ntargets, true);
       }
   }
 
-  template class NetCaffe<NetInputCaffe<ImgCaffeInputFileConn>,NetLayersCaffeMLP,NetLossCaffe>;
-  template class NetCaffe<NetInputCaffe<CSVCaffeInputFileConn>,NetLayersCaffeMLP,NetLossCaffe>;
-  template class NetCaffe<NetInputCaffe<TxtCaffeInputFileConn>,NetLayersCaffeMLP,NetLossCaffe>;
-  template class NetCaffe<NetInputCaffe<SVMCaffeInputFileConn>,NetLayersCaffeMLP,NetLossCaffe>;
+  template class NetCaffe<NetInputCaffe<ImgCaffeInputFileConn>,
+                          NetLayersCaffeMLP, NetLossCaffe>;
+  template class NetCaffe<NetInputCaffe<CSVCaffeInputFileConn>,
+                          NetLayersCaffeMLP, NetLossCaffe>;
+  template class NetCaffe<NetInputCaffe<TxtCaffeInputFileConn>,
+                          NetLayersCaffeMLP, NetLossCaffe>;
+  template class NetCaffe<NetInputCaffe<SVMCaffeInputFileConn>,
+                          NetLayersCaffeMLP, NetLossCaffe>;
 }

--- a/src/generators/net_caffe_mlp.h
+++ b/src/generators/net_caffe_mlp.h
@@ -27,31 +27,30 @@
 namespace dd
 {
 
-  class NetLayersCaffeMLP: public NetLayersCaffe
+  class NetLayersCaffeMLP : public NetLayersCaffe
   {
   public:
-  NetLayersCaffeMLP(caffe::NetParameter *net_params,
-		    caffe::NetParameter *dnet_params,
-		    std::shared_ptr<spdlog::logger> &logger)
-    :NetLayersCaffe(net_params,dnet_params,logger) 
-      {
-	net_params->set_name("mlp");
-	dnet_params->set_name("mlp");
-      }
-    ~NetLayersCaffeMLP() {}
+    NetLayersCaffeMLP(caffe::NetParameter *net_params,
+                      caffe::NetParameter *dnet_params,
+                      std::shared_ptr<spdlog::logger> &logger)
+        : NetLayersCaffe(net_params, dnet_params, logger)
+    {
+      net_params->set_name("mlp");
+      dnet_params->set_name("mlp");
+    }
+    ~NetLayersCaffeMLP()
+    {
+    }
 
     void add_basic_block(caffe::NetParameter *net_param,
-			 const std::string &bottom,
-			 const std::string &top,
-			 const int &num_output,
-			 const std::string &activation,
-			 const double &dropout_ratio,
-			 const bool &bn,
-			 const bool &sparse);
-    
+                         const std::string &bottom, const std::string &top,
+                         const int &num_output, const std::string &activation,
+                         const double &dropout_ratio, const bool &bn,
+                         const bool &sparse);
+
     void configure_net(const APIData &ad_mllib);
   };
-  
+
 }
 
 #endif

--- a/src/generators/net_caffe_recurrent.cc
+++ b/src/generators/net_caffe_recurrent.cc
@@ -26,32 +26,28 @@
 namespace dd
 {
 
-
-  void NetLayersCaffeRecurrent::add_basic_block(caffe::NetParameter *net_param,
-                                                const std::vector<std::string> &bottom_seqs,
-                                                const std::string &bottom_cont,
-                                                const std::string &top,
-                                                const int &num_output,
-                                                const double &dropout_ratio,
-                                                const std::string weight_filler,
-                                                const std::string bias_filler,
-                                                const std::string &type,
-                                                const int id)
+  void NetLayersCaffeRecurrent::add_basic_block(
+      caffe::NetParameter *net_param,
+      const std::vector<std::string> &bottom_seqs,
+      const std::string &bottom_cont, const std::string &top,
+      const int &num_output, const double &dropout_ratio,
+      const std::string weight_filler, const std::string bias_filler,
+      const std::string &type, const int id)
   {
 
     std::string bottom_seq;
-    std::string ctype = (type == _rnn_str ?  "RNN" : "LSTM");
-    std::string name =ctype+std::to_string(id);
+    std::string ctype = (type == _rnn_str ? "RNN" : "LSTM");
+    std::string name = ctype + std::to_string(id);
 
     if (bottom_seqs.size() > 1)
       {
         // add concat
         caffe::LayerParameter *lparam = net_param->add_layer();
         lparam->set_type("Concat");
-        lparam->set_name(name+"_concat");
-        lparam->add_top(name+"_concat");
-        bottom_seq = name+"_concat";
-        for (std::string s:bottom_seqs)
+        lparam->set_name(name + "_concat");
+        lparam->add_top(name + "_concat");
+        bottom_seq = name + "_concat";
+        for (std::string s : bottom_seqs)
           lparam->add_bottom(s);
         caffe::ConcatParameter *cparam = lparam->mutable_concat_param();
         cparam->set_axis(2);
@@ -62,43 +58,45 @@ namespace dd
     caffe::LayerParameter *lparam = net_param->add_layer();
     lparam->set_type(ctype);
     lparam->set_name(name);
-    if (dropout_ratio ==0)
+    if (dropout_ratio == 0)
       lparam->add_top(top);
     else
-      lparam->add_top(ctype+std::to_string(id)+"_undropped");
+      lparam->add_top(ctype + std::to_string(id) + "_undropped");
     lparam->add_bottom(bottom_seq);
     lparam->add_bottom(bottom_cont);
     caffe::RecurrentParameter *rparam = lparam->mutable_recurrent_param();
     rparam->set_num_output(num_output);
-    caffe::FillerParameter *weight_filler_param = rparam->mutable_weight_filler();
+    caffe::FillerParameter *weight_filler_param
+        = rparam->mutable_weight_filler();
     weight_filler_param->set_type(weight_filler);
     if (weight_filler == "uniform")
       {
-        weight_filler_param->set_min(-1.0/sqrt(num_output));
-        weight_filler_param->set_max(1.0/sqrt(num_output));
+        weight_filler_param->set_min(-1.0 / sqrt(num_output));
+        weight_filler_param->set_max(1.0 / sqrt(num_output));
       }
     caffe::FillerParameter *bias_filler_param = rparam->mutable_bias_filler();
     bias_filler_param->set_type(bias_filler);
     if (bias_filler == "uniform")
       {
-        bias_filler_param->set_min(-1.0/sqrt(num_output));
-        bias_filler_param->set_max(1.0/sqrt(num_output));
+        bias_filler_param->set_min(-1.0 / sqrt(num_output));
+        bias_filler_param->set_max(1.0 / sqrt(num_output));
       }
 
-    if (dropout_ratio !=0)
+    if (dropout_ratio != 0)
       {
         lparam = net_param->add_layer();
         lparam->set_type("Dropout");
-        lparam->set_name(ctype+std::to_string(id)+"_dropout");
+        lparam->set_name(ctype + std::to_string(id) + "_dropout");
         lparam->add_top(top);
-        lparam->add_bottom(ctype+std::to_string(id)+"_undropped");
+        lparam->add_bottom(ctype + std::to_string(id) + "_undropped");
         caffe::DropoutParameter *drop_param = lparam->mutable_dropout_param();
         drop_param->set_dropout_ratio(dropout_ratio);
       }
   }
 
   void NetLayersCaffeRecurrent::add_flatten(caffe::NetParameter *net_params,
-                                            std::string name, std::string bottom,
+                                            std::string name,
+                                            std::string bottom,
                                             std::string top, int axis)
   {
     caffe::LayerParameter *lparam = net_params->add_layer();
@@ -106,13 +104,12 @@ namespace dd
     lparam->set_name(name);
     lparam->add_top(top);
     lparam->add_bottom(bottom);
-    caffe::FlattenParameter * fparam = lparam->mutable_flatten_param();
+    caffe::FlattenParameter *fparam = lparam->mutable_flatten_param();
     fparam->set_axis(axis);
   }
 
   void NetLayersCaffeRecurrent::add_slicer(caffe::NetParameter *net_params,
-                                           int slice_point,
-                                           std::string bottom,
+                                           int slice_point, std::string bottom,
                                            std::string targets_name,
                                            std::string inputs_name,
                                            std::string cont_seq)
@@ -131,11 +128,14 @@ namespace dd
     lparam->add_bottom(bottom);
   }
 
-  void NetLayersCaffeRecurrent::add_permute(caffe::NetParameter *net_params, std::string top, std::string bottom, int naxis, bool train, bool test)
+  void NetLayersCaffeRecurrent::add_permute(caffe::NetParameter *net_params,
+                                            std::string top,
+                                            std::string bottom, int naxis,
+                                            bool train, bool test)
   {
     caffe::LayerParameter *lparam = net_params->add_layer();
     lparam->set_type("Permute");
-    lparam->set_name("permute_T_N_"+bottom);
+    lparam->set_name("permute_T_N_" + bottom);
     lparam->add_top(top);
     lparam->add_bottom(bottom);
     caffe::PermuteParameter *pparam = lparam->mutable_permute_param();
@@ -156,12 +156,10 @@ namespace dd
         nsr = lparam->add_include();
         nsr->set_phase(caffe::TEST);
       }
-
   }
 
   void NetLayersCaffeRecurrent::add_concat(caffe::NetParameter *net_params,
-                                           std::string name,
-                                           std::string top,
+                                           std::string name, std::string top,
                                            std::vector<std::string> bottoms,
                                            int axis)
   {
@@ -177,14 +175,11 @@ namespace dd
     cparam->set_axis(axis);
   }
 
-  void NetLayersCaffeRecurrent::add_affine(caffe::NetParameter *net_params,
-                                           std::string name,
-                                           const std::vector<std::string> &bottoms,
-                                           std::string top,
-                                           const std::string weight_filler,
-                                           const std::string bias_filler,
-                                           int nout,
-                                           int nin)
+  void NetLayersCaffeRecurrent::add_affine(
+      caffe::NetParameter *net_params, std::string name,
+      const std::vector<std::string> &bottoms, std::string top,
+      const std::string weight_filler, const std::string bias_filler, int nout,
+      int nin)
   {
     std::string bottom;
 
@@ -193,10 +188,10 @@ namespace dd
         // add concat
         caffe::LayerParameter *lparam = net_params->add_layer();
         lparam->set_type("Concat");
-        lparam->set_name(name+"_concat");
-        lparam->add_top(name+"_concat");
-        bottom = name+"_concat";
-        for (std::string s:bottoms)
+        lparam->set_name(name + "_concat");
+        lparam->add_top(name + "_concat");
+        bottom = name + "_concat";
+        for (std::string s : bottoms)
           lparam->add_bottom(s);
         caffe::ConcatParameter *cparam = lparam->mutable_concat_param();
         cparam->set_axis(2);
@@ -209,47 +204,47 @@ namespace dd
     lparam->set_name(name);
     lparam->add_top(top);
     lparam->add_bottom(bottom);
-    caffe::InnerProductParameter *cparam = lparam->mutable_inner_product_param();
+    caffe::InnerProductParameter *cparam
+        = lparam->mutable_inner_product_param();
     cparam->set_num_output(nout);
     cparam->set_axis(2);
     caffe::FillerParameter *wfparam = cparam->mutable_weight_filler();
     wfparam->set_type(weight_filler);
     if (weight_filler == "uniform")
       {
-        wfparam->set_min(-1.0/sqrt(nin));
-        wfparam->set_max(1.0/sqrt(nin));
+        wfparam->set_min(-1.0 / sqrt(nin));
+        wfparam->set_max(1.0 / sqrt(nin));
       }
     caffe::FillerParameter *bfparam = cparam->mutable_bias_filler();
     bfparam->set_type(bias_filler);
     if (bias_filler == "uniform")
       {
-        bfparam->set_min(-1.0/sqrt(nin));
-        bfparam->set_max(1.0/sqrt(nin));
+        bfparam->set_min(-1.0 / sqrt(nin));
+        bfparam->set_max(1.0 / sqrt(nin));
       }
   }
 
-
-  void NetLayersCaffeRecurrent::parse_recurrent_layers(const std::vector<std::string>&layers,
-                                                       std::vector<std::string> &r_layers,
-                                                       std::vector<int> &h_sizes)
+  void NetLayersCaffeRecurrent::parse_recurrent_layers(
+      const std::vector<std::string> &layers,
+      std::vector<std::string> &r_layers, std::vector<int> &h_sizes)
   {
     for (auto s : layers)
       {
         size_t pos = 0;
-        if ((pos=s.find(_lstm_str))!= std::string::npos)
+        if ((pos = s.find(_lstm_str)) != std::string::npos)
           {
             r_layers.push_back(_lstm_str);
-            h_sizes.push_back(std::stoi(s.substr(pos+_lstm_str.size())));
+            h_sizes.push_back(std::stoi(s.substr(pos + _lstm_str.size())));
           }
-        else if ((pos=s.find(_rnn_str))!= std::string::npos)
+        else if ((pos = s.find(_rnn_str)) != std::string::npos)
           {
             r_layers.push_back(_rnn_str);
-            h_sizes.push_back(std::stoi(s.substr(pos+_rnn_str.size())));
+            h_sizes.push_back(std::stoi(s.substr(pos + _rnn_str.size())));
           }
-        else if ((pos=s.find(_affine_str))!= std::string::npos)
+        else if ((pos = s.find(_affine_str)) != std::string::npos)
           {
             r_layers.push_back(_affine_str);
-            h_sizes.push_back(std::stoi(s.substr(pos+_affine_str.size())));
+            h_sizes.push_back(std::stoi(s.substr(pos + _affine_str.size())));
           }
         else
           {
@@ -258,9 +253,12 @@ namespace dd
                 h_sizes.push_back(std::stoi(s));
                 r_layers.push_back(_lstm_str);
               }
-            catch(std::exception &e)
+            catch (std::exception &e)
               {
-                throw MLLibBadParamException("timeseries template requires layers of the form \"L50\". L for LSTM, R for RNN, A for affine dimension reduction,  and 50 for a hidden cell size of 50");
+                throw MLLibBadParamException(
+                    "timeseries template requires layers of the form \"L50\". "
+                    "L for LSTM, R for RNN, A for affine dimension reduction, "
+                    " and 50 for a hidden cell size of 50");
               }
           }
       }
@@ -272,7 +270,7 @@ namespace dd
     std::vector<std::string> layers;
     std::vector<int> osize;
     std::vector<double> dropouts; // default
-    std::map<int,int> types;
+    std::map<int, int> types;
     std::string loss = "L1";
     std::string loss_temp;
     std::string init = "uniform";
@@ -281,7 +279,8 @@ namespace dd
 
     if (ad_mllib.has("layers"))
       {
-        std::vector<std::string> apilayers = ad_mllib.get("layers").get<std::vector<std::string>>();
+        std::vector<std::string> apilayers
+            = ad_mllib.get("layers").get<std::vector<std::string>>();
         parse_recurrent_layers(apilayers, layers, osize);
       }
     if (ad_mllib.has("dropout"))
@@ -289,7 +288,7 @@ namespace dd
         try
           {
             double dropout = ad_mllib.get("dropout").get<double>();
-            dropouts =std::vector<double>(layers.size(), dropout);
+            dropouts = std::vector<double>(layers.size(), dropout);
           }
         catch (std::exception &e)
           {
@@ -297,10 +296,11 @@ namespace dd
               {
                 dropouts = ad_mllib.get("dropout").get<std::vector<double>>();
               }
-            catch(std::exception &e)
-		{
-		  throw InputConnectorBadParamException("wrong type for dropout parameter");
-		}
+            catch (std::exception &e)
+              {
+                throw InputConnectorBadParamException(
+                    "wrong type for dropout parameter");
+              }
           }
       }
     if (ad_mllib.has("loss"))
@@ -322,30 +322,31 @@ namespace dd
     //     init = ad_mllib.get("init").get<std::string>();
     //   }
 
-
     // first permute
-    add_permute(this->_net_params, "permuted_data", "data", 4,false,false);
-    add_permute(this->_dnet_params, "permuted_data", "data", 4,false,false);
-
+    add_permute(this->_net_params, "permuted_data", "data", 4, false, false);
+    add_permute(this->_dnet_params, "permuted_data", "data", 4, false, false);
 
     int slice_point = 1 + ntargets;
 
-    add_slicer(this->_net_params, slice_point, "permuted_data",
-               "target_seq","input_seq","cont_seq_unshaped");
-    add_slicer(this->_dnet_params, slice_point, "permuted_data",
-               "target_seq","input_seq","cont_seq_unshaped");
+    add_slicer(this->_net_params, slice_point, "permuted_data", "target_seq",
+               "input_seq", "cont_seq_unshaped");
+    add_slicer(this->_dnet_params, slice_point, "permuted_data", "target_seq",
+               "input_seq", "cont_seq_unshaped");
 
-    add_flatten(this->_net_params, "shape_cont_seq", "cont_seq_unshaped","cont_seq", 1);
-    add_flatten(this->_dnet_params,"shape_cont_seq", "cont_seq_unshaped","cont_seq", 1);
+    add_flatten(this->_net_params, "shape_cont_seq", "cont_seq_unshaped",
+                "cont_seq", 1);
+    add_flatten(this->_dnet_params, "shape_cont_seq", "cont_seq_unshaped",
+                "cont_seq", 1);
 
-    add_flatten(this->_net_params, "flatten_input", "input_seq","input_seq_flattened", 2);
-    add_flatten(this->_dnet_params,"flatten_input", "input_seq","input_seq_flattened", 2);
-
+    add_flatten(this->_net_params, "flatten_input", "input_seq",
+                "input_seq_flattened", 2);
+    add_flatten(this->_dnet_params, "flatten_input", "input_seq",
+                "input_seq_flattened", 2);
 
     std::string type;
-    std::vector<std::string> bottoms = {"input_seq_flattened"};
+    std::vector<std::string> bottoms = { "input_seq_flattened" };
     std::string top;
-    for (unsigned int i=0; i<layers.size(); ++i)
+    for (unsigned int i = 0; i < layers.size(); ++i)
       {
         if (layers[i] == _rnn_str)
           type = "RNN";
@@ -354,48 +355,52 @@ namespace dd
         else if (layers[i] == _affine_str)
           type = "AFFINE";
 
-        top = type+"_"+std::to_string(i);
-        if ((i == layers.size() -1) && osize[osize.size()-1] == ntargets)
+        top = type + "_" + std::to_string(i);
+        if ((i == layers.size() - 1) && osize[osize.size() - 1] == ntargets)
           top = "rnn_pred";
         else
-          top = type+"_"+std::to_string(i);
+          top = type + "_" + std::to_string(i);
         if (type == "AFFINE")
           {
-            int isize = i==0? osize[i] : osize[i-1]; //used only for initing weights
-            add_affine(this->_net_params,"affine_"+std::to_string(i),bottoms,top, init, init,
-                       osize[i],isize);
-            add_affine(this->_dnet_params,"affine_"+std::to_string(i), bottoms,top,  init, init,
-                       osize[i],isize);
-
+            int isize = i == 0 ? osize[i]
+                               : osize[i - 1]; // used only for initing weights
+            add_affine(this->_net_params, "affine_" + std::to_string(i),
+                       bottoms, top, init, init, osize[i], isize);
+            add_affine(this->_dnet_params, "affine_" + std::to_string(i),
+                       bottoms, top, init, init, osize[i], isize);
           }
         else
           {
-            add_basic_block(this->_net_params,bottoms,
-                            "cont_seq",top,osize[i], dropouts[i],init,init,layers[i], i);
-            add_basic_block(this->_dnet_params,bottoms,
-                            "cont_seq",top,osize[i], dropouts[i],init,init,layers[i], i);
+            add_basic_block(this->_net_params, bottoms, "cont_seq", top,
+                            osize[i], dropouts[i], init, init, layers[i], i);
+            add_basic_block(this->_dnet_params, bottoms, "cont_seq", top,
+                            osize[i], dropouts[i], init, init, layers[i], i);
           }
         if (!residual)
           bottoms.clear();
         bottoms.push_back(top);
       }
 
-    // add affine dim reduction only if num of  outputs of last layer  do not match ntarget number
-    if (osize[osize.size()-1] != ntargets)
+    // add affine dim reduction only if num of  outputs of last layer  do not
+    // match ntarget number
+    if (osize[osize.size() - 1] != ntargets)
       {
-        add_affine(this->_net_params,"affine_final",bottoms,"rnn_pred", init, init, ntargets,osize[osize.size()-1]);
-        add_affine(this->_dnet_params,"affine_final", bottoms,"rnn_pred",  init, init, ntargets,osize[osize.size()-1]);
+        add_affine(this->_net_params, "affine_final", bottoms, "rnn_pred",
+                   init, init, ntargets, osize[osize.size() - 1]);
+        add_affine(this->_dnet_params, "affine_final", bottoms, "rnn_pred",
+                   init, init, ntargets, osize[osize.size() - 1]);
       }
 
-    add_permute(this->_net_params, "permuted_rnn_pred", "rnn_pred", 3,true,false);
-    add_permute(this->_net_params, "permuted_target_seq", "target_seq", 3,true,false);
-
-
+    add_permute(this->_net_params, "permuted_rnn_pred", "rnn_pred", 3, true,
+                false);
+    add_permute(this->_net_params, "permuted_target_seq", "target_seq", 3,
+                true, false);
 
     if (loss == "EuclideanLoss")
       {
         caffe::LayerParameter *lparam;
-        lparam = CaffeCommon::add_layer(this->_net_params,"permuted_rnn_pred","loss","loss",loss);
+        lparam = CaffeCommon::add_layer(this->_net_params, "permuted_rnn_pred",
+                                        "loss", "loss", loss);
         lparam->add_bottom("permuted_target_seq");
         caffe::NetStateRule *nsr;
         nsr = lparam->add_include();
@@ -405,16 +410,18 @@ namespace dd
       {
 
         caffe::LayerParameter *lparam;
-        lparam = CaffeCommon::add_layer(this->_net_params,"permuted_target_seq", "permuted_target_seq_flattened",
-                                        "Target_Seq_Dim","Flatten");
+        lparam = CaffeCommon::add_layer(
+            this->_net_params, "permuted_target_seq",
+            "permuted_target_seq_flattened", "Target_Seq_Dim", "Flatten");
         caffe::FlattenParameter *ffp = lparam->mutable_flatten_param();
         ffp->set_axis(2);
         caffe::NetStateRule *nsr;
         nsr = lparam->add_include();
         nsr->set_phase(caffe::TRAIN);
 
-        lparam = CaffeCommon::add_layer(this->_net_params,"permuted_rnn_pred", "difference",
-                                        "Loss_Sum_Layer","Eltwise");
+        lparam = CaffeCommon::add_layer(this->_net_params, "permuted_rnn_pred",
+                                        "difference", "Loss_Sum_Layer",
+                                        "Eltwise");
         lparam->add_bottom("permuted_target_seq_flattened");
         caffe::EltwiseParameter *ep = lparam->mutable_eltwise_param();
         ep->set_operation(caffe::EltwiseParameter::SUM);
@@ -423,16 +430,18 @@ namespace dd
         nsr = lparam->add_include();
         nsr->set_phase(caffe::TRAIN);
 
-        lparam = CaffeCommon::add_layer(this->_net_params,"difference","summed_difference",
-                                        "Loss_Reduction","Reduction");
+        lparam = CaffeCommon::add_layer(this->_net_params, "difference",
+                                        "summed_difference", "Loss_Reduction",
+                                        "Reduction");
         caffe::ReductionParameter *rp = lparam->mutable_reduction_param();
         rp->set_operation(caffe::ReductionParameter::ASUM);
         rp->set_axis(1);
         nsr = lparam->add_include();
         nsr->set_phase(caffe::TRAIN);
 
-        lparam = CaffeCommon::add_layer(this->_net_params,"summed_difference","scaled_difference",
-                                        "Loss_Scale","Scale");
+        lparam = CaffeCommon::add_layer(this->_net_params, "summed_difference",
+                                        "scaled_difference", "Loss_Scale",
+                                        "Scale");
         caffe::ScaleParameter *sp = lparam->mutable_scale_param();
         caffe::FillerParameter *fp = sp->mutable_filler();
         fp->set_type("constant");
@@ -445,15 +454,15 @@ namespace dd
         nsr = lparam->add_include();
         nsr->set_phase(caffe::TRAIN);
 
-        lparam = CaffeCommon::add_layer(this->_net_params,"scaled_difference","loss",
-                                        "Loss_Reduction_Batch","Reduction");
+        lparam = CaffeCommon::add_layer(this->_net_params, "scaled_difference",
+                                        "loss", "Loss_Reduction_Batch",
+                                        "Reduction");
         rp = lparam->mutable_reduction_param();
         rp->set_operation(caffe::ReductionParameter::SUM);
         lparam->add_loss_weight(1.0);
         nsr = lparam->add_include();
         nsr->set_phase(caffe::TRAIN);
       }
-
   }
 
   template <class TInputConnectorStrategy>
@@ -463,38 +472,40 @@ namespace dd
                                     std::shared_ptr<spdlog::logger> &logger)
   {
     caffe::NetParameter dnet_param;
-    NetCaffe<NetInputCaffe<TInputConnectorStrategy>,NetLayersCaffeRecurrent,NetLossCaffe> netcaffe(&net_param,&dnet_param,logger);
-    netcaffe._nic.configure_inputs(ad,inputc);
+    NetCaffe<NetInputCaffe<TInputConnectorStrategy>, NetLayersCaffeRecurrent,
+             NetLossCaffe>
+        netcaffe(&net_param, &dnet_param, logger);
+    netcaffe._nic.configure_inputs(ad, inputc);
     // add ntargets to ad
-    const_cast<APIData&>(ad).add("ntargets",(int)inputc._ntargets);
+    const_cast<APIData &>(ad).add("ntargets", (int)inputc._ntargets);
     netcaffe._nlac.configure_net(ad);
     // will be changed at predict time
     // small default for debug
     net_param.mutable_layer(0)->mutable_memory_data_param()->set_channels(10);
-
   }
 
-
 #ifdef USE_CAFFE
-  template class NetCaffe<NetInputCaffe<CSVTSCaffeInputFileConn>,NetLayersCaffeRecurrent,NetLossCaffe>;
+  template class NetCaffe<NetInputCaffe<CSVTSCaffeInputFileConn>,
+                          NetLayersCaffeRecurrent, NetLossCaffe>;
 #endif
 #ifdef USE_TORCH
-  template void configure_recurrent_template<CSVTSTorchInputFileConn>(const APIData &ad,
-                                                                      CSVTSTorchInputFileConn &inputc,
-                                                                      caffe::NetParameter &net_param,
-                                                                      std::shared_ptr<spdlog::logger> &logger);
-  template void configure_recurrent_template<ImgTorchInputFileConn>(const APIData &ad,
-                                                                      ImgTorchInputFileConn &inputc,
-                                                                      caffe::NetParameter &net_param,
-                                                                      std::shared_ptr<spdlog::logger> &logger);
-  template void configure_recurrent_template<TxtTorchInputFileConn>(const APIData &ad,
-                                                                      TxtTorchInputFileConn &inputc,
-                                                                      caffe::NetParameter &net_param,
-                                                                      std::shared_ptr<spdlog::logger> &logger);
+  template void configure_recurrent_template<CSVTSTorchInputFileConn>(
+      const APIData &ad, CSVTSTorchInputFileConn &inputc,
+      caffe::NetParameter &net_param, std::shared_ptr<spdlog::logger> &logger);
+  template void configure_recurrent_template<ImgTorchInputFileConn>(
+      const APIData &ad, ImgTorchInputFileConn &inputc,
+      caffe::NetParameter &net_param, std::shared_ptr<spdlog::logger> &logger);
+  template void configure_recurrent_template<TxtTorchInputFileConn>(
+      const APIData &ad, TxtTorchInputFileConn &inputc,
+      caffe::NetParameter &net_param, std::shared_ptr<spdlog::logger> &logger);
 #endif
-  // template class NetCaffe<NetInputCaffe<ImgCaffeInputFileConn>,NetLayersCaffeRecurrent,NetLossCaffe>;
-  // template class NetCaffe<NetInputCaffe<CSVCaffeInputFileConn>,NetLayersCaffeRecurrent,NetLossCaffe>;
-  // template class NetCaffe<NetInputCaffe<TxtCaffeInputFileConn>,NetLayersCaffeRecurrent,NetLossCaffe>;
-  // template class NetCaffe<NetInputCaffe<SVMCaffeInputFileConn>,NetLayersCaffeRecurrent,NetLossCaffe>;
+  // template class
+  // NetCaffe<NetInputCaffe<ImgCaffeInputFileConn>,NetLayersCaffeRecurrent,NetLossCaffe>;
+  // template class
+  // NetCaffe<NetInputCaffe<CSVCaffeInputFileConn>,NetLayersCaffeRecurrent,NetLossCaffe>;
+  // template class
+  // NetCaffe<NetInputCaffe<TxtCaffeInputFileConn>,NetLayersCaffeRecurrent,NetLossCaffe>;
+  // template class
+  // NetCaffe<NetInputCaffe<SVMCaffeInputFileConn>,NetLayersCaffeRecurrent,NetLossCaffe>;
 
 }

--- a/src/generators/net_caffe_recurrent.h
+++ b/src/generators/net_caffe_recurrent.h
@@ -27,60 +27,52 @@
 namespace dd
 {
 
-  class NetLayersCaffeRecurrent: public NetLayersCaffe
+  class NetLayersCaffeRecurrent : public NetLayersCaffe
   {
   public:
-  NetLayersCaffeRecurrent(caffe::NetParameter *net_params,
-                          caffe::NetParameter *dnet_params,
-                          std::shared_ptr<spdlog::logger> &logger)
-    :NetLayersCaffe(net_params,dnet_params,logger) 
-      {
-	net_params->set_name("recurrent");
-	dnet_params->set_name("recurrent");
-      }
-    ~NetLayersCaffeRecurrent() {}
+    NetLayersCaffeRecurrent(caffe::NetParameter *net_params,
+                            caffe::NetParameter *dnet_params,
+                            std::shared_ptr<spdlog::logger> &logger)
+        : NetLayersCaffe(net_params, dnet_params, logger)
+    {
+      net_params->set_name("recurrent");
+      dnet_params->set_name("recurrent");
+    }
+    ~NetLayersCaffeRecurrent()
+    {
+    }
 
     void add_basic_block(caffe::NetParameter *net_param,
                          const std::vector<std::string> &bottom_seq,
                          const std::string &bottom_cont,
-                         const std::string &top,
-                         const int &num_output,
+                         const std::string &top, const int &num_output,
                          const double &dropout_ratio,
                          const std::string weight_filler,
                          const std::string bias_filler,
-                         const std::string &type,
-                         const int id);
+                         const std::string &type, const int id);
 
     void configure_net(const APIData &ad_mllib);
 
-    void add_concat(caffe::NetParameter *net_params,
-                    std::string name,
-                    std::string top,
-                    std::vector<std::string> bottoms,
+    void add_concat(caffe::NetParameter *net_params, std::string name,
+                    std::string top, std::vector<std::string> bottoms,
                     int axis);
 
-    void add_slicer(caffe::NetParameter *net_params,
-                    int slice_points,
-                    std::string bottom,
-                    std::string targets_name,
-                    std::string inputs_name,
-                    std::string cont_seq);
+    void add_slicer(caffe::NetParameter *net_params, int slice_points,
+                    std::string bottom, std::string targets_name,
+                    std::string inputs_name, std::string cont_seq);
 
     void add_flatten(caffe::NetParameter *net_params, std::string name,
                      std::string bottom, std::string top, int axis);
 
+    void add_permute(caffe::NetParameter *net_params, std::string top,
+                     std::string bottom, int naxis, bool train, bool test);
 
-    void add_permute(caffe::NetParameter *net_params, std::string top, std::string bottom, int naxis,bool train, bool test);
-
-    void add_affine(caffe::NetParameter *net_params,
-                    std::string name,
-                    const std::vector<std::string> &bottom,
-                    std::string top,
+    void add_affine(caffe::NetParameter *net_params, std::string name,
+                    const std::vector<std::string> &bottom, std::string top,
                     const std::string weight_filler,
-                    const std::string bias_filler,
-                    int nout, int nin);
+                    const std::string bias_filler, int nout, int nin);
 
-    void parse_recurrent_layers(const std::vector<std::string>&layers,
+    void parse_recurrent_layers(const std::vector<std::string> &layers,
                                 std::vector<std::string> &r_layers,
                                 std::vector<int> &h_sizes);
 
@@ -88,9 +80,7 @@ namespace dd
     const std::string _lstm_str = "L";
     const std::string _rnn_str = "R";
     const std::string _affine_str = "A";
-
   };
-
 
   /**
    * \brief	create recurrent.prototxt using api data
@@ -98,12 +88,11 @@ namespace dd
    * @param inputc input connector
    * @param net_param prototxt infos
    */
-  template<class TInputConnectorStrategy>
+  template <class TInputConnectorStrategy>
   void configure_recurrent_template(const APIData &ad,
                                     TInputConnectorStrategy &inputc,
                                     caffe::NetParameter &net_param,
                                     std::shared_ptr<spdlog::logger> &logger);
-
 
 }
 

--- a/src/generators/net_caffe_resnet.cc
+++ b/src/generators/net_caffe_resnet.cc
@@ -23,9 +23,9 @@
   ResNet API layer specification
   ResY, where Y is the number of layers, such that 9*n+2 = Y, i.e. n = (Y-2)/9
         -> pre-fixed stages as {16, 64, 128, 256}
-	-> do n res blocks per stage 1,2,3 (stage 4 is final)
-	-> bn + relu + avg pooling
-	-> add softmax
+        -> do n res blocks per stage 1,2,3 (stage 4 is final)
+        -> bn + relu + avg pooling
+        -> add softmax
  */
 
 #include "net_caffe_resnet.h"
@@ -35,10 +35,10 @@ namespace dd
 {
 
   /*- NetLayersCaffeResnet -*/
-  void NetLayersCaffeResnet::parse_res_layers(const std::vector<std::string> &layers,
-					      std::vector<ConvBlock> &cr_layers,
-					      std::vector<int> &fc_layers,
-					      int &depth, int &n)
+  void NetLayersCaffeResnet::parse_res_layers(
+      const std::vector<std::string> &layers,
+      std::vector<ConvBlock> &cr_layers, std::vector<int> &fc_layers,
+      int &depth, int &n)
   {
     const std::string res_str = "Res";
     const std::string cr_str = "CR";
@@ -46,160 +46,155 @@ namespace dd
       throw MLLibBadParamException("no layers specified for resnet template");
     if (layers.size() == 1) // ResXX generator, for images
       {
-	std::string l = layers.at(0); //TODO: error checking
-	size_t pos = 0;
-	if ((pos=l.find(res_str))!=std::string::npos)
-	  {
-	    std::string sdepth = l.substr(pos+res_str.size());
-	    depth = std::atoi(sdepth.c_str());
-	  }
-	n = std::max(1,static_cast<int>(std::ceil((depth-2)/9)));
+        std::string l = layers.at(0); // TODO: error checking
+        size_t pos = 0;
+        if ((pos = l.find(res_str)) != std::string::npos)
+          {
+            std::string sdepth = l.substr(pos + res_str.size());
+            depth = std::atoi(sdepth.c_str());
+          }
+        n = std::max(1, static_cast<int>(std::ceil((depth - 2) / 9)));
       }
     else // custom convnet resnet
       {
-	parse_conv_layers(layers,cr_layers,fc_layers);
-	depth = cr_layers.size() / 2 - fc_layers.size();
-	n = 2;
+        parse_conv_layers(layers, cr_layers, fc_layers);
+        depth = cr_layers.size() / 2 - fc_layers.size();
+        n = 2;
       }
   }
-  
-  void NetLayersCaffeResnet::add_init_block(caffe::NetParameter *net_param,
-					    const std::string &bottom,
-					    const int &num_output,
-					    const int &kernel_size,
-					    const int &kernel_w,
-					    const int &kernel_h,
-					    std::string &top,
-					    const bool &act,
-					    const bool &pooling)
+
+  void NetLayersCaffeResnet::add_init_block(
+      caffe::NetParameter *net_param, const std::string &bottom,
+      const int &num_output, const int &kernel_size, const int &kernel_w,
+      const int &kernel_h, std::string &top, const bool &act,
+      const bool &pooling)
   {
-    add_conv(net_param,bottom,top,num_output,kernel_size,0,2,kernel_w,kernel_h);
+    add_conv(net_param, bottom, top, num_output, kernel_size, 0, 2, kernel_w,
+             kernel_h);
     if (act)
       {
-	add_bn(net_param,"conv1");
-	add_act(net_param,"conv1","ReLU");
+        add_bn(net_param, "conv1");
+        add_act(net_param, "conv1", "ReLU");
       }
     if (pooling)
       {
-	top = "pool1";
-	add_pooling(net_param,"conv1","pool1",3,2,"MAX"); // large images only, e.g. Imagenet
+        top = "pool1";
+        add_pooling(net_param, "conv1", "pool1", 3, 2,
+                    "MAX"); // large images only, e.g. Imagenet
       }
   }
-  
-  void NetLayersCaffeResnet::add_basic_block(caffe::NetParameter *net_param,
-					     const int &block_num,
-					     const std::string &bottom,
-					     const int &num_output,
-					     const std::string &activation,
-					     const int &stride,
-					     const bool &identity,
-					     std::string &top)
+
+  void NetLayersCaffeResnet::add_basic_block(
+      caffe::NetParameter *net_param, const int &block_num,
+      const std::string &bottom, const int &num_output,
+      const std::string &activation, const int &stride, const bool &identity,
+      std::string &top)
   {
     std::string tmp_top = bottom + "_tmp";
-    add_bn(net_param,bottom,tmp_top);
-    add_act(net_param,tmp_top,activation);
+    add_bn(net_param, bottom, tmp_top);
+    add_act(net_param, tmp_top, activation);
     int kernel_size = 1;
     int pad = 0;
     std::string block_num_str = std::to_string(block_num);
     std::string conv_name = "conv1_branch" + block_num_str;
-    add_conv(net_param,tmp_top,conv_name,num_output,kernel_size,pad,stride); //TODO: stride as parameter to function
+    add_conv(net_param, tmp_top, conv_name, num_output, kernel_size, pad,
+             stride); // TODO: stride as parameter to function
 
     pad = 1;
     kernel_size = 3;
-    add_bn(net_param,conv_name);
-    add_act(net_param,conv_name,activation);
+    add_bn(net_param, conv_name);
+    add_act(net_param, conv_name, activation);
     std::string conv2_name = "conv2_branch" + block_num_str;
-    add_conv(net_param,conv_name,conv2_name,num_output,kernel_size,pad,1);
+    add_conv(net_param, conv_name, conv2_name, num_output, kernel_size, pad,
+             1);
 
     pad = 0;
     kernel_size = 1;
-    add_bn(net_param,conv2_name);
-    add_act(net_param,conv2_name,activation);
+    add_bn(net_param, conv2_name);
+    add_act(net_param, conv2_name, activation);
     std::string conv3_name = "conv3_branch" + block_num_str;
-    add_conv(net_param,conv2_name,conv3_name,num_output,kernel_size,pad,1);
-    
+    add_conv(net_param, conv2_name, conv3_name, num_output, kernel_size, pad,
+             1);
+
     // resize shortcut if input size != output size
     std::string bottom_scale = bottom;
     if (!identity)
       {
-	bottom_scale = bottom + "_branch";
-	add_conv(net_param,bottom,bottom_scale,num_output,1,0,stride,0,0,0,0,"shortcut_"+bottom);
+        bottom_scale = bottom + "_branch";
+        add_conv(net_param, bottom, bottom_scale, num_output, 1, 0, stride, 0,
+                 0, 0, 0, "shortcut_" + bottom);
       }
-    
+
     // residual
     top = "res" + block_num_str;
-    add_eltwise(net_param,bottom_scale,conv3_name,top);
+    add_eltwise(net_param, bottom_scale, conv3_name, top);
   }
 
-  void NetLayersCaffeResnet::add_basic_block_flat(caffe::NetParameter *net_param,
-						  const int &block_num,
-						  const std::string &bottom,
-						  const int &num_output,
-						  const std::string &activation,
-						  const int &stride,
-						  const int &kernel_w,
-						  const int &kernel_h,
-						  const bool &identity,
-						  std::string &top)
+  void NetLayersCaffeResnet::add_basic_block_flat(
+      caffe::NetParameter *net_param, const int &block_num,
+      const std::string &bottom, const int &num_output,
+      const std::string &activation, const int &stride, const int &kernel_w,
+      const int &kernel_h, const bool &identity, std::string &top)
   {
     int kernel_size = 0; // unset
     int pad = 0;
     std::string block_num_str = std::to_string(block_num);
     std::string conv_name = "conv1_branch" + block_num_str;
-    add_conv(net_param,bottom,conv_name,num_output,kernel_size,pad,stride,kernel_w,kernel_h,0,2); //TODO: stride as parameter to function
-    add_bn(net_param,conv_name);
-    add_act(net_param,conv_name,activation);
+    add_conv(net_param, bottom, conv_name, num_output, kernel_size, pad,
+             stride, kernel_w, kernel_h, 0,
+             2); // TODO: stride as parameter to function
+    add_bn(net_param, conv_name);
+    add_act(net_param, conv_name, activation);
 
     std::string conv2_name = "conv2_branch" + block_num_str;
-    add_conv(net_param,conv_name,conv2_name,num_output,kernel_size,pad,stride,kernel_w,kernel_h);
-    add_bn(net_param,conv2_name);
-    add_act(net_param,conv2_name,activation);
+    add_conv(net_param, conv_name, conv2_name, num_output, kernel_size, pad,
+             stride, kernel_w, kernel_h);
+    add_bn(net_param, conv2_name);
+    add_act(net_param, conv2_name, activation);
 
-    
     // resize shortcut if input size != output size
     std::string bottom_scale = bottom;
     if (!identity)
       {
-	bottom_scale = bottom + "_branch";
-	add_conv(net_param,bottom,bottom_scale,num_output,0,0,1,1,1,0,0,"shortcut_"+bottom);
+        bottom_scale = bottom + "_branch";
+        add_conv(net_param, bottom, bottom_scale, num_output, 0, 0, 1, 1, 1, 0,
+                 0, "shortcut_" + bottom);
       }
-    
+
     // residual
     top = "res" + block_num_str;
-    add_eltwise(net_param,bottom_scale,conv2_name,top);
+    add_eltwise(net_param, bottom_scale, conv2_name, top);
   }
-  
-  void NetLayersCaffeResnet::add_basic_block_mlp(caffe::NetParameter *net_param,
-						 const int &block_num,
-						 const std::string &bottom,
-						 const int &num_output,
-						 const std::string &activation,
-						 const bool &identity,
-									 std::string &top)
+
+  void NetLayersCaffeResnet::add_basic_block_mlp(
+      caffe::NetParameter *net_param, const int &block_num,
+      const std::string &bottom, const int &num_output,
+      const std::string &activation, const bool &identity, std::string &top)
   {
     std::string tmp_top = bottom + "_tmp";
-    add_bn(net_param,bottom,tmp_top); //TODO: not in place as to change the layer top name ?
-    add_act(net_param,tmp_top,activation);
+    add_bn(net_param, bottom,
+           tmp_top); // TODO: not in place as to change the layer top name ?
+    add_act(net_param, tmp_top, activation);
     std::string block_num_str = std::to_string(block_num);
     std::string fc_name = "fc_branch" + block_num_str;
-    add_fc(net_param,tmp_top,fc_name,num_output);
-    
-    add_bn(net_param,fc_name);
-    add_act(net_param,fc_name,activation);
+    add_fc(net_param, tmp_top, fc_name, num_output);
+
+    add_bn(net_param, fc_name);
+    add_act(net_param, fc_name, activation);
     std::string fc2_name = "fc2_branch" + block_num_str;
-    add_fc(net_param,fc_name,fc2_name,num_output);
+    add_fc(net_param, fc_name, fc2_name, num_output);
 
     // resize shortcut if input size != output size
     std::string bottom_scale = bottom;
     if (!identity)
       {
-	bottom_scale = bottom + "_branch";
-	add_fc(net_param,bottom,bottom_scale,num_output);
+        bottom_scale = bottom + "_branch";
+        add_fc(net_param, bottom, bottom_scale, num_output);
       }
-    
+
     // residual
     top = "res" + block_num_str;
-    add_eltwise(net_param,bottom_scale,fc2_name,top);
+    add_eltwise(net_param, bottom_scale, fc2_name, top);
   }
 
   void NetLayersCaffeResnet::configure_net_resarch(const APIData &ad_mllib)
@@ -213,7 +208,7 @@ namespace dd
     bool regression = false;
     if (ad_mllib.has("regression"))
       regression = ad_mllib.get("regression").get<bool>();
-    
+
     std::vector<std::string> layers;
     std::string activation = CaffeCommon::set_activation(ad_mllib);
     if (ad_mllib.has("layers"))
@@ -222,47 +217,59 @@ namespace dd
     int n = -1;
     std::vector<ConvBlock> cr_layers;
     std::vector<int> fc_layers;
-    parse_res_layers(layers,cr_layers,fc_layers,depth,n);
-    _logger->info("generating ResNet with depth={} / n={}",depth,n);
+    parse_res_layers(layers, cr_layers, fc_layers, depth, n);
+    _logger->info("generating ResNet with depth={} / n={}", depth, n);
     std::string bottom = "data";
-    
-    //std::vector<int> stages = {16, 64, 128, 256};
-    std::vector<int> stages = {64, 128, 256, 512};
+
+    // std::vector<int> stages = {16, 64, 128, 256};
+    std::vector<int> stages = { 64, 128, 256, 512 };
     std::string top = "conv1";
-    add_init_block(this->_net_params,bottom,64,7,0,0,top);
+    add_init_block(this->_net_params, bottom, 64, 7, 0, 0, top);
     top = "conv1";
-    add_init_block(this->_dnet_params,bottom,64,7,0,0,top);
+    add_init_block(this->_dnet_params, bottom, 64, 7, 0, 0, top);
     bottom = top;
     int block_num = 1;
-    for (size_t s=0;s<stages.size();s++)
+    for (size_t s = 0; s < stages.size(); s++)
       {
-	for (int i=0;i<n;i++)
-	  {
-	    add_basic_block(this->_net_params,block_num,bottom,stages[s],activation,s==0?1:2,i==0?false:true,top);
-	    add_basic_block(this->_dnet_params,block_num,bottom,stages[s],activation,s==0?1:2,i==0?false:true,top);
-	    bottom = top;
-	    ++block_num;
-	  }
+        for (int i = 0; i < n; i++)
+          {
+            add_basic_block(this->_net_params, block_num, bottom, stages[s],
+                            activation, s == 0 ? 1 : 2, i == 0 ? false : true,
+                            top);
+            add_basic_block(this->_dnet_params, block_num, bottom, stages[s],
+                            activation, s == 0 ? 1 : 2, i == 0 ? false : true,
+                            top);
+            bottom = top;
+            ++block_num;
+          }
       }
 
-    add_bn(this->_net_params,bottom);
-    add_bn(this->_dnet_params,bottom);
-    add_act(this->_net_params,bottom,activation);
-    add_act(this->_dnet_params,bottom,activation);
-    int pool_size = std::ceil(std::max(1,static_cast<int>(this->_net_params->layer(1).memory_data_param().width()) / 37));
-    add_pooling(this->_net_params,bottom,"pool_final",pool_size,1,"AVE"); // could be 8 for 300x300 images
-    add_pooling(this->_dnet_params,bottom,"pool_final",pool_size,1,"AVE");
+    add_bn(this->_net_params, bottom);
+    add_bn(this->_dnet_params, bottom);
+    add_act(this->_net_params, bottom, activation);
+    add_act(this->_dnet_params, bottom, activation);
+    int pool_size = std::ceil(std::max(
+        1, static_cast<int>(
+               this->_net_params->layer(1).memory_data_param().width())
+               / 37));
+    add_pooling(this->_net_params, bottom, "pool_final", pool_size, 1,
+                "AVE"); // could be 8 for 300x300 images
+    add_pooling(this->_dnet_params, bottom, "pool_final", pool_size, 1, "AVE");
     bottom = "pool_final";
-    
+
     if (regression)
       {
-	add_euclidean_loss(this->_net_params,bottom,"label","losst",ntargets);
-	add_euclidean_loss(this->_net_params,bottom,"","loss",ntargets,true);
+        add_euclidean_loss(this->_net_params, bottom, "label", "losst",
+                           ntargets);
+        add_euclidean_loss(this->_net_params, bottom, "", "loss", ntargets,
+                           true);
       }
     else
       {
-	add_softmax(this->_net_params,bottom,"label","losst",nclasses > 0 ? nclasses : ntargets);
-	add_softmax(this->_dnet_params,bottom,"","loss",nclasses > 0 ? nclasses : ntargets,true);
+        add_softmax(this->_net_params, bottom, "label", "losst",
+                    nclasses > 0 ? nclasses : ntargets);
+        add_softmax(this->_dnet_params, bottom, "", "loss",
+                    nclasses > 0 ? nclasses : ntargets, true);
       }
   }
 
@@ -287,62 +294,74 @@ namespace dd
     int n = -1;
     std::vector<ConvBlock> cr_layers;
     std::vector<int> fc_layers;
-    parse_res_layers(layers,cr_layers,fc_layers,depth,n);
-    _logger->info("generating CharText ResNet with depth={} / n={}",depth,n);
+    parse_res_layers(layers, cr_layers, fc_layers, depth, n);
+    _logger->info("generating CharText ResNet with depth={} / n={}", depth, n);
     if (ad_mllib.has("dropout"))
       dropout = ad_mllib.get("dropout").get<double>();
     bool bn = false;
     if (ad_mllib.has("bn"))
       bn = ad_mllib.get("bn").get<bool>();
     std::string bottom = "data";
-    int width = this->_net_params->mutable_layer(1)->mutable_memory_data_param()->width();
+    int width = this->_net_params->mutable_layer(1)
+                    ->mutable_memory_data_param()
+                    ->width();
 
     std::string top = "conv1";
-    add_init_block(this->_net_params,bottom,cr_layers.at(0)._num_output,0,width,7,top,false,false);
+    add_init_block(this->_net_params, bottom, cr_layers.at(0)._num_output, 0,
+                   width, 7, top, false, false);
     top = "conv1";
-    add_init_block(this->_dnet_params,bottom,cr_layers.at(0)._num_output,0,width,7,top,false,false);
+    add_init_block(this->_dnet_params, bottom, cr_layers.at(0)._num_output, 0,
+                   width, 7, top, false, false);
     bottom = top;
     int block_num = 1;
-    for (size_t l=0;l<cr_layers.size();l++)
+    for (size_t l = 0; l < cr_layers.size(); l++)
       {
-	for (int i=0;i<cr_layers.at(l)._nconv;i++)
-	  {
-	    int stride = 1;
-	    int kernel_w = 1;
-	    int kernel_h = 3;
-	    bool identity = (i == 0 ? false : true);
-	    add_basic_block_flat(this->_net_params,block_num,bottom,cr_layers.at(l)._num_output,activation,
-				 stride,kernel_w,kernel_h,identity,top);
-	    add_basic_block_flat(this->_dnet_params,block_num,bottom,cr_layers.at(l)._num_output,activation,
-				 stride,kernel_w,kernel_h,identity,top);
-	    bottom = top;
-	    ++block_num;
-	  }
-	top = "pool" + std::to_string(block_num);
-	add_pooling(this->_net_params,bottom,top,0,0,"MAX",1,3,1,2);
-	add_pooling(this->_dnet_params,bottom,top,0,0,"MAX",1,3,1,2);
-	bottom = top;
+        for (int i = 0; i < cr_layers.at(l)._nconv; i++)
+          {
+            int stride = 1;
+            int kernel_w = 1;
+            int kernel_h = 3;
+            bool identity = (i == 0 ? false : true);
+            add_basic_block_flat(this->_net_params, block_num, bottom,
+                                 cr_layers.at(l)._num_output, activation,
+                                 stride, kernel_w, kernel_h, identity, top);
+            add_basic_block_flat(this->_dnet_params, block_num, bottom,
+                                 cr_layers.at(l)._num_output, activation,
+                                 stride, kernel_w, kernel_h, identity, top);
+            bottom = top;
+            ++block_num;
+          }
+        top = "pool" + std::to_string(block_num);
+        add_pooling(this->_net_params, bottom, top, 0, 0, "MAX", 1, 3, 1, 2);
+        add_pooling(this->_dnet_params, bottom, top, 0, 0, "MAX", 1, 3, 1, 2);
+        bottom = top;
       }
 
     int l = 0;
-    for (auto fc: fc_layers)
+    for (auto fc : fc_layers)
       {
-	std::string top = "fc" + std::to_string(fc) + "_" + std::to_string(l);
-	NetLayersCaffeMLP::add_basic_block(this->_net_params,bottom,top,fc,activation,dropout,bn,false);
-	NetLayersCaffeMLP::add_basic_block(this->_dnet_params,bottom,top,fc,activation,0.0,bn,false);
-	bottom = top;
-	++l;
+        std::string top = "fc" + std::to_string(fc) + "_" + std::to_string(l);
+        NetLayersCaffeMLP::add_basic_block(this->_net_params, bottom, top, fc,
+                                           activation, dropout, bn, false);
+        NetLayersCaffeMLP::add_basic_block(this->_dnet_params, bottom, top, fc,
+                                           activation, 0.0, bn, false);
+        bottom = top;
+        ++l;
       }
-    
+
     if (regression)
       {
-	add_euclidean_loss(this->_net_params,bottom,"label","losst",ntargets);
-	add_euclidean_loss(this->_net_params,bottom,"","loss",ntargets,true);
+        add_euclidean_loss(this->_net_params, bottom, "label", "losst",
+                           ntargets);
+        add_euclidean_loss(this->_net_params, bottom, "", "loss", ntargets,
+                           true);
       }
     else
       {
-	add_softmax(this->_net_params,bottom,"label","losst",nclasses > 0 ? nclasses : ntargets);
-	add_softmax(this->_dnet_params,bottom,"","loss",nclasses > 0 ? nclasses : ntargets,true);
+        add_softmax(this->_net_params, bottom, "label", "losst",
+                    nclasses > 0 ? nclasses : ntargets);
+        add_softmax(this->_dnet_params, bottom, "", "loss",
+                    nclasses > 0 ? nclasses : ntargets, true);
       }
   }
 
@@ -361,48 +380,54 @@ namespace dd
     if (ad_mllib.has("regression"))
       regression = ad_mllib.get("regression").get<bool>();
     std::string activation = CaffeCommon::set_activation(ad_mllib);
-     std::vector<int> layers;
+    std::vector<int> layers;
     if (ad_mllib.has("layers"))
       layers = ad_mllib.get("layers").get<std::vector<int>>();
     int depth = layers.size();
     int n = 2;
-        
-    _logger->info("generating MLP ResNet with depth={} / n={}",depth,n);
+
+    _logger->info("generating MLP ResNet with depth={} / n={}", depth, n);
     std::string bottom = "data";
-   
+
     std::string top = "fc1";
     if (sparse)
       {
-	add_sparse_fc(this->_net_params,bottom,top,layers.at(0));
-	add_sparse_fc(this->_dnet_params,bottom,top,layers.at(0));
+        add_sparse_fc(this->_net_params, bottom, top, layers.at(0));
+        add_sparse_fc(this->_dnet_params, bottom, top, layers.at(0));
       }
     else
       {
-	add_fc(this->_net_params,bottom,top,layers.at(0));
-	add_fc(this->_dnet_params,bottom,top,layers.at(0));
+        add_fc(this->_net_params, bottom, top, layers.at(0));
+        add_fc(this->_dnet_params, bottom, top, layers.at(0));
       }
     bottom = top;
     int block_num = 1;
-    for (size_t l=1;l<layers.size();l++)
+    for (size_t l = 1; l < layers.size(); l++)
       {
-	bool identity = (layers.at(l) == layers.at(l-1));
-	add_basic_block_mlp(this->_net_params,block_num,bottom,layers.at(l),activation,identity,top);
-	add_basic_block_mlp(this->_dnet_params,block_num,bottom,layers.at(l),activation,identity,top);
-	bottom = top;
-	++block_num;
-      }    
+        bool identity = (layers.at(l) == layers.at(l - 1));
+        add_basic_block_mlp(this->_net_params, block_num, bottom, layers.at(l),
+                            activation, identity, top);
+        add_basic_block_mlp(this->_dnet_params, block_num, bottom,
+                            layers.at(l), activation, identity, top);
+        bottom = top;
+        ++block_num;
+      }
     if (regression)
       {
-	add_euclidean_loss(this->_net_params,bottom,"label","losst",ntargets);
-	add_euclidean_loss(this->_net_params,bottom,"","loss",ntargets,true);
+        add_euclidean_loss(this->_net_params, bottom, "label", "losst",
+                           ntargets);
+        add_euclidean_loss(this->_net_params, bottom, "", "loss", ntargets,
+                           true);
       }
     else
       {
-	add_softmax(this->_net_params,bottom,"label","losst",nclasses > 0 ? nclasses : ntargets);
-	add_softmax(this->_dnet_params,bottom,"","loss",nclasses > 0 ? nclasses : ntargets,true);
+        add_softmax(this->_net_params, bottom, "label", "losst",
+                    nclasses > 0 ? nclasses : ntargets);
+        add_softmax(this->_dnet_params, bottom, "", "loss",
+                    nclasses > 0 ? nclasses : ntargets, true);
       }
   }
-  
+
   void NetLayersCaffeResnet::configure_net(const APIData &ad_mllib)
   {
     bool flat1dconv = false;
@@ -411,23 +436,26 @@ namespace dd
     bool is_mlp = true;
     try
       {
-	std::vector<std::string> layers = ad_mllib.get("layers").get<std::vector<std::string>>();
-	for (auto s: layers)
-	  if (s.find("CR")!=std::string::npos || s.find("Res")!=std::string::npos)
-	    {
-	      is_mlp = false;
-	      break;
-	    }
+        std::vector<std::string> layers
+            = ad_mllib.get("layers").get<std::vector<std::string>>();
+        for (auto s : layers)
+          if (s.find("CR") != std::string::npos
+              || s.find("Res") != std::string::npos)
+            {
+              is_mlp = false;
+              break;
+            }
       }
-    catch(std::exception &e)
+    catch (std::exception &e)
       {
-	/*std::vector<int> layers = ad_mllib.get("layers").get<std::vector<int>>();
-	  is_mlp = true;*/
+        /*std::vector<int> layers =
+          ad_mllib.get("layers").get<std::vector<int>>(); is_mlp = true;*/
       }
     if (!flat1dconv && !is_mlp)
       configure_net_resarch(ad_mllib);
     else if (!is_mlp)
       configure_net_flat(ad_mllib);
-    else configure_net_mlp(ad_mllib);
-  }  
+    else
+      configure_net_mlp(ad_mllib);
+  }
 }

--- a/src/generators/net_caffe_resnet.h
+++ b/src/generators/net_caffe_resnet.h
@@ -27,72 +27,58 @@
 namespace dd
 {
 
-  class NetLayersCaffeResnet: public NetLayersCaffeConvnet
+  class NetLayersCaffeResnet : public NetLayersCaffeConvnet
   {
   public:
     NetLayersCaffeResnet(caffe::NetParameter *net_params,
-			 caffe::NetParameter *dnet_params,
-			 std::shared_ptr<spdlog::logger> &logger)
-      :NetLayersCaffeConvnet(net_params,dnet_params,logger) 
-      {
-	net_params->set_name("resnet");
-	dnet_params->set_name("resnet");
-      }
-    ~NetLayersCaffeResnet() {}
+                         caffe::NetParameter *dnet_params,
+                         std::shared_ptr<spdlog::logger> &logger)
+        : NetLayersCaffeConvnet(net_params, dnet_params, logger)
+    {
+      net_params->set_name("resnet");
+      dnet_params->set_name("resnet");
+    }
+    ~NetLayersCaffeResnet()
+    {
+    }
 
   private:
     void parse_res_layers(const std::vector<std::string> &layers,
-			  std::vector<ConvBlock> &cr_layers,
-			  std::vector<int> &fc_layers,
-			  int &depth, int &n);
-    
+                          std::vector<ConvBlock> &cr_layers,
+                          std::vector<int> &fc_layers, int &depth, int &n);
+
     void add_init_block(caffe::NetParameter *net_param,
-			const std::string &bottom,
-			const int &num_output,
-			const int &kernel_size,
-			const int &kernel_w,
-			const int &kernel_h,
-			std::string &top,
-			const bool &bn=true,
-			const bool &pooling=true);
-    
-    void add_basic_block(caffe::NetParameter *net_param,
-			 const int &block_num,
-			 const std::string &bottom,
-			 const int &num_output,
-			 const std::string &activation,
-			 const int &stride,
-			 const bool &identity,
-			 std::string &top);
+                        const std::string &bottom, const int &num_output,
+                        const int &kernel_size, const int &kernel_w,
+                        const int &kernel_h, std::string &top,
+                        const bool &bn = true, const bool &pooling = true);
+
+    void add_basic_block(caffe::NetParameter *net_param, const int &block_num,
+                         const std::string &bottom, const int &num_output,
+                         const std::string &activation, const int &stride,
+                         const bool &identity, std::string &top);
 
     void add_basic_block_flat(caffe::NetParameter *net_param,
-			      const int &block_num,
-			      const std::string &bottom,
-			      const int &num_output,
-			      const std::string &activation,
-			      const int &stride,
-			      const int &kernel_w,
-			      const int &kernel_h,
-			      const bool &identity,
-			      std::string &top);
+                              const int &block_num, const std::string &bottom,
+                              const int &num_output,
+                              const std::string &activation, const int &stride,
+                              const int &kernel_w, const int &kernel_h,
+                              const bool &identity, std::string &top);
 
     void add_basic_block_mlp(caffe::NetParameter *net_param,
-			     const int &block_num,
-			     const std::string &bottom,
-			     const int &num_output,
-			     const std::string &activation,
-			     const bool &identity,
-			     std::string &top);
+                             const int &block_num, const std::string &bottom,
+                             const int &num_output,
+                             const std::string &activation,
+                             const bool &identity, std::string &top);
 
     void configure_net_resarch(const APIData &ad_mllib);
     void configure_net_flat(const APIData &ad_mllib);
     void configure_net_mlp(const APIData &ad_mllib);
 
-    
   public:
     void configure_net(const APIData &ad_mllib);
   };
-  
+
 }
 
 #endif

--- a/src/generators/net_generator.h
+++ b/src/generators/net_generator.h
@@ -28,45 +28,62 @@ namespace dd
 {
 
   template <class TNetInput, class TNetLayers, class TNetLoss>
-    class NetGenerator
+  class NetGenerator
   {
   public:
-    NetGenerator() {}
-    ~NetGenerator() {}
+    NetGenerator()
+    {
+    }
+    ~NetGenerator()
+    {
+    }
   };
 
-  template <class TInputConnectorStrategy>
-    class NetInput
+  template <class TInputConnectorStrategy> class NetInput
   {
   public:
-    NetInput() {}
-    ~NetInput() {}
-    
+    NetInput()
+    {
+    }
+    ~NetInput()
+    {
+    }
+
     void configure_inputs(const APIData &ad_input,
-			  const TInputConnectorStrategy &inputc) {}
+                          const TInputConnectorStrategy &inputc)
+    {
+    }
   };
 
   class NetLayers
   {
   public:
-    NetLayers() {}
-    ~NetLayers() {}
+    NetLayers()
+    {
+    }
+    ~NetLayers()
+    {
+    }
 
-    //void add_basic_block();
+    // void add_basic_block();
     void configure_net(const APIData &ad_mllib);
 
-    //TODO: basic layers, e.g. conv, etc ?
+    // TODO: basic layers, e.g. conv, etc ?
   };
 
   class NetLoss
   {
   public:
-    NetLoss() {}
-    ~NetLoss() {}
+    NetLoss()
+    {
+    }
+    ~NetLoss()
+    {
+    }
 
-    //TODO
+    // TODO
   };
-  
+
 }
 
 #endif

--- a/src/graph.cc
+++ b/src/graph.cc
@@ -19,14 +19,13 @@
  * along with deepdetect.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #include "graph.h"
 
 namespace dd
 {
-  template<class TBackend>
-  Graph<CaffeGraphInput,TBackend>::Graph(std::string protofilename)
+  template <class TBackend>
+  Graph<CaffeGraphInput, TBackend>::Graph(std::string protofilename)
   {
-	this->from_proto(protofilename);
+    this->from_proto(protofilename);
   }
 }

--- a/src/graph.h
+++ b/src/graph.h
@@ -43,30 +43,31 @@ namespace dd
   };
 
   template <class TBackend>
-  class Graph<CaffeGraphInput,TBackend>: public CaffeGraphInput, public TBackend
+  class Graph<CaffeGraphInput, TBackend> : public CaffeGraphInput,
+                                           public TBackend
   {
   public:
-	Graph(std::string protofilename);
+    Graph(std::string protofilename);
   };
 #ifdef USE_TORCH
   template <>
-  class Graph<CaffeGraphInput,dd::TorchGraphBackend>: public CaffeGraphInput, public TorchGraphBackend
+  class Graph<CaffeGraphInput, dd::TorchGraphBackend>
+      : public CaffeGraphInput, public TorchGraphBackend
   {
   public:
-	Graph(std::string protofilename, std::vector<int> inputdim) : CaffeGraphInput(protofilename)
-	{
-	  finalize(inputdim);
-	}
-	Graph(std::string protofilename) : CaffeGraphInput(protofilename)
-	{
-	  // we should no finalize in case input dims has not been specified
-	  //	  finalize();
-	}
+    Graph(std::string protofilename, std::vector<int> inputdim)
+        : CaffeGraphInput(protofilename)
+    {
+      finalize(inputdim);
+    }
+    Graph(std::string protofilename) : CaffeGraphInput(protofilename)
+    {
+      // we should no finalize in case input dims has not been specified
+      //	  finalize();
+    }
   };
-
-
 }
-template class dd::Graph<dd::CaffeGraphInput,dd::TorchGraphBackend>;
-typedef dd::Graph<dd::CaffeGraphInput,dd::TorchGraphBackend> CaffeToTorch;
+template class dd::Graph<dd::CaffeGraphInput, dd::TorchGraphBackend>;
+typedef dd::Graph<dd::CaffeGraphInput, dd::TorchGraphBackend> CaffeToTorch;
 #endif
 #endif

--- a/src/httpjsonapi.cc
+++ b/src/httpjsonapi.cc
@@ -38,19 +38,20 @@
 #include <chrono>
 #include <ctime>
 
-DEFINE_string(host,"localhost","host for running the server");
-DEFINE_string(port,"8080","server port");
-DEFINE_int32(nthreads,10,"number of HTTP server threads");
-DEFINE_string(allow_origin,"","Access-Control-Allow-Origin for the server");
+DEFINE_string(host, "localhost", "host for running the server");
+DEFINE_string(port, "8080", "server port");
+DEFINE_int32(nthreads, 10, "number of HTTP server threads");
+DEFINE_string(allow_origin, "", "Access-Control-Allow-Origin for the server");
 
 using namespace boost::iostreams;
 
 namespace dd
 {
 
-  void mergeJObj(JVal& to, JVal& from, JDoc& jd)
+  void mergeJObj(JVal &to, JVal &from, JDoc &jd)
   {
-    for (auto fromIt = from.MemberBegin(); fromIt != from.MemberEnd(); ++ fromIt)
+    for (auto fromIt = from.MemberBegin(); fromIt != from.MemberEnd();
+         ++fromIt)
       {
         auto toIt = to.FindMember(fromIt->name);
         if (toIt == to.MemberEnd())
@@ -58,12 +59,13 @@ namespace dd
         else
           {
             if (fromIt->value.IsArray())
-                for (auto arrayIt = fromIt->value.Begin(); arrayIt != fromIt->value.End(); ++arrayIt)
-                  toIt->value.PushBack(*arrayIt,jd.GetAllocator());
+              for (auto arrayIt = fromIt->value.Begin();
+                   arrayIt != fromIt->value.End(); ++arrayIt)
+                toIt->value.PushBack(*arrayIt, jd.GetAllocator());
             else if (fromIt->value.IsObject())
               mergeJObj(toIt->value, fromIt->value, jd);
             else
-                toIt->value = fromIt->value;
+              toIt->value = fromIt->value;
           }
       }
   }
@@ -72,88 +74,118 @@ namespace dd
   {
     if (!req_query.empty())
       {
-	JDoc jd;
-	JVal jsv(rapidjson::kObjectType);
-	jd.SetObject();
-	std::vector<std::string> voptions = dd::dd_utils::split(req_query,'&');
-	for (const std::string o: voptions)
-	  {
-	    std::vector<std::string> vopt = dd::dd_utils::split(o,'=');
-	    if (vopt.size() == 2)
-	      {
-		bool is_word = false;
-		for (size_t i=0;i<vopt.at(1).size();i++)
-		  {
-		    if (isalpha(vopt.at(1)[i]))
-		      {
-			is_word = true;
-			break;
-		      }
-		  }
-		// we break '.' into JSON sub-objects
-		std::vector<std::string> vpt = dd::dd_utils::split(vopt.at(0),'.');
-		JVal jobj(rapidjson::kObjectType);
-		if (vpt.size() > 1)
-		  {
-		    bool bt = dd::dd_utils::iequals(vopt.at(1),"true");
-		    bool bf = dd::dd_utils::iequals(vopt.at(1),"false");
-		    if (is_word && !bt && !bf)
-		      {
-			jobj.AddMember(JVal().SetString(vpt.back().c_str(),jd.GetAllocator()),JVal().SetString(vopt.at(1).c_str(),jd.GetAllocator()),jd.GetAllocator());
-		      }
-		    else if (bt || bf)
-		      {
-			jobj.AddMember(JVal().SetString(vpt.back().c_str(),jd.GetAllocator()),JVal(bt ? true : false),jd.GetAllocator());
-		      }
-		    else jobj.AddMember(JVal().SetString(vpt.back().c_str(),jd.GetAllocator()),JVal(atoi(vopt.at(1).c_str())),jd.GetAllocator());
-		    for (int b=vpt.size()-2;b>0;b--)
-		      {
-			JVal jnobj(rapidjson::kObjectType);
-			jobj = jnobj.AddMember(JVal().SetString(vpt.at(b).c_str(),jd.GetAllocator()),jobj,jd.GetAllocator());
-		      }
-                  JVal jsv2(rapidjson::kObjectType);
-		    jsv2.AddMember(JVal().SetString(vpt.at(0).c_str(),jd.GetAllocator()),jobj,jd.GetAllocator());
-                  mergeJObj(jsv, jsv2, jd);
-		  }
-		else
-		  {
-		    bool bt = dd::dd_utils::iequals(vopt.at(1),"true");
-		    bool bf = dd::dd_utils::iequals(vopt.at(1),"false");
-		    if (is_word && !bt && !bf)
-		      {
-			jsv.AddMember(JVal().SetString(vopt.at(0).c_str(),jd.GetAllocator()),JVal().SetString(vopt.at(1).c_str(),jd.GetAllocator()),jd.GetAllocator());
-		      }
-		    else if (bt || bf)
-		      {
-			jsv.AddMember(JVal().SetString(vopt.at(0).c_str(),jd.GetAllocator()),JVal(bt ? true : false),jd.GetAllocator());
-		      }
-		    else jsv.AddMember(JVal().SetString(vopt.at(0).c_str(),jd.GetAllocator()),JVal(atoi(vopt.at(1).c_str())),jd.GetAllocator());
-		  }
-	      }
-	  }
-	rapidjson::StringBuffer buffer;
-	rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
-	jsv.Accept(writer);
-	return buffer.GetString();
+        JDoc jd;
+        JVal jsv(rapidjson::kObjectType);
+        jd.SetObject();
+        std::vector<std::string> voptions
+            = dd::dd_utils::split(req_query, '&');
+        for (const std::string o : voptions)
+          {
+            std::vector<std::string> vopt = dd::dd_utils::split(o, '=');
+            if (vopt.size() == 2)
+              {
+                bool is_word = false;
+                for (size_t i = 0; i < vopt.at(1).size(); i++)
+                  {
+                    if (isalpha(vopt.at(1)[i]))
+                      {
+                        is_word = true;
+                        break;
+                      }
+                  }
+                // we break '.' into JSON sub-objects
+                std::vector<std::string> vpt
+                    = dd::dd_utils::split(vopt.at(0), '.');
+                JVal jobj(rapidjson::kObjectType);
+                if (vpt.size() > 1)
+                  {
+                    bool bt = dd::dd_utils::iequals(vopt.at(1), "true");
+                    bool bf = dd::dd_utils::iequals(vopt.at(1), "false");
+                    if (is_word && !bt && !bf)
+                      {
+                        jobj.AddMember(JVal().SetString(vpt.back().c_str(),
+                                                        jd.GetAllocator()),
+                                       JVal().SetString(vopt.at(1).c_str(),
+                                                        jd.GetAllocator()),
+                                       jd.GetAllocator());
+                      }
+                    else if (bt || bf)
+                      {
+                        jobj.AddMember(JVal().SetString(vpt.back().c_str(),
+                                                        jd.GetAllocator()),
+                                       JVal(bt ? true : false),
+                                       jd.GetAllocator());
+                      }
+                    else
+                      jobj.AddMember(JVal().SetString(vpt.back().c_str(),
+                                                      jd.GetAllocator()),
+                                     JVal(atoi(vopt.at(1).c_str())),
+                                     jd.GetAllocator());
+                    for (int b = vpt.size() - 2; b > 0; b--)
+                      {
+                        JVal jnobj(rapidjson::kObjectType);
+                        jobj = jnobj.AddMember(
+                            JVal().SetString(vpt.at(b).c_str(),
+                                             jd.GetAllocator()),
+                            jobj, jd.GetAllocator());
+                      }
+                    JVal jsv2(rapidjson::kObjectType);
+                    jsv2.AddMember(
+                        JVal().SetString(vpt.at(0).c_str(), jd.GetAllocator()),
+                        jobj, jd.GetAllocator());
+                    mergeJObj(jsv, jsv2, jd);
+                  }
+                else
+                  {
+                    bool bt = dd::dd_utils::iequals(vopt.at(1), "true");
+                    bool bf = dd::dd_utils::iequals(vopt.at(1), "false");
+                    if (is_word && !bt && !bf)
+                      {
+                        jsv.AddMember(JVal().SetString(vopt.at(0).c_str(),
+                                                       jd.GetAllocator()),
+                                      JVal().SetString(vopt.at(1).c_str(),
+                                                       jd.GetAllocator()),
+                                      jd.GetAllocator());
+                      }
+                    else if (bt || bf)
+                      {
+                        jsv.AddMember(JVal().SetString(vopt.at(0).c_str(),
+                                                       jd.GetAllocator()),
+                                      JVal(bt ? true : false),
+                                      jd.GetAllocator());
+                      }
+                    else
+                      jsv.AddMember(JVal().SetString(vopt.at(0).c_str(),
+                                                     jd.GetAllocator()),
+                                    JVal(atoi(vopt.at(1).c_str())),
+                                    jd.GetAllocator());
+                  }
+              }
+          }
+        rapidjson::StringBuffer buffer;
+        rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+        jsv.Accept(writer);
+        return buffer.GetString();
       }
-    else return "";
+    else
+      return "";
   }
 }
 
 class APIHandler
 {
 public:
-  APIHandler(dd::HttpJsonAPI *hja)
-    :_hja(hja)
+  APIHandler(dd::HttpJsonAPI *hja) : _hja(hja)
   {
     _logger = spdlog::get("api");
   }
-  
-  ~APIHandler() { }
 
-  /*static boost::network::http::basic_response<std::string> cstock_reply(int status,
-									std::string const& content) {
-    using boost::lexical_cast;
+  ~APIHandler()
+  {
+  }
+
+  /*static boost::network::http::basic_response<std::string> cstock_reply(int
+    status, std::string const& content) { using boost::lexical_cast;
     boost::network::http::basic_response<std::string> rep;
     rep.status = status;
     rep.content = content;
@@ -164,284 +196,318 @@ public:
     rep.headers[1].value = "text/html";
     return rep;
     }*/
-  
-  void fillup_response(http_server::response &response,
-		       const JDoc &janswer,
-		       std::string &access_log,
-		       int &code,
-		       std::chrono::time_point<std::chrono::system_clock> tstart,
-		       const std::string &encoding="")
+
+  void
+  fillup_response(http_server::response &response, const JDoc &janswer,
+                  std::string &access_log, int &code,
+                  std::chrono::time_point<std::chrono::system_clock> tstart,
+                  const std::string &encoding = "")
   {
-    std::chrono::time_point<std::chrono::system_clock> tstop = std::chrono::system_clock::now();
+    std::chrono::time_point<std::chrono::system_clock> tstop
+        = std::chrono::system_clock::now();
     std::string service;
     if (janswer.HasMember("head"))
       {
-	if (janswer["head"].HasMember("service"))
-	  service = janswer["head"]["service"].GetString();
+        if (janswer["head"].HasMember("service"))
+          service = janswer["head"]["service"].GetString();
       }
     if (!service.empty())
       access_log += " " + service;
     code = janswer["status"]["code"].GetInt();
     access_log += " " + std::to_string(code);
-    int proctime = std::chrono::duration_cast<std::chrono::milliseconds>(tstop-tstart).count();
+    int proctime
+        = std::chrono::duration_cast<std::chrono::milliseconds>(tstop - tstart)
+              .count();
     access_log += " " + std::to_string(proctime);
     int outcode = code;
     std::string stranswer;
-    if (janswer.HasMember("template")) // if output template, fillup with rendered template.
+    if (janswer.HasMember(
+            "template")) // if output template, fillup with rendered template.
       {
-	std::string tpl = janswer["template"].GetString();
-	std::stringstream sg;
-	mustache::RenderTemplate(tpl," ",janswer,&sg);
-	stranswer = sg.str();
+        std::string tpl = janswer["template"].GetString();
+        std::stringstream sg;
+        mustache::RenderTemplate(tpl, " ", janswer, &sg);
+        stranswer = sg.str();
       }
     else
       {
-	stranswer = _hja->jrender(janswer);
+        stranswer = _hja->jrender(janswer);
       }
     if (janswer.HasMember("network"))
       {
-	//- grab network call parameters
-	std::string url,http_method="POST",content_type="Content-Type: application/json";
-	if (janswer["network"].HasMember("url"))
-	  url = janswer["network"]["url"].GetString();
-	if (url.empty())
-	  {
-	    _logger->error("missing url in network output connector");
-	    stranswer = _hja->jrender(_hja->dd_bad_request_400());
-	    code = 400;
-	  }
-	else
-	  {
-	    if (janswer["network"].HasMember("http_method"))
-	      http_method = janswer["network"]["http_method"].GetString();
-	    if (janswer["network"].HasMember("content_type"))
-	      content_type = janswer["network"]["content_type"].GetString();
-	    
-	    //- make call
-	    std::string outstr;
-	    try
-	      {
-		dd::httpclient::post_call(url,stranswer,http_method,outcode,outstr,content_type);
-		stranswer = outstr;
-	      }
-	    catch (std::runtime_error &e)
-	      {
-		_logger->error(e.what());
-		_logger->info(stranswer);
-		stranswer = _hja->jrender(_hja->dd_output_connector_network_error_1009());
-	      }
-	  }
+        //- grab network call parameters
+        std::string url, http_method = "POST",
+                         content_type = "Content-Type: application/json";
+        if (janswer["network"].HasMember("url"))
+          url = janswer["network"]["url"].GetString();
+        if (url.empty())
+          {
+            _logger->error("missing url in network output connector");
+            stranswer = _hja->jrender(_hja->dd_bad_request_400());
+            code = 400;
+          }
+        else
+          {
+            if (janswer["network"].HasMember("http_method"))
+              http_method = janswer["network"]["http_method"].GetString();
+            if (janswer["network"].HasMember("content_type"))
+              content_type = janswer["network"]["content_type"].GetString();
+
+            //- make call
+            std::string outstr;
+            try
+              {
+                dd::httpclient::post_call(url, stranswer, http_method, outcode,
+                                          outstr, content_type);
+                stranswer = outstr;
+              }
+            catch (std::runtime_error &e)
+              {
+                _logger->error(e.what());
+                _logger->info(stranswer);
+                stranswer = _hja->jrender(
+                    _hja->dd_output_connector_network_error_1009());
+              }
+          }
       }
     bool has_gzip = (encoding.find("gzip") != std::string::npos);
     if (!encoding.empty() && has_gzip)
       {
-	try
-	  {
-	    std::string gzstr;
-	    filtering_ostream gzout;
-	    gzout.push(gzip_compressor());
-	    gzout.push(boost::iostreams::back_inserter(gzstr));
-	    gzout << stranswer;
-	    boost::iostreams::close(gzout);
-	    stranswer = gzstr;
-	  }
-	catch(const std::exception &e)
-	  {
-	    _logger->error(e.what());
-	    outcode = 400;
-	    stranswer = _hja->jrender(_hja->dd_bad_request_400());
-	  }
+        try
+          {
+            std::string gzstr;
+            filtering_ostream gzout;
+            gzout.push(gzip_compressor());
+            gzout.push(boost::iostreams::back_inserter(gzstr));
+            gzout << stranswer;
+            boost::iostreams::close(gzout);
+            stranswer = gzstr;
+          }
+        catch (const std::exception &e)
+          {
+            _logger->error(e.what());
+            outcode = 400;
+            stranswer = _hja->jrender(_hja->dd_bad_request_400());
+          }
       }
-    response = http_server::response::stock_reply(http_server::response::status_type(outcode),stranswer);
+    response = http_server::response::stock_reply(
+        http_server::response::status_type(outcode), stranswer);
     response.headers[1].value = "application/json";
     if (!encoding.empty() && has_gzip)
       {
-	response.headers.resize(3);
-	response.headers[2].name = "Content-Encoding";
-	response.headers[2].value = "gzip";
+        response.headers.resize(3);
+        response.headers[2].name = "Content-Encoding";
+        response.headers[2].value = "gzip";
       }
     if (!FLAGS_allow_origin.empty())
       {
-	int pos = response.headers.size()+2;
-	response.headers.resize(pos);
-	response.headers[pos-1].name = "Access-Control-Allow-Origin";
-	response.headers[pos-1].value = FLAGS_allow_origin;
+        int pos = response.headers.size() + 2;
+        response.headers.resize(pos);
+        response.headers[pos - 1].name = "Access-Control-Allow-Origin";
+        response.headers[pos - 1].value = FLAGS_allow_origin;
       }
     response.status = static_cast<http_server::response::status_type>(code);
   }
 
   void operator()(http_server::request const &request,
-		  http_server::response &response)
+                  http_server::response &response)
   {
-    //debug
+    // debug
     /*std::cerr << "uri=" << request.destination << std::endl;
     std::cerr << "method=" << request.method << std::endl;
     std::cerr << "source=" << request.source << std::endl;
     std::cerr << "body=" << request.body << std::endl;*/
-    //debug
+    // debug
 
-    std::chrono::time_point<std::chrono::system_clock> tstart = std::chrono::system_clock::now();
-    std::string access_log =  request.source + " \"" + request.method + " " + request.destination + "\"";
-    int code;    
+    std::chrono::time_point<std::chrono::system_clock> tstart
+        = std::chrono::system_clock::now();
+    std::string access_log = request.source + " \"" + request.method + " "
+                             + request.destination + "\"";
+    int code;
     std::string source = request.source;
     if (source == "::1")
       source = "127.0.0.1";
     uri::uri ur;
-    ur << uri::scheme("http")
-       << uri::host(source)
+    ur << uri::scheme("http") << uri::host(source)
        << uri::path(request.destination);
 
     std::string req_method = request.method;
     std::string req_path = uri::path(ur);
     std::string req_query = uri::query(ur);
-    std::transform(req_path.begin(),req_path.end(),req_path.begin(),::tolower);
-    std::transform(req_query.begin(),req_query.end(),req_query.begin(),::tolower);
-    std::vector<std::string> rscs = dd::dd_utils::split(req_path,'/');
+    std::transform(req_path.begin(), req_path.end(), req_path.begin(),
+                   ::tolower);
+    std::transform(req_query.begin(), req_query.end(), req_query.begin(),
+                   ::tolower);
+    std::vector<std::string> rscs = dd::dd_utils::split(req_path, '/');
     if (rscs.empty())
       {
-	_logger->error("empty resource");
-	response = http_server::response::stock_reply(http_server::response::not_found,_hja->jrender(_hja->dd_not_found_404()));
-	return;
+        _logger->error("empty resource");
+        response = http_server::response::stock_reply(
+            http_server::response::not_found,
+            _hja->jrender(_hja->dd_not_found_404()));
+        return;
       }
     std::string body = request.body;
-    
-    //debug
+
+    // debug
     /*std::cerr << "ur=" << ur << std::endl;
     std::cerr << "path=" << req_path << std::endl;
     std::cerr << "query=" << req_query << std::endl;
     std::cerr << "rscs size=" << rscs.size() << std::endl;
     std::cerr << "path1=" << rscs[1] << std::endl;
     _logger->info("HTTP {} / call / uri={}",req_method,ur);*/
-    //debug
+    // debug
 
     std::string content_encoding;
     std::string accept_encoding;
-    for (const auto& header : request.headers) {
-      if (header.name == "Accept-Encoding")
-	  accept_encoding = header.value;
-      else if (header.name == "Content-Encoding")
-	content_encoding = header.value;
-    }
+    for (const auto &header : request.headers)
+      {
+        if (header.name == "Accept-Encoding")
+          accept_encoding = header.value;
+        else if (header.name == "Content-Encoding")
+          content_encoding = header.value;
+      }
     bool encoding_error = false;
     if (!content_encoding.empty())
       {
-	if (content_encoding == "gzip")
-	  {
-	    if (!body.empty())
-	      {
-		try
-		  {
-		    std::string gzstr;
-		    filtering_ostream gzin;
-		    gzin.push(gzip_decompressor());
-		    gzin.push(boost::iostreams::back_inserter(gzstr));
-		    gzin << body;
-		    boost::iostreams::close(gzin);
-		    body = gzstr;
-		  }
-		catch(const std::exception &e)
-		  {
-		    _logger->error(e.what());
-		    fillup_response(response,_hja->dd_bad_request_400(),access_log,code,tstart);
-		    code = 400;
-		    encoding_error = true;
-		  }
-	      }
-	  }
-	else
-	  {
-	    _logger->error("Unsupported content-encoding: {}",content_encoding);
-	    fillup_response(response,_hja->dd_bad_request_400(),access_log,code,tstart);
-	    code = 400;
-	    encoding_error = true;
-	  }
+        if (content_encoding == "gzip")
+          {
+            if (!body.empty())
+              {
+                try
+                  {
+                    std::string gzstr;
+                    filtering_ostream gzin;
+                    gzin.push(gzip_decompressor());
+                    gzin.push(boost::iostreams::back_inserter(gzstr));
+                    gzin << body;
+                    boost::iostreams::close(gzin);
+                    body = gzstr;
+                  }
+                catch (const std::exception &e)
+                  {
+                    _logger->error(e.what());
+                    fillup_response(response, _hja->dd_bad_request_400(),
+                                    access_log, code, tstart);
+                    code = 400;
+                    encoding_error = true;
+                  }
+              }
+          }
+        else
+          {
+            _logger->error("Unsupported content-encoding: {}",
+                           content_encoding);
+            fillup_response(response, _hja->dd_bad_request_400(), access_log,
+                            code, tstart);
+            code = 400;
+            encoding_error = true;
+          }
       }
 
     if (!encoding_error)
       {
-	if (rscs.at(0) == _rsc_info)
-	  {
-	    std::string jstr = dd::uri_query_to_json(req_query);
-	    fillup_response(response,_hja->info(jstr),access_log,code,tstart,accept_encoding);
-	  }
-	else if (rscs.at(0) == _rsc_services)
-	  {
-	    if (rscs.size() < 2)
-	      {
-		fillup_response(response,_hja->dd_bad_request_400(),access_log,code,tstart);
-		_logger->error(access_log);
-		return;
-	      }
-	    std::string sname = rscs.at(1);
-	    if (req_method == "GET")
-	      {
-		fillup_response(response,_hja->service_status(sname),access_log,code,tstart,accept_encoding);
-	      }
-	    else if (req_method == "PUT" || req_method == "POST") // tolerance to using POST
-	      {
-		fillup_response(response,_hja->service_create(sname,body),access_log,code,tstart,accept_encoding);
-	      }
-	    else if (req_method == "DELETE")
-	      {
-		// DELETE does not accept body so query options are turned into JSON for internal processing
-		std::string jstr = dd::uri_query_to_json(req_query);
-		fillup_response(response,_hja->service_delete(sname,jstr),access_log,code,tstart,accept_encoding);
-	      }
-	  }
-	else if (rscs.at(0) == _rsc_predict)
-	  {
-	    if (req_method != "POST")
-	      {
-		fillup_response(response,_hja->dd_bad_request_400(),access_log,code,tstart);
-		_logger->error(access_log);
-		return;
-	      }
-	    fillup_response(response,_hja->service_predict(body),access_log,code,tstart,accept_encoding);
-	  }
-	else if (rscs.at(0) == _rsc_chain)
-	  {
-	    if (rscs.size() < 2)
-	      {
-		fillup_response(response,_hja->dd_bad_request_400(),access_log,code,tstart);
-		_logger->error(access_log);
-		return;
-	      }
-	    std::string cname = rscs.at(1);
-	    if (req_method == "PUT" || req_method == "POST")
-	      {
-		fillup_response(response,_hja->service_chain(cname,body),access_log,code,tstart,accept_encoding);
-	      }
-	  }
-	else if (rscs.at(0) == _rsc_train)
-	  {
-	    if (req_method == "GET")
-	      {
-		std::string jstr = dd::uri_query_to_json(req_query);
-		fillup_response(response,_hja->service_train_status(jstr),access_log,code,tstart,accept_encoding);
-	      }
-	    else if (req_method == "PUT" || req_method == "POST")
-	      {
-		fillup_response(response,_hja->service_train(body),access_log,code,tstart,accept_encoding);
-	      }
-	    else if (req_method == "DELETE")
-	      {
-		// DELETE does not accept body so query options are turned into JSON for internal processing
-		std::string jstr = dd::uri_query_to_json(req_query);
-		fillup_response(response,_hja->service_train_delete(jstr),access_log,code,tstart);
-	      }
-	  }
-	else
-	  {
-	    _logger->error("Unknown Service={}",rscs.at(0));
-	    response = http_server::response::stock_reply(http_server::response::not_found,_hja->jrender(_hja->dd_not_found_404()));
-	    code = 404;
-	  }
+        if (rscs.at(0) == _rsc_info)
+          {
+            std::string jstr = dd::uri_query_to_json(req_query);
+            fillup_response(response, _hja->info(jstr), access_log, code,
+                            tstart, accept_encoding);
+          }
+        else if (rscs.at(0) == _rsc_services)
+          {
+            if (rscs.size() < 2)
+              {
+                fillup_response(response, _hja->dd_bad_request_400(),
+                                access_log, code, tstart);
+                _logger->error(access_log);
+                return;
+              }
+            std::string sname = rscs.at(1);
+            if (req_method == "GET")
+              {
+                fillup_response(response, _hja->service_status(sname),
+                                access_log, code, tstart, accept_encoding);
+              }
+            else if (req_method == "PUT"
+                     || req_method == "POST") // tolerance to using POST
+              {
+                fillup_response(response, _hja->service_create(sname, body),
+                                access_log, code, tstart, accept_encoding);
+              }
+            else if (req_method == "DELETE")
+              {
+                // DELETE does not accept body so query options are turned into
+                // JSON for internal processing
+                std::string jstr = dd::uri_query_to_json(req_query);
+                fillup_response(response, _hja->service_delete(sname, jstr),
+                                access_log, code, tstart, accept_encoding);
+              }
+          }
+        else if (rscs.at(0) == _rsc_predict)
+          {
+            if (req_method != "POST")
+              {
+                fillup_response(response, _hja->dd_bad_request_400(),
+                                access_log, code, tstart);
+                _logger->error(access_log);
+                return;
+              }
+            fillup_response(response, _hja->service_predict(body), access_log,
+                            code, tstart, accept_encoding);
+          }
+        else if (rscs.at(0) == _rsc_chain)
+          {
+            if (rscs.size() < 2)
+              {
+                fillup_response(response, _hja->dd_bad_request_400(),
+                                access_log, code, tstart);
+                _logger->error(access_log);
+                return;
+              }
+            std::string cname = rscs.at(1);
+            if (req_method == "PUT" || req_method == "POST")
+              {
+                fillup_response(response, _hja->service_chain(cname, body),
+                                access_log, code, tstart, accept_encoding);
+              }
+          }
+        else if (rscs.at(0) == _rsc_train)
+          {
+            if (req_method == "GET")
+              {
+                std::string jstr = dd::uri_query_to_json(req_query);
+                fillup_response(response, _hja->service_train_status(jstr),
+                                access_log, code, tstart, accept_encoding);
+              }
+            else if (req_method == "PUT" || req_method == "POST")
+              {
+                fillup_response(response, _hja->service_train(body),
+                                access_log, code, tstart, accept_encoding);
+              }
+            else if (req_method == "DELETE")
+              {
+                // DELETE does not accept body so query options are turned into
+                // JSON for internal processing
+                std::string jstr = dd::uri_query_to_json(req_query);
+                fillup_response(response, _hja->service_train_delete(jstr),
+                                access_log, code, tstart);
+              }
+          }
+        else
+          {
+            _logger->error("Unknown Service={}", rscs.at(0));
+            response = http_server::response::stock_reply(
+                http_server::response::not_found,
+                _hja->jrender(_hja->dd_not_found_404()));
+            code = 404;
+          }
       }
     if (code == 200 || code == 201)
       _logger->info(access_log);
-    else _logger->error(access_log);
+    else
+      _logger->error(access_log);
   }
-  
+
   void log(http_server::string_type const &info)
   {
     _logger->error(info);
@@ -463,9 +529,8 @@ namespace dd
   /* variables for C-like signal handling */
   HttpJsonAPI *_ghja = nullptr;
   http_server *_gdd_server = nullptr;
-  
-  HttpJsonAPI::HttpJsonAPI()
-    :JsonAPI()
+
+  HttpJsonAPI::HttpJsonAPI() : JsonAPI()
   {
   }
 
@@ -475,83 +540,81 @@ namespace dd
   }
 
   int HttpJsonAPI::start_server(const std::string &host,
-				const std::string &port,
-				const int &nthreads)
+                                const std::string &port, const int &nthreads)
   {
     APIHandler ahandler(this);
     http_server::options options(ahandler);
-    _dd_server = new http_server(options.address(host)
-				 .port(port)
-				 .linger(false)
-				 .reuse_address(true));
+    _dd_server = new http_server(
+        options.address(host).port(port).linger(false).reuse_address(true));
     _ghja = this;
     _gdd_server = _dd_server;
-    _logger->info("Running DeepDetect HTTP server on {}:{}",host,port);
+    _logger->info("Running DeepDetect HTTP server on {}:{}", host, port);
 
     if (!FLAGS_allow_origin.empty())
-      _logger->info("Allowing origin from {}",FLAGS_allow_origin);
-    
+      _logger->info("Allowing origin from {}", FLAGS_allow_origin);
+
     std::vector<std::thread> ts;
-    for (int i=0;i<nthreads;i++)
-      ts.push_back(std::thread(std::bind(&http_server::run,_dd_server)));
-    try {
-      _dd_server->run();
-    }
-    catch(std::exception &e)
+    for (int i = 0; i < nthreads; i++)
+      ts.push_back(std::thread(std::bind(&http_server::run, _dd_server)));
+    try
       {
-	_logger->error(e.what());
-	return 1;
+        _dd_server->run();
       }
-    for (int i=0;i<nthreads;i++)
+    catch (std::exception &e)
+      {
+        _logger->error(e.what());
+        return 1;
+      }
+    for (int i = 0; i < nthreads; i++)
       ts.at(i).join();
     return 0;
   }
 
   int HttpJsonAPI::start_server_daemon(const std::string &host,
-				       const std::string &port,
-				       const int &nthreads)
+                                       const std::string &port,
+                                       const int &nthreads)
   {
     //_ft = std::async(&HttpJsonAPI::start_server,this,host,port,nthreads);
-    std::thread t(&HttpJsonAPI::start_server,this,host,port,nthreads);
+    std::thread t(&HttpJsonAPI::start_server, this, host, port, nthreads);
     t.detach();
     return 0;
   }
-  
+
   void HttpJsonAPI::stop_server()
   {
     _logger->info("stopping HTTP server");
     if (_dd_server)
       {
-	try
-	  {
-	    _dd_server->stop();
-	    _ft.wait();
-	    delete _dd_server;
-	    _gdd_server = nullptr;
-	    _dd_server = nullptr;
-	  }
-	catch (std::exception &e)
-	  {
-	    _logger->error(e.what());
-	  }
+        try
+          {
+            _dd_server->stop();
+            _ft.wait();
+            delete _dd_server;
+            _gdd_server = nullptr;
+            _dd_server = nullptr;
+          }
+        catch (std::exception &e)
+          {
+            _logger->error(e.what());
+          }
       }
   }
 
   void HttpJsonAPI::terminate(int param)
-   {
+  {
     (void)param;
     if (_ghja)
       {
-	_ghja->stop_server();
+        _ghja->stop_server();
       }
-   }
-   
+  }
+
   int HttpJsonAPI::boot(int argc, char *argv[])
   {
     google::ParseCommandLineFlags(&argc, &argv, true);
-    std::signal(SIGINT,terminate);
-    JsonAPI::boot(argc,argv);
-    return start_server(FLAGS_host,FLAGS_port,FLAGS_nthreads);
+    std::signal(SIGINT, terminate);
+    JsonAPI::boot(argc, argv);
+    return start_server(FLAGS_host, FLAGS_port, FLAGS_nthreads);
   }
 
 }

--- a/src/httpjsonapi.h
+++ b/src/httpjsonapi.h
@@ -35,7 +35,7 @@ typedef http::server<APIHandler> http_server;
 namespace dd
 {
   std::string uri_query_to_json(const std::string &req_query);
-  
+
   class HttpJsonAPI : public JsonAPI
   {
   public:
@@ -43,18 +43,16 @@ namespace dd
     ~HttpJsonAPI();
 
     void stop_server();
-    int start_server_daemon(const std::string &host,
-			    const std::string &port,
-			    const int &nthreads);
-    int start_server(const std::string &host,
-		     const std::string &port,
-		     const int &nthreads);
+    int start_server_daemon(const std::string &host, const std::string &port,
+                            const int &nthreads);
+    int start_server(const std::string &host, const std::string &port,
+                     const int &nthreads);
     int boot(int argc, char *argv[]);
     static void terminate(int param);
-    void mergeJObj(JVal& to, JVal& from, JDoc& jd);
+    void mergeJObj(JVal &to, JVal &from, JDoc &jd);
 
-    
-    http_server *_dd_server = nullptr; /**< main reusable pointer to server object */
+    http_server *_dd_server
+        = nullptr;        /**< main reusable pointer to server object */
     std::future<int> _ft; /**< holds the results from the main server thread */
   };
 }

--- a/src/imginputfileconn.h
+++ b/src/imginputfileconn.h
@@ -41,175 +41,213 @@
 
 namespace dd
 {
-  
+
   class DDImg
   {
   public:
-    DDImg() {}
-    ~DDImg() {}
+    DDImg()
+    {
+    }
+    ~DDImg()
+    {
+    }
 
     // base64 detection
     bool is_within_base64_range(char c) const
     {
-      if ((c >= 'A' && c <= 'Z')
-	  || (c >= 'a' && c <= 'z')
-	  || (c >= '0' && c <= '9')
-	  || (c == '+' || c=='/' || c=='='))
-	return true;
-      else return false;
+      if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
+          || (c >= '0' && c <= '9') || (c == '+' || c == '/' || c == '='))
+        return true;
+      else
+        return false;
     }
 
     bool possibly_base64(const std::string &s) const
     {
       bool ism = is_multiple_four(s);
       if (!ism)
-	return false;
-      for (char c: s)
-	{
-	  bool within_64 = is_within_base64_range(c);
-	  if (!within_64)
-	    return false;
-	}
+        return false;
+      for (char c : s)
+        {
+          bool within_64 = is_within_base64_range(c);
+          if (!within_64)
+            return false;
+        }
       return true;
     }
-    
+
     bool is_multiple_four(const std::string &s) const
     {
       if (s.length() % 4 == 0)
-	return true;
-      else return false;
+        return true;
+      else
+        return false;
     }
 
-    void resize(const cv::Mat &src, cv::Mat &dst,
-		const cv::Size &cvsize,
-		const double &fx, const double &fy) const
+    void resize(const cv::Mat &src, cv::Mat &dst, const cv::Size &cvsize,
+                const double &fx, const double &fy) const
     {
 #ifdef USE_CUDA_CV
       if (_cuda)
-	{
-	  cv::cuda::GpuMat d_src;
-	  d_src.upload(src);
-	  cv::cuda::GpuMat d_dst;
-	  cv::cuda::resize(d_src, d_dst, cvsize, fx, fy, select_cv_interp());
-	  if (_rgb)
-	    cv::cuda::cvtColor(d_dst, d_dst, CV_BGR2RGB);
-	  d_dst.download(dst);
-	}
+        {
+          cv::cuda::GpuMat d_src;
+          d_src.upload(src);
+          cv::cuda::GpuMat d_dst;
+          cv::cuda::resize(d_src, d_dst, cvsize, fx, fy, select_cv_interp());
+          if (_rgb)
+            cv::cuda::cvtColor(d_dst, d_dst, CV_BGR2RGB);
+          d_dst.download(dst);
+        }
       else
 #endif
-	{
-	  cv::resize(src, dst, cvsize, fx, fy, select_cv_interp());
-	  if (_rgb)
-	    cv::cvtColor(dst, dst, CV_BGR2RGB);
-	}
+        {
+          cv::resize(src, dst, cvsize, fx, fy, select_cv_interp());
+          if (_rgb)
+            cv::cvtColor(dst, dst, CV_BGR2RGB);
+        }
     }
-    
-    void scale(const cv::Mat &src, cv::Mat &dst) const {
-      float coef = std::min(static_cast<float>(_scale_max) / std::max(src.rows, src.cols),
-			    static_cast<float>(_scale_min) / std::min(src.rows, src.cols));
-      
+
+    void scale(const cv::Mat &src, cv::Mat &dst) const
+    {
+      float coef = std::min(
+          static_cast<float>(_scale_max) / std::max(src.rows, src.cols),
+          static_cast<float>(_scale_min) / std::min(src.rows, src.cols));
+
       resize(src, dst, cv::Size(), coef, coef);
     }
 
     // decode image
     void decode(const std::string &str)
-      {
-	std::vector<unsigned char> vdat(str.begin(),str.end());
-	cv::Mat img = cv::Mat(cv::imdecode(cv::Mat(vdat,false),
-					   _unchanged_data ? CV_LOAD_IMAGE_UNCHANGED :
-					   (_bw ? CV_LOAD_IMAGE_GRAYSCALE : CV_LOAD_IMAGE_COLOR)));
-      	if (_keep_orig)
-	  _orig_imgs.push_back(img);
-	_imgs_size.push_back(std::pair<int,int>(img.rows,img.cols));
-	cv::Mat rimg;
-	if (_scaled)
-	  scale(img, rimg);
-	else if (_width == 0 || _height == 0) {
-	  if (_width == 0 && _height == 0) {
-	    // XXX - Do nothing and keep native resolution. May cause issues if batched images are different resolutions
-            rimg = img;
-	  } else {
-	    // Resize so that the larger dimension is set to whichever (width or height) is non-zero, maintaining aspect ratio
-	    // XXX - This may cause issues if batch images are different resolutions
-	    size_t currMaxDim = std::max(img.rows, img.cols);
-	    double scale = static_cast<double>(std::max(_width, _height)) / static_cast<double>(currMaxDim);
-	    resize(img,rimg,cv::Size(),scale,scale);
-	  }
-	} else {
-	  // Resize normally to the specified width and height
-	  resize(img,rimg,cv::Size(_width,_height),0,0);
-	}
-	
-	if (_crop_width != 0 && _crop_height != 0) {
-	  int widthBorder = (_width - _crop_width)/2;
-	  int heightBorder = (_height - _crop_height)/2;
-	  rimg = rimg(cv::Rect(widthBorder, heightBorder, _crop_width, _crop_height));
-	}
+    {
+      std::vector<unsigned char> vdat(str.begin(), str.end());
+      cv::Mat img = cv::Mat(cv::imdecode(
+          cv::Mat(vdat, false),
+          _unchanged_data
+              ? CV_LOAD_IMAGE_UNCHANGED
+              : (_bw ? CV_LOAD_IMAGE_GRAYSCALE : CV_LOAD_IMAGE_COLOR)));
+      if (_keep_orig)
+        _orig_imgs.push_back(img);
+      _imgs_size.push_back(std::pair<int, int>(img.rows, img.cols));
+      cv::Mat rimg;
+      if (_scaled)
+        scale(img, rimg);
+      else if (_width == 0 || _height == 0)
+        {
+          if (_width == 0 && _height == 0)
+            {
+              // XXX - Do nothing and keep native resolution. May cause issues
+              // if batched images are different resolutions
+              rimg = img;
+            }
+          else
+            {
+              // Resize so that the larger dimension is set to whichever (width
+              // or height) is non-zero, maintaining aspect ratio
+              // XXX - This may cause issues if batch images are different
+              // resolutions
+              size_t currMaxDim = std::max(img.rows, img.cols);
+              double scale = static_cast<double>(std::max(_width, _height))
+                             / static_cast<double>(currMaxDim);
+              resize(img, rimg, cv::Size(), scale, scale);
+            }
+        }
+      else
+        {
+          // Resize normally to the specified width and height
+          resize(img, rimg, cv::Size(_width, _height), 0, 0);
+        }
 
-	_imgs.push_back(std::move(rimg));
-      }
-    
+      if (_crop_width != 0 && _crop_height != 0)
+        {
+          int widthBorder = (_width - _crop_width) / 2;
+          int heightBorder = (_height - _crop_height) / 2;
+          rimg = rimg(
+              cv::Rect(widthBorder, heightBorder, _crop_width, _crop_height));
+        }
+
+      _imgs.push_back(std::move(rimg));
+    }
+
     // deserialize image, independent of format
     void deserialize(std::stringstream &input)
-      {
-	size_t size = 0;
-	input.seekg(0,input.end);
-	size = input.tellg();
-	input.seekg(0,input.beg);
-	char* data = new char[size];
-	input.read(data, size);
-	std::string str(data,data+size);
-	delete[]data;
-	decode(str);
-      }
-    
+    {
+      size_t size = 0;
+      input.seekg(0, input.end);
+      size = input.tellg();
+      input.seekg(0, input.beg);
+      char *data = new char[size];
+      input.read(data, size);
+      std::string str(data, data + size);
+      delete[] data;
+      decode(str);
+    }
+
     // data acquisition
     int read_file(const std::string &fname)
     {
-      cv::Mat img = cv::imread(fname, _unchanged_data ? CV_LOAD_IMAGE_UNCHANGED :
-			       (_bw ? CV_LOAD_IMAGE_GRAYSCALE : CV_LOAD_IMAGE_COLOR));
+      cv::Mat img
+          = cv::imread(fname, _unchanged_data ? CV_LOAD_IMAGE_UNCHANGED
+                                              : (_bw ? CV_LOAD_IMAGE_GRAYSCALE
+                                                     : CV_LOAD_IMAGE_COLOR));
       if (_keep_orig)
-	_orig_imgs.push_back(img);
+        _orig_imgs.push_back(img);
       if (img.empty())
-	{
-	  _logger->error("empty image {}",fname);
-	  return -1;
-	}
-      _imgs_size.push_back(std::pair<int,int>(img.rows,img.cols));
+        {
+          _logger->error("empty image {}", fname);
+          return -1;
+        }
+      _imgs_size.push_back(std::pair<int, int>(img.rows, img.cols));
       cv::Mat rimg;
       try
-	{
-	  if (_scaled)
-	    scale(img, rimg);
-	  else if (_width == 0 || _height == 0) {
-	    if (_width == 0 && _height == 0) {
-	      // Do nothing and keep native resolution. May cause issues if batched images are different resolutions
-	      rimg = img;
-	    } else {
-	      // Resize so that the larger dimension is set to whichever (width or height) is non-zero, maintaining aspect ratio
-	      // XXX - This may cause issues if batch images are different resolutions
-	      size_t currMaxDim = std::max(img.rows, img.cols);
-	      double scale = static_cast<double>(std::max(_width, _height)) / static_cast<double>(currMaxDim);
-	      resize(img,rimg,cv::Size(),scale,scale);
-	    }
-	  } else {
-	    // Resize normally to the specified width and height
-	    resize(img,rimg,cv::Size(_width,_height),0,0);
-	  }
-	}
-      catch(...)
-	{
-	  throw InputConnectorBadParamException("failed resizing image " + fname);
-	}
-      if (_crop_width != 0 && _crop_height != 0) {
-	int widthBorder = (_width - _crop_width)/2;
-	int heightBorder = (_height - _crop_height)/2;
-	try {
-	  rimg = rimg(cv::Rect(widthBorder, heightBorder, _crop_width, _crop_height));
-	} catch(...) {
-	  throw InputConnectorBadParamException("failed cropping image " + fname);
-	}
-      }
+        {
+          if (_scaled)
+            scale(img, rimg);
+          else if (_width == 0 || _height == 0)
+            {
+              if (_width == 0 && _height == 0)
+                {
+                  // Do nothing and keep native resolution. May cause issues if
+                  // batched images are different resolutions
+                  rimg = img;
+                }
+              else
+                {
+                  // Resize so that the larger dimension is set to whichever
+                  // (width or height) is non-zero, maintaining aspect ratio
+                  // XXX - This may cause issues if batch images are different
+                  // resolutions
+                  size_t currMaxDim = std::max(img.rows, img.cols);
+                  double scale = static_cast<double>(std::max(_width, _height))
+                                 / static_cast<double>(currMaxDim);
+                  resize(img, rimg, cv::Size(), scale, scale);
+                }
+            }
+          else
+            {
+              // Resize normally to the specified width and height
+              resize(img, rimg, cv::Size(_width, _height), 0, 0);
+            }
+        }
+      catch (...)
+        {
+          throw InputConnectorBadParamException("failed resizing image "
+                                                + fname);
+        }
+      if (_crop_width != 0 && _crop_height != 0)
+        {
+          int widthBorder = (_width - _crop_width) / 2;
+          int heightBorder = (_height - _crop_height) / 2;
+          try
+            {
+              rimg = rimg(cv::Rect(widthBorder, heightBorder, _crop_width,
+                                   _crop_height));
+            }
+          catch (...)
+            {
+              throw InputConnectorBadParamException("failed cropping image "
+                                                    + fname);
+            }
+        }
       _imgs.push_back(std::move(rimg));
       return 0;
     }
@@ -219,26 +257,26 @@ namespace dd
       _db_fname = fname;
       return 0;
     }
-    
+
     int read_mem(const std::string &content)
     {
       _in_mem = true;
       cv::Mat timg;
       _b64 = possibly_base64(content);
       if (_b64)
-	{
-	  std::string ccontent;
-	  Base64::Decode(content,&ccontent);
-	  std::stringstream sstr;
-	  sstr << ccontent;
-	  deserialize(sstr);
-	}
+        {
+          std::string ccontent;
+          Base64::Decode(content, &ccontent);
+          std::stringstream sstr;
+          sstr << ccontent;
+          deserialize(sstr);
+        }
       else
-	{
-	  decode(content);
-	}
+        {
+          decode(content);
+        }
       if (_imgs.at(0).empty())
-	return -1;
+        return -1;
       return 0;
     }
 
@@ -246,118 +284,145 @@ namespace dd
     {
       // list directories in dir
       std::unordered_set<std::string> subdirs;
-      if (fileops::list_directory(dir,false,true,false,subdirs))
-	throw InputConnectorBadParamException("failed reading text subdirectories in data directory " + dir);
-      _logger->info("imginputfileconn: list subdirs size={}",subdirs.size());
-      
+      if (fileops::list_directory(dir, false, true, false, subdirs))
+        throw InputConnectorBadParamException(
+            "failed reading text subdirectories in data directory " + dir);
+      _logger->info("imginputfileconn: list subdirs size={}", subdirs.size());
+
       // list files and classes
-      std::vector<std::pair<std::string,int>> lfiles; // labeled files
-      std::unordered_map<int,std::string> hcorresp; // correspondence class number / class name
+      std::vector<std::pair<std::string, int>> lfiles; // labeled files
+      std::unordered_map<int, std::string>
+          hcorresp; // correspondence class number / class name
       if (!subdirs.empty())
-	{
-	  int cl = 0;
-	  auto uit = subdirs.begin();
-	  while(uit!=subdirs.end())
-	    {
-	      std::unordered_set<std::string> subdir_files;
-	      if (fileops::list_directory((*uit),true,false,true,subdir_files))
-		throw InputConnectorBadParamException("failed reading image data sub-directory " + (*uit));
-	      auto fit = subdir_files.begin();
-	      while(fit!=subdir_files.end()) // XXX: re-iterating the file is not optimal
-		{
-		  lfiles.push_back(std::pair<std::string,int>((*fit),cl));
-		  ++fit;
-		}
-	      ++cl;
-	      ++uit;
-	    }
-	}
+        {
+          int cl = 0;
+          auto uit = subdirs.begin();
+          while (uit != subdirs.end())
+            {
+              std::unordered_set<std::string> subdir_files;
+              if (fileops::list_directory((*uit), true, false, true,
+                                          subdir_files))
+                throw InputConnectorBadParamException(
+                    "failed reading image data sub-directory " + (*uit));
+              auto fit = subdir_files.begin();
+              while (fit != subdir_files.end()) // XXX: re-iterating the file
+                                                // is not optimal
+                {
+                  lfiles.push_back(std::pair<std::string, int>((*fit), cl));
+                  ++fit;
+                }
+              ++cl;
+              ++uit;
+            }
+        }
       else
-	{
-	  std::unordered_set<std::string> test_files;
-	  fileops::list_directory(dir,true,false,false,test_files);
-	  auto fit = test_files.begin();
-	  while(fit!=test_files.end())
-	    {
-	      lfiles.push_back(std::pair<std::string,int>((*fit),-1)); // -1 for no class
-	      ++fit;
-	    }
-	}
-      
+        {
+          std::unordered_set<std::string> test_files;
+          fileops::list_directory(dir, true, false, false, test_files);
+          auto fit = test_files.begin();
+          while (fit != test_files.end())
+            {
+              lfiles.push_back(
+                  std::pair<std::string, int>((*fit), -1)); // -1 for no class
+              ++fit;
+            }
+        }
+
       // read images
       _imgs.reserve(lfiles.size());
       _img_files.reserve(lfiles.size());
       _labels.reserve(lfiles.size());
-      for (std::pair<std::string,int> &p: lfiles)
-	{
-	  cv::Mat img = cv::imread(p.first, _unchanged_data ? CV_LOAD_IMAGE_UNCHANGED :
-                             (_bw ? CV_LOAD_IMAGE_GRAYSCALE : CV_LOAD_IMAGE_COLOR));
-	  _imgs_size.push_back(std::pair<int,int>(img.rows,img.cols));
-	  if (_keep_orig)
-	    _orig_imgs.push_back(img);
-	  cv::Mat rimg;
+      for (std::pair<std::string, int> &p : lfiles)
+        {
+          cv::Mat img = cv::imread(
+              p.first, _unchanged_data ? CV_LOAD_IMAGE_UNCHANGED
+                                       : (_bw ? CV_LOAD_IMAGE_GRAYSCALE
+                                              : CV_LOAD_IMAGE_COLOR));
+          _imgs_size.push_back(std::pair<int, int>(img.rows, img.cols));
+          if (_keep_orig)
+            _orig_imgs.push_back(img);
+          cv::Mat rimg;
 
-	  try
-	    {
-	      if (_scaled)
-		scale(img, rimg);
-	      else if (_width == 0 || _height == 0) {
-		if (_width == 0 && _height == 0) {
-		  // Do nothing and keep native resolution. May cause issues if batched images are different resolutions
-		  rimg = img;
-		} else {
-		  // Resize so that the larger dimension is set to whichever (width or height) is non-zero, maintaining aspect ratio
-		  // XXX - This may cause issues if batch images are different resolutions
-		  size_t currMaxDim = std::max(img.rows, img.cols);
-		  double scale = static_cast<double>(std::max(_width, _height)) / static_cast<double>(currMaxDim);
-		  resize(img,rimg,cv::Size(),scale,scale);
-		}
-	      } else {
-		// Resize normally to the specified width and height
-		resize(img,rimg,cv::Size(_width,_height),0,0);
-	      }
-	    }
-	  catch(...)
-	    {
-	      throw InputConnectorBadParamException("failed resizing image " + p.first);
-	    }
-	  if (_crop_width != 0 && _crop_height != 0) {
-	    int widthBorder = (_width - _crop_width)/2;
-	    int heightBorder = (_height - _crop_height)/2;
-	    try {
-	      rimg = rimg(cv::Rect(widthBorder, heightBorder, _crop_width, _crop_height));
-	    } catch(...) {
-	      throw InputConnectorBadParamException("failed cropping image " + p.first);
-	    }
-	  }
-	  _imgs.push_back(std::move(rimg));
-	  _img_files.push_back(p.first);
-	  if (p.second >= 0)
-	    _labels.push_back(p.second);
-	  if (_imgs.size() % 1000 == 0)
-	    _logger->info("read {} images",_imgs.size());
-	}
+          try
+            {
+              if (_scaled)
+                scale(img, rimg);
+              else if (_width == 0 || _height == 0)
+                {
+                  if (_width == 0 && _height == 0)
+                    {
+                      // Do nothing and keep native resolution. May cause
+                      // issues if batched images are different resolutions
+                      rimg = img;
+                    }
+                  else
+                    {
+                      // Resize so that the larger dimension is set to
+                      // whichever (width or height) is non-zero, maintaining
+                      // aspect ratio
+                      // XXX - This may cause issues if batch images are
+                      // different resolutions
+                      size_t currMaxDim = std::max(img.rows, img.cols);
+                      double scale
+                          = static_cast<double>(std::max(_width, _height))
+                            / static_cast<double>(currMaxDim);
+                      resize(img, rimg, cv::Size(), scale, scale);
+                    }
+                }
+              else
+                {
+                  // Resize normally to the specified width and height
+                  resize(img, rimg, cv::Size(_width, _height), 0, 0);
+                }
+            }
+          catch (...)
+            {
+              throw InputConnectorBadParamException("failed resizing image "
+                                                    + p.first);
+            }
+          if (_crop_width != 0 && _crop_height != 0)
+            {
+              int widthBorder = (_width - _crop_width) / 2;
+              int heightBorder = (_height - _crop_height) / 2;
+              try
+                {
+                  rimg = rimg(cv::Rect(widthBorder, heightBorder, _crop_width,
+                                       _crop_height));
+                }
+              catch (...)
+                {
+                  throw InputConnectorBadParamException(
+                      "failed cropping image " + p.first);
+                }
+            }
+          _imgs.push_back(std::move(rimg));
+          _img_files.push_back(p.first);
+          if (p.second >= 0)
+            _labels.push_back(p.second);
+          if (_imgs.size() % 1000 == 0)
+            _logger->info("read {} images", _imgs.size());
+        }
       return 0;
     }
 
     int select_cv_interp() const
     {
       if (_interp == "nearest")
-	return cv::INTER_NEAREST;
+        return cv::INTER_NEAREST;
       else if (_interp == "linear")
-	return cv::INTER_LINEAR;
+        return cv::INTER_LINEAR;
       else if (_interp == "area")
-	return cv::INTER_AREA;
+        return cv::INTER_AREA;
       else if (_interp == "lanczos4")
-	return cv::INTER_LANCZOS4;
-      else /* if (_interp == "cubic") */
-	return cv::INTER_CUBIC; // default
+        return cv::INTER_LANCZOS4;
+      else                      /* if (_interp == "cubic") */
+        return cv::INTER_CUBIC; // default
     }
-    
+
     std::vector<cv::Mat> _imgs;
     std::vector<cv::Mat> _orig_imgs;
     std::vector<std::string> _img_files;
-    std::vector<std::pair<int,int>> _imgs_size;
+    std::vector<std::pair<int, int>> _imgs_size;
     bool _bw = false;
     bool _rgb = false;
     bool _in_mem = false;
@@ -380,25 +445,30 @@ namespace dd
     std::string _db_fname;
     std::shared_ptr<spdlog::logger> _logger;
   };
-  
+
   class ImgInputFileConn : public InputConnectorStrategy
   {
   public:
-  ImgInputFileConn()
-    :InputConnectorStrategy(){}
+    ImgInputFileConn() : InputConnectorStrategy()
+    {
+    }
     ImgInputFileConn(const ImgInputFileConn &i)
-      :InputConnectorStrategy(i),
-      _width(i._width),_height(i._height),
-      _crop_width(i._crop_width),_crop_height(i._crop_height),
-      _bw(i._bw),_unchanged_data(i._unchanged_data),
-      _mean(i._mean),_has_mean_scalar(i._has_mean_scalar),_scale(i._scale),
-      _scaled(i._scaled), _scale_min(i._scale_min), _scale_max(i._scale_max),
-      _keep_orig(i._keep_orig), _interp(i._interp)
+        : InputConnectorStrategy(i), _width(i._width), _height(i._height),
+          _crop_width(i._crop_width), _crop_height(i._crop_height), _bw(i._bw),
+          _unchanged_data(i._unchanged_data), _mean(i._mean),
+          _has_mean_scalar(i._has_mean_scalar), _scale(i._scale),
+          _scaled(i._scaled), _scale_min(i._scale_min),
+          _scale_max(i._scale_max), _keep_orig(i._keep_orig),
+          _interp(i._interp)
 #ifdef USE_CUDA_CV
-      , _cuda(i._cuda)
+          ,
+          _cuda(i._cuda)
 #endif
-      {}
-    ~ImgInputFileConn() {}
+    {
+    }
+    ~ImgInputFileConn()
+    {
+    }
 
     void init(const APIData &ad)
     {
@@ -409,85 +479,98 @@ namespace dd
     {
       // optional parameters.
       if (ad.has("width"))
-	_width = ad.get("width").get<int>();
+        _width = ad.get("width").get<int>();
       if (ad.has("height"))
-	_height = ad.get("height").get<int>();
-      if (ad.has("crop_width")) {
-		  _crop_width = ad.get("crop_width").get<int>();
-		  if (_crop_width > _width) {
-			  _logger->error("Crop width must be less than or equal to width");
-			  throw InputConnectorBadParamException("Crop width must be less than or equal to width");
-		  }
-	  }
-      if (ad.has("crop_height")) {
-		  _crop_height = ad.get("crop_height").get<int>();
-		  if (_crop_height > _height) {
-			  _logger->error("Crop height must be less than or equal to height");
-			  throw InputConnectorBadParamException("Crop height must be less than or equal to height");
-		  }
-	  }
+        _height = ad.get("height").get<int>();
+      if (ad.has("crop_width"))
+        {
+          _crop_width = ad.get("crop_width").get<int>();
+          if (_crop_width > _width)
+            {
+              _logger->error("Crop width must be less than or equal to width");
+              throw InputConnectorBadParamException(
+                  "Crop width must be less than or equal to width");
+            }
+        }
+      if (ad.has("crop_height"))
+        {
+          _crop_height = ad.get("crop_height").get<int>();
+          if (_crop_height > _height)
+            {
+              _logger->error(
+                  "Crop height must be less than or equal to height");
+              throw InputConnectorBadParamException(
+                  "Crop height must be less than or equal to height");
+            }
+        }
       if (ad.has("bw"))
-	_bw = ad.get("bw").get<bool>();
+        _bw = ad.get("bw").get<bool>();
       if (ad.has("rgb"))
-	_rgb = ad.get("rgb").get<bool>();
+        _rgb = ad.get("rgb").get<bool>();
       if (ad.has("unchanged_data"))
         _unchanged_data = ad.get("unchanged_data").get<bool>();
       if (ad.has("shuffle"))
-	_shuffle = ad.get("shuffle").get<bool>();
+        _shuffle = ad.get("shuffle").get<bool>();
       if (ad.has("seed"))
-	_seed = ad.get("seed").get<int>();
+        _seed = ad.get("seed").get<int>();
       if (ad.has("test_split"))
-	_test_split = ad.get("test_split").get<double>();
+        _test_split = ad.get("test_split").get<double>();
       if (ad.has("mean"))
-	{
-	  apitools::get_floats(ad, "mean", _mean);
-	  _has_mean_scalar = true;
-	}
+        {
+          apitools::get_floats(ad, "mean", _mean);
+          _has_mean_scalar = true;
+        }
       if (ad.has("std"))
-	{
-	  apitools::get_floats(ad, "std", _std);
-	}
-      
+        {
+          apitools::get_floats(ad, "std", _std);
+        }
+
       // Variable size
       if (ad.has("scale"))
-	  _scale = ad.get("scale").get<double>();
+        _scale = ad.get("scale").get<double>();
       if (ad.has("scaled") || ad.has("scale_min") || ad.has("scale_max"))
-	_scaled = true;
+        _scaled = true;
       if (ad.has("scale_min"))
-	_scale_min = ad.get("scale_min").get<int>();
+        _scale_min = ad.get("scale_min").get<int>();
       if (ad.has("scale_max"))
-	_scale_max = ad.get("scale_max").get<int>();
+        _scale_max = ad.get("scale_max").get<int>();
 
       // whether to keep original image (for chained ops, e.g. cropping)
       if (ad.has("keep_orig"))
-	_keep_orig = ad.get("keep_orig").get<bool>();
+        _keep_orig = ad.get("keep_orig").get<bool>();
 
       // image interpolation method
       if (ad.has("interp"))
-	_interp = ad.get("interp").get<std::string>();
+        _interp = ad.get("interp").get<std::string>();
 
       // timeout
       this->set_timeout(ad);
-      
+
 #ifdef USE_CUDA_CV
       // image resizing on GPU
       if (ad.has("cuda"))
-	_cuda = ad.get("cuda").get<bool>();
+        _cuda = ad.get("cuda").get<bool>();
 #endif
     }
-    
+
     int feature_size() const
     {
-      if (_bw || _unchanged_data) {
-		  // XXX: only valid for single channels
-      	if (_crop_width != 0 && _crop_height != 0) return _crop_width*_crop_height;
-      	else return _width*_height;
-      }
-      else {
-	  	// RGB
-	  	if (_crop_width != 0 && _crop_height != 0) return _crop_width*_crop_height*3;
-	  	else return _width*_height*3;
-      }
+      if (_bw || _unchanged_data)
+        {
+          // XXX: only valid for single channels
+          if (_crop_width != 0 && _crop_height != 0)
+            return _crop_width * _crop_height;
+          else
+            return _width * _height;
+        }
+      else
+        {
+          // RGB
+          if (_crop_width != 0 && _crop_height != 0)
+            return _crop_width * _crop_height * 3;
+          else
+            return _width * _height * 3;
+        }
     }
 
     int batch_size() const
@@ -504,65 +587,67 @@ namespace dd
     {
       // check for raw cv::Mat
       if (ad.has("data_raw_img"))
-	{
-	  if (ad.has("ids"))
-	    _ids = ad.get("ids").get<std::vector<std::string>>();
-	  if (ad.has("meta_uris"))
-	    _meta_uris = ad.get("meta_uris").get<std::vector<std::string>>();
-	  if (ad.has("index_uris"))
-	    _index_uris = ad.get("index_uris").get<std::vector<std::string>>();
-	  
-	  _images = ad.get("data_raw_img").get<std::vector<cv::Mat>>();
-	  std::vector<cv::Mat> rimgs;
-	  std::vector<std::string> uris;
-	  int i = 0;
-	  for (auto img: _images)
-	    {
-	      cv::Mat rimg;
-	      resize(img,rimg,cv::Size(_width,_height),0,0);
-	      if (_bw && rimg.channels() > 1)
-		{
-		  cv::Mat bwimg;
-		  cv::cvtColor(rimg, bwimg, CV_BGR2GRAY);
-		  rimg = bwimg;
-		}
-	      _images_size.push_back(std::pair<int,int>(img.rows,img.cols));
-	      if (_keep_orig)
-		_orig_images.push_back(std::move(img));
-	      if (!_ids.empty())
-		uris.push_back(_ids.at(i));
-	      else
-		{
-		  _ids.push_back(std::to_string(i));
-		  uris.push_back(_ids.back());
-		}
-	      rimgs.push_back(std::move(rimg));
-	      ++i;
-	    }
-	  _images = rimgs;
-	  if (!uris.empty())
-	    _uris = uris;
-	}
-      else InputConnectorStrategy::get_data(ad);
+        {
+          if (ad.has("ids"))
+            _ids = ad.get("ids").get<std::vector<std::string>>();
+          if (ad.has("meta_uris"))
+            _meta_uris = ad.get("meta_uris").get<std::vector<std::string>>();
+          if (ad.has("index_uris"))
+            _index_uris = ad.get("index_uris").get<std::vector<std::string>>();
+
+          _images = ad.get("data_raw_img").get<std::vector<cv::Mat>>();
+          std::vector<cv::Mat> rimgs;
+          std::vector<std::string> uris;
+          int i = 0;
+          for (auto img : _images)
+            {
+              cv::Mat rimg;
+              resize(img, rimg, cv::Size(_width, _height), 0, 0);
+              if (_bw && rimg.channels() > 1)
+                {
+                  cv::Mat bwimg;
+                  cv::cvtColor(rimg, bwimg, CV_BGR2GRAY);
+                  rimg = bwimg;
+                }
+              _images_size.push_back(std::pair<int, int>(img.rows, img.cols));
+              if (_keep_orig)
+                _orig_images.push_back(std::move(img));
+              if (!_ids.empty())
+                uris.push_back(_ids.at(i));
+              else
+                {
+                  _ids.push_back(std::to_string(i));
+                  uris.push_back(_ids.back());
+                }
+              rimgs.push_back(std::move(rimg));
+              ++i;
+            }
+          _images = rimgs;
+          if (!uris.empty())
+            _uris = uris;
+        }
+      else
+        InputConnectorStrategy::get_data(ad);
     }
-    
+
     void transform(const APIData &ad)
     {
-      if (ad.has("parameters")) // hotplug of parameters, overriding the defaults
-	{
-	  APIData ad_param = ad.getobj("parameters");
-	  if (ad_param.has("input"))
-	    {
-	      fillup_parameters(ad_param.getobj("input"));
-	    }
-	}
+      if (ad.has(
+              "parameters")) // hotplug of parameters, overriding the defaults
+        {
+          APIData ad_param = ad.getobj("parameters");
+          if (ad_param.has("input"))
+            {
+              fillup_parameters(ad_param.getobj("input"));
+            }
+        }
 
       get_data(ad);
       if (!_images.empty()) // got ready raw images
-	{
-	  return;
-	}
-      
+        {
+          return;
+        }
+
       int catch_read = 0;
       std::string catch_msg;
       std::vector<std::string> uris;
@@ -570,132 +655,142 @@ namespace dd
       std::vector<std::string> index_uris;
       std::vector<std::string> failed_uris;
 #pragma omp parallel for
-      for (size_t i=0;i<_uris.size();i++)
-	{
-	  bool no_img = false;
-	  std::string u = _uris.at(i);
-	  DataEl<DDImg> dimg(this->_input_timeout);
-	  dimg._ctype._bw = _bw;
+      for (size_t i = 0; i < _uris.size(); i++)
+        {
+          bool no_img = false;
+          std::string u = _uris.at(i);
+          DataEl<DDImg> dimg(this->_input_timeout);
+          dimg._ctype._bw = _bw;
           dimg._ctype._rgb = _rgb;
-	  dimg._ctype._unchanged_data = _unchanged_data;
-	  dimg._ctype._width = _width;
-	  dimg._ctype._height = _height;
-	  dimg._ctype._crop_width = _crop_width;
-	  dimg._ctype._crop_height = _crop_height;
-	  dimg._ctype._scale = _scale;
-	  dimg._ctype._scaled = _scaled;
-	  dimg._ctype._scale_min = _scale_min;
-	  dimg._ctype._scale_max = _scale_max;
-	  dimg._ctype._keep_orig = _keep_orig;
-	  dimg._ctype._interp = _interp;
+          dimg._ctype._unchanged_data = _unchanged_data;
+          dimg._ctype._width = _width;
+          dimg._ctype._height = _height;
+          dimg._ctype._crop_width = _crop_width;
+          dimg._ctype._crop_height = _crop_height;
+          dimg._ctype._scale = _scale;
+          dimg._ctype._scaled = _scaled;
+          dimg._ctype._scale_min = _scale_min;
+          dimg._ctype._scale_max = _scale_max;
+          dimg._ctype._keep_orig = _keep_orig;
+          dimg._ctype._interp = _interp;
 #ifdef USE_CUDA_CV
-	  dimg._ctype._cuda = _cuda;
+          dimg._ctype._cuda = _cuda;
 #endif
-	  try
-	    {
-	      if (dimg.read_element(u,this->_logger))
-		{
-		  _logger->error("no data for image {}",u);
-		  no_img = true;
-		}
-	      if (!dimg._ctype._db_fname.empty())
-		_db_fname = dimg._ctype._db_fname;
-	    }
-	  catch(std::exception &e)
-	    {
+          try
+            {
+              if (dimg.read_element(u, this->_logger))
+                {
+                  _logger->error("no data for image {}", u);
+                  no_img = true;
+                }
+              if (!dimg._ctype._db_fname.empty())
+                _db_fname = dimg._ctype._db_fname;
+            }
+          catch (std::exception &e)
+            {
 #pragma omp critical
-	      {
-		++catch_read;
-		catch_msg = e.what();
-		failed_uris.push_back(u);
-		no_img = true;
-	      }
-	    }
-	  if (no_img)
-	    continue;
-	  if (!_db_fname.empty())
-	    continue;
-	  
+              {
+                ++catch_read;
+                catch_msg = e.what();
+                failed_uris.push_back(u);
+                no_img = true;
+              }
+            }
+          if (no_img)
+            continue;
+          if (!_db_fname.empty())
+            continue;
+
 #pragma omp critical
-	  {
-	    _images.insert(_images.end(),
-	      std::make_move_iterator(dimg._ctype._imgs.begin()),
-	      std::make_move_iterator(dimg._ctype._imgs.end()));
-	    if (_keep_orig)
-	      _orig_images.insert(_orig_images.end(),
-				  std::make_move_iterator(dimg._ctype._orig_imgs.begin()),
-				  std::make_move_iterator(dimg._ctype._orig_imgs.end()));
-	    _images_size.insert(_images_size.end(),
-				std::make_move_iterator(dimg._ctype._imgs_size.begin()),
-				std::make_move_iterator(dimg._ctype._imgs_size.end()));
-	    if (!dimg._ctype._labels.empty())
-	      _test_labels.insert(_test_labels.end(),
-	      std::make_move_iterator(dimg._ctype._labels.begin()),
-	      std::make_move_iterator(dimg._ctype._labels.end()));
-	    if (!_ids.empty())
-	      uris.push_back(_ids.at(i));
-	    else if (!dimg._ctype._b64 && dimg._ctype._imgs.size() == 1)
-	      uris.push_back(u);
-	    else if (!dimg._ctype._img_files.empty())
-	      uris.insert(uris.end(),
-	      std::make_move_iterator(dimg._ctype._img_files.begin()),
-	      std::make_move_iterator(dimg._ctype._img_files.end()));
-	    else uris.push_back(std::to_string(i));
-	    if (!_meta_uris.empty())
-	      meta_uris.push_back(_meta_uris.at(i));
-	    if (!_index_uris.empty())
-	      index_uris.push_back(_index_uris.at(i));
-	  }
-	}
+          {
+            _images.insert(_images.end(),
+                           std::make_move_iterator(dimg._ctype._imgs.begin()),
+                           std::make_move_iterator(dimg._ctype._imgs.end()));
+            if (_keep_orig)
+              _orig_images.insert(
+                  _orig_images.end(),
+                  std::make_move_iterator(dimg._ctype._orig_imgs.begin()),
+                  std::make_move_iterator(dimg._ctype._orig_imgs.end()));
+            _images_size.insert(
+                _images_size.end(),
+                std::make_move_iterator(dimg._ctype._imgs_size.begin()),
+                std::make_move_iterator(dimg._ctype._imgs_size.end()));
+            if (!dimg._ctype._labels.empty())
+              _test_labels.insert(
+                  _test_labels.end(),
+                  std::make_move_iterator(dimg._ctype._labels.begin()),
+                  std::make_move_iterator(dimg._ctype._labels.end()));
+            if (!_ids.empty())
+              uris.push_back(_ids.at(i));
+            else if (!dimg._ctype._b64 && dimg._ctype._imgs.size() == 1)
+              uris.push_back(u);
+            else if (!dimg._ctype._img_files.empty())
+              uris.insert(
+                  uris.end(),
+                  std::make_move_iterator(dimg._ctype._img_files.begin()),
+                  std::make_move_iterator(dimg._ctype._img_files.end()));
+            else
+              uris.push_back(std::to_string(i));
+            if (!_meta_uris.empty())
+              meta_uris.push_back(_meta_uris.at(i));
+            if (!_index_uris.empty())
+              index_uris.push_back(_index_uris.at(i));
+          }
+        }
       if (catch_read)
-	{
-	  for (auto s: failed_uris)
-	    _logger->error("failed reading image {}",s);
-	  throw InputConnectorBadParamException(catch_msg);
-	}
+        {
+          for (auto s : failed_uris)
+            _logger->error("failed reading image {}", s);
+          throw InputConnectorBadParamException(catch_msg);
+        }
       _uris = uris;
-      _ids = _uris; // since uris may be in different order than before transform
+      _ids = _uris; // since uris may be in different order than before
+                    // transform
       _meta_uris = meta_uris;
       _index_uris = index_uris;
       if (!_db_fname.empty())
-	return; // db filename is passed to backend
-      
+        return; // db filename is passed to backend
+
       // shuffle before possible split
       if (_shuffle)
-	{
-	  std::mt19937 g;
-	  if (_seed >= 0)
-	    g = std::mt19937(_seed);
-	  else
-	    {
-	      std::random_device rd;
-	      g = std::mt19937(rd());
-	    }
-	  std::shuffle(_images.begin(),_images.end(),g); //XXX beware: labels are not shuffled, i.e. let's not shuffle while testing
-	}
+        {
+          std::mt19937 g;
+          if (_seed >= 0)
+            g = std::mt19937(_seed);
+          else
+            {
+              std::random_device rd;
+              g = std::mt19937(rd());
+            }
+          std::shuffle(_images.begin(), _images.end(),
+                       g); // XXX beware: labels are not shuffled, i.e. let's
+                           // not shuffle while testing
+        }
       // split as required
       if (_test_split > 0)
-	{
-	  int split_size = std::floor(_images.size() * (1.0-_test_split));
-	  auto chit = _images.begin();
-	  auto dchit = chit;
-	  int cpos = 0;
-	  while(chit!=_images.end())
-	    {
-	      if (cpos == split_size)
-		{
-		  if (dchit == _images.begin())
-		    dchit = chit;
-		  _test_images.push_back((*chit));
-		}
-	      else ++cpos;
-	      ++chit;
-	    }
-	  _images.erase(dchit,_images.end());
-	  _logger->info("data split test size={} / remaining data size={}",_test_images.size(),_images.size());
-	}
+        {
+          int split_size = std::floor(_images.size() * (1.0 - _test_split));
+          auto chit = _images.begin();
+          auto dchit = chit;
+          int cpos = 0;
+          while (chit != _images.end())
+            {
+              if (cpos == split_size)
+                {
+                  if (dchit == _images.begin())
+                    dchit = chit;
+                  _test_images.push_back((*chit));
+                }
+              else
+                ++cpos;
+              ++chit;
+            }
+          _images.erase(dchit, _images.end());
+          _logger->info("data split test size={} / remaining data size={}",
+                        _test_images.size(), _images.size());
+        }
       if (_images.empty())
-	throw InputConnectorBadParamException("no image could be found");
+        throw InputConnectorBadParamException("no image could be found");
     }
 
     // data
@@ -703,20 +798,21 @@ namespace dd
     std::vector<cv::Mat> _orig_images; /**< stored upon request. */
     std::vector<cv::Mat> _test_images;
     std::vector<int> _test_labels;
-    std::vector<std::pair<int,int>> _images_size;
-    
+    std::vector<std::pair<int, int>> _images_size;
+
     // image parameters
     int _width = 224;
     int _height = 224;
     int _crop_width = 0;
     int _crop_height = 0;
-    bool _bw = false; /**< whether to convert to black & white. */
-    bool _rgb = false; /**< whether to convert to rgb. */
+    bool _bw = false;             /**< whether to convert to black & white. */
+    bool _rgb = false;            /**< whether to convert to rgb. */
     bool _unchanged_data = false; /**< IMREAD_UNCHANGED flag. */
-    double _test_split = 0.0; /**< auto-split of the dataset. */
-    int _seed = -1; /**< shuffling seed. */
-    std::vector<float> _mean; /**< mean image pixels, to be subtracted from images. */
-    std::vector<float> _std; /**< std, to divide image values. */
+    double _test_split = 0.0;     /**< auto-split of the dataset. */
+    int _seed = -1;               /**< shuffling seed. */
+    std::vector<float>
+        _mean; /**< mean image pixels, to be subtracted from images. */
+    std::vector<float> _std;       /**< std, to divide image values. */
     bool _has_mean_scalar = false; /**< whether scalar is set. */
     std::string _db_fname;
     double _scale = 1.0;

--- a/src/inputconnectorstrategy.h
+++ b/src/inputconnectorstrategy.h
@@ -35,71 +35,83 @@ namespace dd
 
   /**
    * \brief fetched data element
-   * Note: functions read_mem and read_file must be defined in template type DDT
+   * Note: functions read_mem and read_file must be defined in template type
+   * DDT
    */
   template <class DDT> class DataEl
   {
   public:
     DataEl(const int &timeout)
-      {
-	if (timeout != -1)
-	  _timeout = timeout;
-      }
-    ~DataEl() {}
+    {
+      if (timeout != -1)
+        _timeout = timeout;
+    }
+    ~DataEl()
+    {
+    }
 
     int read_element(const std::string &uri,
-		     std::shared_ptr<spdlog::logger> &logger)
+                     std::shared_ptr<spdlog::logger> &logger)
     {
       _ctype._logger = logger;
       bool dir = false;
-      if (uri.rfind("https://", 0) == 0
-	  || uri.rfind("http://", 0) == 0
-	  || uri.rfind("file://", 0) == 0)
-	{
+      if (uri.rfind("https://", 0) == 0 || uri.rfind("http://", 0) == 0
+          || uri.rfind("file://", 0) == 0)
+        {
 #ifdef WIN32
-      return -1;
+          return -1;
 #else
-	  int outcode = -1;
-	  try
-	    {
-	      httpclient::get_call(uri,"GET",outcode,_content,_timeout);
-	    }
-	  catch(...)
-	    {
-	      throw;
-	    }
-	  if (outcode != 200)
-	    return -1;
-	  return _ctype.read_mem(_content);
+          int outcode = -1;
+          try
+            {
+              httpclient::get_call(uri, "GET", outcode, _content, _timeout);
+            }
+          catch (...)
+            {
+              throw;
+            }
+          if (outcode != 200)
+            return -1;
+          return _ctype.read_mem(_content);
 #endif
-	}
-      else if (fileops::file_exists(uri,dir))
-	{
-	  if (fileops::is_db(uri))
-	    return _ctype.read_db(uri); // XXX: db can acutally be a dir (e.g. lmdb)
-	  else if (dir)
-	    return _ctype.read_dir(uri);
-	  else return _ctype.read_file(uri);
-	}
-      else return _ctype.read_mem(uri);
+        }
+      else if (fileops::file_exists(uri, dir))
+        {
+          if (fileops::is_db(uri))
+            return _ctype.read_db(
+                uri); // XXX: db can acutally be a dir (e.g. lmdb)
+          else if (dir)
+            return _ctype.read_dir(uri);
+          else
+            return _ctype.read_file(uri);
+        }
+      else
+        return _ctype.read_mem(uri);
       return 0;
     }
-    
+
     std::string _content;
     int _timeout = 600; // 10 mins is default
     DDT _ctype;
   };
-  
+
   /**
    * \brief bad parameter exception
    */
   class InputConnectorBadParamException : public std::exception
   {
   public:
-    InputConnectorBadParamException(const std::string &s)
-      :_s(s) {}
-    ~InputConnectorBadParamException() {}
-    const char* what() const noexcept { return _s.c_str(); }
+    InputConnectorBadParamException(const std::string &s) : _s(s)
+    {
+    }
+    ~InputConnectorBadParamException()
+    {
+    }
+    const char *what() const noexcept
+    {
+      return _s.c_str();
+    }
+
   private:
     std::string _s;
   };
@@ -110,38 +122,52 @@ namespace dd
   class InputConnectorInternalException : public std::exception
   {
   public:
-    InputConnectorInternalException(const std::string &s)
-      :_s(s) {}
-    ~InputConnectorInternalException() {}
-    const char* what() const noexcept { return _s.c_str(); }
+    InputConnectorInternalException(const std::string &s) : _s(s)
+    {
+    }
+    ~InputConnectorInternalException()
+    {
+    }
+    const char *what() const noexcept
+    {
+      return _s.c_str();
+    }
+
   private:
     std::string _s;
   };
-  
+
   /**
    * \brief main input connector class
    */
   class InputConnectorStrategy
   {
   public:
-    InputConnectorStrategy() {}
+    InputConnectorStrategy()
+    {
+    }
     InputConnectorStrategy(const InputConnectorStrategy &i)
-      :_model_repo(i._model_repo),_logger(i._logger),
-       _input_timeout(i._input_timeout) {}
-    ~InputConnectorStrategy() {}
-    
+        : _model_repo(i._model_repo), _logger(i._logger),
+          _input_timeout(i._input_timeout)
+    {
+    }
+    ~InputConnectorStrategy()
+    {
+    }
+
     /**
      * \brief initializsation of input connector
      * @param ad data object for "parameters/input"
      */
     void init(const APIData &ad);
-    
+
     /**
      * \brief input data reading, called from ML library
-     * @param ap root data object (requires access to "data" and "parameters/input")
+     * @param ap root data object (requires access to "data" and
+     * "parameters/input")
      */
     void transform(const APIData &ap);
-    
+
     /**
      * \brief input feature size
      */
@@ -151,7 +177,7 @@ namespace dd
      * \brief input batch size (also used for training set)
      */
     int batch_size() const;
-    
+
     /**
      * \brief input test batch size, when applicable
      */
@@ -165,31 +191,31 @@ namespace dd
     void get_data(const APIData &ad)
     {
       try
-	{
-	  _uris = ad.get("data").get<std::vector<std::string>>();
-	  if (ad.has("ids"))
-	    _ids = ad.get("ids").get<std::vector<std::string>>();
-	  if (ad.has("meta_uris"))
-	    _meta_uris = ad.get("meta_uris").get<std::vector<std::string>>();
-	  if (ad.has("index_uris"))
-	    _index_uris = ad.get("index_uris").get<std::vector<std::string>>();
-	}
-      catch(...)
-	{
-	  throw InputConnectorBadParamException("missing data");
-	}
+        {
+          _uris = ad.get("data").get<std::vector<std::string>>();
+          if (ad.has("ids"))
+            _ids = ad.get("ids").get<std::vector<std::string>>();
+          if (ad.has("meta_uris"))
+            _meta_uris = ad.get("meta_uris").get<std::vector<std::string>>();
+          if (ad.has("index_uris"))
+            _index_uris = ad.get("index_uris").get<std::vector<std::string>>();
+        }
+      catch (...)
+        {
+          throw InputConnectorBadParamException("missing data");
+        }
       if (_uris.empty())
-	{
-	  throw InputConnectorBadParamException("missing data");
-	}
+        {
+          throw InputConnectorBadParamException("missing data");
+        }
     }
 
     void set_timeout(const APIData &ad)
     {
       if (ad.has("timeout"))
-	_input_timeout = ad.get("timeout").get<int>();
+        _input_timeout = ad.get("timeout").get<int>();
     }
-    
+
     /**
      * \brief input parameters to return to user through API,
      *        especially when they have been automatically modified,
@@ -200,21 +226,27 @@ namespace dd
     {
       (void)out;
     }
-    
-    bool _train = false; /**< whether in train or predict mode. */
-    bool _shuffle = false; /**< whether to shuffle the dataset, usually before splitting. */
+
+    bool _train = false;   /**< whether in train or predict mode. */
+    bool _shuffle = false; /**< whether to shuffle the dataset, usually before
+                              splitting. */
     bool _timeserie = false; /**< whether connector is a timeserie connector */
 
     std::vector<std::string> _uris;
     std::vector<std::string> _ids;
-    std::vector<std::string> _meta_uris; /**< first level URIs, used with chains typically. */
-    std::vector<std::string> _index_uris; /**< URI to be stored in similarity search index. */
-    std::string _model_repo; /**< model repository, useful when connector needs to read from saved data (e.g. vocabulary). */
+    std::vector<std::string>
+        _meta_uris; /**< first level URIs, used with chains typically. */
+    std::vector<std::string>
+        _index_uris; /**< URI to be stored in similarity search index. */
+    std::string _model_repo; /**< model repository, useful when connector needs
+                                to read from saved data (e.g. vocabulary). */
     std::shared_ptr<spdlog::logger> _logger;
 
-    int _input_timeout = -1; /**< timeout on input data retrieval: -1 means using default (600sec), otherwise set via input parameters. */
+    int _input_timeout
+        = -1; /**< timeout on input data retrieval: -1 means using default
+                 (600sec), otherwise set via input parameters. */
   };
-  
+
 }
 
 #endif

--- a/src/jsonapi.cc
+++ b/src/jsonapi.cc
@@ -28,16 +28,17 @@
 #include "ext/rapidjson/writer.h"
 #include <gflags/gflags.h>
 
-DEFINE_string(service_start_list,"","list of JSON calls to be executed at startup");
-DEFINE_bool(service_start_list_no_exit_on_failure, false, "do not exit on failure for any JSON calls executed at startup");
+DEFINE_string(service_start_list, "",
+              "list of JSON calls to be executed at startup");
+DEFINE_bool(service_start_list_no_exit_on_failure, false,
+            "do not exit on failure for any JSON calls executed at startup");
 
 namespace dd
 {
   std::string JsonAPI::_json_blob_fname = "model.json";
   std::string JsonAPI::_json_config_blob_fname = "config.json";
-  
-  JsonAPI::JsonAPI()
-    :APIStrategy()
+
+  JsonAPI::JsonAPI() : APIStrategy()
   {
   }
 
@@ -48,97 +49,114 @@ namespace dd
   int JsonAPI::boot(int argc, char *argv[])
   {
     google::ParseCommandLineFlags(&argc, &argv, true);
-    if (!FLAGS_service_start_list.empty()) {
-        JDoc response = service_autostart(FLAGS_service_start_list, FLAGS_service_start_list_no_exit_on_failure);
-        if (!FLAGS_service_start_list_no_exit_on_failure) {
-            if (response != dd_created_201()) {
+    if (!FLAGS_service_start_list.empty())
+      {
+        JDoc response
+            = service_autostart(FLAGS_service_start_list,
+                                FLAGS_service_start_list_no_exit_on_failure);
+        if (!FLAGS_service_start_list_no_exit_on_failure)
+          {
+            if (response != dd_created_201())
+              {
                 _logger->error("Service autostart failed, exiting");
                 exit(1);
-            }
-        }
-    }
+              }
+          }
+      }
     return 0;
   }
 
-  JDoc JsonAPI::service_autostart(const std::string &autostart_file, const bool &no_exit_on_failure /* = true */)
+  JDoc JsonAPI::service_autostart(const std::string &autostart_file,
+                                  const bool &no_exit_on_failure /* = true */)
   {
     if (autostart_file.empty())
       return dd_ok_200();
     if (!fileops::file_exists(autostart_file))
       {
-	_logger->error("JSON autostart file not found: {}",autostart_file);
-	return dd_bad_request_400();
+        _logger->error("JSON autostart file not found: {}", autostart_file);
+        return dd_bad_request_400();
       }
     std::ifstream injsonfile(autostart_file);
     if (!injsonfile.is_open())
       {
-	_logger->error("Failed opening JSON autostart file {}",autostart_file);
-	return dd_internal_error_500();
+        _logger->error("Failed opening JSON autostart file {}",
+                       autostart_file);
+        return dd_internal_error_500();
       }
 
     std::vector<JDoc> calls_output;
     std::string line;
     int lines = 0;
-    while(std::getline(injsonfile,line))
+    while (std::getline(injsonfile, line))
       {
-	// file format is service_create;sname;JSON or service_predict;JSON
-	std::vector<std::string> elts = dd_utils::split(line,';');
-	std::string api_call = elts.at(0);
-	if ((api_call == "service_create" && elts.size() != 3)
-	    || (api_call == "service_predict" && elts.size() != 2))
-	  {
-	    _logger->error("Error parsing autostart JSON file {} line {}: wrong number of elements",autostart_file,lines);
-	    return dd_bad_request_400();
-	  }
-	
-	// dispatch to service calls.
-	if (api_call == "service_create")
-	  {
-	    std::string sname = elts.at(1);
-	    std::string body = elts.at(2);
-	    calls_output.push_back(service_create(sname,body));
-	    if (calls_output.back() != dd_created_201()) {
-	        _logger->error("Service creation failed for {}",sname);
-	        if (!no_exit_on_failure) return dd_bad_request_400();
-	    }
-	  }
-	else if (api_call == "service_predict")
-	  {
-	    std::string body = elts.at(1);
-	    calls_output.push_back(service_predict(body));
-	    if (calls_output.back() != dd_ok_200()) {
-	        _logger->error("Service predict failed for {}",body);
-	        if (!no_exit_on_failure) return dd_bad_request_400();
-	    }
-	  }
-	++lines;
+        // file format is service_create;sname;JSON or service_predict;JSON
+        std::vector<std::string> elts = dd_utils::split(line, ';');
+        std::string api_call = elts.at(0);
+        if ((api_call == "service_create" && elts.size() != 3)
+            || (api_call == "service_predict" && elts.size() != 2))
+          {
+            _logger->error("Error parsing autostart JSON file {} line {}: "
+                           "wrong number of elements",
+                           autostart_file, lines);
+            return dd_bad_request_400();
+          }
+
+        // dispatch to service calls.
+        if (api_call == "service_create")
+          {
+            std::string sname = elts.at(1);
+            std::string body = elts.at(2);
+            calls_output.push_back(service_create(sname, body));
+            if (calls_output.back() != dd_created_201())
+              {
+                _logger->error("Service creation failed for {}", sname);
+                if (!no_exit_on_failure)
+                  return dd_bad_request_400();
+              }
+          }
+        else if (api_call == "service_predict")
+          {
+            std::string body = elts.at(1);
+            calls_output.push_back(service_predict(body));
+            if (calls_output.back() != dd_ok_200())
+              {
+                _logger->error("Service predict failed for {}", body);
+                if (!no_exit_on_failure)
+                  return dd_bad_request_400();
+              }
+          }
+        ++lines;
       }
-    _logger->info("Successfully executed calls from autostart JSON file {}",autostart_file);
+    _logger->info("Successfully executed calls from autostart JSON file {}",
+                  autostart_file);
     return dd_created_201();
   }
-  
-  void JsonAPI::render_status(JDoc &jst,
-			      const uint32_t &code, const std::string &msg,
-			      const uint32_t &dd_code, const std::string &dd_msg) const
+
+  void JsonAPI::render_status(JDoc &jst, const uint32_t &code,
+                              const std::string &msg, const uint32_t &dd_code,
+                              const std::string &dd_msg) const
   {
     JVal jsv(rapidjson::kObjectType);
-    jsv.AddMember("code",JVal(code).Move(),jst.GetAllocator());
+    jsv.AddMember("code", JVal(code).Move(), jst.GetAllocator());
     if (!msg.empty())
-      jsv.AddMember("msg",JVal().SetString(msg.c_str(),jst.GetAllocator()),jst.GetAllocator());
+      jsv.AddMember("msg", JVal().SetString(msg.c_str(), jst.GetAllocator()),
+                    jst.GetAllocator());
     if (dd_code > 0)
       {
-	jsv.AddMember("dd_code",JVal(dd_code).Move(),jst.GetAllocator());
-	if (!dd_msg.empty())
-	  jsv.AddMember("dd_msg",JVal().SetString(dd_msg.c_str(),jst.GetAllocator()),jst.GetAllocator());
+        jsv.AddMember("dd_code", JVal(dd_code).Move(), jst.GetAllocator());
+        if (!dd_msg.empty())
+          jsv.AddMember("dd_msg",
+                        JVal().SetString(dd_msg.c_str(), jst.GetAllocator()),
+                        jst.GetAllocator());
       }
-    jst.AddMember("status",jsv,jst.GetAllocator());
+    jst.AddMember("status", jsv, jst.GetAllocator());
   }
 
   JDoc JsonAPI::dd_ok_200() const
   {
     JDoc jd;
     jd.SetObject();
-    render_status(jd,200,"OK");
+    render_status(jd, 200, "OK");
     return jd;
   }
 
@@ -146,7 +164,7 @@ namespace dd
   {
     JDoc jd;
     jd.SetObject();
-    render_status(jd,201,"Created");
+    render_status(jd, 201, "Created");
     return jd;
   }
 
@@ -155,16 +173,17 @@ namespace dd
     JDoc jd;
     jd.SetObject();
     if (msg.empty())
-      render_status(jd,400,"BadRequest");
-    else render_status(jd,400,"BadRequest",400,msg);
+      render_status(jd, 400, "BadRequest");
+    else
+      render_status(jd, 400, "BadRequest", 400, msg);
     return jd;
   }
-  
+
   JDoc JsonAPI::dd_forbidden_403() const
   {
     JDoc jd;
     jd.SetObject();
-    render_status(jd,403,"Forbidden");
+    render_status(jd, 403, "Forbidden");
     return jd;
   }
 
@@ -172,15 +191,15 @@ namespace dd
   {
     JDoc jd;
     jd.SetObject();
-    render_status(jd,404,"NotFound");
+    render_status(jd, 404, "NotFound");
     return jd;
   }
-  
+
   JDoc JsonAPI::dd_conflict_409() const
   {
     JDoc jd;
     jd.SetObject();
-    render_status(jd,409,"Conflict");
+    render_status(jd, 409, "Conflict");
     return jd;
   }
 
@@ -189,16 +208,17 @@ namespace dd
     JDoc jd;
     jd.SetObject();
     if (msg.empty())
-      render_status(jd,500,"InternalError");
-    else render_status(jd,500,"InternalError",500,msg);
+      render_status(jd, 500, "InternalError");
+    else
+      render_status(jd, 500, "InternalError", 500, msg);
     return jd;
   }
-  
+
   JDoc JsonAPI::dd_unknown_library_1000() const
   {
     JDoc jd;
     jd.SetObject();
-    render_status(jd,404,"NotFound",1000,"Unknown Library");
+    render_status(jd, 404, "NotFound", 1000, "Unknown Library");
     return jd;
   }
 
@@ -206,7 +226,7 @@ namespace dd
   {
     JDoc jd;
     jd.SetObject();
-    render_status(jd,400,"BadRequest",1001,"No Data");
+    render_status(jd, 400, "BadRequest", 1001, "No Data");
     return jd;
   }
 
@@ -214,15 +234,15 @@ namespace dd
   {
     JDoc jd;
     jd.SetObject();
-    render_status(jd,400,"NotFound",1002,"Service Not Found");
+    render_status(jd, 400, "NotFound", 1002, "Service Not Found");
     return jd;
   }
-  
+
   JDoc JsonAPI::dd_job_not_found_1003() const
   {
     JDoc jd;
     jd.SetObject();
-    render_status(jd,404,"NotFound",1003,"Job Not Found");
+    render_status(jd, 404, "NotFound", 1003, "Job Not Found");
     return jd;
   }
 
@@ -230,7 +250,7 @@ namespace dd
   {
     JDoc jd;
     jd.SetObject();
-    render_status(jd,404,"NotFound",1004,"Input Connector Not Found");
+    render_status(jd, 404, "NotFound", 1004, "Input Connector Not Found");
     return jd;
   }
 
@@ -239,24 +259,28 @@ namespace dd
     JDoc jd;
     jd.SetObject();
     if (msg.empty())
-      render_status(jd,400,"BadRequest",1005,"Service Input Error");
-    else render_status(jd,400,"BadRequest",1005,"Service Input Error: " + msg);
+      render_status(jd, 400, "BadRequest", 1005, "Service Input Error");
+    else
+      render_status(jd, 400, "BadRequest", 1005,
+                    "Service Input Error: " + msg);
     return jd;
   }
-  
+
   JDoc JsonAPI::dd_service_bad_request_1006(const std::string &msg) const
   {
     JDoc jd;
     jd.SetObject();
-    render_status(jd,400,"BadRequest",1006,msg.empty() ? "Service Bad Request Error" : "Service Bad Request Error: " + msg);
+    render_status(jd, 400, "BadRequest", 1006,
+                  msg.empty() ? "Service Bad Request Error"
+                              : "Service Bad Request Error: " + msg);
     return jd;
   }
-  
+
   JDoc JsonAPI::dd_internal_mllib_error_1007(const std::string &what) const
   {
     JDoc jd;
     jd.SetObject();
-    render_status(jd,500,"InternalError",1007,what);
+    render_status(jd, 500, "InternalError", 1007, what);
     return jd;
   }
 
@@ -264,7 +288,7 @@ namespace dd
   {
     JDoc jd;
     jd.SetObject();
-    render_status(jd,409,"Conflict",1008,"Train / Predict Conflict");
+    render_status(jd, 409, "Conflict", 1008, "Train / Predict Conflict");
     return jd;
   }
 
@@ -272,7 +296,8 @@ namespace dd
   {
     JDoc jd;
     jd.SetObject();
-    render_status(jd,404,"Not Found",1009,"Output Connector Network Error");
+    render_status(jd, 404, "Not Found", 1009,
+                  "Output Connector Network Error");
     return jd;
   }
 
@@ -281,7 +306,8 @@ namespace dd
   {
     JDoc jd;
     jd.SetObject();
-    render_status(jd,403,"Forbidden",1010,"Cannot index after similarity search tree has been built");
+    render_status(jd, 403, "Forbidden", 1010,
+                  "Cannot index after similarity search tree has been built");
     return jd;
   }
 
@@ -289,7 +315,9 @@ namespace dd
   {
     JDoc jd;
     jd.SetObject();
-    render_status(jd,403,"Forbidden",1011,"Cannot search before similarity search tree has been built");
+    render_status(
+        jd, 403, "Forbidden", 1011,
+        "Cannot search before similarity search tree has been built");
     return jd;
   }
 #endif
@@ -298,7 +326,7 @@ namespace dd
   {
     JDoc jd;
     jd.SetObject();
-    render_status(jd,400,"BadRequest",1012, msg);
+    render_status(jd, 400, "BadRequest", 1012, msg);
     return jd;
   }
 
@@ -306,10 +334,10 @@ namespace dd
   {
     JDoc jd;
     jd.SetObject();
-    render_status(jd,400,"InternalError",1013, msg);
+    render_status(jd, 400, "InternalError", 1013, msg);
     return jd;
   }
-  
+
   std::string JsonAPI::jrender(const JDoc &jst) const
   {
     rapidjson::StringBuffer buffer;
@@ -332,417 +360,635 @@ namespace dd
 
     if (!jstr.empty())
       {
-	rapidjson::Document d;
-	d.Parse(jstr.c_str());
-	if (d.HasParseError())
-	  {
-	    _logger->error("JSON parsing error on string: {}",jstr);
-	    return dd_bad_request_400();
-	  }
-	
-	// parameters
-	APIData ad;
-	try
-	  {
-	    ad = APIData(d);
-	    if (ad.has("status"))
-	      status = ad.get("status").get<bool>();
-	  }
-	catch(RapidjsonException &e)
-	  {
-	    _logger->error("JSON error {}",e.what());
-	    return dd_bad_request_400(e.what());
-	  }
-	catch(...)
-	  {
-	 return dd_bad_request_400();
-	  }
+        rapidjson::Document d;
+        d.Parse(jstr.c_str());
+        if (d.HasParseError())
+          {
+            _logger->error("JSON parsing error on string: {}", jstr);
+            return dd_bad_request_400();
+          }
+
+        // parameters
+        APIData ad;
+        try
+          {
+            ad = APIData(d);
+            if (ad.has("status"))
+              status = ad.get("status").get<bool>();
+          }
+        catch (RapidjsonException &e)
+          {
+            _logger->error("JSON error {}", e.what());
+            return dd_bad_request_400(e.what());
+          }
+        catch (...)
+          {
+            return dd_bad_request_400();
+          }
       }
-	
+
     // answer info call.
     JDoc jinfo = dd_ok_200();
     JVal jhead(rapidjson::kObjectType);
-    jhead.AddMember("method","/info",jinfo.GetAllocator());
-    std::string sversion = std::to_string(VERSION_MAJOR) + "." + std::to_string(VERSION_MINOR);
-    jhead.AddMember("version",JVal().SetString(sversion.c_str(),jinfo.GetAllocator()),jinfo.GetAllocator());
-    jhead.AddMember("branch",JVal().SetString(GIT_BRANCH,jinfo.GetAllocator()),jinfo.GetAllocator());
-    jhead.AddMember("commit",JVal().SetString(GIT_COMMIT_HASH,jinfo.GetAllocator()),jinfo.GetAllocator());
+    jhead.AddMember("method", "/info", jinfo.GetAllocator());
+    std::string sversion
+        = std::to_string(VERSION_MAJOR) + "." + std::to_string(VERSION_MINOR);
+    jhead.AddMember("version",
+                    JVal().SetString(sversion.c_str(), jinfo.GetAllocator()),
+                    jinfo.GetAllocator());
+    jhead.AddMember("branch",
+                    JVal().SetString(GIT_BRANCH, jinfo.GetAllocator()),
+                    jinfo.GetAllocator());
+    jhead.AddMember("commit",
+                    JVal().SetString(GIT_COMMIT_HASH, jinfo.GetAllocator()),
+                    jinfo.GetAllocator());
     JVal jservs(rapidjson::kArrayType);
     auto hit = _mlservices.begin();
-    while(hit!=_mlservices.end())
+    while (hit != _mlservices.end())
       {
-	APIData ad = mapbox::util::apply_visitor(visitor_info(status),(*hit).second);
-	JVal jserv(rapidjson::kObjectType);
-	ad.toJVal(jinfo,jserv);
-	jservs.PushBack(jserv,jinfo.GetAllocator());
-	++hit;
+        APIData ad
+            = mapbox::util::apply_visitor(visitor_info(status), (*hit).second);
+        JVal jserv(rapidjson::kObjectType);
+        ad.toJVal(jinfo, jserv);
+        jservs.PushBack(jserv, jinfo.GetAllocator());
+        ++hit;
       }
-    jhead.AddMember("services",jservs,jinfo.GetAllocator());
-    jinfo.AddMember("head",jhead,jinfo.GetAllocator());
+    jhead.AddMember("services", jservs, jinfo.GetAllocator());
+    jinfo.AddMember("head", jhead, jinfo.GetAllocator());
     return jinfo;
   }
 
   JDoc JsonAPI::service_create(const std::string &sname,
-			       const std::string &jstr)
+                               const std::string &jstr)
   {
     if (sname.empty())
       {
-	_logger->error("missing service resource name: {}",sname);
-	return dd_not_found_404();
+        _logger->error("missing service resource name: {}", sname);
+        return dd_not_found_404();
       }
 
     rapidjson::Document d;
     d.Parse(jstr.c_str());
     if (d.HasParseError())
       {
-	_logger->error("JSON parsing error on string: {}",jstr);
-	return dd_bad_request_400();
+        _logger->error("JSON parsing error on string: {}", jstr);
+        return dd_bad_request_400();
       }
 
-    std::string mllib,input;
-    std::string type,description;
+    std::string mllib, input;
+    std::string type, description;
     bool store_config = false;
-    APIData ad,ad_model;
+    APIData ad, ad_model;
     try
       {
-	// mandatory parameters.
-	mllib = d["mllib"].GetString();
-	input = d["parameters"]["input"]["connector"].GetString();
+        // mandatory parameters.
+        mllib = d["mllib"].GetString();
+        input = d["parameters"]["input"]["connector"].GetString();
 
-	// optional parameters.
-	if (d.HasMember("type"))
-	  type = d["type"].GetString();
-	else type = "supervised"; // default
-	if (d.HasMember("description"))
-	  description = d["description"].GetString();
-	
-	// model parameters (mandatory).
-	ad = APIData(d);
-	ad_model = ad.getobj("model");
-	APIData ad_param = ad.getobj("parameters");
-	if (ad_param.has("output"))
-	  {
-	    APIData ad_output = ad_param.getobj("output");
-	    if (ad_output.has("store_config"))
-	      store_config = ad_output.get("store_config").get<bool>();
-	  }
+        // optional parameters.
+        if (d.HasMember("type"))
+          type = d["type"].GetString();
+        else
+          type = "supervised"; // default
+        if (d.HasMember("description"))
+          description = d["description"].GetString();
+
+        // model parameters (mandatory).
+        ad = APIData(d);
+        ad_model = ad.getobj("model");
+        APIData ad_param = ad.getobj("parameters");
+        if (ad_param.has("output"))
+          {
+            APIData ad_output = ad_param.getobj("output");
+            if (ad_output.has("store_config"))
+              store_config = ad_output.get("store_config").get<bool>();
+          }
       }
-    catch(RapidjsonException &e)
+    catch (RapidjsonException &e)
       {
-	_logger->error("JSON error {}",e.what());
-	return dd_bad_request_400(e.what());
+        _logger->error("JSON error {}", e.what());
+        return dd_bad_request_400(e.what());
       }
-    catch(...)
+    catch (...)
       {
-	return dd_bad_request_400();
+        return dd_bad_request_400();
       }
-        
+
     // create service.
     try
       {
-	if (mllib.empty())
-	  {
-	    return dd_unknown_library_1000();
-	  }
+        if (mllib.empty())
+          {
+            return dd_unknown_library_1000();
+          }
 #ifdef USE_CAFFE
-	else if (mllib == "caffe")
-	  {
-	    CaffeModel cmodel(ad_model,ad,_logger);
-	    read_metrics_json(cmodel._repo,ad);
-	    if (type == "supervised")
-	      {
-		if (input == "image")
-		  add_service(sname,std::move(MLService<CaffeLib,ImgCaffeInputFileConn,SupervisedOutput,CaffeModel>(sname,cmodel,description)),ad);
-		else if (input == "csv")
-		  add_service(sname,std::move(MLService<CaffeLib,CSVCaffeInputFileConn,SupervisedOutput,CaffeModel>(sname,cmodel,description)),ad);
-		else if (input == "csv_ts" || input == "csvts")
-		  add_service(sname,std::move(MLService<CaffeLib,CSVTSCaffeInputFileConn,SupervisedOutput,CaffeModel>(sname,cmodel,description)),ad);
-		else if (input == "txt")
-		  add_service(sname,std::move(MLService<CaffeLib,TxtCaffeInputFileConn,SupervisedOutput,CaffeModel>(sname,cmodel,description)),ad);
-		else if (input == "svm")
-		  add_service(sname,std::move(MLService<CaffeLib,SVMCaffeInputFileConn,SupervisedOutput,CaffeModel>(sname,cmodel,description)),ad);
-		else return dd_input_connector_not_found_1004();
-		if (JsonAPI::store_json_blob(cmodel._repo,jstr)) // store successful call json blob
-		  _logger->error("couldn't write {} file in model repository {}",JsonAPI::_json_blob_fname,cmodel._repo);
-		if (store_config)
-		  if (JsonAPI::store_json_config_blob(cmodel._repo,jstr))
-		    _logger->error("couldn't write {} file in model repository {}",JsonAPI::_json_config_blob_fname,cmodel._repo);
-	      }
-	    else if (type == "unsupervised")
-	      {
-		if (input == "image")
-		  add_service(sname,std::move(MLService<CaffeLib,ImgCaffeInputFileConn,UnsupervisedOutput,CaffeModel>(sname,cmodel,description)),ad);
-		else if (input == "csv")
-		  add_service(sname,std::move(MLService<CaffeLib,CSVCaffeInputFileConn,UnsupervisedOutput,CaffeModel>(sname,cmodel,description)),ad);
-		else if (input == "csv_ts")
-		  add_service(sname,std::move(MLService<CaffeLib,CSVTSCaffeInputFileConn,UnsupervisedOutput,CaffeModel>(sname,cmodel,description)),ad);
-		else if (input == "txt")
-		  add_service(sname,std::move(MLService<CaffeLib,TxtCaffeInputFileConn,UnsupervisedOutput,CaffeModel>(sname,cmodel,description)),ad);
-		else if (input == "svm")
-		  add_service(sname,std::move(MLService<CaffeLib,SVMCaffeInputFileConn,UnsupervisedOutput,CaffeModel>(sname,cmodel,description)),ad);
-		else return dd_input_connector_not_found_1004();
-		if (JsonAPI::store_json_blob(cmodel._repo,jstr)) // store successful call json blob
-		  _logger->error("couldn't write {} file in model repository {}",JsonAPI::_json_blob_fname,cmodel._repo);
-		if (store_config)
-		  if (JsonAPI::store_json_config_blob(cmodel._repo,jstr))
-		    _logger->error("couldn't write {} file in model repository {}",JsonAPI::_json_config_blob_fname,cmodel._repo);
-	      }
-	    else
-	      {
-		// unknown service type
-		return dd_service_bad_request_1006();
-	      }
-	  }
+        else if (mllib == "caffe")
+          {
+            CaffeModel cmodel(ad_model, ad, _logger);
+            read_metrics_json(cmodel._repo, ad);
+            if (type == "supervised")
+              {
+                if (input == "image")
+                  add_service(
+                      sname,
+                      std::move(MLService<CaffeLib, ImgCaffeInputFileConn,
+                                          SupervisedOutput, CaffeModel>(
+                          sname, cmodel, description)),
+                      ad);
+                else if (input == "csv")
+                  add_service(
+                      sname,
+                      std::move(MLService<CaffeLib, CSVCaffeInputFileConn,
+                                          SupervisedOutput, CaffeModel>(
+                          sname, cmodel, description)),
+                      ad);
+                else if (input == "csv_ts" || input == "csvts")
+                  add_service(
+                      sname,
+                      std::move(MLService<CaffeLib, CSVTSCaffeInputFileConn,
+                                          SupervisedOutput, CaffeModel>(
+                          sname, cmodel, description)),
+                      ad);
+                else if (input == "txt")
+                  add_service(
+                      sname,
+                      std::move(MLService<CaffeLib, TxtCaffeInputFileConn,
+                                          SupervisedOutput, CaffeModel>(
+                          sname, cmodel, description)),
+                      ad);
+                else if (input == "svm")
+                  add_service(
+                      sname,
+                      std::move(MLService<CaffeLib, SVMCaffeInputFileConn,
+                                          SupervisedOutput, CaffeModel>(
+                          sname, cmodel, description)),
+                      ad);
+                else
+                  return dd_input_connector_not_found_1004();
+                if (JsonAPI::store_json_blob(
+                        cmodel._repo, jstr)) // store successful call json blob
+                  _logger->error(
+                      "couldn't write {} file in model repository {}",
+                      JsonAPI::_json_blob_fname, cmodel._repo);
+                if (store_config)
+                  if (JsonAPI::store_json_config_blob(cmodel._repo, jstr))
+                    _logger->error(
+                        "couldn't write {} file in model repository {}",
+                        JsonAPI::_json_config_blob_fname, cmodel._repo);
+              }
+            else if (type == "unsupervised")
+              {
+                if (input == "image")
+                  add_service(
+                      sname,
+                      std::move(MLService<CaffeLib, ImgCaffeInputFileConn,
+                                          UnsupervisedOutput, CaffeModel>(
+                          sname, cmodel, description)),
+                      ad);
+                else if (input == "csv")
+                  add_service(
+                      sname,
+                      std::move(MLService<CaffeLib, CSVCaffeInputFileConn,
+                                          UnsupervisedOutput, CaffeModel>(
+                          sname, cmodel, description)),
+                      ad);
+                else if (input == "csv_ts")
+                  add_service(
+                      sname,
+                      std::move(MLService<CaffeLib, CSVTSCaffeInputFileConn,
+                                          UnsupervisedOutput, CaffeModel>(
+                          sname, cmodel, description)),
+                      ad);
+                else if (input == "txt")
+                  add_service(
+                      sname,
+                      std::move(MLService<CaffeLib, TxtCaffeInputFileConn,
+                                          UnsupervisedOutput, CaffeModel>(
+                          sname, cmodel, description)),
+                      ad);
+                else if (input == "svm")
+                  add_service(
+                      sname,
+                      std::move(MLService<CaffeLib, SVMCaffeInputFileConn,
+                                          UnsupervisedOutput, CaffeModel>(
+                          sname, cmodel, description)),
+                      ad);
+                else
+                  return dd_input_connector_not_found_1004();
+                if (JsonAPI::store_json_blob(
+                        cmodel._repo, jstr)) // store successful call json blob
+                  _logger->error(
+                      "couldn't write {} file in model repository {}",
+                      JsonAPI::_json_blob_fname, cmodel._repo);
+                if (store_config)
+                  if (JsonAPI::store_json_config_blob(cmodel._repo, jstr))
+                    _logger->error(
+                        "couldn't write {} file in model repository {}",
+                        JsonAPI::_json_config_blob_fname, cmodel._repo);
+              }
+            else
+              {
+                // unknown service type
+                return dd_service_bad_request_1006();
+              }
+          }
 #endif
 #ifdef USE_CAFFE2
 
-	else if (mllib == "caffe2") {
-	  Caffe2Model c2model(ad_model,ad,_logger);
-	  read_metrics_json(c2model._repo,ad);
-	  if (type == "supervised") {
+        else if (mllib == "caffe2")
+          {
+            Caffe2Model c2model(ad_model, ad, _logger);
+            read_metrics_json(c2model._repo, ad);
+            if (type == "supervised")
+              {
 
-	    if (input == "image")
-	      add_service(sname, std::move(MLService<Caffe2Lib, ImgCaffe2InputFileConn, SupervisedOutput, Caffe2Model>(sname, c2model, description)), ad);
-	    else {
-	      return dd_input_connector_not_found_1004();
-	    }
+                if (input == "image")
+                  add_service(
+                      sname,
+                      std::move(MLService<Caffe2Lib, ImgCaffe2InputFileConn,
+                                          SupervisedOutput, Caffe2Model>(
+                          sname, c2model, description)),
+                      ad);
+                else
+                  {
+                    return dd_input_connector_not_found_1004();
+                  }
+              }
+            else if (type == "unsupervised")
+              {
 
-	  } else if (type == "unsupervised") {
+                if (input == "image")
+                  add_service(
+                      sname,
+                      std::move(MLService<Caffe2Lib, ImgCaffe2InputFileConn,
+                                          UnsupervisedOutput, Caffe2Model>(
+                          sname, c2model, description)),
+                      ad);
+                else
+                  {
+                    return dd_input_connector_not_found_1004();
+                  }
+              }
+            else
+              return dd_service_bad_request_1006(); // unknown service type
 
-	    if (input == "image")
-	      add_service(sname, std::move(MLService<Caffe2Lib, ImgCaffe2InputFileConn, UnsupervisedOutput, Caffe2Model>(sname, c2model, description)), ad);
-	    else {
-	      return dd_input_connector_not_found_1004();
-	    }
+            // store successful call json blob
+            if (JsonAPI::store_json_blob(c2model._repo, jstr))
+              {
+                _logger->error("couldn't write {} file in model repository {}",
+                               JsonAPI::_json_blob_fname, c2model._repo);
+              }
 
-	  } else return dd_service_bad_request_1006(); // unknown service type
-
-	  // store successful call json blob
-	  if (JsonAPI::store_json_blob(c2model._repo, jstr)) {
-	    _logger->error("couldn't write {} file in model repository {}",
-			   JsonAPI::_json_blob_fname, c2model._repo);
-	  }
-
-	  // store model configuration json blob
-	  if (store_config && JsonAPI::store_json_config_blob(c2model._repo, jstr)) {
-	    _logger->error("couldn't write {} file in model repository {}",
-			   JsonAPI::_json_config_blob_fname, c2model._repo);
-	  }
-	}
+            // store model configuration json blob
+            if (store_config
+                && JsonAPI::store_json_config_blob(c2model._repo, jstr))
+              {
+                _logger->error("couldn't write {} file in model repository {}",
+                               JsonAPI::_json_config_blob_fname,
+                               c2model._repo);
+              }
+          }
 
 #endif // USE_CAFFE2
 
 #ifdef USE_NCNN
-  else if (mllib == "ncnn")
-  {
-    NCNNModel ncnnmodel(ad_model,ad,_logger);
-    read_metrics_json(ncnnmodel._repo,ad);
-    if (type == "supervised")
-    {
-      if (input == "image")
-        add_service(sname, std::move(MLService<NCNNLib,ImgNCNNInputFileConn,SupervisedOutput,NCNNModel>(sname,ncnnmodel,description)), ad);
-      else if (input == "csv_ts" || input == "csvts")
-        add_service(sname,std::move(MLService<NCNNLib,CSVTSNCNNInputFileConn,SupervisedOutput,NCNNModel>(sname,ncnnmodel,description)),ad);
-      else return dd_input_connector_not_found_1004();
-      if (JsonAPI::store_json_blob(ncnnmodel._repo, jstr))
-        _logger->error("couldn't write {} file in model repository {}", JsonAPI::_json_blob_fname, ncnnmodel._repo);
-      // store model configuration json blob
-      if (store_config && JsonAPI::store_json_config_blob(ncnnmodel._repo, jstr)) {
-	_logger->error("couldn't write {} file in model repository {}",
-		       JsonAPI::_json_config_blob_fname, ncnnmodel._repo);
-      }
-    }
-    else
-      {
-	// unknown type
-	return dd_service_bad_request_1006();
-      }
-  }
+        else if (mllib == "ncnn")
+          {
+            NCNNModel ncnnmodel(ad_model, ad, _logger);
+            read_metrics_json(ncnnmodel._repo, ad);
+            if (type == "supervised")
+              {
+                if (input == "image")
+                  add_service(
+                      sname,
+                      std::move(MLService<NCNNLib, ImgNCNNInputFileConn,
+                                          SupervisedOutput, NCNNModel>(
+                          sname, ncnnmodel, description)),
+                      ad);
+                else if (input == "csv_ts" || input == "csvts")
+                  add_service(
+                      sname,
+                      std::move(MLService<NCNNLib, CSVTSNCNNInputFileConn,
+                                          SupervisedOutput, NCNNModel>(
+                          sname, ncnnmodel, description)),
+                      ad);
+                else
+                  return dd_input_connector_not_found_1004();
+                if (JsonAPI::store_json_blob(ncnnmodel._repo, jstr))
+                  _logger->error(
+                      "couldn't write {} file in model repository {}",
+                      JsonAPI::_json_blob_fname, ncnnmodel._repo);
+                // store model configuration json blob
+                if (store_config
+                    && JsonAPI::store_json_config_blob(ncnnmodel._repo, jstr))
+                  {
+                    _logger->error(
+                        "couldn't write {} file in model repository {}",
+                        JsonAPI::_json_config_blob_fname, ncnnmodel._repo);
+                  }
+              }
+            else
+              {
+                // unknown type
+                return dd_service_bad_request_1006();
+              }
+          }
 #endif // USE_NCNN
 
 #ifdef USE_TORCH
-  else if (mllib == "torch")
-  {
-    TorchModel torchmodel(ad_model,ad,_logger);
-    read_metrics_json(torchmodel._repo,ad);
-    if (type == "supervised")
-    {
-      if (input == "image")
-        add_service(sname, std::move(MLService<TorchLib,ImgTorchInputFileConn,SupervisedOutput,TorchModel>(sname,torchmodel,description)), ad);
-      else if (input  == "txt")
-        add_service(sname, std::move(MLService<TorchLib,TxtTorchInputFileConn,SupervisedOutput,TorchModel>(sname,torchmodel,description)), ad);
-	  else if (input == "csvts")
-		add_service(sname, std::move(MLService<TorchLib,CSVTSTorchInputFileConn,SupervisedOutput,TorchModel>(sname,torchmodel,description)), ad);
-      else return dd_input_connector_not_found_1004();
-      if (JsonAPI::store_json_blob(torchmodel._repo, jstr))
-        _logger->error("couldn't write {} file in model repository {}", JsonAPI::_json_blob_fname, torchmodel._repo);
-      // store model configuration json blob
-      if (store_config && JsonAPI::store_json_config_blob(torchmodel._repo, jstr)) {
-        _logger->error("couldn't write {} file in model repository {}",
-		    JsonAPI::_json_config_blob_fname, torchmodel._repo);
-      }
-    }
-    else
-      {
-        // unknown type
-        return dd_service_bad_request_1006();
-      }
-  }
+        else if (mllib == "torch")
+          {
+            TorchModel torchmodel(ad_model, ad, _logger);
+            read_metrics_json(torchmodel._repo, ad);
+            if (type == "supervised")
+              {
+                if (input == "image")
+                  add_service(
+                      sname,
+                      std::move(MLService<TorchLib, ImgTorchInputFileConn,
+                                          SupervisedOutput, TorchModel>(
+                          sname, torchmodel, description)),
+                      ad);
+                else if (input == "txt")
+                  add_service(
+                      sname,
+                      std::move(MLService<TorchLib, TxtTorchInputFileConn,
+                                          SupervisedOutput, TorchModel>(
+                          sname, torchmodel, description)),
+                      ad);
+                else if (input == "csvts")
+                  add_service(
+                      sname,
+                      std::move(MLService<TorchLib, CSVTSTorchInputFileConn,
+                                          SupervisedOutput, TorchModel>(
+                          sname, torchmodel, description)),
+                      ad);
+                else
+                  return dd_input_connector_not_found_1004();
+                if (JsonAPI::store_json_blob(torchmodel._repo, jstr))
+                  _logger->error(
+                      "couldn't write {} file in model repository {}",
+                      JsonAPI::_json_blob_fname, torchmodel._repo);
+                // store model configuration json blob
+                if (store_config
+                    && JsonAPI::store_json_config_blob(torchmodel._repo, jstr))
+                  {
+                    _logger->error(
+                        "couldn't write {} file in model repository {}",
+                        JsonAPI::_json_config_blob_fname, torchmodel._repo);
+                  }
+              }
+            else
+              {
+                // unknown type
+                return dd_service_bad_request_1006();
+              }
+          }
 #endif // USE_TORCH
 
 #ifdef USE_TF
-	else if (mllib == "tensorflow" || mllib == "tf")
-	  {
-	    TFModel tfmodel(ad_model,ad,_logger);
-	    read_metrics_json(tfmodel._repo,ad);
-	    if (type == "supervised")
-	      {
-		if (input == "image")
-		  add_service(sname,std::move(MLService<TFLib,ImgTFInputFileConn,SupervisedOutput,TFModel>(sname,tfmodel,description)),ad);
-		else return dd_input_connector_not_found_1004();
-		if (JsonAPI::store_json_blob(tfmodel._repo,jstr)) // store successful call json blob
-		  _logger->error("couldn't write {} file in model repository {}",JsonAPI::_json_blob_fname,tfmodel._repo);
-	      }
-	    else if (type == "unsupervised")
-	      {
-		if (input == "image")
-		  add_service(sname,std::move(MLService<TFLib,ImgTFInputFileConn,UnsupervisedOutput,TFModel>(sname,tfmodel,description)),ad);
-		else return dd_input_connector_not_found_1004();
-		if (JsonAPI::store_json_blob(tfmodel._repo,jstr)) // store successful call json blob
-		  _logger->error("couldn't write {} file in model repository {}",JsonAPI::_json_blob_fname,tfmodel._repo);
-		if (store_config)
-		  if (JsonAPI::store_json_config_blob(tfmodel._repo,jstr))
-		    _logger->error("couldn't write {} file in model repository {}",JsonAPI::_json_config_blob_fname,tfmodel._repo);
-	      }
-	    else
-	      {
-		// unknown type
-		return dd_service_bad_request_1006();
-	      }
-	  }
+        else if (mllib == "tensorflow" || mllib == "tf")
+          {
+            TFModel tfmodel(ad_model, ad, _logger);
+            read_metrics_json(tfmodel._repo, ad);
+            if (type == "supervised")
+              {
+                if (input == "image")
+                  add_service(sname,
+                              std::move(MLService<TFLib, ImgTFInputFileConn,
+                                                  SupervisedOutput, TFModel>(
+                                  sname, tfmodel, description)),
+                              ad);
+                else
+                  return dd_input_connector_not_found_1004();
+                if (JsonAPI::store_json_blob(
+                        tfmodel._repo,
+                        jstr)) // store successful call json blob
+                  _logger->error(
+                      "couldn't write {} file in model repository {}",
+                      JsonAPI::_json_blob_fname, tfmodel._repo);
+              }
+            else if (type == "unsupervised")
+              {
+                if (input == "image")
+                  add_service(sname,
+                              std::move(MLService<TFLib, ImgTFInputFileConn,
+                                                  UnsupervisedOutput, TFModel>(
+                                  sname, tfmodel, description)),
+                              ad);
+                else
+                  return dd_input_connector_not_found_1004();
+                if (JsonAPI::store_json_blob(
+                        tfmodel._repo,
+                        jstr)) // store successful call json blob
+                  _logger->error(
+                      "couldn't write {} file in model repository {}",
+                      JsonAPI::_json_blob_fname, tfmodel._repo);
+                if (store_config)
+                  if (JsonAPI::store_json_config_blob(tfmodel._repo, jstr))
+                    _logger->error(
+                        "couldn't write {} file in model repository {}",
+                        JsonAPI::_json_config_blob_fname, tfmodel._repo);
+              }
+            else
+              {
+                // unknown type
+                return dd_service_bad_request_1006();
+              }
+          }
 #endif
 #ifdef USE_DLIB
-    else if (mllib == "dlib") {
-            DlibModel dlibmodel(ad_model,ad,_logger);
-	    read_metrics_json(dlibmodel._repo,ad);
-	    if (type == "supervised") {
-	        if (input == "image") {
-	            add_service(sname, std::move(MLService<DlibLib, ImgDlibInputFileConn, SupervisedOutput, DlibModel>(sname, dlibmodel, description)), ad);
-            } else {
-	            return dd_input_connector_not_found_1004();
-            }
-            if (JsonAPI::store_json_blob(dlibmodel._repo,jstr)) { // store successful call json blob
-                _logger->error("couldn't write {} file in model repository {}", JsonAPI::_json_blob_fname, dlibmodel._repo);
-            }
-	    } else if (type == "unsupervised") {
-	        if (input == "image") {
-	            add_service(sname, std::move(MLService<DlibLib, ImgDlibInputFileConn, UnsupervisedOutput, DlibModel>(sname, dlibmodel, description)), ad);
-            } else {
-	            return dd_input_connector_not_found_1004();
-            }
-            if (JsonAPI::store_json_blob(dlibmodel._repo,jstr)) { // store successful call json blob
-                _logger->error("couldn't write {} file in model repository {}", JsonAPI::_json_blob_fname, dlibmodel._repo);
-            }
-	    } else {
-	        // unknown type
-	        return dd_service_bad_request_1006();
-	    }
-	}
+        else if (mllib == "dlib")
+          {
+            DlibModel dlibmodel(ad_model, ad, _logger);
+            read_metrics_json(dlibmodel._repo, ad);
+            if (type == "supervised")
+              {
+                if (input == "image")
+                  {
+                    add_service(
+                        sname,
+                        std::move(MLService<DlibLib, ImgDlibInputFileConn,
+                                            SupervisedOutput, DlibModel>(
+                            sname, dlibmodel, description)),
+                        ad);
+                  }
+                else
+                  {
+                    return dd_input_connector_not_found_1004();
+                  }
+                if (JsonAPI::store_json_blob(dlibmodel._repo, jstr))
+                  { // store successful call json blob
+                    _logger->error(
+                        "couldn't write {} file in model repository {}",
+                        JsonAPI::_json_blob_fname, dlibmodel._repo);
+                  }
+              }
+            else if (type == "unsupervised")
+              {
+                if (input == "image")
+                  {
+                    add_service(
+                        sname,
+                        std::move(MLService<DlibLib, ImgDlibInputFileConn,
+                                            UnsupervisedOutput, DlibModel>(
+                            sname, dlibmodel, description)),
+                        ad);
+                  }
+                else
+                  {
+                    return dd_input_connector_not_found_1004();
+                  }
+                if (JsonAPI::store_json_blob(dlibmodel._repo, jstr))
+                  { // store successful call json blob
+                    _logger->error(
+                        "couldn't write {} file in model repository {}",
+                        JsonAPI::_json_blob_fname, dlibmodel._repo);
+                  }
+              }
+            else
+              {
+                // unknown type
+                return dd_service_bad_request_1006();
+              }
+          }
 #endif
 #ifdef USE_XGBOOST
-	else if (mllib == "xgboost")
-	  {
-	    XGBModel xmodel(ad_model,ad,_logger);
-	    read_metrics_json(xmodel._repo,ad);
-	    if (input == "csv")
-	      add_service(sname,std::move(MLService<XGBLib,CSVXGBInputFileConn,SupervisedOutput,XGBModel>(sname,xmodel,description)),ad);
-	    else if (input == "svm")
-	      add_service(sname,std::move(MLService<XGBLib,SVMXGBInputFileConn,SupervisedOutput,XGBModel>(sname,xmodel,description)),ad);
-	    else if (input == "txt")
-	      add_service(sname,std::move(MLService<XGBLib,TxtXGBInputFileConn,SupervisedOutput,XGBModel>(sname,xmodel,description)),ad);
-	    else return dd_input_connector_not_found_1004();
-	    if (JsonAPI::store_json_blob(xmodel._repo,jstr)) // store successful call json blob
-	      _logger->error("couldn't write {} file in model repository {}",JsonAPI::_json_blob_fname,xmodel._repo);
-	    if (store_config)
-	      if (JsonAPI::store_json_config_blob(xmodel._repo,jstr))
-		_logger->error("couldn't write {} file in model repository {}",JsonAPI::_json_config_blob_fname,xmodel._repo);
-	  }
+        else if (mllib == "xgboost")
+          {
+            XGBModel xmodel(ad_model, ad, _logger);
+            read_metrics_json(xmodel._repo, ad);
+            if (input == "csv")
+              add_service(sname,
+                          std::move(MLService<XGBLib, CSVXGBInputFileConn,
+                                              SupervisedOutput, XGBModel>(
+                              sname, xmodel, description)),
+                          ad);
+            else if (input == "svm")
+              add_service(sname,
+                          std::move(MLService<XGBLib, SVMXGBInputFileConn,
+                                              SupervisedOutput, XGBModel>(
+                              sname, xmodel, description)),
+                          ad);
+            else if (input == "txt")
+              add_service(sname,
+                          std::move(MLService<XGBLib, TxtXGBInputFileConn,
+                                              SupervisedOutput, XGBModel>(
+                              sname, xmodel, description)),
+                          ad);
+            else
+              return dd_input_connector_not_found_1004();
+            if (JsonAPI::store_json_blob(
+                    xmodel._repo, jstr)) // store successful call json blob
+              _logger->error("couldn't write {} file in model repository {}",
+                             JsonAPI::_json_blob_fname, xmodel._repo);
+            if (store_config)
+              if (JsonAPI::store_json_config_blob(xmodel._repo, jstr))
+                _logger->error("couldn't write {} file in model repository {}",
+                               JsonAPI::_json_config_blob_fname, xmodel._repo);
+          }
 #endif
 #ifdef USE_TSNE
-	else if (mllib == "tsne")
-	  {
-	    TSNEModel tmodel(ad_model,ad,_logger);
-	    read_metrics_json(tmodel._repo,ad);
-	    if (input == "csv")
-	      add_service(sname,std::move(MLService<TSNELib,CSVTSNEInputFileConn,UnsupervisedOutput,TSNEModel>(sname,tmodel,description)),ad);
-	    else if (input == "txt")
-	      add_service(sname,std::move(MLService<TSNELib,TxtTSNEInputFileConn,UnsupervisedOutput,TSNEModel>(sname,tmodel,description)),ad);
-	    else return dd_input_connector_not_found_1004();
-	    if (JsonAPI::store_json_blob(tmodel._repo,jstr)) // store successful call json blob
-	      _logger->error("couldn't write {} file in model repository {}",JsonAPI::_json_blob_fname,tmodel._repo);
-	    if (store_config)
-	      if (JsonAPI::store_json_config_blob(tmodel._repo,jstr))
-		_logger->error("couldn't write {} file in model repository {}",JsonAPI::_json_config_blob_fname,tmodel._repo);
-	  }
+        else if (mllib == "tsne")
+          {
+            TSNEModel tmodel(ad_model, ad, _logger);
+            read_metrics_json(tmodel._repo, ad);
+            if (input == "csv")
+              add_service(sname,
+                          std::move(MLService<TSNELib, CSVTSNEInputFileConn,
+                                              UnsupervisedOutput, TSNEModel>(
+                              sname, tmodel, description)),
+                          ad);
+            else if (input == "txt")
+              add_service(sname,
+                          std::move(MLService<TSNELib, TxtTSNEInputFileConn,
+                                              UnsupervisedOutput, TSNEModel>(
+                              sname, tmodel, description)),
+                          ad);
+            else
+              return dd_input_connector_not_found_1004();
+            if (JsonAPI::store_json_blob(
+                    tmodel._repo, jstr)) // store successful call json blob
+              _logger->error("couldn't write {} file in model repository {}",
+                             JsonAPI::_json_blob_fname, tmodel._repo);
+            if (store_config)
+              if (JsonAPI::store_json_config_blob(tmodel._repo, jstr))
+                _logger->error("couldn't write {} file in model repository {}",
+                               JsonAPI::_json_config_blob_fname, tmodel._repo);
+          }
 #endif
 #ifdef USE_TENSORRT
-	else if (mllib == "tensorrt" || mllib == "tensorRT" || mllib == "TensorRT")
-	  {
-	    TensorRTModel  tensorRTmodel(ad_model,ad,_logger);
-	    read_metrics_json(tensorRTmodel._repo,ad);
-	    if (type == "supervised")
-	      {
-		if (input == "image")
-		  add_service(sname, std::move(MLService<TensorRTLib,ImgTensorRTInputFileConn,SupervisedOutput,TensorRTModel>(sname,tensorRTmodel,description)), ad);
-		else return dd_input_connector_not_found_1004();
-		if (JsonAPI::store_json_blob(tensorRTmodel._repo, jstr))
-		  _logger->error("couldn't write {} file in model repository {}", JsonAPI::_json_blob_fname, tensorRTmodel._repo);
-		// store model configuration json blob
-		if (store_config && JsonAPI::store_json_config_blob(tensorRTmodel._repo, jstr)) {
-		  _logger->error("couldn't write {} file in model repository {}",
-				 JsonAPI::_json_config_blob_fname, tensorRTmodel._repo);
-		}
-	      }
-	    else
-	      {
-		// unknown type
-		return dd_service_bad_request_1006();
-	      }
-	  }
+        else if (mllib == "tensorrt" || mllib == "tensorRT"
+                 || mllib == "TensorRT")
+          {
+            TensorRTModel tensorRTmodel(ad_model, ad, _logger);
+            read_metrics_json(tensorRTmodel._repo, ad);
+            if (type == "supervised")
+              {
+                if (input == "image")
+                  add_service(
+                      sname,
+                      std::move(
+                          MLService<TensorRTLib, ImgTensorRTInputFileConn,
+                                    SupervisedOutput, TensorRTModel>(
+                              sname, tensorRTmodel, description)),
+                      ad);
+                else
+                  return dd_input_connector_not_found_1004();
+                if (JsonAPI::store_json_blob(tensorRTmodel._repo, jstr))
+                  _logger->error(
+                      "couldn't write {} file in model repository {}",
+                      JsonAPI::_json_blob_fname, tensorRTmodel._repo);
+                // store model configuration json blob
+                if (store_config
+                    && JsonAPI::store_json_config_blob(tensorRTmodel._repo,
+                                                       jstr))
+                  {
+                    _logger->error(
+                        "couldn't write {} file in model repository {}",
+                        JsonAPI::_json_config_blob_fname, tensorRTmodel._repo);
+                  }
+              }
+            else
+              {
+                // unknown type
+                return dd_service_bad_request_1006();
+              }
+          }
 #endif
-	else
-	  {
-	    return dd_unknown_library_1000();
-	  }
+        else
+          {
+            return dd_unknown_library_1000();
+          }
       }
     catch (ServiceForbiddenException &e)
       {
-	return dd_forbidden_403();
+        return dd_forbidden_403();
       }
     catch (InputConnectorBadParamException &e)
       {
-	return dd_service_input_bad_request_1005(e.what());
+        return dd_service_input_bad_request_1005(e.what());
       }
     catch (MLLibBadParamException &e)
       {
-	return dd_service_bad_request_1006(e.what());
+        return dd_service_bad_request_1006(e.what());
       }
     catch (InputConnectorInternalException &e)
       {
-	return dd_internal_error_500(e.what());
+        return dd_internal_error_500(e.what());
       }
     catch (MLLibInternalException &e)
       {
-	return dd_internal_error_500(e.what());
+        return dd_internal_error_500(e.what());
       }
     catch (std::exception &e)
       {
-	return dd_internal_mllib_error_1007(e.what());
+        return dd_internal_mllib_error_1007(e.what());
       }
     JDoc jsc = dd_created_201();
     return jsc;
   }
-  
+
   JDoc JsonAPI::service_status(const std::string &sname)
   {
     if (sname.empty())
@@ -750,59 +996,59 @@ namespace dd
     if (!this->service_exists(sname))
       return dd_not_found_404();
     auto hit = this->get_service_it(sname);
-    APIData ad = mapbox::util::apply_visitor(visitor_status(),(*hit).second);
+    APIData ad = mapbox::util::apply_visitor(visitor_status(), (*hit).second);
     JDoc jst = dd_ok_200();
     JVal jbody(rapidjson::kObjectType);
-    ad.toJVal(jst,jbody);
-    jst.AddMember("body",jbody,jst.GetAllocator());
+    ad.toJVal(jst, jbody);
+    jst.AddMember("body", jbody, jst.GetAllocator());
     return jst;
   }
 
   JDoc JsonAPI::service_delete(const std::string &sname,
-			       const std::string &jstr)
+                               const std::string &jstr)
   {
     if (sname.empty())
       return dd_service_not_found_1002();
-    
+
     rapidjson::Document d;
     if (!jstr.empty())
       {
-	d.Parse(jstr.c_str());
-	if (d.HasParseError())
-	  {
-	    _logger->error("JSON parsing error on string: {}",jstr);
-	    return dd_bad_request_400();
-	  }
+        d.Parse(jstr.c_str());
+        if (d.HasParseError())
+          {
+            _logger->error("JSON parsing error on string: {}", jstr);
+            return dd_bad_request_400();
+          }
       }
 
     APIData ad;
     try
       {
-	if (!jstr.empty())
-	  ad = APIData(d);
+        if (!jstr.empty())
+          ad = APIData(d);
       }
-    catch(RapidjsonException &e)
+    catch (RapidjsonException &e)
       {
-	_logger->error("JSON error {}",e.what());
-	return dd_bad_request_400(e.what());
+        _logger->error("JSON error {}", e.what());
+        return dd_bad_request_400(e.what());
       }
-    catch(...)
+    catch (...)
       {
-	return dd_bad_request_400();
+        return dd_bad_request_400();
       }
 
     try
       {
-	if (remove_service(sname,ad))
-	  return dd_ok_200();
+        if (remove_service(sname, ad))
+          return dd_ok_200();
       }
     catch (MLLibInternalException &e)
       {
-	return dd_internal_error_500(e.what());
+        return dd_internal_error_500(e.what());
       }
     catch (std::exception &e)
       {
-	return dd_internal_mllib_error_1007(e.what());
+        return dd_internal_mllib_error_1007(e.what());
       }
     return dd_not_found_404();
   }
@@ -813,209 +1059,231 @@ namespace dd
     d.Parse(jstr.c_str());
     if (d.HasParseError())
       {
-	_logger->error("JSON parsing error on string: {}",jstr);
-	return dd_bad_request_400();
+        _logger->error("JSON parsing error on string: {}", jstr);
+        return dd_bad_request_400();
       }
 
     // service
     std::string sname;
     try
       {
-	sname = d["service"].GetString();
-	std::transform(sname.begin(),sname.end(),sname.begin(),::tolower);
-	if (!this->service_exists(sname))
-	  return dd_service_not_found_1002();
+        sname = d["service"].GetString();
+        std::transform(sname.begin(), sname.end(), sname.begin(), ::tolower);
+        if (!this->service_exists(sname))
+          return dd_service_not_found_1002();
       }
-    catch(...)
+    catch (...)
       {
-	return dd_bad_request_400();
+        return dd_bad_request_400();
       }
 
     // data
     APIData ad_data;
     try
       {
-	ad_data = APIData(d);
+        ad_data = APIData(d);
       }
-    catch(RapidjsonException &e)
+    catch (RapidjsonException &e)
       {
-	_logger->error("JSON error {}",e.what());
-	return dd_bad_request_400(e.what());
+        _logger->error("JSON error {}", e.what());
+        return dd_bad_request_400(e.what());
       }
-    catch(...)
+    catch (...)
       {
-	return dd_bad_request_400();
+        return dd_bad_request_400();
       }
-    
+
     // prediction
     APIData out;
     try
       {
-	this->predict(ad_data,sname,out); // we ignore returned status, stored in out data object
+        this->predict(
+            ad_data, sname,
+            out); // we ignore returned status, stored in out data object
       }
     catch (InputConnectorBadParamException &e)
       {
-	return dd_service_input_bad_request_1005(e.what());
+        return dd_service_input_bad_request_1005(e.what());
       }
     catch (MLLibBadParamException &e)
       {
-	return dd_service_bad_request_1006(e.what());
+        return dd_service_bad_request_1006(e.what());
       }
     catch (InputConnectorInternalException &e)
       {
-	return dd_internal_error_500(e.what());
+        return dd_internal_error_500(e.what());
       }
     catch (MLLibInternalException &e)
       {
-	return dd_internal_error_500(e.what());
+        return dd_internal_error_500(e.what());
       }
     catch (MLServiceLockException &e)
       {
-	return dd_train_predict_conflict_1008();
+        return dd_train_predict_conflict_1008();
       }
 #ifdef USE_SIMSEARCH
     catch (SimIndexException &e)
       {
-	return dd_sim_index_error_1010();
+        return dd_sim_index_error_1010();
       }
     catch (SimSearchException &e)
       {
-	return dd_sim_search_error_1011();
+        return dd_sim_search_error_1011();
       }
 #endif
     catch (std::exception &e)
       {
-	return dd_internal_mllib_error_1007(e.what());
+        return dd_internal_mllib_error_1007(e.what());
       }
     JDoc jpred = dd_ok_200();
     JVal jout(rapidjson::kObjectType);
-    out.toJVal(jpred,jout);
-    bool has_measure = ad_data.getobj("parameters").getobj("output").has("measure");
+    out.toJVal(jpred, jout);
+    bool has_measure
+        = ad_data.getobj("parameters").getobj("output").has("measure");
     JVal jhead(rapidjson::kObjectType);
-    jhead.AddMember("method","/predict",jpred.GetAllocator());
-    jhead.AddMember("service",d["service"],jpred.GetAllocator());
+    jhead.AddMember("method", "/predict", jpred.GetAllocator());
+    jhead.AddMember("service", d["service"], jpred.GetAllocator());
     if (!has_measure)
-      jhead.AddMember("time",jout["time"],jpred.GetAllocator());
-    jpred.AddMember("head",jhead,jpred.GetAllocator());
+      jhead.AddMember("time", jout["time"], jpred.GetAllocator());
+    jpred.AddMember("head", jhead, jpred.GetAllocator());
     if (has_measure)
       {
-	jpred.AddMember("body",jout,jpred.GetAllocator());
-	return jpred;
+        jpred.AddMember("body", jout, jpred.GetAllocator());
+        return jpred;
       }
     JVal jbody(rapidjson::kObjectType);
     if (jout.HasMember("predictions"))
-      jbody.AddMember("predictions",jout["predictions"],jpred.GetAllocator());
-    jpred.AddMember("body",jbody,jpred.GetAllocator());
+      jbody.AddMember("predictions", jout["predictions"],
+                      jpred.GetAllocator());
+    jpred.AddMember("body", jbody, jpred.GetAllocator());
     if (ad_data.getobj("parameters").getobj("output").has("template")
-        && ad_data.getobj("parameters").getobj("output").get("template").get<std::string>() != "")
+        && ad_data.getobj("parameters")
+                   .getobj("output")
+                   .get("template")
+                   .get<std::string>()
+               != "")
       {
-	APIData ad_params = ad_data.getobj("parameters");
-	APIData ad_output = ad_params.getobj("output");
-	jpred.AddMember("template",JVal().SetString(ad_output.get("template").get<std::string>().c_str(),jpred.GetAllocator()),jpred.GetAllocator());
+        APIData ad_params = ad_data.getobj("parameters");
+        APIData ad_output = ad_params.getobj("output");
+        jpred.AddMember(
+            "template",
+            JVal().SetString(
+                ad_output.get("template").get<std::string>().c_str(),
+                jpred.GetAllocator()),
+            jpred.GetAllocator());
       }
     if (ad_data.getobj("parameters").getobj("output").has("network"))
       {
-	APIData ad_params = ad_data.getobj("parameters");
-	APIData ad_output = ad_params.getobj("output");
-	APIData ad_net = ad_output.getobj("network");
-	JVal jnet(rapidjson::kObjectType);
-	ad_net.toJVal(jpred,jnet);
-	jpred.AddMember("network",jnet,jpred.GetAllocator());
+        APIData ad_params = ad_data.getobj("parameters");
+        APIData ad_output = ad_params.getobj("output");
+        APIData ad_net = ad_output.getobj("network");
+        JVal jnet(rapidjson::kObjectType);
+        ad_net.toJVal(jpred, jnet);
+        jpred.AddMember("network", jnet, jpred.GetAllocator());
       }
     return jpred;
   }
-  
+
   JDoc JsonAPI::service_train(const std::string &jstr)
   {
     rapidjson::Document d;
     d.Parse(jstr.c_str());
     if (d.HasParseError())
       {
-	_logger->error("JSON parsing error on string: {}",jstr);
-	return dd_bad_request_400();
+        _logger->error("JSON parsing error on string: {}", jstr);
+        return dd_bad_request_400();
       }
-  
+
     // service
     std::string sname;
     try
       {
-	sname = d["service"].GetString();
-	std::transform(sname.begin(),sname.end(),sname.begin(),::tolower);
-	if (!this->service_exists(sname))
-	  return dd_service_not_found_1002();
+        sname = d["service"].GetString();
+        std::transform(sname.begin(), sname.end(), sname.begin(), ::tolower);
+        if (!this->service_exists(sname))
+          return dd_service_not_found_1002();
       }
-    catch(...)
+    catch (...)
       {
-	return dd_bad_request_400();
+        return dd_bad_request_400();
       }
-    
+
     // parameters and data
     APIData ad;
     try
       {
-	ad = APIData(d);
+        ad = APIData(d);
       }
-    catch(RapidjsonException &e)
+    catch (RapidjsonException &e)
       {
-	_logger->error("JSON error {}",e.what());
-	return dd_bad_request_400(e.what());
+        _logger->error("JSON error {}", e.what());
+        return dd_bad_request_400(e.what());
       }
-    catch(...)
+    catch (...)
       {
-	return dd_bad_request_400();
+        return dd_bad_request_400();
       }
-    
+
     // training
     std::string mrepo;
     APIData out;
     try
-      {	
-	this->train(ad,sname,out); // we ignore return status, stored in out data object
-	mrepo = out.getobj("model").get("repository").get<std::string>();
-	if (JsonAPI::store_json_blob(mrepo,jstr)) // store successful call json blob
-	  _logger->error("couldn't write to {} file in model repository {}",JsonAPI::_json_blob_fname,mrepo);
+      {
+        this->train(ad, sname,
+                    out); // we ignore return status, stored in out data object
+        mrepo = out.getobj("model").get("repository").get<std::string>();
+        if (JsonAPI::store_json_blob(mrepo,
+                                     jstr)) // store successful call json blob
+          _logger->error("couldn't write to {} file in model repository {}",
+                         JsonAPI::_json_blob_fname, mrepo);
       }
     catch (InputConnectorBadParamException &e)
       {
-	return dd_service_input_bad_request_1005(e.what());
+        return dd_service_input_bad_request_1005(e.what());
       }
     catch (MLLibBadParamException &e)
       {
-	return dd_service_bad_request_1006(e.what());
+        return dd_service_bad_request_1006(e.what());
       }
     catch (InputConnectorInternalException &e)
       {
-	return dd_internal_error_500(e.what());
+        return dd_internal_error_500(e.what());
       }
     catch (MLLibInternalException &e)
       {
-	return dd_internal_error_500(e.what());
+        return dd_internal_error_500(e.what());
       }
     catch (std::exception &e)
       {
-	return dd_internal_mllib_error_1007(e.what());
+        return dd_internal_mllib_error_1007(e.what());
       }
     JDoc jtrain = dd_created_201();
     JVal jhead(rapidjson::kObjectType);
-    jhead.AddMember("method","/train",jtrain.GetAllocator());
+    jhead.AddMember("method", "/train", jtrain.GetAllocator());
     JVal jout(rapidjson::kObjectType);
-    out.toJVal(jtrain,jout);
+    out.toJVal(jtrain, jout);
     if (jout.HasMember("job")) // async job
       {
-	jhead.AddMember("job",jout["job"].GetInt(),jtrain.GetAllocator());
-	jout.RemoveMember("job");
-	jhead.AddMember("status",JVal().SetString(jout["status"].GetString(),jtrain.GetAllocator()),jtrain.GetAllocator());
-	jout.RemoveMember("status");
+        jhead.AddMember("job", jout["job"].GetInt(), jtrain.GetAllocator());
+        jout.RemoveMember("job");
+        jhead.AddMember("status",
+                        JVal().SetString(jout["status"].GetString(),
+                                         jtrain.GetAllocator()),
+                        jtrain.GetAllocator());
+        jout.RemoveMember("status");
       }
     else
       {
-	jhead.AddMember("time",jout["time"].GetDouble(),jtrain.GetAllocator());
-	jout.RemoveMember("time");
-	jtrain.AddMember("body",jout,jtrain.GetAllocator());
+        jhead.AddMember("time", jout["time"].GetDouble(),
+                        jtrain.GetAllocator());
+        jout.RemoveMember("time");
+        jtrain.AddMember("body", jout, jtrain.GetAllocator());
       }
-    jtrain.AddMember("head",jhead,jtrain.GetAllocator());
-    if (JsonAPI::store_json_blob(mrepo,jrender(jtrain))) // store successful call json blob
-      _logger->error("couldn't write to {} file in model repository {}",JsonAPI::_json_blob_fname,mrepo);
+    jtrain.AddMember("head", jhead, jtrain.GetAllocator());
+    if (JsonAPI::store_json_blob(
+            mrepo, jrender(jtrain))) // store successful call json blob
+      _logger->error("couldn't write to {} file in model repository {}",
+                     JsonAPI::_json_blob_fname, mrepo);
     return jtrain;
   }
 
@@ -1025,116 +1293,128 @@ namespace dd
     d.Parse(jstr.c_str());
     if (d.HasParseError())
       {
-	_logger->error("JSON parsing error on string: {}",jstr);
-	return dd_bad_request_400();
+        _logger->error("JSON parsing error on string: {}", jstr);
+        return dd_bad_request_400();
       }
 
     // service
     std::string sname;
     try
       {
-	sname = d["service"].GetString();
-	std::transform(sname.begin(),sname.end(),sname.begin(),::tolower);
-	if (!this->service_exists(sname))
-	  return dd_service_not_found_1002();
+        sname = d["service"].GetString();
+        std::transform(sname.begin(), sname.end(), sname.begin(), ::tolower);
+        if (!this->service_exists(sname))
+          return dd_service_not_found_1002();
       }
-    catch(...)
+    catch (...)
       {
-	return dd_bad_request_400();
+        return dd_bad_request_400();
       }
-    
+
     // parameters
     APIData ad;
     try
       {
-	ad = APIData(d);
+        ad = APIData(d);
       }
-    catch(RapidjsonException &e)
+    catch (RapidjsonException &e)
       {
-	_logger->error("JSON error {}",e.what());
-	return dd_bad_request_400(e.what());
+        _logger->error("JSON error {}", e.what());
+        return dd_bad_request_400(e.what());
       }
-    catch(...)
+    catch (...)
       {
-	return dd_bad_request_400();
+        return dd_bad_request_400();
       }
     if (!ad.has("job"))
       return dd_job_not_found_1003();
-    
+
     // training status
     APIData out;
     int status = -2;
-    JDoc dout; // this is to store any error message associated with the training job (e.g. if it has died)
+    JDoc dout; // this is to store any error message associated with the
+               // training job (e.g. if it has died)
     dout.SetObject();
     try
       {
-	status = this->train_status(ad,sname,out);
+        status = this->train_status(ad, sname, out);
       }
     catch (InputConnectorBadParamException &e)
       {
-	dout = dd_service_input_bad_request_1005(e.what());
+        dout = dd_service_input_bad_request_1005(e.what());
       }
     catch (MLLibBadParamException &e)
       {
-	dout = dd_service_bad_request_1006(e.what());
+        dout = dd_service_bad_request_1006(e.what());
       }
     catch (InputConnectorInternalException &e)
       {
-	dout = dd_internal_error_500(e.what());
+        dout = dd_internal_error_500(e.what());
       }
     catch (MLLibInternalException &e)
       {
-	dout = dd_internal_error_500(e.what());
+        dout = dd_internal_error_500(e.what());
       }
-    catch(RapidjsonException &e)
+    catch (RapidjsonException &e)
       {
-	_logger->error("JSON error {}",e.what());
-	dout = dd_bad_request_400(e.what());
+        _logger->error("JSON error {}", e.what());
+        dout = dd_bad_request_400(e.what());
       }
     catch (std::exception &e)
       {
-	dout = dd_internal_mllib_error_1007(e.what());
+        dout = dd_internal_mllib_error_1007(e.what());
       }
     JDoc jtrain;
     if (status == 1)
       {
-	jtrain = dd_job_not_found_1003();
-	JVal jhead(rapidjson::kObjectType);
-	jhead.AddMember("method","/train",jtrain.GetAllocator());
-	jhead.AddMember("job",ad.get("job").get<int>(),jtrain.GetAllocator());
-	jtrain.AddMember("head",jhead,jtrain.GetAllocator());
-	return jtrain;
+        jtrain = dd_job_not_found_1003();
+        JVal jhead(rapidjson::kObjectType);
+        jhead.AddMember("method", "/train", jtrain.GetAllocator());
+        jhead.AddMember("job", ad.get("job").get<int>(),
+                        jtrain.GetAllocator());
+        jtrain.AddMember("head", jhead, jtrain.GetAllocator());
+        return jtrain;
       }
     jtrain = dd_ok_200();
     JVal jhead(rapidjson::kObjectType);
-    jhead.AddMember("method","/train",jtrain.GetAllocator());
-    jhead.AddMember("job",ad.get("job").get<int>(),jtrain.GetAllocator());
+    jhead.AddMember("method", "/train", jtrain.GetAllocator());
+    jhead.AddMember("job", ad.get("job").get<int>(), jtrain.GetAllocator());
     JVal jout(rapidjson::kObjectType);
     std::string train_status;
-    if (status != -2) // on failure, the output object from the async job is empty
+    if (status
+        != -2) // on failure, the output object from the async job is empty
       {
-	out.toJVal(jtrain,jout);
-	train_status = jout["status"].GetString();
-	jhead.AddMember("status",JVal().SetString(jout["status"].GetString(),jtrain.GetAllocator()),jtrain.GetAllocator());
-        jhead.AddMember("time",jout["time"].GetDouble(),jtrain.GetAllocator());
-	jout.RemoveMember("time");
-	jout.RemoveMember("status");
+        out.toJVal(jtrain, jout);
+        train_status = jout["status"].GetString();
+        jhead.AddMember("status",
+                        JVal().SetString(jout["status"].GetString(),
+                                         jtrain.GetAllocator()),
+                        jtrain.GetAllocator());
+        jhead.AddMember("time", jout["time"].GetDouble(),
+                        jtrain.GetAllocator());
+        jout.RemoveMember("time");
+        jout.RemoveMember("status");
       }
     if (dout.HasMember("status"))
       {
-	jhead.AddMember("status",JVal().SetString("error",jtrain.GetAllocator()),jtrain.GetAllocator());
-	_logger->error(jrender(dout["status"]));
-	JVal jvout(rapidjson::kObjectType);
-	jvout.CopyFrom(dout["status"],jtrain.GetAllocator());
-	jout.AddMember("Error",jvout,jtrain.GetAllocator());
+        jhead.AddMember("status",
+                        JVal().SetString("error", jtrain.GetAllocator()),
+                        jtrain.GetAllocator());
+        _logger->error(jrender(dout["status"]));
+        JVal jvout(rapidjson::kObjectType);
+        jvout.CopyFrom(dout["status"], jtrain.GetAllocator());
+        jout.AddMember("Error", jvout, jtrain.GetAllocator());
       }
-    jtrain.AddMember("head",jhead,jtrain.GetAllocator());
-    jtrain.AddMember("body",jout,jtrain.GetAllocator());
+    jtrain.AddMember("head", jhead, jtrain.GetAllocator());
+    jtrain.AddMember("body", jout, jtrain.GetAllocator());
     if (train_status == "finished" || train_status == "running")
       {
-	std::string mrepo = out.getobj("model").get("repository").get<std::string>();
-	if (JsonAPI::store_json_blob(mrepo,jrender(jtrain),"metrics.json"))
-	  _logger->error("couldn't write to metrics.json file in model repository {}",mrepo);
+        std::string mrepo
+            = out.getobj("model").get("repository").get<std::string>();
+        if (JsonAPI::store_json_blob(mrepo, jrender(jtrain), "metrics.json"))
+          _logger->error(
+              "couldn't write to metrics.json file in model repository {}",
+              mrepo);
       }
     return jtrain;
   }
@@ -1145,177 +1425,180 @@ namespace dd
     d.Parse(jstr.c_str());
     if (d.HasParseError())
       {
-	_logger->error("JSON parsing error on string: {}",jstr);
-	return dd_bad_request_400();
+        _logger->error("JSON parsing error on string: {}", jstr);
+        return dd_bad_request_400();
       }
-  
+
     // service
     std::string sname;
     try
       {
-	sname = d["service"].GetString();
-	std::transform(sname.begin(),sname.end(),sname.begin(),::tolower);
-	if (!this->service_exists(sname))
-	  return dd_service_not_found_1002();
+        sname = d["service"].GetString();
+        std::transform(sname.begin(), sname.end(), sname.begin(), ::tolower);
+        if (!this->service_exists(sname))
+          return dd_service_not_found_1002();
       }
-    catch(...)
+    catch (...)
       {
-	return dd_bad_request_400();
+        return dd_bad_request_400();
       }
-    
+
     // parameters
     APIData ad;
     try
       {
-	ad = APIData(d);
+        ad = APIData(d);
       }
-    catch(RapidjsonException &e)
+    catch (RapidjsonException &e)
       {
-	_logger->error("JSON error {}",e.what());
-	return dd_bad_request_400(e.what());
+        _logger->error("JSON error {}", e.what());
+        return dd_bad_request_400(e.what());
       }
-    catch(...)
+    catch (...)
       {
-	return dd_bad_request_400();
+        return dd_bad_request_400();
       }
     if (!ad.has("job"))
       return dd_job_not_found_1003();
-    
+
     // delete training job
     APIData out;
-    int status = this->train_delete(ad,sname,out);
+    int status = this->train_delete(ad, sname, out);
     JDoc jd;
     if (status == 1)
       {
-	jd = dd_job_not_found_1003();
-	JVal jhead(rapidjson::kObjectType);
-	jhead.AddMember("method","/train",jd.GetAllocator());
-	jhead.AddMember("job",ad.get("job").get<int>(),jd.GetAllocator());
-	jd.AddMember("head",jhead,jd.GetAllocator());
-	return jd;
+        jd = dd_job_not_found_1003();
+        JVal jhead(rapidjson::kObjectType);
+        jhead.AddMember("method", "/train", jd.GetAllocator());
+        jhead.AddMember("job", ad.get("job").get<int>(), jd.GetAllocator());
+        jd.AddMember("head", jhead, jd.GetAllocator());
+        return jd;
       }
     jd = dd_ok_200();
     JVal jout(rapidjson::kObjectType);
-    out.toJVal(jd,jout);
-    jout.AddMember("method","/train",jd.GetAllocator());
-    jout.AddMember("job",ad.get("job").get<int>(),jd.GetAllocator());
-    jd.AddMember("head",jout,jd.GetAllocator());
+    out.toJVal(jd, jout);
+    jout.AddMember("method", "/train", jd.GetAllocator());
+    jout.AddMember("job", ad.get("job").get<int>(), jd.GetAllocator());
+    jd.AddMember("head", jout, jd.GetAllocator());
     return jd;
   }
 
   JDoc JsonAPI::service_chain(const std::string &cname,
-			      const std::string &jstr)
+                              const std::string &jstr)
   {
     rapidjson::Document d;
     d.Parse(jstr.c_str());
     if (d.HasParseError())
       {
-	_logger->error("JSON parsing error on string: {}",jstr);
-	return dd_bad_request_400();
+        _logger->error("JSON parsing error on string: {}", jstr);
+        return dd_bad_request_400();
       }
 
     // data
     APIData ad_data;
     try
       {
-	ad_data = APIData(d);
+        ad_data = APIData(d);
       }
-    catch(RapidjsonException &e)
+    catch (RapidjsonException &e)
       {
-	_logger->error("JSON error {}",e.what());
-	return dd_bad_request_400(e.what());
+        _logger->error("JSON error {}", e.what());
+        return dd_bad_request_400(e.what());
       }
-    catch(...)
+    catch (...)
       {
-	return dd_bad_request_400();
+        return dd_bad_request_400();
       }
 
     // chained predictions
     APIData out;
     try
       {
-	this->chain(ad_data,cname,out);
+        this->chain(ad_data, cname, out);
       }
     catch (InputConnectorBadParamException &e)
       {
-	return dd_service_input_bad_request_1005(e.what());
+        return dd_service_input_bad_request_1005(e.what());
       }
     catch (MLLibBadParamException &e)
       {
-	return dd_service_bad_request_1006(e.what());
+        return dd_service_bad_request_1006(e.what());
       }
     catch (InputConnectorInternalException &e)
       {
-	return dd_internal_error_500(e.what());
+        return dd_internal_error_500(e.what());
       }
     catch (MLLibInternalException &e)
       {
-	return dd_internal_error_500(e.what());
+        return dd_internal_error_500(e.what());
       }
     catch (MLServiceLockException &e)
       {
-	return dd_train_predict_conflict_1008();
+        return dd_train_predict_conflict_1008();
       }
 #ifdef USE_SIMSEARCH
     catch (SimIndexException &e)
       {
-	return dd_sim_index_error_1010();
+        return dd_sim_index_error_1010();
       }
     catch (SimSearchException &e)
       {
-	return dd_sim_search_error_1011();
+        return dd_sim_search_error_1011();
       }
 #endif
     catch (ActionBadParamException &e)
       {
-	return dd_action_bad_request_1012(e.what());
+        return dd_action_bad_request_1012(e.what());
       }
     catch (ActionInternalException &e)
       {
-	return dd_action_internal_error_1013(e.what());
+        return dd_action_internal_error_1013(e.what());
       }
     catch (std::exception &e)
       {
-	return dd_internal_mllib_error_1007(e.what());
+        return dd_internal_mllib_error_1007(e.what());
       }
 
     JDoc jpred = dd_ok_200();
     JVal jout(rapidjson::kObjectType);
-    out.toJVal(jpred,jout);
+    out.toJVal(jpred, jout);
     JVal jhead(rapidjson::kObjectType);
-    jhead.AddMember("method","/chain",jpred.GetAllocator());
-    //jhead.AddMember("service",d["service"],jpred.GetAllocator());
-    //if (!has_measure)
-    jhead.AddMember("time",jout["time"],jpred.GetAllocator());
-    jpred.AddMember("head",jhead,jpred.GetAllocator());
+    jhead.AddMember("method", "/chain", jpred.GetAllocator());
+    // jhead.AddMember("service",d["service"],jpred.GetAllocator());
+    // if (!has_measure)
+    jhead.AddMember("time", jout["time"], jpred.GetAllocator());
+    jpred.AddMember("head", jhead, jpred.GetAllocator());
     JVal jbody(rapidjson::kObjectType);
     if (jout.HasMember("predictions"))
-      jbody.AddMember("predictions",jout["predictions"],jpred.GetAllocator());
-    jpred.AddMember("body",jbody,jpred.GetAllocator());
+      jbody.AddMember("predictions", jout["predictions"],
+                      jpred.GetAllocator());
+    jpred.AddMember("body", jbody, jpred.GetAllocator());
     return jpred;
   }
-  
+
   int JsonAPI::store_json_blob(const std::string &model_repo,
-			       const std::string &jstr,
-			       const std::string &jfilename)
+                               const std::string &jstr,
+                               const std::string &jfilename)
   {
     std::ofstream outf;
     std::string outfname = model_repo + "/";
     if (!jfilename.empty())
       outfname += jfilename;
-    else outfname += JsonAPI::_json_blob_fname;
-    outf.open(outfname,std::ofstream::out|std::ofstream::trunc);
+    else
+      outfname += JsonAPI::_json_blob_fname;
+    outf.open(outfname, std::ofstream::out | std::ofstream::trunc);
     if (!outf.is_open())
       return 1;
     outf << jstr << std::endl;
     return 0;
   }
-  
+
   int JsonAPI::store_json_config_blob(const std::string &model_repo,
-			       const std::string &jstr)
+                                      const std::string &jstr)
   {
     std::ofstream outf;
-    outf.open(model_repo + "/" + JsonAPI::_json_config_blob_fname,std::ofstream::out|std::ofstream::trunc);
+    outf.open(model_repo + "/" + JsonAPI::_json_config_blob_fname,
+              std::ofstream::out | std::ofstream::trunc);
     if (!outf.is_open())
       return 1;
     outf << jstr << std::endl;
@@ -1324,55 +1607,53 @@ namespace dd
 
   // read_json file blob to apidata
   int JsonAPI::read_json_blob(const std::string &model_repo,
-			      const std::string &jfilename,
-			      APIData &ad)
+                              const std::string &jfilename, APIData &ad)
   {
     std::ifstream inf(model_repo + "/" + jfilename);
     std::stringstream buffer;
     try
       {
-	buffer << inf.rdbuf();
-    }
+        buffer << inf.rdbuf();
+      }
     catch (std::exception &e)
       {
-	return 1;
+        return 1;
       }
     rapidjson::Document d;
     d.Parse(buffer.str().c_str());
     if (d.HasParseError())
       {
-	return 1;
+        return 1;
       }
     try
       {
-	ad = APIData(d);
+        ad = APIData(d);
       }
-    catch(RapidjsonException &e)
+    catch (RapidjsonException &e)
       {
-	return 1;
+        return 1;
       }
     return 0;
   }
 
-    // read_json file blob to apidata
-  void JsonAPI::read_metrics_json(const std::string &model_repo,
-				  APIData &ad)
+  // read_json file blob to apidata
+  void JsonAPI::read_metrics_json(const std::string &model_repo, APIData &ad)
   {
     APIData ad_metrics;
-    if (read_json_blob(model_repo,"metrics.json",ad_metrics))
+    if (read_json_blob(model_repo, "metrics.json", ad_metrics))
       {
-	// quiet
+        // quiet
       }
     else
       {
-	APIData ad_metrics_body = ad_metrics.getobj("body");
-	if (ad_metrics_body.has("measure_hist"))
-	  {
-	    APIData ad_metrics_hist = ad_metrics_body.getobj("measure_hist");
-	    APIData ad_params = ad.getobj("parameters");
-	    ad_params.add("metrics",ad_metrics_hist);
-	    ad.add("parameters",ad_params);
-	  }
+        APIData ad_metrics_body = ad_metrics.getobj("body");
+        if (ad_metrics_body.has("measure_hist"))
+          {
+            APIData ad_metrics_hist = ad_metrics_body.getobj("measure_hist");
+            APIData ad_params = ad.getobj("parameters");
+            ad_params.add("metrics", ad_metrics_hist);
+            ad.add("parameters", ad_params);
+          }
       }
   }
 

--- a/src/jsonapi.h
+++ b/src/jsonapi.h
@@ -45,8 +45,9 @@ namespace dd
      * \brief service autostart from JSON file
      * @param autostart_file JSON file with service API call and JSON body
      */
-    JDoc service_autostart(const std::string &autostart_file, const bool &no_exit_on_failure = true);
-    
+    JDoc service_autostart(const std::string &autostart_file,
+                           const bool &no_exit_on_failure = true);
+
     /**
      * \brief error status generation
      * @param jst JSON document object
@@ -55,18 +56,18 @@ namespace dd
      * @param dd_code deepdetect custom error code
      * @param dd_msg deepdetect custom error message
      */
-    void render_status(JDoc &jst,
-		       const uint32_t &code, const std::string &msg,
-		       const uint32_t &dd_code=0, const std::string &dd_msg="") const;
-    
+    void render_status(JDoc &jst, const uint32_t &code, const std::string &msg,
+                       const uint32_t &dd_code = 0,
+                       const std::string &dd_msg = "") const;
+
     // errors
     JDoc dd_ok_200() const;
     JDoc dd_created_201() const;
-    JDoc dd_bad_request_400(const std::string &msg="") const;
+    JDoc dd_bad_request_400(const std::string &msg = "") const;
     JDoc dd_forbidden_403() const;
     JDoc dd_not_found_404() const;
     JDoc dd_conflict_409() const;
-    JDoc dd_internal_error_500(const std::string &msg="") const;
+    JDoc dd_internal_error_500(const std::string &msg = "") const;
 
     // specific errors
     JDoc dd_unknown_library_1000() const;
@@ -74,16 +75,16 @@ namespace dd
     JDoc dd_service_not_found_1002() const;
     JDoc dd_job_not_found_1003() const;
     JDoc dd_input_connector_not_found_1004() const;
-    JDoc dd_service_input_bad_request_1005(const std::string &what="") const;
-    JDoc dd_service_bad_request_1006(const std::string &what="") const;
+    JDoc dd_service_input_bad_request_1005(const std::string &what = "") const;
+    JDoc dd_service_bad_request_1006(const std::string &what = "") const;
     JDoc dd_internal_mllib_error_1007(const std::string &what) const;
     JDoc dd_train_predict_conflict_1008() const;
     JDoc dd_output_connector_network_error_1009() const;
     JDoc dd_sim_index_error_1010() const;
     JDoc dd_sim_search_error_1011() const;
-    JDoc dd_action_bad_request_1012(const std::string &what="") const;
-    JDoc dd_action_internal_error_1013(const std::string &what="") const;
-    
+    JDoc dd_action_bad_request_1012(const std::string &what = "") const;
+    JDoc dd_action_internal_error_1013(const std::string &what = "") const;
+
     // JSON rendering
     std::string jrender(const JDoc &jst) const;
     std::string jrender(const JVal &jval) const;
@@ -93,9 +94,8 @@ namespace dd
     JDoc info(const std::string &jstr) const;
     JDoc service_create(const std::string &sname, const std::string &jstr);
     JDoc service_status(const std::string &sname);
-    JDoc service_delete(const std::string &sname,
-			const std::string &jstr);
-    
+    JDoc service_delete(const std::string &sname, const std::string &jstr);
+
     JDoc service_predict(const std::string &jstr);
 
     JDoc service_train(const std::string &jstr);
@@ -103,24 +103,22 @@ namespace dd
     JDoc service_train_delete(const std::string &jstr);
 
     JDoc service_chain(const std::string &cname, const std::string &jstr);
-    
+
     static int store_json_blob(const std::string &model_repo,
-			       const std::string &jstr,
-			       const std::string &jfilename="");
+                               const std::string &jstr,
+                               const std::string &jfilename = "");
 
     static int store_json_config_blob(const std::string &model_repo,
-				      const std::string &jstr);
+                                      const std::string &jstr);
 
     static int read_json_blob(const std::string &model_repo,
-			      const std::string &jfilename,
-			      APIData &ad);
+                              const std::string &jfilename, APIData &ad);
 
-    static void read_metrics_json(const std::string &model_repo,
-				  APIData &ad);
-    
+    static void read_metrics_json(const std::string &model_repo, APIData &ad);
+
     static std::string _json_blob_fname;
     static std::string _json_config_blob_fname;
-    //std::string _mrepo; /**< service file repository */
+    // std::string _mrepo; /**< service file repository */
   };
 
   /**
@@ -129,14 +127,17 @@ namespace dd
   class visitor_info
   {
   public:
-    visitor_info(const bool &status):_status(status) {}
-    ~visitor_info() {}
+    visitor_info(const bool &status) : _status(status)
+    {
+    }
+    ~visitor_info()
+    {
+    }
 
-    template<typename T>
-      APIData operator() (T &mllib)
-      {
-	return mllib.info(_status);
-      }
+    template <typename T> APIData operator()(T &mllib)
+    {
+      return mllib.info(_status);
+    }
     bool _status = false;
   };
 
@@ -146,14 +147,17 @@ namespace dd
   class visitor_status
   {
   public:
-    visitor_status() {}
-    ~visitor_status() {}
+    visitor_status()
+    {
+    }
+    ~visitor_status()
+    {
+    }
 
-    template<typename T>
-      APIData operator() (T &mllib)
-      {
-	return mllib.status();
-      }
+    template <typename T> APIData operator()(T &mllib)
+    {
+      return mllib.status();
+    }
   };
 
 }

--- a/src/mlmodel.h
+++ b/src/mlmodel.h
@@ -41,32 +41,34 @@ namespace dd
   class MLModel
   {
   public:
-    MLModel() {}
-
-    MLModel(const APIData &ad, APIData &adg,
-	    const std::shared_ptr<spdlog::logger> &logger)
-      {
-	init_repo_dir(ad,logger.get());
-	if (ad.has("init"))
-	  read_config_json(adg,logger);
-      }
-    
-    MLModel(const APIData &ad)
-      {
-	init_repo_dir(ad,nullptr);
-      }
-    
-    MLModel(const std::string &repo)
-      :_repo(repo) {}
-
-
-  MLModel(const APIData &ad, const std::string &repo)
-    :_repo(repo)
+    MLModel()
     {
-      init_repo_dir(ad,nullptr);
     }
 
-    ~MLModel() {
+    MLModel(const APIData &ad, APIData &adg,
+            const std::shared_ptr<spdlog::logger> &logger)
+    {
+      init_repo_dir(ad, logger.get());
+      if (ad.has("init"))
+        read_config_json(adg, logger);
+    }
+
+    MLModel(const APIData &ad)
+    {
+      init_repo_dir(ad, nullptr);
+    }
+
+    MLModel(const std::string &repo) : _repo(repo)
+    {
+    }
+
+    MLModel(const APIData &ad, const std::string &repo) : _repo(repo)
+    {
+      init_repo_dir(ad, nullptr);
+    }
+
+    ~MLModel()
+    {
 #ifdef USE_SIMSEARCH
       delete _se;
 #endif
@@ -75,32 +77,36 @@ namespace dd
     void read_corresp_file()
     {
       if (!_corresp.empty())
-      {
-	std::ifstream ff(_corresp);
-	if (!ff.is_open())
-	  std::cerr << "cannot open model corresp file=" << _corresp << std::endl;
-	else{
-	  std::string line;
-	  while(!ff.eof())
-	    {
-	      std::getline(ff,line);
-	      std::string key = line.substr(0,line.find(' '));
-	      if (!key.empty())
-		{
-		  std::string value = line.substr(line.find(' ')+1);
-		  _hcorresp.insert(std::pair<int,std::string>(std::stoi(key),value));
-		}
-	    }
-	}
-      }
+        {
+          std::ifstream ff(_corresp);
+          if (!ff.is_open())
+            std::cerr << "cannot open model corresp file=" << _corresp
+                      << std::endl;
+          else
+            {
+              std::string line;
+              while (!ff.eof())
+                {
+                  std::getline(ff, line);
+                  std::string key = line.substr(0, line.find(' '));
+                  if (!key.empty())
+                    {
+                      std::string value = line.substr(line.find(' ') + 1);
+                      _hcorresp.insert(
+                          std::pair<int, std::string>(std::stoi(key), value));
+                    }
+                }
+            }
+        }
     }
 
     inline std::string get_hcorresp(const int &i)
-      {
-	if (_hcorresp.empty())
-	  return std::to_string(i);
-	else return _hcorresp[i];
-      }
+    {
+      if (_hcorresp.empty())
+        return std::to_string(i);
+      else
+        return _hcorresp[i];
+    }
 
 #ifdef USE_SIMSEARCH
     /**
@@ -109,49 +115,53 @@ namespace dd
     void create_sim_search(const int &dim, const APIData ad)
     {
       if (!_se)
-	{
+        {
 #ifdef USE_ANNOY
-	  (void)ad;
-	  _se = new SearchEngine<AnnoySE>(dim,_repo);
-	  _se->_tse->_map_populate = _index_preload;
+          (void)ad;
+          _se = new SearchEngine<AnnoySE>(dim, _repo);
+          _se->_tse->_map_populate = _index_preload;
 #endif
 #ifdef USE_FAISS
-	  _se = new SearchEngine<FaissSE>(dim,_repo);
-      if (ad.has("index_type"))
-        _se->_tse->_index_key = ad.get("index_type").get<std::string>();
-      if (ad.has("train_samples"))
-        _se->_tse->_train_samples_size = ad.get("train_samples").get<int>();
-      if (ad.has("ondisk"))
-        _se->_tse->_ondisk = ad.get("ondisk").get<bool>();
-      if (ad.has("nprobe"))
-        _se->_tse->_nprobe = ad.get("nprobe").get<int>();
-      #ifdef USE_GPU_FAISS
-      if (ad.has("index_gpu"))
-        _se->_tse->_gpu = ad.get("index_gpu").get<bool>();
-      if (ad.has("index_gpuid"))
-        {
-          _se->_tse->_gpu = true;
-          try
+          _se = new SearchEngine<FaissSE>(dim, _repo);
+          if (ad.has("index_type"))
+            _se->_tse->_index_key = ad.get("index_type").get<std::string>();
+          if (ad.has("train_samples"))
+            _se->_tse->_train_samples_size
+                = ad.get("train_samples").get<int>();
+          if (ad.has("ondisk"))
+            _se->_tse->_ondisk = ad.get("ondisk").get<bool>();
+          if (ad.has("nprobe"))
+            _se->_tse->_nprobe = ad.get("nprobe").get<int>();
+#ifdef USE_GPU_FAISS
+          if (ad.has("index_gpu"))
+            _se->_tse->_gpu = ad.get("index_gpu").get<bool>();
+          if (ad.has("index_gpuid"))
             {
-              int gpuid = ad.get("index_gpuid").get<int>();
-              _se->_tse->_gpuids.push_back(gpuid);
-            }
-          catch (std::exception &e)
-            {
+              _se->_tse->_gpu = true;
               try
                 {
-                  _se->_tse->_gpuids = ad.get("index_gpuid").get<std::vector<int>>();
+                  int gpuid = ad.get("index_gpuid").get<int>();
+                  _se->_tse->_gpuids.push_back(gpuid);
                 }
-              catch(std::exception &e)
+              catch (std::exception &e)
                 {
-                  throw MLLibBadParamException("wrong type for index_gpuid : id or [id0, id1, ...]");
+                  try
+                    {
+                      _se->_tse->_gpuids
+                          = ad.get("index_gpuid").get<std::vector<int>>();
+                    }
+                  catch (std::exception &e)
+                    {
+                      throw MLLibBadParamException(
+                          "wrong type for index_gpuid : id or [id0, id1, "
+                          "...]");
+                    }
                 }
             }
-        }
-      #endif
 #endif
-      _se->create_index();
-	}
+#endif
+          _se->create_index();
+        }
     }
 
     /**
@@ -160,7 +170,7 @@ namespace dd
     void create_index()
     {
       if (_se)
-	_se->create_index();
+        _se->create_index();
     }
 
     /**
@@ -169,25 +179,27 @@ namespace dd
     void build_index()
     {
       if (_se)
-	_se->update_index();
+        _se->update_index();
     }
-    
+
     /**
      * \brief remove similarity search index
      */
     void remove_index()
     {
       if (_se)
-	_se->remove_index();
+        _se->remove_index();
     }
 #endif
-    
+
     std::string _repo; /**< model repository. */
     std::string _mlmodel_template_repo = "templates/";
-    std::unordered_map<int,std::string> _hcorresp; /**< table of class correspondences. */
-    std::string _corresp; /**< file name of the class correspondences (e.g. house / 23) */
+    std::unordered_map<int, std::string>
+        _hcorresp;        /**< table of class correspondences. */
+    std::string _corresp; /**< file name of the class correspondences (e.g.
+                             house / 23) */
     std::string _best_model_filename = "/best_model.txt";
-    
+
 #ifdef USE_SIMSEARCH
 #ifdef USE_ANNOY
     SearchEngine<AnnoySE> *_se = nullptr;
@@ -198,96 +210,107 @@ namespace dd
 #endif
 
   private:
-    void init_repo_dir(const APIData &ad,
-		       spdlog::logger *logger)
+    void init_repo_dir(const APIData &ad, spdlog::logger *logger)
     {
       // auto-creation of model directory
-      _repo =  ad.get("repository").get<std::string>();
-      bool create = ad.has("create_repository") && ad.get("create_repository").get<bool>();
+      _repo = ad.get("repository").get<std::string>();
+      bool create = ad.has("create_repository")
+                    && ad.get("create_repository").get<bool>();
       bool isDir;
       bool exists = fileops::file_exists(_repo, isDir);
       if (exists && !isDir)
-        throw MLLibBadParamException("file exists with same name as repository");
+        throw MLLibBadParamException(
+            "file exists with same name as repository");
       if (!exists && create)
-        fileops::create_dir(_repo,0775);
+        fileops::create_dir(_repo, 0775);
 #ifdef USE_SIMSEARCH
       if (ad.has("index_preload") && ad.get("index_preload").get<bool>())
-	_index_preload = true;
+        _index_preload = true;
 #endif
       // auto-install from model archive
       if (ad.has("init"))
-	{
-	  std::string compressedf = ad.get("init").get<std::string>();
+        {
+          std::string compressedf = ad.get("init").get<std::string>();
 
-	  // check whether already in the directory
-	  std::string base_model_fname = compressedf.substr(compressedf.find_last_of("/") + 1);
-	  std::string modelf = _repo + "/" + base_model_fname;
-	  if (fileops::file_exists(modelf))
-	    {
-	      if (logger)
-		logger->warn("Init model {} is already in directory, not fetching it",modelf);
-	      compressedf = modelf;
-	    }
-	  
-	  if (compressedf.find("https://") != std::string::npos
-	      || compressedf.find("http://") != std::string::npos
-	      || compressedf.find("file://") != std::string::npos)
-	    {
+          // check whether already in the directory
+          std::string base_model_fname
+              = compressedf.substr(compressedf.find_last_of("/") + 1);
+          std::string modelf = _repo + "/" + base_model_fname;
+          if (fileops::file_exists(modelf))
+            {
+              if (logger)
+                logger->warn(
+                    "Init model {} is already in directory, not fetching it",
+                    modelf);
+              compressedf = modelf;
+            }
+
+          if (compressedf.find("https://") != std::string::npos
+              || compressedf.find("http://") != std::string::npos
+              || compressedf.find("file://") != std::string::npos)
+            {
 #ifdef WIN32
-          throw MLLibBadParamException("Fetching model archive: " + compressedf + " not implemented on Windows");
+              throw MLLibBadParamException("Fetching model archive: "
+                                           + compressedf
+                                           + " not implemented on Windows");
 #else
-	      int outcode = -1;
-	      std::string content;
-	      try
-		{
-		  if (logger)
-		    logger->info("Downloading init model {}",compressedf);
-		  httpclient::get_call(compressedf,"GET",outcode,content);
-		}
-	      catch(...)
-		{
-		  throw MLLibBadParamException("failed fetching model archive: " + compressedf + " with code: " + std::to_string(outcode));
-		}
-	      std::ofstream mof(modelf);
-	      mof << content;
-	      mof.close();
-	      compressedf = modelf;
+              int outcode = -1;
+              std::string content;
+              try
+                {
+                  if (logger)
+                    logger->info("Downloading init model {}", compressedf);
+                  httpclient::get_call(compressedf, "GET", outcode, content);
+                }
+              catch (...)
+                {
+                  throw MLLibBadParamException(
+                      "failed fetching model archive: " + compressedf
+                      + " with code: " + std::to_string(outcode));
+                }
+              std::ofstream mof(modelf);
+              mof << content;
+              mof.close();
+              compressedf = modelf;
 #endif
-	    }
-	  
-	  if (fileops::uncompress(compressedf,_repo))
-	    throw MLLibBadParamException("failed installing model from archive, check 'init' argument to model");
-	}
+            }
+
+          if (fileops::uncompress(compressedf, _repo))
+            throw MLLibBadParamException(
+                "failed installing model from archive, check 'init' argument "
+                "to model");
+        }
     }
 
     void read_config_json(APIData &adg,
-			  const std::shared_ptr<spdlog::logger> &logger)
+                          const std::shared_ptr<spdlog::logger> &logger)
     {
       const std::string cf = _repo + "/config.json";
       if (!fileops::file_exists(cf))
-	return;
+        return;
       std::ifstream is(cf);
       std::stringstream jbuf;
       jbuf << is.rdbuf();
       rapidjson::Document d;
       d.Parse(jbuf.str().c_str());
       if (d.HasParseError())
-	{
-	  logger->error("config.json parsing error on string: {}",jbuf.str());
-	  throw MLLibBadParamException("Failed parsing config file " + cf);
-	}
+        {
+          logger->error("config.json parsing error on string: {}", jbuf.str());
+          throw MLLibBadParamException("Failed parsing config file " + cf);
+        }
       APIData adcj;
       try
-	{
-	  adcj = APIData(d);
-	}
-      catch(RapidjsonException &e)
-	{
-	  logger->error("JSON error {}",e.what());
-	  throw MLLibBadParamException("Failed converting JSON file to internal data format");
-	}
+        {
+          adcj = APIData(d);
+        }
+      catch (RapidjsonException &e)
+        {
+          logger->error("JSON error {}", e.what());
+          throw MLLibBadParamException(
+              "Failed converting JSON file to internal data format");
+        }
       APIData adcj_parameters = adcj.getobj("parameters");
-      adg.add("parameters",adcj_parameters);
+      adg.add("parameters", adcj_parameters);
     }
   };
 }

--- a/src/mlservice.h
+++ b/src/mlservice.h
@@ -44,37 +44,56 @@ namespace dd
   class MLServiceLockException : public std::exception
   {
   public:
-    MLServiceLockException(const std::string &s)
-      :_s(s) {}
-    ~MLServiceLockException() {}
-    const char* what() const noexcept { return _s.c_str(); }
+    MLServiceLockException(const std::string &s) : _s(s)
+    {
+    }
+    ~MLServiceLockException()
+    {
+    }
+    const char *what() const noexcept
+    {
+      return _s.c_str();
+    }
+
   private:
     std::string _s;
   };
 
   /**
-   * \brief training job 
+   * \brief training job
    */
   class tjob
   {
   public:
     tjob(std::future<int> &&ft,
-	 const std::chrono::time_point<std::chrono::system_clock> &tstart)
-      :_ft(std::move(ft)),_tstart(tstart),_status(1) {}
+         const std::chrono::time_point<std::chrono::system_clock> &tstart)
+        : _ft(std::move(ft)), _tstart(tstart), _status(1)
+    {
+    }
     tjob(tjob &&tj)
-      :_ft(std::move(tj._ft)),_tstart(std::move(tj._tstart)),_status(std::move(tj._status)) {}
-    ~tjob() {}
+        : _ft(std::move(tj._ft)), _tstart(std::move(tj._tstart)),
+          _status(std::move(tj._status))
+    {
+    }
+    ~tjob()
+    {
+    }
 
     std::future<int> _ft; /**< training job output status upon termination. */
-    std::chrono::time_point<std::chrono::system_clock> _tstart; /**< date at which the training job has started*/
-    int _status = 0; /**< 0: not started, 1: running, 2: finished or terminated */
+    std::chrono::time_point<std::chrono::system_clock>
+        _tstart; /**< date at which the training job has started*/
+    int _status
+        = 0; /**< 0: not started, 1: running, 2: finished or terminated */
   };
-  
+
   /**
    * \brief main machine learning service encapsulation
    */
-  template<template <class U,class V,class W> class TMLLib, class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
-    class MLService : public TMLLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>
+  template <template <class U, class V, class W> class TMLLib,
+            class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  class MLService : public TMLLib<TInputConnectorStrategy,
+                                  TOutputConnectorStrategy, TMLModel>
   {
   public:
     /**
@@ -83,34 +102,42 @@ namespace dd
      * @param mlmodel model object
      * @param description optional string
      */
-    MLService(const std::string &sname,
-	      const TMLModel &mlmodel,
-	      const std::string &description="")
-      :TMLLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>(mlmodel),_sname(sname),_description(description),_tjobs_counter(0)
-      {
+    MLService(const std::string &sname, const TMLModel &mlmodel,
+              const std::string &description = "")
+        : TMLLib<TInputConnectorStrategy, TOutputConnectorStrategy, TMLModel>(
+            mlmodel),
+          _sname(sname), _description(description), _tjobs_counter(0)
+    {
 #ifdef USE_DD_SYSLOG
-	this->_logger = spdlog::syslog_logger(_sname);
+      this->_logger = spdlog::syslog_logger(_sname);
 #else
-	this->_logger = spdlog::stdout_logger_mt(_sname);
+      this->_logger = spdlog::stdout_logger_mt(_sname);
 #endif
-      }
-    
+    }
+
     /**
      * \brief copy-constructor
      * @param mls ML service
      */
     MLService(MLService &&mls) noexcept
-      :TMLLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>(std::move(mls)),_sname(std::move(mls._sname)),_description(std::move(mls._description)),_init_parameters(std::move(mls._init_parameters)),_tjobs_counter(mls._tjobs_counter.load()),_training_jobs(std::move(mls._training_jobs))
-      {}
-    
+        : TMLLib<TInputConnectorStrategy, TOutputConnectorStrategy, TMLModel>(
+            std::move(mls)),
+          _sname(std::move(mls._sname)),
+          _description(std::move(mls._description)),
+          _init_parameters(std::move(mls._init_parameters)),
+          _tjobs_counter(mls._tjobs_counter.load()),
+          _training_jobs(std::move(mls._training_jobs))
+    {
+    }
+
     /**
      * \brief destructor
      */
-    ~MLService() 
-      {
-	kill_jobs();
-	spdlog::drop(_sname);
-      }
+    ~MLService()
+    {
+      kill_jobs();
+      spdlog::drop(_sname);
+    }
 
     /**
      * \brief machine learning service initialization:
@@ -121,9 +148,10 @@ namespace dd
      */
     void init(const APIData &ad)
     {
-      this->_inputc._model_repo = ad.getobj("model").get("repository").get<std::string>();
+      this->_inputc._model_repo
+          = ad.getobj("model").get("repository").get<std::string>();
       if (this->_inputc._model_repo.empty())
-	throw MLLibBadParamException("empty repository");
+        throw MLLibBadParamException("empty repository");
 
       this->_inputc._logger = this->_logger;
       this->_outputc._logger = this->_logger;
@@ -136,86 +164,94 @@ namespace dd
 
     /**
      * \brief terminates all service's jobs
-     */ 
+     */
     void kill_jobs()
     {
       std::lock_guard<std::mutex> lock(_tjobs_mutex);
       auto hit = _training_jobs.begin();
-      while(hit!=_training_jobs.end())
-	{
-	  std::future_status status = (*hit).second._ft.wait_for(std::chrono::seconds(0));
-	  if (status == std::future_status::timeout
-	      && (*hit).second._status == 1) // process is running, terminate it
-	    {
-	      this->_tjob_running.store(false);
-	      (*hit).second._ft.wait();
-	      auto ohit = _training_out.find((*hit).first);
-	      if (ohit!=_training_out.end())
-		_training_out.erase(ohit);
-	    }
-	  ++hit;
-	}
+      while (hit != _training_jobs.end())
+        {
+          std::future_status status
+              = (*hit).second._ft.wait_for(std::chrono::seconds(0));
+          if (status == std::future_status::timeout
+              && (*hit).second._status
+                     == 1) // process is running, terminate it
+            {
+              this->_tjob_running.store(false);
+              (*hit).second._ft.wait();
+              auto ohit = _training_out.find((*hit).first);
+              if (ohit != _training_out.end())
+                _training_out.erase(ohit);
+            }
+          ++hit;
+        }
     }
-    
+
     /**
      * \brief get info about the service
      * @return info data object
      */
-    APIData info(const bool &status=false) const
+    APIData info(const bool &status = false) const
     {
       APIData ad;
       if (!status)
-	{
-	  ad.add("name",_sname);
-	  ad.add("description",_description);
-	  ad.add("mllib",this->_libname);
-	  if (this->_has_predict)
-	    ad.add("predict",true);
-	  else ad.add("training",true);
-	  ad.add("mltype",this->_mltype);
-	}
+        {
+          ad.add("name", _sname);
+          ad.add("description", _description);
+          ad.add("mllib", this->_libname);
+          if (this->_has_predict)
+            ad.add("predict", true);
+          else
+            ad.add("training", true);
+          ad.add("mltype", this->_mltype);
+        }
       else
-	{
-	  ad = info(false);
-	  std::vector<APIData> vad;
-	  std::lock_guard<std::mutex> lock(_tjobs_mutex);
-	  auto hit = _training_jobs.begin();
-	  while(hit!=_training_jobs.end())
-	    {
-	      APIData jad;
-	      jad.add("job",(*hit).first);
-	      int jstatus = (*hit).second._status;
-	      if (jstatus == 0)
-		jad.add("status",std::string("not started"));
-	      else if (jstatus == 1)
-		{
-		  jad.add("status",std::string("running"));
-		  APIData tjob;
-		  std::future_status status = (*hit).second._ft.wait_for(std::chrono::seconds(0));
-		  if (status == std::future_status::timeout)
-		    {
-		      this->collect_measures(jad);
-		      this->est_remain_time(jad);
-		      std::chrono::time_point<std::chrono::system_clock> trun = std::chrono::system_clock::now();
-		      jad.add("time",std::chrono::duration_cast<std::chrono::seconds>(trun-(*hit).second._tstart).count());
-		    }
-		}
-	      else if (jstatus == 2)
-		jad.add("status",std::string("finished"));
-	      vad.push_back(jad);
-	      ++hit;
-	    }
-	  ad.add("jobs",vad);
-	  if (this->_has_predict)
-	    {
-	      ad.add("repository",this->_inputc._model_repo);
-	      ad.add("width",this->_inputc.width());
-	      ad.add("height",this->_inputc.height());
-	    }
-	}
+        {
+          ad = info(false);
+          std::vector<APIData> vad;
+          std::lock_guard<std::mutex> lock(_tjobs_mutex);
+          auto hit = _training_jobs.begin();
+          while (hit != _training_jobs.end())
+            {
+              APIData jad;
+              jad.add("job", (*hit).first);
+              int jstatus = (*hit).second._status;
+              if (jstatus == 0)
+                jad.add("status", std::string("not started"));
+              else if (jstatus == 1)
+                {
+                  jad.add("status", std::string("running"));
+                  APIData tjob;
+                  std::future_status status
+                      = (*hit).second._ft.wait_for(std::chrono::seconds(0));
+                  if (status == std::future_status::timeout)
+                    {
+                      this->collect_measures(jad);
+                      this->est_remain_time(jad);
+                      std::chrono::time_point<std::chrono::system_clock> trun
+                          = std::chrono::system_clock::now();
+                      jad.add("time",
+                              std::chrono::duration_cast<std::chrono::seconds>(
+                                  trun - (*hit).second._tstart)
+                                  .count());
+                    }
+                }
+              else if (jstatus == 2)
+                jad.add("status", std::string("finished"));
+              vad.push_back(jad);
+              ++hit;
+            }
+          ad.add("jobs", vad);
+          if (this->_has_predict)
+            {
+              ad.add("repository", this->_inputc._model_repo);
+              ad.add("width", this->_inputc.width());
+              ad.add("height", this->_inputc.height());
+            }
+        }
       return ad;
     }
-    
+
     /**
      * \brief get status of the service
      *        To be surcharged in related classes
@@ -227,38 +263,42 @@ namespace dd
       std::vector<APIData> vad;
       std::lock_guard<std::mutex> lock(_tjobs_mutex);
       auto hit = _training_jobs.begin();
-      while(hit!=_training_jobs.end())
-	{
-	  APIData jad;
-	  jad.add("job",(*hit).first);
-	  int jstatus = (*hit).second._status;
-	  if (jstatus == 0)
-	    jad.add("status",std::string("not started"));
-	  else if (jstatus == 1)
-	    jad.add("status",std::string("running"));
-	  else if (jstatus == 2)
-	    jad.add("status",std::string("finished"));
-	  vad.push_back(jad);
-	  ++hit;
-	}
+      while (hit != _training_jobs.end())
+        {
+          APIData jad;
+          jad.add("job", (*hit).first);
+          int jstatus = (*hit).second._status;
+          if (jstatus == 0)
+            jad.add("status", std::string("not started"));
+          else if (jstatus == 1)
+            jad.add("status", std::string("running"));
+          else if (jstatus == 2)
+            jad.add("status", std::string("finished"));
+          vad.push_back(jad);
+          ++hit;
+        }
       APIData stats;
-      stats.add("flops",this->_model_flops);
-      stats.add("params",this->_model_params);
-      stats.add("data_mem_train",static_cast<long int>(this->_mem_used_train * sizeof(float)));
-      stats.add("data_mem_test",static_cast<long int>(this->_mem_used_test * sizeof(float)));
+      stats.add("flops", this->_model_flops);
+      stats.add("params", this->_model_params);
+      stats.add("data_mem_train",
+                static_cast<long int>(this->_mem_used_train * sizeof(float)));
+      stats.add("data_mem_test",
+                static_cast<long int>(this->_mem_used_test * sizeof(float)));
       ad.add("stats", stats);
-      ad.add("jobs",vad);
-      ad.add("parameters",_init_parameters);
-      ad.add("repository",this->_inputc._model_repo);
-      ad.add("mltype",this->_mltype);
+      ad.add("jobs", vad);
+      ad.add("parameters", _init_parameters);
+      ad.add("repository", this->_inputc._model_repo);
+      ad.add("mltype", this->_mltype);
       if (typeid(this->_outputc) == typeid(UnsupervisedOutput))
-	ad.add("type",std::string("unsupervised"));
-      else ad.add("type",std::string("supervised"));
+        ad.add("type", std::string("unsupervised"));
+      else
+        ad.add("type", std::string("supervised"));
       return ad;
     }
 
     /**
-     * \brief starts a possibly asynchronous training job and returns status or job number (async job).
+     * \brief starts a possibly asynchronous training job and returns status or
+     * job number (async job).
      * @param ad root data object
      * @param out output data object
      * @return training job number if async, otherwise status upon termination
@@ -266,41 +306,47 @@ namespace dd
     int train_job(const APIData &ad, APIData &out)
     {
       APIData jmrepo;
-      jmrepo.add("repository",this->_mlmodel._repo);
-      out.add("model",jmrepo);
-      //this->fillup_measures_history(ad);
+      jmrepo.add("repository", this->_mlmodel._repo);
+      out.add("model", jmrepo);
+      // this->fillup_measures_history(ad);
       if (!ad.has("async") || (ad.has("async") && ad.get("async").get<bool>()))
-	{
-	  std::lock_guard<std::mutex> lock(_tjobs_mutex);
-	  std::chrono::time_point<std::chrono::system_clock> tstart = std::chrono::system_clock::now();
-	  ++_tjobs_counter;
-	  int local_tcounter = _tjobs_counter;
-	  this->_has_predict = false;
-	  _training_jobs.emplace(local_tcounter,
-				 std::move(tjob(std::async(std::launch::async,
-							   [this,ad,local_tcounter]
-							   {
-							     // XXX: due to lock below, queued jobs may not start in requested order
-							     boost::unique_lock< boost::shared_mutex > lock(_train_mutex);
-							     APIData out;
-							     int run_code = this->train(ad,out);
-							     std::pair<int,APIData> p(local_tcounter,std::move(out));
-							     _training_out.insert(std::move(p));
-							     return run_code;
-							   }),
-						tstart)));
-	  return _tjobs_counter;
-	}
-	else 
-	  {
-	    boost::unique_lock< boost::shared_mutex > lock(_train_mutex);
-	    int status = this->train(ad,out);
-	    //this->collect_measures(out);
-	    APIData ad_params_out = ad.getobj("parameters").getobj("output");
-	    if (ad_params_out.has("measure_hist") && ad_params_out.get("measure_hist").get<bool>())
-	      this->collect_measures_history(out);
-	    return status;
-	  }
+        {
+          std::lock_guard<std::mutex> lock(_tjobs_mutex);
+          std::chrono::time_point<std::chrono::system_clock> tstart
+              = std::chrono::system_clock::now();
+          ++_tjobs_counter;
+          int local_tcounter = _tjobs_counter;
+          this->_has_predict = false;
+          _training_jobs.emplace(
+              local_tcounter,
+              std::move(tjob(
+                  std::async(std::launch::async,
+                             [this, ad, local_tcounter] {
+                               // XXX: due to lock below, queued jobs may not
+                               // start in requested order
+                               boost::unique_lock<boost::shared_mutex> lock(
+                                   _train_mutex);
+                               APIData out;
+                               int run_code = this->train(ad, out);
+                               std::pair<int, APIData> p(local_tcounter,
+                                                         std::move(out));
+                               _training_out.insert(std::move(p));
+                               return run_code;
+                             }),
+                  tstart)));
+          return _tjobs_counter;
+        }
+      else
+        {
+          boost::unique_lock<boost::shared_mutex> lock(_train_mutex);
+          int status = this->train(ad, out);
+          // this->collect_measures(out);
+          APIData ad_params_out = ad.getobj("parameters").getobj("output");
+          if (ad_params_out.has("measure_hist")
+              && ad_params_out.get("measure_hist").get<bool>())
+            this->collect_measures_history(out);
+          return status;
+        }
     }
 
     /**
@@ -314,77 +360,90 @@ namespace dd
       int j = ad.get("job").get<int>();
       int secs = 0;
       if (ad.has("timeout"))
-	secs = ad.get("timeout").get<int>();
+        secs = ad.get("timeout").get<int>();
       APIData ad_params_out = ad.getobj("parameters").getobj("output");
       std::lock_guard<std::mutex> lock(_tjobs_mutex);
-      std::unordered_map<int,tjob>::iterator hit;
-      if ((hit=_training_jobs.find(j))!=_training_jobs.end())
-	{
-	  std::future_status status = (*hit).second._ft.wait_for(std::chrono::seconds(secs));
-	  if (status == std::future_status::timeout)
-	    {
-	      out.add("status",std::string("running"));
-	      APIData jmrepo;
-	      jmrepo.add("repository",this->_mlmodel._repo);
-	      out.add("model",jmrepo);
-	      this->collect_measures(out);
-	      this->est_remain_time(out);
-	      std::chrono::time_point<std::chrono::system_clock> trun = std::chrono::system_clock::now();
-	      out.add("time",std::chrono::duration_cast<std::chrono::seconds>(trun-(*hit).second._tstart).count());
-	      int max_hist_points = 10000; // default
-	      if (ad_params_out.has("max_hist_points"))
-		max_hist_points = ad_params_out.get("max_hist_points").get<int>();
-	      this->collect_measures_history(out,max_hist_points);
-	    }
-	  else if (status == std::future_status::ready)
-	    {
-	      int st;
-	      try
-		{
-		  st = (*hit).second._ft.get();
-		}
-	      catch (std::exception &e)
-		{
-		  auto ohit = _training_out.find((*hit).first);
-		  if (ohit!=_training_out.end())
-		    _training_out.erase(ohit);
-		  _training_jobs.erase(hit);
-		  throw;
-		}
-	      auto ohit = _training_out.find((*hit).first);
-	      if (ohit!=_training_out.end())
-		{
-		  out = std::move((*ohit).second); // get async process output object
-		  _training_out.erase(ohit);
-		}
-	      if (st == 0)
-		{
-		  out.add("status",std::string("finished"));
-		  this->_has_predict = true;
-		}
-	      else out.add("status",std::string("unknown error"));
-	      //this->collect_measures(out); // XXX: beware if there was a queue, since the job has finished, there might be a new one running.
-	      APIData jmrepo;
-	      jmrepo.add("repository",this->_mlmodel._repo);
-	      out.add("model",jmrepo);
-	      std::chrono::time_point<std::chrono::system_clock> trun = std::chrono::system_clock::now();
-	      out.add("time",std::chrono::duration_cast<std::chrono::seconds>(trun-(*hit).second._tstart).count());
-	      // metrics history is force-collected when training finishes
-	      int max_hist_points = 10000; // default
-	      if (ad_params_out.has("max_hist_points"))
-		max_hist_points = ad_params_out.get("max_hist_points").get<int>();
-	      this->collect_measures_history(out,max_hist_points);
-	      out.add("mltype",this->_mltype);
-	      out.add("sname",this->_sname);
-	      out.add("description",this->_description);
-	      _training_jobs.erase(hit);
-	    }
-	  return 0;
-	}
+      std::unordered_map<int, tjob>::iterator hit;
+      if ((hit = _training_jobs.find(j)) != _training_jobs.end())
+        {
+          std::future_status status
+              = (*hit).second._ft.wait_for(std::chrono::seconds(secs));
+          if (status == std::future_status::timeout)
+            {
+              out.add("status", std::string("running"));
+              APIData jmrepo;
+              jmrepo.add("repository", this->_mlmodel._repo);
+              out.add("model", jmrepo);
+              this->collect_measures(out);
+              this->est_remain_time(out);
+              std::chrono::time_point<std::chrono::system_clock> trun
+                  = std::chrono::system_clock::now();
+              out.add("time", std::chrono::duration_cast<std::chrono::seconds>(
+                                  trun - (*hit).second._tstart)
+                                  .count());
+              int max_hist_points = 10000; // default
+              if (ad_params_out.has("max_hist_points"))
+                max_hist_points
+                    = ad_params_out.get("max_hist_points").get<int>();
+              this->collect_measures_history(out, max_hist_points);
+            }
+          else if (status == std::future_status::ready)
+            {
+              int st;
+              try
+                {
+                  st = (*hit).second._ft.get();
+                }
+              catch (std::exception &e)
+                {
+                  auto ohit = _training_out.find((*hit).first);
+                  if (ohit != _training_out.end())
+                    _training_out.erase(ohit);
+                  _training_jobs.erase(hit);
+                  throw;
+                }
+              auto ohit = _training_out.find((*hit).first);
+              if (ohit != _training_out.end())
+                {
+                  out = std::move(
+                      (*ohit).second); // get async process output object
+                  _training_out.erase(ohit);
+                }
+              if (st == 0)
+                {
+                  out.add("status", std::string("finished"));
+                  this->_has_predict = true;
+                }
+              else
+                out.add("status", std::string("unknown error"));
+              // this->collect_measures(out); // XXX: beware if there was a
+              // queue, since the job has finished, there might be a new one
+              // running.
+              APIData jmrepo;
+              jmrepo.add("repository", this->_mlmodel._repo);
+              out.add("model", jmrepo);
+              std::chrono::time_point<std::chrono::system_clock> trun
+                  = std::chrono::system_clock::now();
+              out.add("time", std::chrono::duration_cast<std::chrono::seconds>(
+                                  trun - (*hit).second._tstart)
+                                  .count());
+              // metrics history is force-collected when training finishes
+              int max_hist_points = 10000; // default
+              if (ad_params_out.has("max_hist_points"))
+                max_hist_points
+                    = ad_params_out.get("max_hist_points").get<int>();
+              this->collect_measures_history(out, max_hist_points);
+              out.add("mltype", this->_mltype);
+              out.add("sname", this->_sname);
+              out.add("description", this->_description);
+              _training_jobs.erase(hit);
+            }
+          return 0;
+        }
       else
-	{
-	  return 1; // job not found
-	}
+        {
+          return 1; // job not found
+        }
     }
 
     /**
@@ -397,30 +456,37 @@ namespace dd
     {
       int j = ad.get("job").get<int>();
       std::lock_guard<std::mutex> lock(_tjobs_mutex);
-      std::unordered_map<int,tjob>::iterator hit;
-      if ((hit=_training_jobs.find(j))!=_training_jobs.end())
-	{
-	  std::future_status status = (*hit).second._ft.wait_for(std::chrono::seconds(0));
-	  if (status == std::future_status::timeout
-	      && (*hit).second._status == 1) // process is running, terminate it
-	    {
-	      this->_tjob_running.store(false); // signals the process
-	      (*hit).second._ft.wait(); // XXX: default timeout in case the process does not return ?
-	      out.add("status",std::string("terminated"));
-	      std::chrono::time_point<std::chrono::system_clock> trun = std::chrono::system_clock::now();
-	      out.add("time",std::chrono::duration_cast<std::chrono::seconds>(trun-(*hit).second._tstart).count());
-	      _training_jobs.erase(hit);
-	      auto ohit = _training_out.find((*hit).first);
-	      if (ohit!=_training_out.end())
-		_training_out.erase(ohit);
-	    }
-	  else if ((*hit).second._status == 0)
-	    {
-	      out.add("status",std::string("not started"));
-	    }
-	  return 0;
-	}
-      else return 1; // job not found
+      std::unordered_map<int, tjob>::iterator hit;
+      if ((hit = _training_jobs.find(j)) != _training_jobs.end())
+        {
+          std::future_status status
+              = (*hit).second._ft.wait_for(std::chrono::seconds(0));
+          if (status == std::future_status::timeout
+              && (*hit).second._status
+                     == 1) // process is running, terminate it
+            {
+              this->_tjob_running.store(false); // signals the process
+              (*hit).second._ft.wait(); // XXX: default timeout in case the
+                                        // process does not return ?
+              out.add("status", std::string("terminated"));
+              std::chrono::time_point<std::chrono::system_clock> trun
+                  = std::chrono::system_clock::now();
+              out.add("time", std::chrono::duration_cast<std::chrono::seconds>(
+                                  trun - (*hit).second._tstart)
+                                  .count());
+              _training_jobs.erase(hit);
+              auto ohit = _training_out.find((*hit).first);
+              if (ohit != _training_out.end())
+                _training_out.erase(ohit);
+            }
+          else if ((*hit).second._status == 0)
+            {
+              out.add("status", std::string("not started"));
+            }
+          return 0;
+        }
+      else
+        return 1; // job not found
     }
 
     /**
@@ -429,49 +495,53 @@ namespace dd
      * @param out output data object
      * @return predict job status
      */
-    int predict_job(const APIData &ad, APIData &out, const bool &chain=false)
+    int predict_job(const APIData &ad, APIData &out, const bool &chain = false)
     {
-      //TODO: collect input transformed data for chain, store it here in memory
+      // TODO: collect input transformed data for chain, store it here in
+      // memory
       // -> beware, the input connector is a copy...
-      
+
       if (!this->_online)
-	{
-	  if (!_train_mutex.try_lock_shared())
-	    throw MLServiceLockException("Predict call while training with an offline learning algorithm");
-	  int err = 0;
-	  try
-	    {
-	      if (chain)
-		const_cast<APIData&>(ad).add("chain",true);
-	      err = this->predict(ad,out);
-	    }
-	  catch(std::exception &e)
-	    {
-	      _train_mutex.unlock_shared();
-	      throw;
-	    }
-	  _train_mutex.unlock_shared();
-	  return err;
-	}
+        {
+          if (!_train_mutex.try_lock_shared())
+            throw MLServiceLockException("Predict call while training with an "
+                                         "offline learning algorithm");
+          int err = 0;
+          try
+            {
+              if (chain)
+                const_cast<APIData &>(ad).add("chain", true);
+              err = this->predict(ad, out);
+            }
+          catch (std::exception &e)
+            {
+              _train_mutex.unlock_shared();
+              throw;
+            }
+          _train_mutex.unlock_shared();
+          return err;
+        }
       else // wait til a lock can be acquired
-	{
-	  boost::shared_lock< boost::shared_mutex > lock(_train_mutex);
-	  return this->predict(ad,out);
-	}
+        {
+          boost::shared_lock<boost::shared_mutex> lock(_train_mutex);
+          return this->predict(ad, out);
+        }
       return 0;
     }
 
-    std::string _sname; /**< service name. */
+    std::string _sname;       /**< service name. */
     std::string _description; /**< optional description of the service. */
     APIData _init_parameters; /**< service creation parameters. */
-    
+
     mutable std::mutex _tjobs_mutex; /**< mutex around training jobs. */
-    std::atomic<int> _tjobs_counter = {0}; /**< training jobs counter. */
-    std::unordered_map<int,tjob> _training_jobs; // XXX: the futures' dtor blocks if the object is being terminated
-    std::unordered_map<int,APIData> _training_out;
+    std::atomic<int> _tjobs_counter = { 0 }; /**< training jobs counter. */
+    std::unordered_map<int, tjob>
+        _training_jobs; // XXX: the futures' dtor blocks if the object is being
+                        // terminated
+    std::unordered_map<int, APIData> _training_out;
     boost::shared_mutex _train_mutex;
   };
-  
+
 }
 
 #endif

--- a/src/outputconnectorstrategy.h
+++ b/src/outputconnectorstrategy.h
@@ -42,10 +42,17 @@ namespace dd
   class OutputConnectorBadParamException : public std::exception
   {
   public:
-    OutputConnectorBadParamException(const std::string &s)
-      :_s(s) {}
-    ~OutputConnectorBadParamException() {}
-    const char* what() const noexcept { return _s.c_str(); }
+    OutputConnectorBadParamException(const std::string &s) : _s(s)
+    {
+    }
+    ~OutputConnectorBadParamException()
+    {
+    }
+    const char *what() const noexcept
+    {
+      return _s.c_str();
+    }
+
   private:
     std::string _s;
   };
@@ -56,35 +63,45 @@ namespace dd
   class OutputConnectorInternalException : public std::exception
   {
   public:
-    OutputConnectorInternalException(const std::string &s)
-      :_s(s) {}
-    ~OutputConnectorInternalException() {}
-    const char* what() const noexcept { return _s.c_str(); }
+    OutputConnectorInternalException(const std::string &s) : _s(s)
+    {
+    }
+    ~OutputConnectorInternalException()
+    {
+    }
+    const char *what() const noexcept
+    {
+      return _s.c_str();
+    }
+
   private:
     std::string _s;
   };
-  
+
   /**
    * \brief main output connector class
    */
   class OutputConnectorStrategy
   {
   public:
-    OutputConnectorStrategy() {}
-    ~OutputConnectorStrategy() {}
+    OutputConnectorStrategy()
+    {
+    }
+    ~OutputConnectorStrategy()
+    {
+    }
 
-  OutputConnectorStrategy(const OutputConnectorStrategy &out)
-    : OutputConnectorStrategy()
-      {
-        this->_logger = out._logger;
-      }
-
+    OutputConnectorStrategy(const OutputConnectorStrategy &out)
+        : OutputConnectorStrategy()
+    {
+      this->_logger = out._logger;
+    }
 
     /**
      * \brief output data reading
      */
-    //int transform() { return 1; }
-    
+    // int transform() { return 1; }
+
     /**
      * \brief initialization of output data connector
      * @param ad data object for "parameters/output"
@@ -102,7 +119,8 @@ namespace dd
      * @param ad_in data output object from the API call
      * @param ad_out data object as the call response
      */
-    void finalize(const APIData &ad_in, APIData &ad_out, MLModel *mlm=nullptr);
+    void finalize(const APIData &ad_in, APIData &ad_out,
+                  MLModel *mlm = nullptr);
 
     std::shared_ptr<spdlog::logger> _logger;
   };
@@ -113,11 +131,14 @@ namespace dd
   class NoOutputConn : public OutputConnectorStrategy
   {
   public:
-    NoOutputConn()
-      :OutputConnectorStrategy() {}
-    ~NoOutputConn() {}
+    NoOutputConn() : OutputConnectorStrategy()
+    {
+    }
+    ~NoOutputConn()
+    {
+    }
   };
-  
+
 }
 
 #include "supervisedoutputconnector.h"

--- a/src/services.h
+++ b/src/services.h
@@ -72,83 +72,108 @@ namespace dd
   /* service types as variant type. */
   typedef mapbox::util::variant<
 #ifdef USE_CAFFE
-    MLService<CaffeLib,ImgCaffeInputFileConn,SupervisedOutput,CaffeModel>,
-    MLService<CaffeLib,CSVCaffeInputFileConn,SupervisedOutput,CaffeModel>,
-    MLService<CaffeLib,CSVTSCaffeInputFileConn,SupervisedOutput,CaffeModel>,
-    MLService<CaffeLib,TxtCaffeInputFileConn,SupervisedOutput,CaffeModel>,
-    MLService<CaffeLib,SVMCaffeInputFileConn,SupervisedOutput,CaffeModel>,
-    MLService<CaffeLib,ImgCaffeInputFileConn,UnsupervisedOutput,CaffeModel>,
-    MLService<CaffeLib,CSVCaffeInputFileConn,UnsupervisedOutput,CaffeModel>,
-    MLService<CaffeLib,CSVTSCaffeInputFileConn,UnsupervisedOutput,CaffeModel>,
-    MLService<CaffeLib,TxtCaffeInputFileConn,UnsupervisedOutput,CaffeModel>,
-    MLService<CaffeLib,SVMCaffeInputFileConn,UnsupervisedOutput,CaffeModel>
+      MLService<CaffeLib, ImgCaffeInputFileConn, SupervisedOutput, CaffeModel>,
+      MLService<CaffeLib, CSVCaffeInputFileConn, SupervisedOutput, CaffeModel>,
+      MLService<CaffeLib, CSVTSCaffeInputFileConn, SupervisedOutput,
+                CaffeModel>,
+      MLService<CaffeLib, TxtCaffeInputFileConn, SupervisedOutput, CaffeModel>,
+      MLService<CaffeLib, SVMCaffeInputFileConn, SupervisedOutput, CaffeModel>,
+      MLService<CaffeLib, ImgCaffeInputFileConn, UnsupervisedOutput,
+                CaffeModel>,
+      MLService<CaffeLib, CSVCaffeInputFileConn, UnsupervisedOutput,
+                CaffeModel>,
+      MLService<CaffeLib, CSVTSCaffeInputFileConn, UnsupervisedOutput,
+                CaffeModel>,
+      MLService<CaffeLib, TxtCaffeInputFileConn, UnsupervisedOutput,
+                CaffeModel>,
+      MLService<CaffeLib, SVMCaffeInputFileConn, UnsupervisedOutput,
+                CaffeModel>
 #endif
 #ifdef USE_CAFFE2
-    #ifdef USE_CAFFE
-    ,
-    #endif
-    MLService<Caffe2Lib,ImgCaffe2InputFileConn,SupervisedOutput,Caffe2Model>,
-    MLService<Caffe2Lib,ImgCaffe2InputFileConn,UnsupervisedOutput,Caffe2Model>
+#ifdef USE_CAFFE
+      ,
+#endif
+      MLService<Caffe2Lib, ImgCaffe2InputFileConn, SupervisedOutput,
+                Caffe2Model>,
+      MLService<Caffe2Lib, ImgCaffe2InputFileConn, UnsupervisedOutput,
+                Caffe2Model>
 #endif
 #ifdef USE_TF
-    #if defined(USE_CAFFE) || defined(USE_CAFFE2)
-    ,
-    #endif
-    MLService<TFLib,ImgTFInputFileConn,SupervisedOutput,TFModel>,
-    MLService<TFLib,ImgTFInputFileConn,UnsupervisedOutput,TFModel>
+#if defined(USE_CAFFE) || defined(USE_CAFFE2)
+      ,
+#endif
+      MLService<TFLib, ImgTFInputFileConn, SupervisedOutput, TFModel>,
+      MLService<TFLib, ImgTFInputFileConn, UnsupervisedOutput, TFModel>
 #endif
 #ifdef USE_DLIB
-    #if defined(USE_CAFFE) || defined(USE_CAFFE2) || defined(USE_TF)
-    ,
-    #endif
-    MLService<DlibLib,ImgDlibInputFileConn,SupervisedOutput,DlibModel>,
-    MLService<DlibLib,ImgDlibInputFileConn,UnsupervisedOutput,DlibModel>
+#if defined(USE_CAFFE) || defined(USE_CAFFE2) || defined(USE_TF)
+      ,
+#endif
+      MLService<DlibLib, ImgDlibInputFileConn, SupervisedOutput, DlibModel>,
+      MLService<DlibLib, ImgDlibInputFileConn, UnsupervisedOutput, DlibModel>
 #endif
 #ifdef USE_XGBOOST
-    #if defined(USE_CAFFE) || defined(USE_CAFFE2) || defined(USE_TF) || defined(USE_DLIB)
-    ,
-    #endif
-    MLService<XGBLib,CSVXGBInputFileConn,SupervisedOutput,XGBModel>,
-    MLService<XGBLib,SVMXGBInputFileConn,SupervisedOutput,XGBModel>,
-    MLService<XGBLib,TxtXGBInputFileConn,SupervisedOutput,XGBModel>
+#if defined(USE_CAFFE) || defined(USE_CAFFE2) || defined(USE_TF)              \
+    || defined(USE_DLIB)
+      ,
+#endif
+      MLService<XGBLib, CSVXGBInputFileConn, SupervisedOutput, XGBModel>,
+      MLService<XGBLib, SVMXGBInputFileConn, SupervisedOutput, XGBModel>,
+      MLService<XGBLib, TxtXGBInputFileConn, SupervisedOutput, XGBModel>
 #endif
 #ifdef USE_TSNE
-    #if defined(USE_CAFFE) || defined(USE_CAFFE2) || defined(USE_TF) || defined(USE_DLIB) || defined(USE_XGBOOST)
-    ,
-    #endif
-    MLService<TSNELib,CSVTSNEInputFileConn,UnsupervisedOutput,TSNEModel>,
-    MLService<TSNELib,TxtTSNEInputFileConn,UnsupervisedOutput,TSNEModel>
+#if defined(USE_CAFFE) || defined(USE_CAFFE2) || defined(USE_TF)              \
+    || defined(USE_DLIB) || defined(USE_XGBOOST)
+      ,
+#endif
+      MLService<TSNELib, CSVTSNEInputFileConn, UnsupervisedOutput, TSNEModel>,
+      MLService<TSNELib, TxtTSNEInputFileConn, UnsupervisedOutput, TSNEModel>
 #endif
 #ifdef USE_NCNN
-    #if defined(USE_CAFFE) || defined(USE_CAFFE2) || defined(USE_TF) || defined(USE_DLIB) || defined(USE_XGBOOST) || defined(USE_TSNE)
-    ,
-    #endif
-    MLService<NCNNLib,CSVTSNCNNInputFileConn,SupervisedOutput,NCNNModel>,
-    MLService<NCNNLib,ImgNCNNInputFileConn,SupervisedOutput,NCNNModel>
+#if defined(USE_CAFFE) || defined(USE_CAFFE2) || defined(USE_TF)              \
+    || defined(USE_DLIB) || defined(USE_XGBOOST) || defined(USE_TSNE)
+      ,
+#endif
+      MLService<NCNNLib, CSVTSNCNNInputFileConn, SupervisedOutput, NCNNModel>,
+      MLService<NCNNLib, ImgNCNNInputFileConn, SupervisedOutput, NCNNModel>
 #endif
 #ifdef USE_TORCH
-    #if defined(USE_CAFFE) || defined(USE_CAFFE2) || defined(USE_TF) || defined(USE_DLIB) || defined(USE_XGBOOST) || defined(USE_TSNE) || defined(USE_NCNN)
-    ,
-    #endif
-    MLService<TorchLib,ImgTorchInputFileConn,SupervisedOutput,TorchModel>,
-	MLService<TorchLib,TxtTorchInputFileConn,SupervisedOutput,TorchModel>,
-	MLService<TorchLib,CSVTSTorchInputFileConn,SupervisedOutput,TorchModel>
+#if defined(USE_CAFFE) || defined(USE_CAFFE2) || defined(USE_TF)              \
+    || defined(USE_DLIB) || defined(USE_XGBOOST) || defined(USE_TSNE)         \
+    || defined(USE_NCNN)
+      ,
+#endif
+      MLService<TorchLib, ImgTorchInputFileConn, SupervisedOutput, TorchModel>,
+      MLService<TorchLib, TxtTorchInputFileConn, SupervisedOutput, TorchModel>,
+      MLService<TorchLib, CSVTSTorchInputFileConn, SupervisedOutput,
+                TorchModel>
 #endif
 #ifdef USE_TENSORRT
-#if defined(USE_CAFFE) || defined(USE_CAFFE2) || defined(USE_TF) || defined(USE_DLIB) || defined(USE_XGBOOST) || defined(USE_TSNE) || defined(USE_NCNN) || defined(USE_TORCH)
-    ,
+#if defined(USE_CAFFE) || defined(USE_CAFFE2) || defined(USE_TF)              \
+    || defined(USE_DLIB) || defined(USE_XGBOOST) || defined(USE_TSNE)         \
+    || defined(USE_NCNN) || defined(USE_TORCH)
+      ,
 #endif
-    MLService<TensorRTLib,ImgTensorRTInputFileConn,SupervisedOutput,TensorRTModel>
+      MLService<TensorRTLib, ImgTensorRTInputFileConn, SupervisedOutput,
+                TensorRTModel>
 #endif
-    > mls_variant_type;
+      >
+      mls_variant_type;
 
   class ServiceForbiddenException : public std::exception
   {
   public:
-    ServiceForbiddenException(const std::string &s)
-      :_s(s) {}
-    ~ServiceForbiddenException() {}
-    const char* what() const noexcept { return _s.c_str(); }
+    ServiceForbiddenException(const std::string &s) : _s(s)
+    {
+    }
+    ~ServiceForbiddenException()
+    {
+    }
+    const char *what() const noexcept
+    {
+      return _s.c_str();
+    }
+
   private:
     std::string _s;
   };
@@ -156,24 +181,34 @@ namespace dd
   class ServiceNotFoundException : public std::exception
   {
   public:
-    ServiceNotFoundException(const std::string &s)
-      :_s(s) {}
-    ~ServiceNotFoundException() {}
-    const char* what() const noexcept { return _s.c_str(); }
+    ServiceNotFoundException(const std::string &s) : _s(s)
+    {
+    }
+    ~ServiceNotFoundException()
+    {
+    }
+    const char *what() const noexcept
+    {
+      return _s.c_str();
+    }
+
   private:
     std::string _s;
   };
-  
+
   class output
   {
   public:
-    output() {}
-    output(const int &status, const APIData &out)
-      :_status(status),_out(out)
-    {}
-    ~output() 
-      {}
-    
+    output()
+    {
+    }
+    output(const int &status, const APIData &out) : _status(status), _out(out)
+    {
+    }
+    ~output()
+    {
+    }
+
     int _status = 0;
     APIData _out;
   };
@@ -181,16 +216,19 @@ namespace dd
   class visitor_predict
   {
   public:
-    visitor_predict() {}
-    ~visitor_predict() {}
-    
-    template<typename T>
-      output operator() (T &mllib)
-      {
-        int r = mllib.predict_job(_ad,_out,_chain);
-	return output(r,_out);
-      }
-    
+    visitor_predict()
+    {
+    }
+    ~visitor_predict()
+    {
+    }
+
+    template <typename T> output operator()(T &mllib)
+    {
+      int r = mllib.predict_job(_ad, _out, _chain);
+      return output(r, _out);
+    }
+
     APIData _ad;
     APIData _out;
     bool _chain = false;
@@ -202,16 +240,19 @@ namespace dd
   class visitor_train
   {
   public:
-    visitor_train() {}
-    ~visitor_train() {}
-    
-    template<typename T>
-      output operator() (T &mllib)
-      {
-        int r = mllib.train_job(_ad,_out);
-	return output(r,_out);
-      }
-    
+    visitor_train()
+    {
+    }
+    ~visitor_train()
+    {
+    }
+
+    template <typename T> output operator()(T &mllib)
+    {
+      int r = mllib.train_job(_ad, _out);
+      return output(r, _out);
+    }
+
     APIData _ad;
     APIData _out;
   };
@@ -222,16 +263,19 @@ namespace dd
   class visitor_train_status
   {
   public:
-    visitor_train_status() {}
-    ~visitor_train_status() {}
-    
-    template<typename T>
-      output operator() (T &mllib)
-      {
-        int r = mllib.training_job_status(_ad,_out);
-	return output(r,_out);
-      }
-    
+    visitor_train_status()
+    {
+    }
+    ~visitor_train_status()
+    {
+    }
+
+    template <typename T> output operator()(T &mllib)
+    {
+      int r = mllib.training_job_status(_ad, _out);
+      return output(r, _out);
+    }
+
     APIData _ad;
     APIData _out;
   };
@@ -242,16 +286,19 @@ namespace dd
   class visitor_train_delete
   {
   public:
-    visitor_train_delete() {}
-    ~visitor_train_delete() {}
-    
-    template<typename T>
-      output operator() (T &mllib)
-      {
-        int r = mllib.training_job_delete(_ad,_out);
-	return output(r,_out);
-      }
-    
+    visitor_train_delete()
+    {
+    }
+    ~visitor_train_delete()
+    {
+    }
+
+    template <typename T> output operator()(T &mllib)
+    {
+      int r = mllib.training_job_delete(_ad, _out);
+      return output(r, _out);
+    }
+
     APIData _ad;
     APIData _out;
   };
@@ -262,71 +309,80 @@ namespace dd
   class visitor_init
   {
   public:
-    visitor_init(const APIData &ad)
-      :_ad(ad) {}
-    ~visitor_init() {}
-    
-    template<typename T>
-      void operator() (T &mllib)
-      {
-	mllib.init(_ad);
-      }
-    
+    visitor_init(const APIData &ad) : _ad(ad)
+    {
+    }
+    ~visitor_init()
+    {
+    }
+
+    template <typename T> void operator()(T &mllib)
+    {
+      mllib.init(_ad);
+    }
+
     APIData _ad;
   };
-  
+
   /**
    * \brief service deletion visitor class
    */
   class visitor_clear
   {
   public:
-    visitor_clear(const APIData &ad)
-      :_ad(ad) {}
-    ~visitor_clear() {}
-    
-    template<typename T>
-      void operator() (T &mllib)
-      {
-	mllib.kill_jobs();
-	if (_ad.has("clear"))
-	  {
-	    std::string clear = _ad.get("clear").get<std::string>();
-	    if (clear == "full")
-	      mllib.clear_full();
+    visitor_clear(const APIData &ad) : _ad(ad)
+    {
+    }
+    ~visitor_clear()
+    {
+    }
+
+    template <typename T> void operator()(T &mllib)
+    {
+      mllib.kill_jobs();
+      if (_ad.has("clear"))
+        {
+          std::string clear = _ad.get("clear").get<std::string>();
+          if (clear == "full")
+            mllib.clear_full();
 #ifdef USE_SIMSEARCH
-	    else if (clear == "lib")
-	      {
-		mllib.clear_mllib(_ad);
-		mllib.clear_index();
-	      }
+          else if (clear == "lib")
+            {
+              mllib.clear_mllib(_ad);
+              mllib.clear_index();
+            }
 #else
-	    else if (clear == "lib")
-	      mllib.clear_mllib(_ad);
+          else if (clear == "lib")
+            mllib.clear_mllib(_ad);
 #endif
-           else if (clear == "dir")
-             mllib.clear_dir();
+          else if (clear == "dir")
+            mllib.clear_dir();
 #ifdef USE_SIMSEARCH
-	    else if (clear == "index")
-	      mllib.clear_index();
+          else if (clear == "index")
+            mllib.clear_index();
 #endif
-	  }
-      }
-    
+        }
+    }
+
     APIData _ad;
   };
-  
+
   /**
    * \brief class for deepetect machine learning services.
    *        Each service instanciates a machine learning library and channels
    *        data for training and prediction along with parameters from API
-   *        Service uses a variant type and store instances in a single iterable container.
+   *        Service uses a variant type and store instances in a single
+   * iterable container.
    */
   class Services
   {
   public:
-    Services() {}
-    ~Services() {}
+    Services()
+    {
+    }
+    ~Services()
+    {
+    }
 
     /**
      * \brief get number of services
@@ -336,51 +392,52 @@ namespace dd
     {
       return _mlservices.size();
     }
-    
+
     /**
      * \brief add a new service
      * @param sname service name
      * @param mls service object as variant
      * @param ad optional root data object holding service's parameters
      */
-    void add_service(const std::string &sname,
-		     mls_variant_type &&mls,
-		     const APIData &ad=APIData()) 
+    void add_service(const std::string &sname, mls_variant_type &&mls,
+                     const APIData &ad = APIData())
     {
-      std::unordered_map<std::string,mls_variant_type>::const_iterator hit;
-      if ((hit=_mlservices.find(sname))!=_mlservices.end())
-	{
-	  throw ServiceForbiddenException("Service already exists");
-	}
+      std::unordered_map<std::string, mls_variant_type>::const_iterator hit;
+      if ((hit = _mlservices.find(sname)) != _mlservices.end())
+        {
+          throw ServiceForbiddenException("Service already exists");
+        }
 
       auto llog = spdlog::get(sname);
       visitor_init vi(ad);
       try
-	{
-	  mapbox::util::apply_visitor(vi,mls);
-	  std::lock_guard<std::mutex> lock(_mlservices_mtx);
-	  _mlservices.insert(std::pair<std::string,mls_variant_type>(sname,std::move(mls)));
-	}
+        {
+          mapbox::util::apply_visitor(vi, mls);
+          std::lock_guard<std::mutex> lock(_mlservices_mtx);
+          _mlservices.insert(
+              std::pair<std::string, mls_variant_type>(sname, std::move(mls)));
+        }
       catch (InputConnectorBadParamException &e)
-	{
-	  llog->error("service creation input connector bad param: {}",e.what());
-	  throw;
-	}
+        {
+          llog->error("service creation input connector bad param: {}",
+                      e.what());
+          throw;
+        }
       catch (MLLibBadParamException &e)
-	{
-	  llog->error("service creation mllib bad param: {}",e.what());
-	  throw;
-	}
+        {
+          llog->error("service creation mllib bad param: {}", e.what());
+          throw;
+        }
       catch (MLLibInternalException &e)
-	{
-	  llog->error("service creation mllib internal error: {}",e.what());
-	  throw;
-	}
-      catch(...)
-	{
-	  llog->error("service creation call failed");
-	  throw;
-	}
+        {
+          llog->error("service creation mllib internal error: {}", e.what());
+          throw;
+        }
+      catch (...)
+        {
+          llog->error("service creation call failed");
+          throw;
+        }
     }
 
     /**
@@ -389,40 +446,39 @@ namespace dd
      * @param ad root data object
      * @return true if service was removed, false otherwise (i.e. not found)
      */
-    bool remove_service(const std::string &sname,
-			const APIData &ad)
+    bool remove_service(const std::string &sname, const APIData &ad)
     {
       std::lock_guard<std::mutex> lock(_mlservices_mtx);
       auto hit = _mlservices.begin();
-      if ((hit=_mlservices.find(sname))!=_mlservices.end())
-	{
-	  auto llog = spdlog::get(sname);
-	  if (ad.has("clear"))
-	    {
-	      visitor_clear vc(ad);
-	      try
-		{
-		  mapbox::util::apply_visitor(vc,(*hit).second);
-		}
-	      catch (MLLibBadParamException &e)
-		{
-		  llog->error("mllib bad param: {}",e.what());
-		  throw;
-		}
-	      catch (MLLibInternalException &e)
-		{
-		  llog->error("mllib internal error: {}",e.what());
-	  	  throw;
-		}
-	      catch(...)
-		{
-		  llog->error("delete service call failed");
-	  	  throw;
-		}
-	    }
-	  _mlservices.erase(hit);
-	  return true;
-	}
+      if ((hit = _mlservices.find(sname)) != _mlservices.end())
+        {
+          auto llog = spdlog::get(sname);
+          if (ad.has("clear"))
+            {
+              visitor_clear vc(ad);
+              try
+                {
+                  mapbox::util::apply_visitor(vc, (*hit).second);
+                }
+              catch (MLLibBadParamException &e)
+                {
+                  llog->error("mllib bad param: {}", e.what());
+                  throw;
+                }
+              catch (MLLibInternalException &e)
+                {
+                  llog->error("mllib internal error: {}", e.what());
+                  throw;
+                }
+              catch (...)
+                {
+                  llog->error("delete service call failed");
+                  throw;
+                }
+            }
+          _mlservices.erase(hit);
+          return true;
+        }
       auto llog = spdlog::get("api");
       llog->error("cannot find service for removal");
       return false;
@@ -433,13 +489,14 @@ namespace dd
      * @param sname service name
      * @return service position, end of container if not found
      */
-    std::unordered_map<std::string,mls_variant_type>::iterator get_service_it(const std::string &sname)
-      {
-	std::unordered_map<std::string,mls_variant_type>::iterator hit;
-	if ((hit=_mlservices.find(sname))!=_mlservices.end())
-	  return hit;
-	return _mlservices.end();
-      }
+    std::unordered_map<std::string, mls_variant_type>::iterator
+    get_service_it(const std::string &sname)
+    {
+      std::unordered_map<std::string, mls_variant_type>::iterator hit;
+      if ((hit = _mlservices.find(sname)) != _mlservices.end())
+        return hit;
+      return _mlservices.end();
+    }
 
     /**
      * \brief checks whether a service exists
@@ -450,10 +507,10 @@ namespace dd
     {
       auto hit = get_service_it(sname);
       if (hit == _mlservices.end())
-	return false;
+        return false;
       return true;
     }
-    
+
     /**
      * \brief train a statistical model using a service
      * @param ad root data object
@@ -462,56 +519,60 @@ namespace dd
      */
     int train(const APIData &ad, const std::string &sname, APIData &out)
     {
-      std::chrono::time_point<std::chrono::system_clock> tstart = std::chrono::system_clock::now();
+      std::chrono::time_point<std::chrono::system_clock> tstart
+          = std::chrono::system_clock::now();
       visitor_train vt;
       vt._ad = ad;
       output pout;
       auto llog = spdlog::get(sname);
       try
-	{
-	  auto hit = get_service_it(sname);
-	  pout = mapbox::util::apply_visitor(vt,(*hit).second);
-	}
+        {
+          auto hit = get_service_it(sname);
+          pout = mapbox::util::apply_visitor(vt, (*hit).second);
+        }
       catch (InputConnectorBadParamException &e)
-	{
-	  llog->error("mllib bad param: {}",e.what());
-	  pout._status = -2;
-	  throw;
-	}
+        {
+          llog->error("mllib bad param: {}", e.what());
+          pout._status = -2;
+          throw;
+        }
       catch (MLLibBadParamException &e)
-	{
-	  llog->error("mllib bad param: {}",e.what());
-	  pout._status = -2;
-	  throw;
-	}
+        {
+          llog->error("mllib bad param: {}", e.what());
+          pout._status = -2;
+          throw;
+        }
       catch (MLLibInternalException &e)
-	{
-	  llog->error("mllib internal error: {}",e.what());
-	  pout._status = -1;
-	  throw;
-	}
-      catch(...)
-	{
-	  llog->error("training call failed");
-	  pout._status = -1;
-	  throw;
-	}
+        {
+          llog->error("mllib internal error: {}", e.what());
+          pout._status = -1;
+          throw;
+        }
+      catch (...)
+        {
+          llog->error("training call failed");
+          pout._status = -1;
+          throw;
+        }
       out = pout._out;
       if (ad.has("async") && ad.get("async").get<bool>())
-	{
-	  out.add("job",pout._status); // status holds the job id...
-	  out.add("status",std::string("running"));
-	  return 0; // status is OK i.e. the job has started.
-	}
+        {
+          out.add("job", pout._status); // status holds the job id...
+          out.add("status", std::string("running"));
+          return 0; // status is OK i.e. the job has started.
+        }
       else
-	{
-	  std::chrono::time_point<std::chrono::system_clock> tstop = std::chrono::system_clock::now();
-	  double elapsed = std::chrono::duration_cast<std::chrono::seconds>(tstop-tstart).count();
-	  out.add("time",elapsed);
-	}
+        {
+          std::chrono::time_point<std::chrono::system_clock> tstop
+              = std::chrono::system_clock::now();
+          double elapsed = std::chrono::duration_cast<std::chrono::seconds>(
+                               tstop - tstart)
+                               .count();
+          out.add("time", elapsed);
+        }
       return pout._status;
     }
-    
+
     /**
      * \brief access to training job status
      * @param ad root data object
@@ -524,21 +585,21 @@ namespace dd
       vt._ad = ad;
       output pout;
       try
-	{
-	  auto hit = get_service_it(sname);
-	  pout = mapbox::util::apply_visitor(vt,(*hit).second);
-	}
-      catch(...)
-	{
-	  auto llog = spdlog::get(sname);
-	  llog->error("training status call failed");
-	  pout._status = -1;
-	  throw;
-	}
+        {
+          auto hit = get_service_it(sname);
+          pout = mapbox::util::apply_visitor(vt, (*hit).second);
+        }
+      catch (...)
+        {
+          auto llog = spdlog::get(sname);
+          llog->error("training status call failed");
+          pout._status = -1;
+          throw;
+        }
       out = pout._out;
       return pout._status;
     }
-    
+
     /**
      * \brief kills a training job
      * @param ad root data object
@@ -551,350 +612,397 @@ namespace dd
       vt._ad = ad;
       output pout;
       try
-	{
-	  auto hit = get_service_it(sname);
-	  pout = mapbox::util::apply_visitor(vt,(*hit).second);
-	}
-      catch(...)
-	{
-	  auto llog = spdlog::get(sname);
-	  llog->error("training delete call failed");
-	  pout._status = -1;
-	  throw;
-	}
+        {
+          auto hit = get_service_it(sname);
+          pout = mapbox::util::apply_visitor(vt, (*hit).second);
+        }
+      catch (...)
+        {
+          auto llog = spdlog::get(sname);
+          llog->error("training delete call failed");
+          pout._status = -1;
+          throw;
+        }
       out = pout._out;
       return pout._status;
     }
-    
+
     /**
      * \brief prediction from statistical model
      * @param ad root data object
      * @param sname service name
      * @param out output data object
      */
-    int predict(const APIData &ad, const std::string &sname, APIData &out, const bool &chain=false)
+    int predict(const APIData &ad, const std::string &sname, APIData &out,
+                const bool &chain = false)
     {
-      std::chrono::time_point<std::chrono::system_clock> tstart = std::chrono::system_clock::now();
+      std::chrono::time_point<std::chrono::system_clock> tstart
+          = std::chrono::system_clock::now();
       visitor_predict vp;
       vp._ad = ad;
       vp._chain = chain;
       output pout;
       auto llog = spdlog::get(sname);
       try
-	{
-	  auto hit = get_service_it(sname);
-	  pout = mapbox::util::apply_visitor(vp,(*hit).second);
-	}
+        {
+          auto hit = get_service_it(sname);
+          pout = mapbox::util::apply_visitor(vp, (*hit).second);
+        }
       catch (InputConnectorBadParamException &e)
-	{
-	  llog->error("mllib bad param: {}",e.what());
-	  pout._status = -2;
-	  throw;
-	}
+        {
+          llog->error("mllib bad param: {}", e.what());
+          pout._status = -2;
+          throw;
+        }
       catch (MLLibBadParamException &e)
-	{
-	  llog->error("mllib bad param: {}",e.what());
-	  pout._status = -2;
-	  throw;
-	}
+        {
+          llog->error("mllib bad param: {}", e.what());
+          pout._status = -2;
+          throw;
+        }
       catch (MLLibInternalException &e)
-	{
-	  llog->error("mllib internal error: {}",e.what());
-	  pout._status = -1;
-	  throw;
-	}
+        {
+          llog->error("mllib internal error: {}", e.what());
+          pout._status = -1;
+          throw;
+        }
       catch (MLServiceLockException &e)
-	{
-	  llog->error("mllib lock error: {}",e.what());
-	  pout._status = -3;
-	  throw;
-	}
-	  catch (const std::exception &e)
-    {
-      // catch anything thrown within try block that derives from std::exception
-	  llog->error("other error: {}",e.what());
-	  pout._status = -1;
-	  throw;
-	}
-      catch(...)
-	{
-	  llog->error("prediction call failed");
-	  pout._status = -1;
-	  throw;
-	}
+        {
+          llog->error("mllib lock error: {}", e.what());
+          pout._status = -3;
+          throw;
+        }
+      catch (const std::exception &e)
+        {
+          // catch anything thrown within try block that derives from
+          // std::exception
+          llog->error("other error: {}", e.what());
+          pout._status = -1;
+          throw;
+        }
+      catch (...)
+        {
+          llog->error("prediction call failed");
+          pout._status = -1;
+          throw;
+        }
       out = pout._out;
-      std::chrono::time_point<std::chrono::system_clock> tstop = std::chrono::system_clock::now();
-      double elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(tstop-tstart).count();
-      out.add("time",elapsed);
+      std::chrono::time_point<std::chrono::system_clock> tstop
+          = std::chrono::system_clock::now();
+      double elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+                           tstop - tstart)
+                           .count();
+      out.add("time", elapsed);
       return pout._status;
     }
 
     int chain_service(const std::string &cname,
-		      const std::shared_ptr<spdlog::logger> &chain_logger,
-		      APIData &adc,
-		      ChainData &cdata,
-		      const std::string &pred_id,
-		      std::vector<std::string> &meta_uris,
-		      std::vector<std::string> &index_uris,
-		      const std::string &parent_id,
-		      const int chain_pos,
-		      int &npredicts)
+                      const std::shared_ptr<spdlog::logger> &chain_logger,
+                      APIData &adc, ChainData &cdata,
+                      const std::string &pred_id,
+                      std::vector<std::string> &meta_uris,
+                      std::vector<std::string> &index_uris,
+                      const std::string &parent_id, const int chain_pos,
+                      int &npredicts)
     {
       std::string sname = adc.get("service").get<std::string>();
-      chain_logger->info("[" + std::to_string(chain_pos) + "] / executing predict on service " + sname);
-      
+      chain_logger->info("[" + std::to_string(chain_pos)
+                         + "] / executing predict on service " + sname);
+
       // need to check that service exists
       if (!service_exists(sname))
-	{
-	  spdlog::drop(cname);
-	  throw ServiceNotFoundException("Service " + sname + " does not exist");
-	}
+        {
+          spdlog::drop(cname);
+          throw ServiceNotFoundException("Service " + sname
+                                         + " does not exist");
+        }
 
       // if not first predict call in the chain, need to setup the input data!
       if (chain_pos != 0)
-	{
-	  // take data from the previous action
-	  APIData act_data = cdata.get_action_data(parent_id);
-	  if (act_data.empty())
-	    {
-	      spdlog::drop(cname);
-	      throw InputConnectorBadParamException("no action data for action id " + parent_id);
-	    }
-	  if (act_data.has("data"))
-	    {
-	      adc.add("data",act_data.get("data").get<std::vector<std::string>>()); // action output data must be string for now (more types to be supported / auto-detected)
-	    }
-	  else if (act_data.has("data_raw_img")) // raw images
-	    {
-	      adc.add("data_raw_img",act_data.get("data_raw_img").get<std::vector<cv::Mat>>());
-	    }
-	  adc.add("ids",act_data.get("cids").get<std::vector<std::string>>()); // chain ids of processed elements
-	  adc.add("meta_uris",meta_uris);
-	  adc.add("index_uris",index_uris);
-	}
-      else {
-	cdata._first_id = pred_id;
-      }
-      
+        {
+          // take data from the previous action
+          APIData act_data = cdata.get_action_data(parent_id);
+          if (act_data.empty())
+            {
+              spdlog::drop(cname);
+              throw InputConnectorBadParamException(
+                  "no action data for action id " + parent_id);
+            }
+          if (act_data.has("data"))
+            {
+              adc.add(
+                  "data",
+                  act_data.get("data")
+                      .get<std::vector<std::string>>()); // action output data
+                                                         // must be string for
+                                                         // now (more types to
+                                                         // be supported /
+                                                         // auto-detected)
+            }
+          else if (act_data.has("data_raw_img")) // raw images
+            {
+              adc.add(
+                  "data_raw_img",
+                  act_data.get("data_raw_img").get<std::vector<cv::Mat>>());
+            }
+          adc.add("ids",
+                  act_data.get("cids")
+                      .get<std::vector<std::string>>()); // chain ids of
+                                                         // processed elements
+          adc.add("meta_uris", meta_uris);
+          adc.add("index_uris", index_uris);
+        }
+      else
+        {
+          cdata._first_id = pred_id;
+        }
+
       APIData pred_out;
       try
-	{
-	  predict(adc,sname,pred_out,true);
-	}
-      catch(...)
-	{
-	  spdlog::drop(cname);
-	  throw;
-	}
-      
+        {
+          predict(adc, sname, pred_out, true);
+        }
+      catch (...)
+        {
+          spdlog::drop(cname);
+          throw;
+        }
+
       // check on results
       std::vector<APIData> vad = pred_out.getv("predictions");
       if (vad.empty())
-	{
-	  chain_logger->info("[" + std::to_string(chain_pos) + "]  no predictions");
-	  return 1;
-	}
-      
+        {
+          chain_logger->info("[" + std::to_string(chain_pos)
+                             + "]  no predictions");
+          return 1;
+        }
+
       int classes_size = 0;
       int vals_size = 0;
       std::vector<std::string> nmeta_uris;
       std::vector<std::string> nindex_uris;
-      for (size_t j=0;j<vad.size();j++)
-	{
-	  size_t npred_classes = std::max(vad.at(j).getv("classes").size(),vad.at(j).getv("vector").size());
-	  classes_size += npred_classes;
-	  vals_size += static_cast<int>(vad.at(j).has("vals"));
-	  if (chain_pos == 0) // first call's response contains uniformized top level URIs.
-	    {
-	      for (size_t k=0;k<npred_classes;k++)
-		{
-		  nmeta_uris.push_back(vad.at(j).get("uri").get<std::string>());
-		  if (vad.at(j).has("index_uri"))
-		    nindex_uris.push_back(vad.at(j).get("index_uri").get<std::string>());
-		}
-	    }
-	  else // update meta uris to batch size at the current level of the chain
-	    {
-	      for (size_t k=0;k<npred_classes;k++)
-		{
-		  nmeta_uris.push_back(meta_uris.at(j));
-		  if (!index_uris.empty())
-		    nindex_uris.push_back(index_uris.at(j));
-		}
-	    }
-	}
+      for (size_t j = 0; j < vad.size(); j++)
+        {
+          size_t npred_classes = std::max(vad.at(j).getv("classes").size(),
+                                          vad.at(j).getv("vector").size());
+          classes_size += npred_classes;
+          vals_size += static_cast<int>(vad.at(j).has("vals"));
+          if (chain_pos == 0) // first call's response contains uniformized top
+                              // level URIs.
+            {
+              for (size_t k = 0; k < npred_classes; k++)
+                {
+                  nmeta_uris.push_back(
+                      vad.at(j).get("uri").get<std::string>());
+                  if (vad.at(j).has("index_uri"))
+                    nindex_uris.push_back(
+                        vad.at(j).get("index_uri").get<std::string>());
+                }
+            }
+          else // update meta uris to batch size at the current level of the
+               // chain
+            {
+              for (size_t k = 0; k < npred_classes; k++)
+                {
+                  nmeta_uris.push_back(meta_uris.at(j));
+                  if (!index_uris.empty())
+                    nindex_uris.push_back(index_uris.at(j));
+                }
+            }
+        }
       meta_uris = nmeta_uris;
       index_uris = nindex_uris;
-      
+
       if (!classes_size && !vals_size)
-	{
-	  chain_logger->info("[" + std::to_string(chain_pos) + "] / no result from prediction");
-	  cdata.add_model_data(pred_id,pred_out); // store empty model output
-	  return 1;
-	}
+        {
+          chain_logger->info("[" + std::to_string(chain_pos)
+                             + "] / no result from prediction");
+          cdata.add_model_data(pred_id, pred_out); // store empty model output
+          return 1;
+        }
       ++npredicts;
-      
+
       // store model output
-      cdata.add_model_data(pred_id,pred_out);
+      cdata.add_model_data(pred_id, pred_out);
 
       return 0;
     }
 
     int chain_action(const std::shared_ptr<spdlog::logger> &chain_logger,
-		     APIData &adc,
-		     ChainData &cdata,
-		     const int &chain_pos,
-		     const std::string &prec_pred_id)
+                     APIData &adc, ChainData &cdata, const int &chain_pos,
+                     const std::string &prec_pred_id)
     {
-      std::string action_type = adc.getobj("action").get("type").get<std::string>();
+      std::string action_type
+          = adc.getobj("action").get("type").get<std::string>();
 
       APIData prev_data = cdata.get_model_data(prec_pred_id);
       if (!prev_data.getv("predictions").size())
-	{
-	  // no prediction to work from
-	  chain_logger->info("no prediction to act on");
-	  return 1;
-	}
-      
+        {
+          // no prediction to work from
+          chain_logger->info("no prediction to act on");
+          return 1;
+        }
+
       // call chain action factory
-      chain_logger->info("[" + std::to_string(chain_pos) + "] / executing action " + action_type);
+      chain_logger->info("[" + std::to_string(chain_pos)
+                         + "] / executing action " + action_type);
       ChainActionFactory caf(adc);
-      caf.apply_action(action_type,
-		       prev_data,
-		       cdata,
-		       chain_logger);
-      
+      caf.apply_action(action_type, prev_data, cdata, chain_logger);
+
       // replace prev_data in cdata for prec_pred_id
-      cdata.add_model_data(prec_pred_id,prev_data);
-      
+      cdata.add_model_data(prec_pred_id, prev_data);
+
       std::vector<APIData> vad = prev_data.getv("predictions");
       if (vad.empty())
-	{
-	  // no prediction to work from
-	  chain_logger->info("no prediction to act on after applying action " + action_type);
-	  return 1;
-	}
-      
+        {
+          // no prediction to work from
+          chain_logger->info("no prediction to act on after applying action "
+                             + action_type);
+          return 1;
+        }
+
       int classes_size = 0;
       int vals_size = 0;
-      for (size_t i=0;i<vad.size();i++)
-	{
-	  int npred_classes = std::max(vad.at(i).getv("classes").size(),vad.at(i).getv("vector").size());
-	  classes_size += npred_classes;
-	  vals_size += static_cast<int>(vad.at(i).has("vals"));
-	}
-      
+      for (size_t i = 0; i < vad.size(); i++)
+        {
+          int npred_classes = std::max(vad.at(i).getv("classes").size(),
+                                       vad.at(i).getv("vector").size());
+          classes_size += npred_classes;
+          vals_size += static_cast<int>(vad.at(i).has("vals"));
+        }
+
       if (!classes_size && !vals_size)
-	{
-	  chain_logger->info("[" + std::to_string(chain_pos) + "] / no result after applying action " + action_type);
-	  return 1;
-	}      
+        {
+          chain_logger->info("[" + std::to_string(chain_pos)
+                             + "] / no result after applying action "
+                             + action_type);
+          return 1;
+        }
 
       return 0;
     }
-    
+
     int chain(const APIData &ad, const std::string &cname, APIData &out)
     {
       try
-	{
+        {
 #ifdef USE_DD_SYSLOG
-	  auto chain_logger = spdlog::syslog_logger(cname);
+          auto chain_logger = spdlog::syslog_logger(cname);
 #else
-	  auto chain_logger = spdlog::stdout_logger_mt(cname);
+          auto chain_logger = spdlog::stdout_logger_mt(cname);
 #endif
-	  
-	  std::chrono::time_point<std::chrono::system_clock> tstart = std::chrono::system_clock::now();
-	  
-	  // - iterate chain of calls
-	  // - if predict call, use the visitor to execute it
-	  //      - this requires storing output into mlservice object / have a flag for telling the called service it's part of a chain
-	  // - if action call, execute the generic code for it
-	  std::vector<APIData> ad_calls = ad.getobj("chain").getv("calls");
-	  chain_logger->info("number of calls=" + std::to_string(ad_calls.size()));
-	  
-	  // debug
-	  /*std::vector<std::string> ckeys = ad.list_keys();
-	    for (auto s: ckeys)
-	    std::cerr << s << std::endl;*/
-	  //debug
-	  
-	  ChainData cdata;
-	  std::vector<std::string> meta_uris;
-	  std::vector<std::string> index_uris;
-	  std::unordered_map<std::string,std::vector<std::string>> um_meta_uris;
-	  std::unordered_map<std::string,std::vector<std::string>> um_index_uris;
-	  int npredicts = 0;
-	  std::string prec_pred_id;
-	  std::string prec_action_id;
-	  int aid = 0;
-	  for (size_t i=0;i<ad_calls.size();i++)
-	    {
-	      APIData adc = ad_calls.at(i);
-	      if (adc.has("service"))
-		{
-		  std::string pred_id;
-		  if (adc.has("id"))
-		    pred_id = adc.get("id").get<std::string>();
-		  else pred_id = std::to_string(i);
-		  
-		  std::string parent_id;
-		  if (adc.has("parent_id"))
-		    parent_id = adc.get("parent_id").get<std::string>();
-		  else parent_id = prec_action_id;
-		  
-		  auto hit = um_meta_uris.find(parent_id);
-		  if (hit!=um_meta_uris.end())
-		    meta_uris = (*hit).second;
-		  hit = um_index_uris.find(parent_id);
-		  if (hit!=um_index_uris.end())
-		    index_uris = (*hit).second;
-		  cdata.add_model_sname(pred_id,adc.get("service").get<std::string>());
-		  if (chain_service(cname,chain_logger,adc,cdata,
-				    pred_id,meta_uris,index_uris,
-				    parent_id,i,npredicts))
-		    break;
-		  prec_pred_id = pred_id;
-		}
-	      else if (adc.has("action"))
-		{
-		  if (chain_action(chain_logger,adc,cdata,i,prec_pred_id))
-		    break;
-		  if (adc.has("id"))
-		    prec_action_id = adc.get("id").get<std::string>();
-		  else prec_action_id = std::to_string(aid);
-		  um_meta_uris.insert(std::pair<std::string,std::vector<std::string>>(prec_action_id,meta_uris));
-		  um_index_uris.insert(std::pair<std::string,std::vector<std::string>>(prec_action_id,index_uris));
-		  ++aid;
-		}
-	    }
-	  
-	  // producing a nested output
-	  APIData nested_out;
-	  if (npredicts > 1)
-	    nested_out = cdata.nested_chain_output();
-	  else nested_out = cdata.get_model_data(cdata._first_id);
-	  
-	  out = nested_out;
-	  std::chrono::time_point<std::chrono::system_clock> tstop = std::chrono::system_clock::now();
-	  double elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(tstop-tstart).count();
-	  out.add("time",elapsed);
-	}
-      catch(...)
-	{
-	  spdlog::drop(cname);
-	  throw;
-	}
+
+          std::chrono::time_point<std::chrono::system_clock> tstart
+              = std::chrono::system_clock::now();
+
+          // - iterate chain of calls
+          // - if predict call, use the visitor to execute it
+          //      - this requires storing output into mlservice object / have a
+          //      flag for telling the called service it's part of a chain
+          // - if action call, execute the generic code for it
+          std::vector<APIData> ad_calls = ad.getobj("chain").getv("calls");
+          chain_logger->info("number of calls="
+                             + std::to_string(ad_calls.size()));
+
+          // debug
+          /*std::vector<std::string> ckeys = ad.list_keys();
+            for (auto s: ckeys)
+            std::cerr << s << std::endl;*/
+          // debug
+
+          ChainData cdata;
+          std::vector<std::string> meta_uris;
+          std::vector<std::string> index_uris;
+          std::unordered_map<std::string, std::vector<std::string>>
+              um_meta_uris;
+          std::unordered_map<std::string, std::vector<std::string>>
+              um_index_uris;
+          int npredicts = 0;
+          std::string prec_pred_id;
+          std::string prec_action_id;
+          int aid = 0;
+          for (size_t i = 0; i < ad_calls.size(); i++)
+            {
+              APIData adc = ad_calls.at(i);
+              if (adc.has("service"))
+                {
+                  std::string pred_id;
+                  if (adc.has("id"))
+                    pred_id = adc.get("id").get<std::string>();
+                  else
+                    pred_id = std::to_string(i);
+
+                  std::string parent_id;
+                  if (adc.has("parent_id"))
+                    parent_id = adc.get("parent_id").get<std::string>();
+                  else
+                    parent_id = prec_action_id;
+
+                  auto hit = um_meta_uris.find(parent_id);
+                  if (hit != um_meta_uris.end())
+                    meta_uris = (*hit).second;
+                  hit = um_index_uris.find(parent_id);
+                  if (hit != um_index_uris.end())
+                    index_uris = (*hit).second;
+                  cdata.add_model_sname(pred_id,
+                                        adc.get("service").get<std::string>());
+                  if (chain_service(cname, chain_logger, adc, cdata, pred_id,
+                                    meta_uris, index_uris, parent_id, i,
+                                    npredicts))
+                    break;
+                  prec_pred_id = pred_id;
+                }
+              else if (adc.has("action"))
+                {
+                  if (chain_action(chain_logger, adc, cdata, i, prec_pred_id))
+                    break;
+                  if (adc.has("id"))
+                    prec_action_id = adc.get("id").get<std::string>();
+                  else
+                    prec_action_id = std::to_string(aid);
+                  um_meta_uris.insert(
+                      std::pair<std::string, std::vector<std::string>>(
+                          prec_action_id, meta_uris));
+                  um_index_uris.insert(
+                      std::pair<std::string, std::vector<std::string>>(
+                          prec_action_id, index_uris));
+                  ++aid;
+                }
+            }
+
+          // producing a nested output
+          APIData nested_out;
+          if (npredicts > 1)
+            nested_out = cdata.nested_chain_output();
+          else
+            nested_out = cdata.get_model_data(cdata._first_id);
+
+          out = nested_out;
+          std::chrono::time_point<std::chrono::system_clock> tstop
+              = std::chrono::system_clock::now();
+          double elapsed
+              = std::chrono::duration_cast<std::chrono::milliseconds>(tstop
+                                                                      - tstart)
+                    .count();
+          out.add("time", elapsed);
+        }
+      catch (...)
+        {
+          spdlog::drop(cname);
+          throw;
+        }
       spdlog::drop(cname);
-      
+
       return 0;
     }
-    
-    std::unordered_map<std::string,mls_variant_type> _mlservices; /**< container of instanciated services. */
-    
+
+    std::unordered_map<std::string, mls_variant_type>
+        _mlservices; /**< container of instanciated services. */
+
   protected:
     std::mutex _mlservices_mtx; /**< mutex around adding/removing services. */
   };
-  
+
 }
 
 #endif

--- a/src/simsearch.cc
+++ b/src/simsearch.cc
@@ -37,13 +37,13 @@ namespace dd
 
   /*-- URIData --*/
   char URIData::_enc_char = '^';
-  
+
   std::string URIData::encode() const
   {
     if (_bbox.empty())
       return _uri;
     std::string enc = _uri + _enc_char;
-    for (auto b: _bbox)
+    for (auto b : _bbox)
       enc += std::to_string(b) + _enc_char;
     enc += std::to_string(_prob) + _enc_char;
     enc += _cat;
@@ -52,58 +52,54 @@ namespace dd
 
   void URIData::decode(const std::string &tmp)
   {
-    std::vector<std::string> tok = dd_utils::split(tmp,_enc_char);
+    std::vector<std::string> tok = dd_utils::split(tmp, _enc_char);
     _uri = tok.at(0);
     if (tok.size() == 1)
       return;
-    for (int i=1;i<5;i++) // bbox is 4 double
+    for (int i = 1; i < 5; i++) // bbox is 4 double
       {
-	_bbox.push_back(std::stod(tok.at(i)));
+        _bbox.push_back(std::stod(tok.at(i)));
       }
     _prob = std::stod(tok.at(5));
     _cat = tok.at(6);
   }
-  
+
   /*-- SearchEngine --*/
   template <class TSE>
   SearchEngine<TSE>::SearchEngine(const int &dim,
-				  const std::string &model_repo)
-    :_dim(dim)
+                                  const std::string &model_repo)
+      : _dim(dim)
   {
-    _tse = new TSE(_dim,model_repo);
+    _tse = new TSE(_dim, model_repo);
   }
 
-  template <class TSE>
-  SearchEngine<TSE>::~SearchEngine()
+  template <class TSE> SearchEngine<TSE>::~SearchEngine()
   {
     delete _tse;
   }
-  
-  template <class TSE>
-  void SearchEngine<TSE>::create_index()
+
+  template <class TSE> void SearchEngine<TSE>::create_index()
   {
     _tse->create_index();
   }
 
-  template <class TSE>
-  void SearchEngine<TSE>::update_index()
+  template <class TSE> void SearchEngine<TSE>::update_index()
   {
     _tse->update_index();
   }
 
-  template <class TSE>
-  void SearchEngine<TSE>::remove_index()
+  template <class TSE> void SearchEngine<TSE>::remove_index()
   {
     std::cerr << "removing index\n";
     _tse->remove_index();
   }
-  
+
   template <class TSE>
   void SearchEngine<TSE>::index(const URIData &uri,
-				const std::vector<double> &data)
+                                const std::vector<double> &data)
   {
     std::lock_guard<std::mutex> lock(_index_mutex);
-    _tse->index(uri,data);
+    _tse->index(uri, data);
   }
 
   template <class TSE>
@@ -111,28 +107,24 @@ namespace dd
                                 const std::vector<std::vector<double>> &datas)
   {
     std::lock_guard<std::mutex> lock(_index_mutex);
-    _tse->index(uris,datas);
+    _tse->index(uris, datas);
   }
-
 
   template <class TSE>
   void SearchEngine<TSE>::search(const std::vector<double> &data,
-				 const int &nn,
-				 std::vector<URIData> &uris,
-				 std::vector<double> &distances)
+                                 const int &nn, std::vector<URIData> &uris,
+                                 std::vector<double> &distances)
   {
-    _tse->search(data,nn,uris,distances);
+    _tse->search(data, nn, uris, distances);
   }
-
 
 #ifdef USE_ANNOY
   /*- AnnoySE -*/
 
-  AnnoySE::AnnoySE(const int &f,
-		   const std::string &model_repo)
-    :_f(f),_model_repo(model_repo)
+  AnnoySE::AnnoySE(const int &f, const std::string &model_repo)
+      : _f(f), _model_repo(model_repo)
   {
-    _aindex = new AnnoyIndex<int,double,Angular,Kiss32Random>(f);
+    _aindex = new AnnoyIndex<int, double, Angular, Kiss32Random>(f);
     _db = caffe::db::GetDB(_db_backend);
   }
 
@@ -144,31 +136,31 @@ namespace dd
     delete _db;
   }
 
-  void AnnoySE::create_index() //TODO: exception
+  void AnnoySE::create_index() // TODO: exception
   {
     std::string index_filename = _model_repo + "/" + _index_name;
     if (fileops::file_exists(index_filename))
       {
-	_saved_tree = true;
-	_aindex->load(index_filename.c_str(),_map_populate);
-	_built_index = true;
+        _saved_tree = true;
+        _aindex->load(index_filename.c_str(), _map_populate);
+        _built_index = true;
       }
     std::string db_filename = _model_repo + "/" + _db_name;
     if (fileops::file_exists(db_filename))
       {
-	std::cerr << "open existing index db\n";
-	_db->Open(db_filename,caffe::db::WRITE);
+        std::cerr << "open existing index db\n";
+        _db->Open(db_filename, caffe::db::WRITE);
       }
     else
       {
-	std::cerr << "create index db\n";
-	_db->Open(db_filename,caffe::db::NEW);
+        std::cerr << "create index db\n";
+        _db->Open(db_filename, caffe::db::NEW);
       }
   }
 
   void AnnoySE::remove_index()
   {
-    fileops::remove_file(_model_repo,_index_name);
+    fileops::remove_file(_model_repo, _index_name);
     std::string db_filename = _model_repo + "/" + _db_name;
     fileops::clear_directory(db_filename);
     rmdir(db_filename.c_str());
@@ -179,13 +171,13 @@ namespace dd
     build_tree();
     save_tree(); // no turning back
   }
-  
+
   void AnnoySE::build_tree()
   {
     if (_count_put % _count_put_max != 0)
       {
-	_txn->Commit(); // last pending db commit
-	_txn = std::unique_ptr<caffe::db::Transaction>(_db->NewTransaction());
+        _txn->Commit(); // last pending db commit
+        _txn = std::unique_ptr<caffe::db::Transaction>(_db->NewTransaction());
       }
     _aindex->build(_ntrees);
     _built_index = true;
@@ -200,79 +192,73 @@ namespace dd
   void AnnoySE::save_tree()
   {
     std::string index_path = _model_repo + "/" + _index_name;
-    _aindex->save(index_path.c_str(),_map_populate);
+    _aindex->save(index_path.c_str(), _map_populate);
     _saved_tree = true;
   }
-  
+
   // must be protected by mutex
-  void AnnoySE::index(const URIData &uri,
-		      const std::vector<double> &vec)
+  void AnnoySE::index(const URIData &uri, const std::vector<double> &vec)
   {
     if (_saved_tree)
       throw SimIndexException("Cannot index after Annoy index has been saved");
     int idx = _index_size;
-    _aindex->add_item(idx,&vec[0]);
+    _aindex->add_item(idx, &vec[0]);
     ++_index_size;
-    add_to_db(idx,uri);
+    add_to_db(idx, uri);
   }
 
   void AnnoySE::index(const std::vector<URIData> &uris,
                       const std::vector<std::vector<double>> &vecs)
   {
-    for (size_t i =0; i<uris.size(); ++i)
+    for (size_t i = 0; i < uris.size(); ++i)
       {
         index(uris[i], vecs[i]);
       }
   }
 
-
-  void AnnoySE::search(const std::vector<double> &vec,
-		       const int &nn,
-		       std::vector<URIData> &uris,
-		       std::vector<double> &distances)
+  void AnnoySE::search(const std::vector<double> &vec, const int &nn,
+                       std::vector<URIData> &uris,
+                       std::vector<double> &distances)
   {
     if (!_built_index)
-      throw SimSearchException("Cannot search before the Annoy tree has been built");
+      throw SimSearchException(
+          "Cannot search before the Annoy tree has been built");
     std::vector<int> result;
-    _aindex->get_nns_by_vector(&vec[0],nn,-1,&result,&distances);
-    for (auto i: result)
+    _aindex->get_nns_by_vector(&vec[0], nn, -1, &result, &distances);
+    for (auto i : result)
       {
-	URIData uri;
-	get_from_db(i,uri);
-	uris.push_back(uri);
+        URIData uri;
+        get_from_db(i, uri);
+        uris.push_back(uri);
       }
   }
 
-  void AnnoySE::add_to_db(const int &idx,
-			  const URIData &fmap)
+  void AnnoySE::add_to_db(const int &idx, const URIData &fmap)
   {
     if (_count_put == 0)
       _txn = std::unique_ptr<caffe::db::Transaction>(_db->NewTransaction());
-    _txn->Put(std::to_string(idx),fmap.encode());
+    _txn->Put(std::to_string(idx), fmap.encode());
     ++_count_put;
     if (_count_put % _count_put_max == 0)
       {
-	_txn->Commit(); // batch commit
-	_txn = std::unique_ptr<caffe::db::Transaction>(_db->NewTransaction());
+        _txn->Commit(); // batch commit
+        _txn = std::unique_ptr<caffe::db::Transaction>(_db->NewTransaction());
       }
   }
-  
-  void AnnoySE::get_from_db(const int &idx,
-			    URIData &fmap)
+
+  void AnnoySE::get_from_db(const int &idx, URIData &fmap)
   {
     std::string tmp;
-    _db->Get(std::to_string(idx),tmp);
+    _db->Get(std::to_string(idx), tmp);
     fmap.decode(tmp);
   }
-  
 
   template class SearchEngine<AnnoySE>;
 #endif
 
 #ifdef USE_FAISS
-  FaissSE::FaissSE(const int &f,
-                   const std::string &model_repo)
-    :_f(f),_model_repo(model_repo)
+  FaissSE::FaissSE(const int &f, const std::string &model_repo)
+      : _f(f), _model_repo(model_repo)
   {
     _db = caffe::db::GetDB(_db_backend);
     _index_key = std::string("Flat");
@@ -294,46 +280,51 @@ namespace dd
     if (fileops::file_exists(index_filename))
       {
         if (_ondisk)
-          _findex = faiss::read_index(index_filename.c_str(),faiss::IO_FLAG_MMAP);
+          _findex
+              = faiss::read_index(index_filename.c_str(), faiss::IO_FLAG_MMAP);
         else
           _findex = faiss::read_index(index_filename.c_str());
         _index_size = _findex->ntotal;
       }
     else
       {
-        _findex = faiss::index_factory(_f,_index_key.c_str());
+        _findex = faiss::index_factory(_f, _index_key.c_str());
         if (_ondisk)
           {
-            std::string odilfn =  _model_repo + "/" + _il_name;
-            faiss::IndexIVF * iivf = dynamic_cast<faiss::IndexIVF*>(_findex);
+            std::string odilfn = _model_repo + "/" + _il_name;
+            faiss::IndexIVF *iivf = dynamic_cast<faiss::IndexIVF *>(_findex);
             if (iivf)
               {
-                faiss::OnDiskInvertedLists* odil =
-                  new faiss::OnDiskInvertedLists(iivf->nlist, iivf->code_size,  odilfn.c_str());
+                faiss::OnDiskInvertedLists *odil
+                    = new faiss::OnDiskInvertedLists(
+                        iivf->nlist, iivf->code_size, odilfn.c_str());
                 iivf->own_invlists = true;
                 iivf->replace_invlists(odil, true);
               }
             else
               {
-                faiss::IndexPreTransform * ipivf = dynamic_cast<faiss::IndexPreTransform*>(_findex);
+                faiss::IndexPreTransform *ipivf
+                    = dynamic_cast<faiss::IndexPreTransform *>(_findex);
                 if (ipivf)
                   {
-                    faiss::IndexIVF * iivf = dynamic_cast<faiss::IndexIVF*>(ipivf->index);
+                    faiss::IndexIVF *iivf
+                        = dynamic_cast<faiss::IndexIVF *>(ipivf->index);
                     if (iivf)
                       {
-                        faiss::OnDiskInvertedLists* odil =
-                          new faiss::OnDiskInvertedLists(iivf->nlist, iivf->code_size, odilfn.c_str());
+                        faiss::OnDiskInvertedLists *odil
+                            = new faiss::OnDiskInvertedLists(
+                                iivf->nlist, iivf->code_size, odilfn.c_str());
                         iivf->own_invlists = true;
                         iivf->replace_invlists(odil, true);
                       }
                   }
                 else
-                  std::cerr << "cannot put index on disk : neither IVF nor vectorTransform+IVF\n";
+                  std::cerr << "cannot put index on disk : neither IVF nor "
+                               "vectorTransform+IVF\n";
               }
           }
         _index_size = 0;
       }
-
 
 #ifdef USE_GPU_FAISS
     if (_gpu)
@@ -341,42 +332,42 @@ namespace dd
         if (_gpuids.size() == 0)
           {
             int ngpus = faiss::gpu::getNumDevices();
-            for(int i = 0; i < ngpus; i++)
+            for (int i = 0; i < ngpus; i++)
               _gpuids.push_back(i);
           }
-        for (unsigned int i=0; i< _gpuids.size(); ++i)
+        for (unsigned int i = 0; i < _gpuids.size(); ++i)
           {
             _gpu_res.push_back(new faiss::gpu::StandardGpuResources);
           }
 
         if (_gpuids.size() > 1)
           {
-            faiss::Index* gindex = faiss::gpu::index_cpu_to_gpu_multiple(_gpu_res, _gpuids, _findex);
+            faiss::Index *gindex = faiss::gpu::index_cpu_to_gpu_multiple(
+                _gpu_res, _gpuids, _findex);
             delete _findex;
-            _findex  = gindex;
+            _findex = gindex;
           }
         else
           {
-            faiss::Index*  gindex = faiss::gpu::index_cpu_to_gpu(_gpu_res[0], _gpuids[0], _findex);
+            faiss::Index *gindex = faiss::gpu::index_cpu_to_gpu(
+                _gpu_res[0], _gpuids[0], _findex);
             delete _findex;
             _findex = gindex;
           }
       }
 #endif
 
-
     std::string db_filename = _model_repo + "/" + _db_name;
     if (fileops::file_exists(db_filename))
       {
         std::cerr << "open existing index db\n";
-        _db->Open(db_filename,caffe::db::WRITE);
+        _db->Open(db_filename, caffe::db::WRITE);
       }
     else
       {
         std::cerr << "create index db\n";
-        _db->Open(db_filename,caffe::db::NEW);
+        _db->Open(db_filename, caffe::db::NEW);
       }
-
   }
 
   void FaissSE::train()
@@ -384,15 +375,17 @@ namespace dd
     // train
     try
       {
-        _findex->train(_train_samples.size()/_f,_train_samples.data());
+        _findex->train(_train_samples.size() / _f, _train_samples.data());
       }
     catch (std::exception &e)
       {
-        std::cerr << "could not train, maybe not enough data to train with selected index type. index likely to be  empty" << e.what() << std::endl;
+        std::cerr << "could not train, maybe not enough data to train with "
+                     "selected index type. index likely to be  empty"
+                  << e.what() << std::endl;
         return;
       }
     // then add data to index
-    _findex->add(_train_samples.size()/_f,_train_samples.data());
+    _findex->add(_train_samples.size() / _f, _train_samples.data());
     // then throw away data
     _train_samples.clear();
   }
@@ -405,7 +398,7 @@ namespace dd
 #ifdef USE_GPU_FAISS
     if (_gpu)
       {
-        faiss::Index* cindex = faiss::gpu::index_gpu_to_cpu(_findex);
+        faiss::Index *cindex = faiss::gpu::index_gpu_to_cpu(_findex);
         faiss::write_index(cindex, index_path.c_str());
         delete cindex;
       }
@@ -420,33 +413,31 @@ namespace dd
     _txn = std::unique_ptr<caffe::db::Transaction>(_db->NewTransaction());
   }
 
-
   void FaissSE::remove_index()
   {
-    fileops::remove_file(_model_repo,_index_name);
-    fileops::remove_file(_model_repo,_il_name);
+    fileops::remove_file(_model_repo, _index_name);
+    fileops::remove_file(_model_repo, _il_name);
     std::string db_filename = _model_repo + "/" + _db_name;
     fileops::clear_directory(db_filename);
     rmdir(db_filename.c_str());
   }
 
-  void FaissSE::index(const URIData &uri,
-             const std::vector<double> &data)
+  void FaissSE::index(const URIData &uri, const std::vector<double> &data)
   {
     if (!_findex->is_trained && _index_size >= _train_samples_size)
       train();
     long int idx = _index_size;
     if (_findex->is_trained)
       {
-        std::vector<float> d(data.begin(),data.end());
-        _findex->add(1,d.data());
+        std::vector<float> d(data.begin(), data.end());
+        _findex->add(1, d.data());
       }
     else
       {
-        _train_samples.insert(_train_samples.end(),data.begin(),data.end());
+        _train_samples.insert(_train_samples.end(), data.begin(), data.end());
       }
     ++_index_size;
-    add_to_db(idx,uri);
+    add_to_db(idx, uri);
   }
 
   void FaissSE::index(const std::vector<URIData> &uris,
@@ -458,32 +449,31 @@ namespace dd
     if (_findex->is_trained)
       {
         std::vector<float> d;
-        for (std::vector<double> data: datas)
-          d.insert(d.end(), data.begin(),data.end());
-        _findex->add(uris.size(),d.data());
+        for (std::vector<double> data : datas)
+          d.insert(d.end(), data.begin(), data.end());
+        _findex->add(uris.size(), d.data());
       }
     else
       {
         for (std::vector<double> data : datas)
-          _train_samples.insert(_train_samples.end(),data.begin(),data.end());
+          _train_samples.insert(_train_samples.end(), data.begin(),
+                                data.end());
       }
     _index_size += uris.size();
-    for (unsigned long int i =0; i<uris.size(); ++i)
-      add_to_db(idx+i,uris[i]);
+    for (unsigned long int i = 0; i < uris.size(); ++i)
+      add_to_db(idx + i, uris[i]);
   }
 
-
-  void FaissSE::search(const std::vector<double> &vec,
-                       const int &nn,
+  void FaissSE::search(const std::vector<double> &vec, const int &nn,
                        std::vector<URIData> &uris,
                        std::vector<double> &distances)
   {
     if (!_findex->is_trained)
       train();
-    std::vector<long int> labels(nn,-1);
-    std::vector<float> d(nn,-1.0);
-    std::vector<float> v(vec.begin(),vec.end());
-    faiss::IndexIVF * iivf = dynamic_cast<faiss::IndexIVF*>(_findex);
+    std::vector<long int> labels(nn, -1);
+    std::vector<float> d(nn, -1.0);
+    std::vector<float> v(vec.begin(), vec.end());
+    faiss::IndexIVF *iivf = dynamic_cast<faiss::IndexIVF *>(_findex);
     if (iivf)
       {
         if (_nprobe == -1)
@@ -498,27 +488,25 @@ namespace dd
           iivf->nprobe = _nprobe;
       }
 
-    _findex->search(1,v.data(),nn,d.data(),labels.data());
-    for (int i = 0; i< nn ; ++i)
+    _findex->search(1, v.data(), nn, d.data(), labels.data());
+    for (int i = 0; i < nn; ++i)
       {
         long int label = labels[i];
         if (label != -1)
           {
             URIData uri;
-            get_from_db(label,uri);
+            get_from_db(label, uri);
             uris.push_back(uri);
-            distances.push_back(d[i]/((double)vec.size()));
+            distances.push_back(d[i] / ((double)vec.size()));
           }
       }
   }
 
-
-  void FaissSE::add_to_db(const int &idx,
-                          const URIData &fmap)
+  void FaissSE::add_to_db(const int &idx, const URIData &fmap)
   {
     if (_count_put == 0)
       _txn = std::unique_ptr<caffe::db::Transaction>(_db->NewTransaction());
-    _txn->Put(std::to_string(idx),fmap.encode());
+    _txn->Put(std::to_string(idx), fmap.encode());
     ++_count_put;
     if (_count_put % _count_put_max == 0)
       {
@@ -527,11 +515,10 @@ namespace dd
       }
   }
 
-  void FaissSE::get_from_db(const int &idx,
-                            URIData &fmap)
+  void FaissSE::get_from_db(const int &idx, URIData &fmap)
   {
     std::string tmp;
-    _db->Get(std::to_string(idx),tmp);
+    _db->Get(std::to_string(idx), tmp);
     fmap.decode(tmp);
   }
 

--- a/src/simsearch.h
+++ b/src/simsearch.h
@@ -48,10 +48,17 @@ namespace dd
   class SimIndexException : public std::exception
   {
   public:
-    SimIndexException(const std::string &s)
-      :_s(s) {}
-    ~SimIndexException() {}
-    const char* what() const noexcept { return _s.c_str(); }
+    SimIndexException(const std::string &s) : _s(s)
+    {
+    }
+    ~SimIndexException()
+    {
+    }
+    const char *what() const noexcept
+    {
+      return _s.c_str();
+    }
+
   private:
     std::string _s;
   };
@@ -62,10 +69,17 @@ namespace dd
   class SimSearchException : public std::exception
   {
   public:
-    SimSearchException(const std::string &s)
-      :_s(s) {}
-    ~SimSearchException() {}
-    const char* what() const noexcept { return _s.c_str(); }
+    SimSearchException(const std::string &s) : _s(s)
+    {
+    }
+    ~SimSearchException()
+    {
+    }
+    const char *what() const noexcept
+    {
+      return _s.c_str();
+    }
+
   private:
     std::string _s;
   };
@@ -76,55 +90,53 @@ namespace dd
   class URIData
   {
   public:
-    URIData() {}
-    URIData(const std::string &uri,
-	    const std::vector<double> &bbox = {},
-	    const double &prob = 0.0,
-	    const std::string &cat = "")
-      :_uri(uri),_bbox(bbox),_prob(prob),_cat(cat) {}
-    ~URIData() {}
+    URIData()
+    {
+    }
+    URIData(const std::string &uri, const std::vector<double> &bbox = {},
+            const double &prob = 0.0, const std::string &cat = "")
+        : _uri(uri), _bbox(bbox), _prob(prob), _cat(cat)
+    {
+    }
+    ~URIData()
+    {
+    }
 
     std::string encode() const;
     void decode(const std::string &str);
-    
+
     std::string _uri;
     std::vector<double> _bbox;
     double _prob = 0.0;
     std::string _cat;
     static char _enc_char;
   };
-  
-  template <class TSE>
-    class SearchEngine
-    {
-    public:
-      SearchEngine(const int &dim, const std::string &model_repo);
-      ~SearchEngine();
-      
-      void create_index();
 
-      void update_index();
+  template <class TSE> class SearchEngine
+  {
+  public:
+    SearchEngine(const int &dim, const std::string &model_repo);
+    ~SearchEngine();
 
-      void remove_index();
-      
-      void index(const URIData &uri,
-		 const std::vector<double> &data);
+    void create_index();
 
-      //batch index
-      void index(const std::vector<URIData> &uris,
-                 const std::vector<std::vector<double>> &data);
-      
-      void search(const std::vector<double> &data,
-		  const int &nn,
-		  std::vector<URIData> &uris,
-		  std::vector<double> &distances);
+    void update_index();
 
-      const int _dim = 128; /**< indexed vector length. */
-      TSE *_tse = nullptr;
-      std::mutex _index_mutex; /**< mutex around indexing calls. */
-    };
+    void remove_index();
 
+    void index(const URIData &uri, const std::vector<double> &data);
 
+    // batch index
+    void index(const std::vector<URIData> &uris,
+               const std::vector<std::vector<double>> &data);
+
+    void search(const std::vector<double> &data, const int &nn,
+                std::vector<URIData> &uris, std::vector<double> &distances);
+
+    const int _dim = 128; /**< indexed vector length. */
+    TSE *_tse = nullptr;
+    std::mutex _index_mutex; /**< mutex around indexing calls. */
+  };
 
 #ifdef USE_ANNOY
   class AnnoySE
@@ -137,38 +149,36 @@ namespace dd
     void create_index();
 
     void update_index();
-    
+
     void remove_index();
 
-    void index(const URIData &uri,
-	       const std::vector<double> &data);
+    void index(const URIData &uri, const std::vector<double> &data);
 
     void index(const std::vector<URIData> &uris,
                const std::vector<std::vector<double>> &datas);
-    
-    void search(const std::vector<double> &vec,
-		const int &nn,
-		std::vector<URIData> &uris,
-		std::vector<double> &distances);
-      
+
+    void search(const std::vector<double> &vec, const int &nn,
+                std::vector<URIData> &uris, std::vector<double> &distances);
+
     // internal functions
     void build_tree();
 
     void unbuild_tree();
 
     void save_tree();
-    
-    void add_to_db(const int &idx,
-		   const URIData &fmap);
-    
-    void get_from_db(const int &idx,
-		     URIData &fmap);
 
-    void set_ntrees(const int &ntrees) { _ntrees = ntrees; }
-    
-    int _f = 128; /**< indexed vector length. */
+    void add_to_db(const int &idx, const URIData &fmap);
+
+    void get_from_db(const int &idx, URIData &fmap);
+
+    void set_ntrees(const int &ntrees)
+    {
+      _ntrees = ntrees;
+    }
+
+    int _f = 128;      /**< indexed vector length. */
     int _ntrees = 100; /**< number of trees. */
-    AnnoyIndex<int,double,Angular,Kiss32Random> *_aindex = nullptr;
+    AnnoyIndex<int, double, Angular, Kiss32Random> *_aindex = nullptr;
     int _index_size = 0;
     std::string _model_repo; /**< model directory */
     const std::string _db_name = "names.bin";
@@ -178,9 +188,10 @@ namespace dd
     int _count_put = 0;
     int _count_put_max = 1000;
     const std::string _index_name = "index.ann";
-    bool _saved_tree = false; /**< whether the tree has been saved. */
+    bool _saved_tree = false;  /**< whether the tree has been saved. */
     bool _built_index = false; /**< whether the index has been built. */
-    bool _map_populate = true; /**< whether to use MAP_POPULATE when mmapping the full index. */
+    bool _map_populate = true; /**< whether to use MAP_POPULATE when mmapping
+                                  the full index. */
   };
 #endif
 
@@ -198,23 +209,19 @@ namespace dd
 
     void remove_index();
 
-    void index(const URIData &uri,
-               const std::vector<double> &data);
+    void index(const URIData &uri, const std::vector<double> &data);
 
     void index(const std::vector<URIData> &uris,
                const std::vector<std::vector<double>> &datas);
 
-    void search(const std::vector<double> &vec,
-                const int &nn,
-                std::vector<URIData> &uris,
-                std::vector<double> &distances);
-
+    void search(const std::vector<double> &vec, const int &nn,
+                std::vector<URIData> &uris, std::vector<double> &distances);
 
     void train();
     void add_to_db(const int &idx, const URIData &fmap);
     void get_from_db(const int &idx, URIData &fmap);
 
-    faiss::Index * _findex = nullptr;
+    faiss::Index *_findex = nullptr;
     std::string _index_key;
 
     int _f = 128; /**< indexed vector length. */
@@ -235,8 +242,8 @@ namespace dd
 
 #ifdef USE_GPU_FAISS
     bool _gpu = false;
-    faiss::Index * _gpu_index;
-    std::vector<faiss::gpu::GpuResources*> _gpu_res;
+    faiss::Index *_gpu_index;
+    std::vector<faiss::gpu::GpuResources *> _gpu_res;
     std::vector<int> _gpuids;
 #endif
   };

--- a/src/supervisedoutputconnector.h
+++ b/src/supervisedoutputconnector.h
@@ -23,25 +23,26 @@
 #define SUPERVISEDOUTPUTCONNECTOR_H
 
 template <typename T>
-bool SortScorePairDescend(const std::pair<double, T>& pair1,
-			  const std::pair<double, T>& pair2) {
+bool SortScorePairDescend(const std::pair<double, T> &pair1,
+                          const std::pair<double, T> &pair2)
+{
   return pair1.first > pair2.first;
-}    
-template bool SortScorePairDescend(const std::pair<double, int>& pair1,
-				   const std::pair<double, int>& pair2);
-template bool SortScorePairDescend(const std::pair<double, std::pair<int, int> >& pair1,
-				   const std::pair<double, std::pair<int, int> >& pair2);
+}
+template bool SortScorePairDescend(const std::pair<double, int> &pair1,
+                                   const std::pair<double, int> &pair2);
+template bool
+SortScorePairDescend(const std::pair<double, std::pair<int, int>> &pair1,
+                     const std::pair<double, std::pair<int, int>> &pair2);
 
 namespace dd
 {
 
-    /**
+  /**
    * \brief supervised machine learning output connector class
    */
   class SupervisedOutput : public OutputConnectorStrategy
   {
   public:
-
     /**
      * \brief supervised result
      */
@@ -52,13 +53,17 @@ namespace dd
        * \brief constructor
        * @param loss result loss
        */
-      sup_result(const std::string &label, const double &loss=0.0)
-	:_label(label),_loss(loss) {}
-      
+      sup_result(const std::string &label, const double &loss = 0.0)
+          : _label(label), _loss(loss)
+      {
+      }
+
       /**
        * \brief destructor
        */
-      ~sup_result() {}
+      ~sup_result()
+      {
+      }
 
       /**
        * \brief add category to result
@@ -67,77 +72,86 @@ namespace dd
        */
       inline void add_cat(const double &prob, const std::string &cat)
       {
-	_cats.insert(std::pair<double,std::string>(prob,cat));
+        _cats.insert(std::pair<double, std::string>(prob, cat));
       }
 
       inline void add_bbox(const double &prob, const APIData &ad)
       {
-        _bboxes.insert(std::pair<double,APIData>(prob,ad));
+        _bboxes.insert(std::pair<double, APIData>(prob, ad));
       }
 
       inline void add_mask(const double &prob, const APIData &mask)
       {
-        _masks.insert(std::pair<double,APIData>(prob,mask));
+        _masks.insert(std::pair<double, APIData>(prob, mask));
       }
 
       inline void add_val(const double &prob, const APIData &ad)
       {
-        _vals.insert(std::pair<double,APIData>(prob,ad));
+        _vals.insert(std::pair<double, APIData>(prob, ad));
       }
 
-      inline void add_timeseries(const double &prob, const APIData&ad)
+      inline void add_timeseries(const double &prob, const APIData &ad)
       {
-        _series.insert(std::pair<double,APIData>(prob,ad));
+        _series.insert(std::pair<double, APIData>(prob, ad));
       }
 
 #ifdef USE_SIMSEARCH
       void add_nn(const double &dist, const URIData &uri)
       {
-	_nns.insert(std::pair<double,URIData>(dist,uri));
+        _nns.insert(std::pair<double, URIData>(dist, uri));
       }
-      
+
       void add_bbox_nn(const int &bb, const double &dist, const URIData &uri)
       {
-	if (_bbox_nns.empty())
-	  _bbox_nns = std::vector<std::multimap<double,URIData>>(_bboxes.size(),std::multimap<double,URIData>());
-	_bbox_nns.at(bb).insert(std::pair<double,URIData>(dist,uri));
+        if (_bbox_nns.empty())
+          _bbox_nns = std::vector<std::multimap<double, URIData>>(
+              _bboxes.size(), std::multimap<double, URIData>());
+        _bbox_nns.at(bb).insert(std::pair<double, URIData>(dist, uri));
       }
 #endif
 
       std::string _label;
       double _loss = 0.0; /**< result loss. */
-      std::multimap<double,std::string,std::greater<double>> _cats; /**< categories and probabilities for this result */
-      std::multimap<double,APIData,std::greater<double>> _bboxes; /**< bounding boxes information */
-      std::multimap<double,APIData,std::greater<double>> _vals; /**< extra data or information added to output, e.g. roi */
-      std::multimap<double,APIData,std::greater<double>> _series; /** <extra data for timeseries */
-      std::multimap<double,APIData,std::greater<double>> _masks; /**< masks information */
+      std::multimap<double, std::string, std::greater<double>>
+          _cats; /**< categories and probabilities for this result */
+      std::multimap<double, APIData, std::greater<double>>
+          _bboxes; /**< bounding boxes information */
+      std::multimap<double, APIData, std::greater<double>>
+          _vals; /**< extra data or information added to output, e.g. roi */
+      std::multimap<double, APIData, std::greater<double>>
+          _series; /** <extra data for timeseries */
+      std::multimap<double, APIData, std::greater<double>>
+          _masks; /**< masks information */
 #ifdef USE_SIMSEARCH
       bool _indexed = false;
-      std::multimap<double,URIData> _nns; /**< nearest neigbors. */
-      std::vector<std::multimap<double,URIData>> _bbox_nns; /**< per bbox nearest neighbors. */
-      std::string _index_uri; /**< alternative URI to store in index in place of original URI. */
-#endif      
+      std::multimap<double, URIData> _nns; /**< nearest neigbors. */
+      std::vector<std::multimap<double, URIData>>
+          _bbox_nns;          /**< per bbox nearest neighbors. */
+      std::string _index_uri; /**< alternative URI to store in index in place
+                                 of original URI. */
+#endif
     };
 
   public:
     /**
      * \brief supervised output connector constructor
      */
-  SupervisedOutput()
-      :OutputConnectorStrategy()
-      {
-      }
-    
+    SupervisedOutput() : OutputConnectorStrategy()
+    {
+    }
+
     /**
      * \brief supervised output connector copy-constructor
      * @param sout supervised output connector
      */
     SupervisedOutput(const SupervisedOutput &sout)
-      :OutputConnectorStrategy(sout),_best(sout._best)
-      {
-      }
-    
-    ~SupervisedOutput() {}
+        : OutputConnectorStrategy(sout), _best(sout._best)
+    {
+    }
+
+    ~SupervisedOutput()
+    {
+    }
 
     /**
      * \brief supervised output connector initialization
@@ -147,9 +161,9 @@ namespace dd
     {
       APIData ad_out = ad.getobj("parameters").getobj("output");
       if (ad_out.has("best"))
-	_best = ad_out.get("best").get<int>();
+        _best = ad_out.get("best").get<int>();
       if (_best == -1)
-	_best = ad_out.get("nclasses").get<int>();
+        _best = ad_out.get("nclasses").get<int>();
     }
 
     /**
@@ -158,188 +172,225 @@ namespace dd
      */
     inline void add_results(const std::vector<APIData> &vrad)
     {
-      std::unordered_map<std::string,int>::iterator hit;
-      for (APIData ad: vrad)
-	{ 
-	  std::string uri = ad.get("uri").get<std::string>();
-	  std::string index_uri;
+      std::unordered_map<std::string, int>::iterator hit;
+      for (APIData ad : vrad)
+        {
+          std::string uri = ad.get("uri").get<std::string>();
+          std::string index_uri;
 #ifdef USE_SIMSEARCH
-	  if (ad.has("index_uri"))
-	    index_uri = ad.get("index_uri").get<std::string>();
+          if (ad.has("index_uri"))
+            index_uri = ad.get("index_uri").get<std::string>();
 #endif
-	  double loss = ad.get("loss").get<double>();
-	  std::vector<double> probs = ad.get("probs").get<std::vector<double>>();
-	  std::vector<std::string> cats;
-         if (ad.has("cats"))
-           cats = ad.get("cats").get<std::vector<std::string>>();
-	  std::vector<APIData> bboxes;
-	  std::vector<APIData> rois;
-	  std::vector<APIData> masks;
-	  if (ad.has("bboxes"))
-	    bboxes = ad.getv("bboxes");
-	  if (ad.has("vals")) {
-	    rois = ad.getv("vals");
-	  }
-         std::vector<APIData> series;
-         if (ad.has("series"))
-           {
-             series = ad.getv("series");
-           }
+          double loss = ad.get("loss").get<double>();
+          std::vector<double> probs
+              = ad.get("probs").get<std::vector<double>>();
+          std::vector<std::string> cats;
+          if (ad.has("cats"))
+            cats = ad.get("cats").get<std::vector<std::string>>();
+          std::vector<APIData> bboxes;
+          std::vector<APIData> rois;
+          std::vector<APIData> masks;
+          if (ad.has("bboxes"))
+            bboxes = ad.getv("bboxes");
+          if (ad.has("vals"))
+            {
+              rois = ad.getv("vals");
+            }
+          std::vector<APIData> series;
+          if (ad.has("series"))
+            {
+              series = ad.getv("series");
+            }
 
-	  if (ad.has("masks"))
-	    masks = ad.getv("masks");
-	  if ((hit=_vcats.find(uri))==_vcats.end())
-	    {
-	      auto resit = _vcats.insert(std::pair<std::string,int>(uri,_vvcats.size()));
-	      sup_result supres(uri,loss);
+          if (ad.has("masks"))
+            masks = ad.getv("masks");
+          if ((hit = _vcats.find(uri)) == _vcats.end())
+            {
+              auto resit = _vcats.insert(
+                  std::pair<std::string, int>(uri, _vvcats.size()));
+              sup_result supres(uri, loss);
 
 #ifdef USE_SIMSEARCH
-	      if (!index_uri.empty())
-		supres._index_uri = index_uri;
+              if (!index_uri.empty())
+                supres._index_uri = index_uri;
 #endif
-	      _vvcats.push_back(supres);
-	      hit = resit.first;
-	      for (size_t i=0;i<probs.size();i++)
-		{
-		  if (!cats.empty())
-		    _vvcats.at((*hit).second).add_cat(probs.at(i),cats.at(i));
-		  if (!bboxes.empty())
-		    _vvcats.at((*hit).second).add_bbox(probs.at(i),bboxes.at(i));
-		  if (!rois.empty())
-		    _vvcats.at((*hit).second).add_val(probs.at(i),rois.at(i));
-		  if (!series.empty())
-		    _vvcats.at((*hit).second).add_timeseries(probs.at(i),series.at(i));
-		  if (!masks.empty())
-		    _vvcats.at((*hit).second).add_mask(probs.at(i),masks.at(i));
-		}
-	    }
-	}
+              _vvcats.push_back(supres);
+              hit = resit.first;
+              for (size_t i = 0; i < probs.size(); i++)
+                {
+                  if (!cats.empty())
+                    _vvcats.at((*hit).second).add_cat(probs.at(i), cats.at(i));
+                  if (!bboxes.empty())
+                    _vvcats.at((*hit).second)
+                        .add_bbox(probs.at(i), bboxes.at(i));
+                  if (!rois.empty())
+                    _vvcats.at((*hit).second).add_val(probs.at(i), rois.at(i));
+                  if (!series.empty())
+                    _vvcats.at((*hit).second)
+                        .add_timeseries(probs.at(i), series.at(i));
+                  if (!masks.empty())
+                    _vvcats.at((*hit).second)
+                        .add_mask(probs.at(i), masks.at(i));
+                }
+            }
+        }
     }
-    
+
     /**
      * \brief best categories selection from results
      * @param ad_out output data object
      * @param bcats supervised output connector
      */
-    void best_cats(const APIData &ad_out, SupervisedOutput &bcats, const int &nclasses,
-		   const bool &has_bbox, const bool &has_roi, const bool &has_mask) const
+    void best_cats(const APIData &ad_out, SupervisedOutput &bcats,
+                   const int &nclasses, const bool &has_bbox,
+                   const bool &has_roi, const bool &has_mask) const
     {
       int best = _best;
       if (ad_out.has("best"))
-	best = ad_out.get("best").get<int>();
+        best = ad_out.get("best").get<int>();
       if (best == -1)
-	best = nclasses;
+        best = nclasses;
       if (!has_bbox && !has_roi && !has_mask)
-	{
-	  for (size_t i=0;i<_vvcats.size();i++)
-	    {
-	      sup_result sresult = _vvcats.at(i);
-	      sup_result bsresult(sresult._label,sresult._loss);
+        {
+          for (size_t i = 0; i < _vvcats.size(); i++)
+            {
+              sup_result sresult = _vvcats.at(i);
+              sup_result bsresult(sresult._label, sresult._loss);
 #ifdef USE_SIMSEARCH
-	      bsresult._index_uri = sresult._index_uri;
+              bsresult._index_uri = sresult._index_uri;
 #endif
-	      std::copy_n(sresult._cats.begin(),std::min(best,static_cast<int>(sresult._cats.size())),
-			  std::inserter(bsresult._cats,bsresult._cats.end()));
-	      if (!sresult._bboxes.empty())
-		std::copy_n(sresult._bboxes.begin(),std::min(best,static_cast<int>(sresult._bboxes.size())),
-			    std::inserter(bsresult._bboxes,bsresult._bboxes.end()));
-	      if (!sresult._vals.empty())
-		std::copy_n(sresult._vals.begin(),std::min(best,static_cast<int>(sresult._vals.size())),
-			    std::inserter(bsresult._vals,bsresult._vals.end()));
-	      if (!sresult._masks.empty())
-		std::copy_n(sresult._masks.begin(),std::min(best,static_cast<int>(sresult._masks.size())),
-			    std::inserter(bsresult._masks,bsresult._masks.end()));
-	      
-	      bcats._vcats.insert(std::pair<std::string,int>(sresult._label,bcats._vvcats.size()));
-	      bcats._vvcats.push_back(bsresult);
-	    }
-	}
+              std::copy_n(
+                  sresult._cats.begin(),
+                  std::min(best, static_cast<int>(sresult._cats.size())),
+                  std::inserter(bsresult._cats, bsresult._cats.end()));
+              if (!sresult._bboxes.empty())
+                std::copy_n(
+                    sresult._bboxes.begin(),
+                    std::min(best, static_cast<int>(sresult._bboxes.size())),
+                    std::inserter(bsresult._bboxes, bsresult._bboxes.end()));
+              if (!sresult._vals.empty())
+                std::copy_n(
+                    sresult._vals.begin(),
+                    std::min(best, static_cast<int>(sresult._vals.size())),
+                    std::inserter(bsresult._vals, bsresult._vals.end()));
+              if (!sresult._masks.empty())
+                std::copy_n(
+                    sresult._masks.begin(),
+                    std::min(best, static_cast<int>(sresult._masks.size())),
+                    std::inserter(bsresult._masks, bsresult._masks.end()));
+
+              bcats._vcats.insert(std::pair<std::string, int>(
+                  sresult._label, bcats._vvcats.size()));
+              bcats._vvcats.push_back(bsresult);
+            }
+        }
       else
-	{
-	  for (size_t i=0;i<_vvcats.size();i++)
-	    {
-	      sup_result sresult = _vvcats.at(i);
-	      sup_result bsresult(sresult._label,sresult._loss);
+        {
+          for (size_t i = 0; i < _vvcats.size(); i++)
+            {
+              sup_result sresult = _vvcats.at(i);
+              sup_result bsresult(sresult._label, sresult._loss);
 #ifdef USE_SIMSEARCH
-	      bsresult._index_uri = sresult._index_uri;
+              bsresult._index_uri = sresult._index_uri;
 #endif
-	      
-	      if (best == nclasses)
-		{
-		  int nbest = sresult._cats.size();
-		  std::copy_n(sresult._cats.begin(),std::min(nbest,static_cast<int>(sresult._cats.size())),
-			      std::inserter(bsresult._cats,bsresult._cats.end()));
-		  if (!sresult._bboxes.empty())
-		    std::copy_n(sresult._bboxes.begin(),std::min(nbest,static_cast<int>(sresult._bboxes.size())),
-				std::inserter(bsresult._bboxes,bsresult._bboxes.end()));
-		}
-	      else
-		{
-		  std::unordered_map<std::string,int> lboxes;
-		  auto bbit = lboxes.begin();
-		  auto mit = sresult._cats.begin();
-		  auto mitx = sresult._bboxes.begin();
-		  auto mity = sresult._vals.begin();
-		  auto mitmask = sresult._masks.begin();
-		  while(mitx!=sresult._bboxes.end())
-		    {
-		      APIData bbad = (*mitx).second;
-		      APIData vvad;
-		      if (has_roi)
-			vvad = (*mity).second;
-		      APIData maskad;
-		      if (has_mask)
-			maskad = (*mitmask).second;
-		      std::string bbkey = std::to_string(bbad.get("xmin").get<double>())
-			+ "-" + std::to_string(bbad.get("ymin").get<double>())
-			+ "-" + std::to_string(bbad.get("xmax").get<double>())
-			+ "-" + std::to_string(bbad.get("ymax").get<double>());
-		      if ((bbit=lboxes.find(bbkey))!=lboxes.end())
-			{
-			  (*bbit).second += 1;
-			  if ((*bbit).second <= best)
-			    {
-			      bsresult._cats.insert(std::pair<double,std::string>((*mit).first,(*mit).second));
-			      bsresult._bboxes.insert(std::pair<double,APIData>((*mitx).first,bbad));
-			      if (has_roi)
-				bsresult._vals.insert(std::pair<double,APIData>((*mity).first,vvad));
-			      if (has_mask)
-				bsresult._masks.insert(std::pair<double,APIData>((*mitmask).first,maskad));
-			    }
-			}
-		      else
-			{
-			  lboxes.insert(std::pair<std::string,int>(bbkey,1));
-			  bsresult._cats.insert(std::pair<double,std::string>((*mit).first,(*mit).second));
-			  bsresult._bboxes.insert(std::pair<double,APIData>((*mitx).first,bbad));
-			  if (has_roi)
-			    bsresult._vals.insert(std::pair<double,APIData>((*mity).first,vvad));
-			  if (has_mask)
-			    bsresult._masks.insert(std::pair<double,APIData>((*mitmask).first,maskad));
-			}
-		      ++mitx;
-		      ++mit;
-		      if (has_roi)
-			++mity;
-		      if (has_mask)
-			++mitmask;
-		    }
-		}
-	      bcats._vcats.insert(std::pair<std::string,int>(sresult._label,bcats._vvcats.size()));
-	      bcats._vvcats.push_back(bsresult);
-	    }
-	}
+
+              if (best == nclasses)
+                {
+                  int nbest = sresult._cats.size();
+                  std::copy_n(
+                      sresult._cats.begin(),
+                      std::min(nbest, static_cast<int>(sresult._cats.size())),
+                      std::inserter(bsresult._cats, bsresult._cats.end()));
+                  if (!sresult._bboxes.empty())
+                    std::copy_n(sresult._bboxes.begin(),
+                                std::min(nbest, static_cast<int>(
+                                                    sresult._bboxes.size())),
+                                std::inserter(bsresult._bboxes,
+                                              bsresult._bboxes.end()));
+                }
+              else
+                {
+                  std::unordered_map<std::string, int> lboxes;
+                  auto bbit = lboxes.begin();
+                  auto mit = sresult._cats.begin();
+                  auto mitx = sresult._bboxes.begin();
+                  auto mity = sresult._vals.begin();
+                  auto mitmask = sresult._masks.begin();
+                  while (mitx != sresult._bboxes.end())
+                    {
+                      APIData bbad = (*mitx).second;
+                      APIData vvad;
+                      if (has_roi)
+                        vvad = (*mity).second;
+                      APIData maskad;
+                      if (has_mask)
+                        maskad = (*mitmask).second;
+                      std::string bbkey
+                          = std::to_string(bbad.get("xmin").get<double>())
+                            + "-"
+                            + std::to_string(bbad.get("ymin").get<double>())
+                            + "-"
+                            + std::to_string(bbad.get("xmax").get<double>())
+                            + "-"
+                            + std::to_string(bbad.get("ymax").get<double>());
+                      if ((bbit = lboxes.find(bbkey)) != lboxes.end())
+                        {
+                          (*bbit).second += 1;
+                          if ((*bbit).second <= best)
+                            {
+                              bsresult._cats.insert(
+                                  std::pair<double, std::string>(
+                                      (*mit).first, (*mit).second));
+                              bsresult._bboxes.insert(
+                                  std::pair<double, APIData>((*mitx).first,
+                                                             bbad));
+                              if (has_roi)
+                                bsresult._vals.insert(
+                                    std::pair<double, APIData>((*mity).first,
+                                                               vvad));
+                              if (has_mask)
+                                bsresult._masks.insert(
+                                    std::pair<double, APIData>(
+                                        (*mitmask).first, maskad));
+                            }
+                        }
+                      else
+                        {
+                          lboxes.insert(std::pair<std::string, int>(bbkey, 1));
+                          bsresult._cats.insert(std::pair<double, std::string>(
+                              (*mit).first, (*mit).second));
+                          bsresult._bboxes.insert(
+                              std::pair<double, APIData>((*mitx).first, bbad));
+                          if (has_roi)
+                            bsresult._vals.insert(std::pair<double, APIData>(
+                                (*mity).first, vvad));
+                          if (has_mask)
+                            bsresult._masks.insert(std::pair<double, APIData>(
+                                (*mitmask).first, maskad));
+                        }
+                      ++mitx;
+                      ++mit;
+                      if (has_roi)
+                        ++mity;
+                      if (has_mask)
+                        ++mitmask;
+                    }
+                }
+              bcats._vcats.insert(std::pair<std::string, int>(
+                  sresult._label, bcats._vvcats.size()));
+              bcats._vvcats.push_back(bsresult);
+            }
+        }
     }
 
 #ifdef USE_SIMSEARCH
-    double multibox_distance(const double &dist,
-			     const double &prob)
+    double multibox_distance(const double &dist, const double &prob)
     {
       (void)prob; // XXX: probability is unused at the moment
       return dist;
     }
 #endif
-    
+
     /**
      * \brief finalize output supervised connector data
      * @param ad_in data output object from the API call
@@ -355,30 +406,31 @@ namespace dd
       bool autoencoder = false;
       int nclasses = -1;
       if (ad_out.has("nclasses"))
-	nclasses = ad_out.get("nclasses").get<int>();
+        nclasses = ad_out.get("nclasses").get<int>();
       if (ad_out.has("regression"))
-	{
-	  if (ad_out.get("regression").get<bool>())
-	    {
-	      regression = true;
-	      _best = ad_out.get("nclasses").get<int>();
-	    }
-	  ad_out.erase("regression");
-	  ad_out.erase("nclasses");
-	}
+        {
+          if (ad_out.get("regression").get<bool>())
+            {
+              regression = true;
+              _best = ad_out.get("nclasses").get<int>();
+            }
+          ad_out.erase("regression");
+          ad_out.erase("nclasses");
+        }
       if (ad_out.has("autoencoder") && ad_out.get("autoencoder").get<bool>())
-	{
-	  autoencoder = true;
-	  _best = 1;
-	  ad_out.erase("autoencoder");
-	}
+        {
+          autoencoder = true;
+          _best = 1;
+          ad_out.erase("autoencoder");
+        }
 
       bool has_bbox = ad_out.has("bbox") && ad_out.get("bbox").get<bool>();
       bool has_roi = ad_out.has("roi") && ad_out.get("roi").get<bool>();
       bool has_mask = ad_out.has("mask") && ad_out.get("mask").get<bool>();
-      bool has_multibox_rois = has_roi &&
-        ad_out.has("multibox_rois") && ad_out.get("multibox_rois").get<bool>();
-      bool timeseries = ad_out.has("timeseries") && ad_out.get("timeseries").get<bool>();
+      bool has_multibox_rois = has_roi && ad_out.has("multibox_rois")
+                               && ad_out.get("multibox_rois").get<bool>();
+      bool timeseries
+          = ad_out.has("timeseries") && ad_out.get("timeseries").get<bool>();
 
       if (timeseries)
         ad_out.erase("timeseries");
@@ -390,238 +442,282 @@ namespace dd
         }
 
       if (!timeseries)
-        best_cats(ad_in,bcats,nclasses,has_bbox,has_roi,has_mask);
+        best_cats(ad_in, bcats, nclasses, has_bbox, has_roi, has_mask);
 
       std::unordered_set<std::string> indexed_uris;
 #ifdef USE_SIMSEARCH
       // index
       if (ad_in.has("index") && ad_in.get("index").get<bool>())
-	{
-	  // check whether index has been created
-	  if (!mlm->_se)
-	    {
-	      bool create_index = true;
-	      int index_dim = _best;
-	      if (has_roi)
-		{
-		  if (!bcats._vvcats.empty())
-		    {
-		      if (!bcats._vvcats.at(0)._vals.empty()
-			  && (*bcats._vvcats.at(0)._vals.begin()).second.has("vals"))  
-			index_dim = (*bcats._vvcats.at(0)._vals.begin()).second.get("vals").get<std::vector<double>>().size(); // lookup to the first roi dimensions
-		      else create_index = false;
-		    }
-		  else create_index = false;
-		}
-	      if (create_index)
-            mlm->create_sim_search(index_dim,ad_in);
-	    }
-
-	  // index output content
-	  if (!has_roi)
-	    {
-#ifdef USE_FAISS
-          std::vector<URIData> urids;
-          std::vector<std::vector<double>> probsv;
-#endif
-	      for (size_t i=0;i<bcats._vvcats.size();i++)
+        {
+          // check whether index has been created
+          if (!mlm->_se)
             {
-              std::vector<double> probs;
-              auto mit = bcats._vvcats.at(i)._cats.begin();
-              while(mit!=bcats._vvcats.at(i)._cats.end())
+              bool create_index = true;
+              int index_dim = _best;
+              if (has_roi)
                 {
-                  probs.push_back((*mit).first);
-                  ++mit;
+                  if (!bcats._vvcats.empty())
+                    {
+                      if (!bcats._vvcats.at(0)._vals.empty()
+                          && (*bcats._vvcats.at(0)._vals.begin())
+                                 .second.has("vals"))
+                        index_dim = (*bcats._vvcats.at(0)._vals.begin())
+                                        .second.get("vals")
+                                        .get<std::vector<double>>()
+                                        .size(); // lookup to the first roi
+                                                 // dimensions
+                      else
+                        create_index = false;
+                    }
+                  else
+                    create_index = false;
                 }
-              URIData urid(bcats._vvcats.at(i)._label);
-#ifdef USE_FAISS
-              urids.push_back(urid);
-              probsv.push_back(probs);
-#else
-              mlm->_se->index(urid,probs);
-#endif
-              indexed_uris.insert(urid._uri);
+              if (create_index)
+                mlm->create_sim_search(index_dim, ad_in);
             }
-#ifdef USE_FAISS
-          mlm->_se->index(urids,probsv);
-#endif
 
-	    }
-	  else // roi
-	    {
-	      int nrois = 0;
-	      for (size_t i=0;i<bcats._vvcats.size();i++)
-		{
-		  auto vit = bcats._vvcats.at(i)._vals.begin();
-		  auto bit = bcats._vvcats.at(i)._bboxes.begin();
-		  auto mit = bcats._vvcats.at(i)._cats.begin();
+          // index output content
+          if (!has_roi)
+            {
 #ifdef USE_FAISS
-          std::vector<URIData> urids;
-          std::vector<std::vector<double>> datas;
+              std::vector<URIData> urids;
+              std::vector<std::vector<double>> probsv;
 #endif
-		  while(mit!=bcats._vvcats.at(i)._cats.end())
-		    {
-		      std::vector<double> bbox = {(*bit).second.get("xmin").get<double>(),
-						  (*bit).second.get("ymin").get<double>(),
-						  (*bit).second.get("xmax").get<double>(),
-						  (*bit).second.get("ymax").get<double>()};
-		      double prob = (*mit).first;
-		      std::string cat = (*mit).second;
-		      URIData urid(bcats._vvcats.at(i)._label,
-				   bbox,prob,cat);
+              for (size_t i = 0; i < bcats._vvcats.size(); i++)
+                {
+                  std::vector<double> probs;
+                  auto mit = bcats._vvcats.at(i)._cats.begin();
+                  while (mit != bcats._vvcats.at(i)._cats.end())
+                    {
+                      probs.push_back((*mit).first);
+                      ++mit;
+                    }
+                  URIData urid(bcats._vvcats.at(i)._label);
 #ifdef USE_FAISS
-              urids.push_back(urid);
-              datas.push_back((*vit).second.get("vals").get<std::vector<double>>());
+                  urids.push_back(urid);
+                  probsv.push_back(probs);
 #else
-              mlm->_se->index(urid,(*vit).second.get("vals").get<std::vector<double>>());
+                  mlm->_se->index(urid, probs);
 #endif
-		      ++mit;
-		      ++vit;
-		      ++bit;
-		      ++nrois;
-		      indexed_uris.insert(urid._uri);
-		    }
+                  indexed_uris.insert(urid._uri);
+                }
 #ifdef USE_FAISS
-          mlm->_se->index(urids,datas);
+              mlm->_se->index(urids, probsv);
 #endif
+            }
+          else // roi
+            {
+              int nrois = 0;
+              for (size_t i = 0; i < bcats._vvcats.size(); i++)
+                {
+                  auto vit = bcats._vvcats.at(i)._vals.begin();
+                  auto bit = bcats._vvcats.at(i)._bboxes.begin();
+                  auto mit = bcats._vvcats.at(i)._cats.begin();
+#ifdef USE_FAISS
+                  std::vector<URIData> urids;
+                  std::vector<std::vector<double>> datas;
+#endif
+                  while (mit != bcats._vvcats.at(i)._cats.end())
+                    {
+                      std::vector<double> bbox
+                          = { (*bit).second.get("xmin").get<double>(),
+                              (*bit).second.get("ymin").get<double>(),
+                              (*bit).second.get("xmax").get<double>(),
+                              (*bit).second.get("ymax").get<double>() };
+                      double prob = (*mit).first;
+                      std::string cat = (*mit).second;
+                      URIData urid(bcats._vvcats.at(i)._label, bbox, prob,
+                                   cat);
+#ifdef USE_FAISS
+                      urids.push_back(urid);
+                      datas.push_back((*vit)
+                                          .second.get("vals")
+                                          .get<std::vector<double>>());
+#else
+                      mlm->_se->index(urid, (*vit)
+                                                .second.get("vals")
+                                                .get<std::vector<double>>());
+#endif
+                      ++mit;
+                      ++vit;
+                      ++bit;
+                      ++nrois;
+                      indexed_uris.insert(urid._uri);
+                    }
+#ifdef USE_FAISS
+                  mlm->_se->index(urids, datas);
+#endif
+                }
+            }
+        }
 
-		}
-	    }
-	}
-      
       // build index
       if (ad_in.has("build_index") && ad_in.get("build_index").get<bool>())
-	{
-	  if (mlm->_se)
-	    mlm->build_index();
-	  else throw SimIndexException("Cannot build index if not created");
-	}
+        {
+          if (mlm->_se)
+            mlm->build_index();
+          else
+            throw SimIndexException("Cannot build index if not created");
+        }
 
       // search
       if (ad_in.has("search") && ad_in.get("search").get<bool>())
-	{
-	  // check whether index has been created
-	  if (!mlm->_se)
-	    {
-	      int index_dim = _best;
-	      if (has_roi && !bcats._vvcats.at(0)._vals.empty())
-		{
-		  index_dim = (*bcats._vvcats.at(0)._vals.begin()).second.get("vals").get<std::vector<double>>().size(); // lookup to the first roi dimensions
-		  mlm->create_sim_search(index_dim,ad_in);
-		}
-	    }
-	  
-	  int search_nn = _best;
-	  if (has_roi)
-	    search_nn = _search_nn;
-	  if (ad_in.has("search_nn"))
-	    search_nn = ad_in.get("search_nn").get<int>();
+        {
+          // check whether index has been created
+          if (!mlm->_se)
+            {
+              int index_dim = _best;
+              if (has_roi && !bcats._vvcats.at(0)._vals.empty())
+                {
+                  index_dim
+                      = (*bcats._vvcats.at(0)._vals.begin())
+                            .second.get("vals")
+                            .get<std::vector<double>>()
+                            .size(); // lookup to the first roi dimensions
+                  mlm->create_sim_search(index_dim, ad_in);
+                }
+            }
+
+          int search_nn = _best;
+          if (has_roi)
+            search_nn = _search_nn;
+          if (ad_in.has("search_nn"))
+            search_nn = ad_in.get("search_nn").get<int>();
 #ifdef USE_FAISS
-      if (ad_in.has("nprobe"))
-        mlm->_se->_tse->_nprobe = ad_in.get("nprobe").get<int>();
+          if (ad_in.has("nprobe"))
+            mlm->_se->_tse->_nprobe = ad_in.get("nprobe").get<int>();
 #endif
-	  if (!has_roi)
-	    {
-	      for (size_t i=0;i<bcats._vvcats.size();i++)
-		{
-		  std::vector<double> probs;
-		  auto mit = bcats._vvcats.at(i)._cats.begin();
-		  while(mit!=bcats._vvcats.at(i)._cats.end())
-		    {
-		      probs.push_back((*mit).first);
-		      ++mit;
-		    }
-		  std::vector<URIData> nn_uris;
-		  std::vector<double> nn_distances;
-		  mlm->_se->search(probs,search_nn,nn_uris,nn_distances);
-		  for (size_t j=0;j<nn_uris.size();j++)
-		    {
-		      bcats._vvcats.at(i).add_nn(nn_distances.at(j),nn_uris.at(j));
-		    }
-		}
-	    }
-	  else if (has_roi && has_multibox_rois)
-	    {
-	      for (size_t i=0;i<bcats._vvcats.size();i++)
-		{
-		  std::unordered_map<std::string,std::pair<double,int>> multibox_nn; // one uri (image) / total distance, count
-		  std::unordered_map<std::string,std::pair<double,int>>::iterator hit; 
-		  auto vit = bcats._vvcats.at(i)._vals.begin();
-		  auto mit = bcats._vvcats.at(i)._cats.begin();
-		  while(mit!=bcats._vvcats.at(i)._cats.end()) // equivalent to iterating the bboxes
-		    {
-		      std::vector<URIData> nn_uris;
-		      std::vector<double> nn_distances;
-		      mlm->_se->search((*vit).second.get("vals").get<std::vector<double>>(),
-				       search_nn,nn_uris,nn_distances);
-		      for (size_t j=0;j<nn_uris.size();j++)
-			{
-			  if ((hit=multibox_nn.find(nn_uris.at(j)._uri))==multibox_nn.end())
-			    {
-			      double mb_dist = multibox_distance(nn_distances.at(j),nn_uris.at(j)._prob);
-			      multibox_nn.insert(std::pair<std::string,std::pair<double,int>>(nn_uris.at(j)._uri,std::pair<double,int>(mb_dist,1)));
-			    }
-			  else
-			    {
-			      (*hit).second.first += multibox_distance(nn_distances.at(j),nn_uris.at(j)._prob);
-			      (*hit).second.second += 1;
-			    }
-			}
-		      
-		      ++mit;
-		      ++vit;
-		    }
-		  // final ranking per images and store final results here
-		  hit = multibox_nn.begin();
-		  while(hit!=multibox_nn.end()) // unsorted
-		    {
-		      //std::cerr << "adding uri=" << (*hit).first << " / dist=" << (*hit).second.first / static_cast<double>((*hit).second.second) << std::endl;
-		      bcats._vvcats.at(i).add_nn((*hit).second.first/static_cast<double>((*hit).second.second),URIData((*hit).first)); // sorted as per multimap
-		      ++hit;
-		    }
-		}
-	    }
-	  else // has_roi
-	    {
-	      for (size_t i=0;i<bcats._vvcats.size();i++)
-		{
-		  int bb = 0;
-		  auto vit = bcats._vvcats.at(i)._vals.begin();
-		  auto mit = bcats._vvcats.at(i)._cats.begin(); 
-		  while(mit!=bcats._vvcats.at(i)._cats.end()) // equivalent to iterating the bboxes
-		    {
-		      std::vector<URIData> nn_uris;
-		      std::vector<double> nn_distances;
-		      mlm->_se->search((*vit).second.get("vals").get<std::vector<double>>(),
-				       search_nn,nn_uris,nn_distances);
-		      ++mit;
-		      ++vit;
-		      for (size_t j=0;j<nn_uris.size();j++)
-			{
-			  bcats._vvcats.at(i).add_bbox_nn(bb,nn_distances.at(j),nn_uris.at(j));
-			}
-		      ++bb;
-		    }
-		}
-	    }
-	}      
+          if (!has_roi)
+            {
+              for (size_t i = 0; i < bcats._vvcats.size(); i++)
+                {
+                  std::vector<double> probs;
+                  auto mit = bcats._vvcats.at(i)._cats.begin();
+                  while (mit != bcats._vvcats.at(i)._cats.end())
+                    {
+                      probs.push_back((*mit).first);
+                      ++mit;
+                    }
+                  std::vector<URIData> nn_uris;
+                  std::vector<double> nn_distances;
+                  mlm->_se->search(probs, search_nn, nn_uris, nn_distances);
+                  for (size_t j = 0; j < nn_uris.size(); j++)
+                    {
+                      bcats._vvcats.at(i).add_nn(nn_distances.at(j),
+                                                 nn_uris.at(j));
+                    }
+                }
+            }
+          else if (has_roi && has_multibox_rois)
+            {
+              for (size_t i = 0; i < bcats._vvcats.size(); i++)
+                {
+                  std::unordered_map<std::string, std::pair<double, int>>
+                      multibox_nn; // one uri (image) / total distance, count
+                  std::unordered_map<std::string,
+                                     std::pair<double, int>>::iterator hit;
+                  auto vit = bcats._vvcats.at(i)._vals.begin();
+                  auto mit = bcats._vvcats.at(i)._cats.begin();
+                  while (mit
+                         != bcats._vvcats.at(i)
+                                ._cats
+                                .end()) // equivalent to iterating the bboxes
+                    {
+                      std::vector<URIData> nn_uris;
+                      std::vector<double> nn_distances;
+                      mlm->_se->search(
+                          (*vit).second.get("vals").get<std::vector<double>>(),
+                          search_nn, nn_uris, nn_distances);
+                      for (size_t j = 0; j < nn_uris.size(); j++)
+                        {
+                          if ((hit = multibox_nn.find(nn_uris.at(j)._uri))
+                              == multibox_nn.end())
+                            {
+                              double mb_dist = multibox_distance(
+                                  nn_distances.at(j), nn_uris.at(j)._prob);
+                              multibox_nn.insert(
+                                  std::pair<std::string,
+                                            std::pair<double, int>>(
+                                      nn_uris.at(j)._uri,
+                                      std::pair<double, int>(mb_dist, 1)));
+                            }
+                          else
+                            {
+                              (*hit).second.first += multibox_distance(
+                                  nn_distances.at(j), nn_uris.at(j)._prob);
+                              (*hit).second.second += 1;
+                            }
+                        }
+
+                      ++mit;
+                      ++vit;
+                    }
+                  // final ranking per images and store final results here
+                  hit = multibox_nn.begin();
+                  while (hit != multibox_nn.end()) // unsorted
+                    {
+                      // std::cerr << "adding uri=" << (*hit).first << " /
+                      // dist=" << (*hit).second.first /
+                      // static_cast<double>((*hit).second.second) <<
+                      // std::endl;
+                      bcats._vvcats.at(i).add_nn(
+                          (*hit).second.first
+                              / static_cast<double>((*hit).second.second),
+                          URIData((*hit).first)); // sorted as per multimap
+                      ++hit;
+                    }
+                }
+            }
+          else // has_roi
+            {
+              for (size_t i = 0; i < bcats._vvcats.size(); i++)
+                {
+                  int bb = 0;
+                  auto vit = bcats._vvcats.at(i)._vals.begin();
+                  auto mit = bcats._vvcats.at(i)._cats.begin();
+                  while (mit
+                         != bcats._vvcats.at(i)
+                                ._cats
+                                .end()) // equivalent to iterating the bboxes
+                    {
+                      std::vector<URIData> nn_uris;
+                      std::vector<double> nn_distances;
+                      mlm->_se->search(
+                          (*vit).second.get("vals").get<std::vector<double>>(),
+                          search_nn, nn_uris, nn_distances);
+                      ++mit;
+                      ++vit;
+                      for (size_t j = 0; j < nn_uris.size(); j++)
+                        {
+                          bcats._vvcats.at(i).add_bbox_nn(
+                              bb, nn_distances.at(j), nn_uris.at(j));
+                        }
+                      ++bb;
+                    }
+                }
+            }
+        }
 #endif
 
       if (has_multibox_rois)
-	has_roi = false;
+        has_roi = false;
       if (!timeseries)
-        bcats.to_ad(ad_out,regression,autoencoder,has_bbox,has_roi,has_mask,timeseries,indexed_uris);
+        bcats.to_ad(ad_out, regression, autoencoder, has_bbox, has_roi,
+                    has_mask, timeseries, indexed_uris);
       else
-        to_ad(ad_out,regression,autoencoder,has_bbox,has_roi,has_mask,timeseries,indexed_uris);
+        to_ad(ad_out, regression, autoencoder, has_bbox, has_roi, has_mask,
+              timeseries, indexed_uris);
     }
-    
-    struct PredictionAndAnswer {
+
+    struct PredictionAndAnswer
+    {
       float prediction;
-      unsigned char answer; //this is either 0 or 1
+      unsigned char answer; // this is either 0 or 1
     };
 
     // measure
-    static void measure(const APIData &ad_res, const APIData &ad_out, APIData &out)
+    static void measure(const APIData &ad_res, const APIData &ad_out,
+                        APIData &out)
     {
       APIData meas_out;
       bool tloss = ad_res.has("train_loss");
@@ -639,371 +735,454 @@ namespace dd
         timeseries = ad_res.get("timeseries").get<int>();
 
       if (ad_out.has("measure"))
-	{
-	  std::vector<std::string> measures = ad_out.get("measure").get<std::vector<std::string>>();
-      	  bool bauc = (std::find(measures.begin(),measures.end(),"auc")!=measures.end());
-	  bool bacc = false;
+        {
+          std::vector<std::string> measures
+              = ad_out.get("measure").get<std::vector<std::string>>();
+          bool bauc = (std::find(measures.begin(), measures.end(), "auc")
+                       != measures.end());
+          bool bacc = false;
 
-	  if (!multilabel && !segmentation && !net_meas && !bbox)
-	    {
-	      for (auto s: measures)
-		if (s.find("acc")!=std::string::npos)
-		  {
-		    bacc = true;
-		    break;
-		  }
-	    }
-	  bool bf1 = (std::find(measures.begin(),measures.end(),"f1")!=measures.end());
-	  bool bf1full = (std::find(measures.begin(),measures.end(),"f1full")!=measures.end());
-	  bool bmcll = (std::find(measures.begin(),measures.end(),"mcll")!=measures.end());
-	  bool bgini = (std::find(measures.begin(),measures.end(),"gini")!=measures.end());
-	  bool beucll = false;
-      float beucll_thres = -1;
-      find_presence_and_thres("eucll", measures, beucll, beucll_thres);
-	  bool bmcc = (std::find(measures.begin(),measures.end(),"mcc")!=measures.end());
-	  bool baccv = false;
-	  bool mlacc = false;
-      bool mlsoft_kl = false;
-      float mlsoft_kl_thres = -1;
-      bool mlsoft_js = false;
-      float mlsoft_js_thres = -1;
-      bool mlsoft_was = false;
-      float mlsoft_was_thres = -1;
-      bool mlsoft_ks = false;
-      float mlsoft_ks_thres = -1;
-      bool mlsoft_dc = false;
-      float mlsoft_dc_thres = -1;
-      bool mlsoft_r2 = false;
-      float mlsoft_r2_thres = -1;
-      bool mlsoft_deltas = false;
-      float mlsoft_deltas_thres = -1;
-      bool raw = false;
-
-      raw = std::find(measures.begin(),measures.end(),"raw")!=measures.end();
-
-       if (segmentation)
-	    baccv = (std::find(measures.begin(),measures.end(),"acc")!=measures.end());
-       if (multilabel && !regression)
-	    mlacc = (std::find(measures.begin(),measures.end(),"acc")!=measures.end());
-      if (multilabel && regression)
-        {
-	  bool acc =  (std::find(measures.begin(),measures.end(),"acc")!=measures.end());
-	  if (acc)
-	    {
-	      mlsoft_kl = mlsoft_js = mlsoft_was = mlsoft_ks = mlsoft_dc = mlsoft_r2 = mlsoft_deltas = true;
-	    }
-	  else
-	    {
-          find_presence_and_thres("kl", measures, mlsoft_kl, mlsoft_kl_thres);
-          find_presence_and_thres("js", measures, mlsoft_js, mlsoft_js_thres);
-          find_presence_and_thres("was", measures, mlsoft_was, mlsoft_was_thres);
-          find_presence_and_thres("ks", measures, mlsoft_ks, mlsoft_ks_thres);
-          find_presence_and_thres("dc", measures, mlsoft_dc, mlsoft_dc_thres);
-          find_presence_and_thres("r2", measures, mlsoft_r2, mlsoft_r2_thres);
-          find_presence_and_thres("deltas", measures, mlsoft_deltas, mlsoft_deltas_thres);
-	    }
-	}
-      if (bbox)
-	{
-	  bool bbmap = (std::find(measures.begin(),measures.end(),"map")!=measures.end());
-	  if (bbmap)
-	    {
-	      std::map<int,float> aps;
-	      double bmap = ap(ad_res,aps);
-	      meas_out.add("map",bmap);
-	      for (auto ap: aps)
-               {
-                 std::string s = "map_" + std::to_string(ap.first);
-                 meas_out.add(s,static_cast<double>(ap.second));
-	       }
-	    }
-      bool raw = (std::find(measures.begin(),measures.end(),"raw")!=measures.end());
-      if (raw)
-        {
-          std::vector<std::string> clnames = ad_res.get("clnames").get<std::vector<std::string>>();
-          APIData ap = raw_detection_results(ad_res,clnames);
-          meas_out.add("raw", ap);
-        }
-	}
-      if (net_meas) // measure is coming from the net directly
-	{
-	  double acc = straight_meas(ad_res);
-	  meas_out.add("acc",acc);
-	}
-      if (bauc) // XXX: applies two binary classification problems only
-	{
-	  double mauc = auc(ad_res);
-	  meas_out.add("auc",mauc);
-	}
-      if (bacc)
-	{
-	  std::map<std::string,double> accs = acc(ad_res,measures);
-	  auto mit = accs.begin();
-	  while(mit!=accs.end())
-	    {
-	      meas_out.add((*mit).first,(*mit).second);
-	      ++mit;
-	    }
-	}
-      if (baccv)
-	{
-	  double meanacc, meaniou;
-	  std::vector<double> clacc;
-	  std::vector<double> cliou;
-	  double accs = acc_v(ad_res,meanacc,meaniou,clacc,cliou);
-	  meas_out.add("acc",accs);
-	  meas_out.add("meanacc",meanacc);
-	  meas_out.add("meaniou",meaniou);
-	  meas_out.add("clacc",clacc);
-         meas_out.add("cliou",cliou);
-	}
-      if (mlacc)
-	{
-	  double f1, sensitivity, specificity, harmmean, precision;
-	  multilabel_acc(ad_res,sensitivity,specificity,harmmean,precision,f1);
-	  meas_out.add("f1",f1);
-	  meas_out.add("precision",precision);
-	  meas_out.add("sensitivity",sensitivity);
-	  meas_out.add("specificity",specificity);
-	  meas_out.add("harmmean",harmmean);
-	}
-      if (mlsoft_kl)
-        {
-          double kl_divergence = multilabel_soft_kl(ad_res,-1); // kl: amount of lost info if using pred instead of truth
-          meas_out.add("kl_divergence",kl_divergence);
-          double kl_divergence_thres = multilabel_soft_kl(ad_res,mlsoft_kl_thres);
-          std::string b = "kl_divergence_no_" +std::to_string(mlsoft_kl_thres);
-          meas_out.add(b,kl_divergence_thres);
-        }
-      if (mlsoft_js)
-        {
-          double js_divergence = multilabel_soft_js(ad_res,-1) ; // jsd: symetrized version of kl
-	      meas_out.add("js_divergence",js_divergence);
-          double js_divergence_thres = multilabel_soft_js(ad_res,mlsoft_js_thres) ;
-          std::string b = "js_divergence_no_" + std::to_string(mlsoft_js_thres);
-          meas_out.add(b,js_divergence_thres);
-        }
-      if (mlsoft_was)
-        {
-          double wasserstein = multilabel_soft_was(ad_res,-1); // wasserstein distance
-	      meas_out.add("wasserstein",wasserstein);
-          double wasserstein_thres = multilabel_soft_was(ad_res,mlsoft_was_thres);
-          std::string b = "wasserstein_no_" + std::to_string(mlsoft_was_thres);
-          meas_out.add(b,wasserstein_thres);
-        }
-      if (mlsoft_ks)
-        {
-          double kolmogorov_smirnov = multilabel_soft_ks(ad_res,-1); // kolmogorov-smirnov test aka max individual error
-	      meas_out.add("kolmogorov_smirnov",kolmogorov_smirnov);
-          double kolmogorov_smirnov_thres = multilabel_soft_ks(ad_res,mlsoft_ks_thres);
-          std::string b = "kolmogorov_smirnov_no_" + std::to_string(kolmogorov_smirnov_thres);
-          meas_out.add(b,kolmogorov_smirnov_thres);
-        }
-      if (mlsoft_dc)
-        {
-          double distance_correlation = multilabel_soft_dc(ad_res,-1); // distance correlation , same as brownian correlation
-	      meas_out.add("distance_correlation",distance_correlation);
-          double distance_correlation_thres = multilabel_soft_dc(ad_res,mlsoft_dc_thres);
-          std::string b = "distance_correlation_no_" + std::to_string(mlsoft_dc_thres);
-          meas_out.add(b,distance_correlation_thres);
-        }
-      if (mlsoft_r2)
-        {
-          double r_2 = multilabel_soft_r2(ad_res,-1); // r_2 score: best  is 1, min is 0
-          meas_out.add("r2",r_2);
-          double r_2_thres = multilabel_soft_r2(ad_res,mlsoft_r2_thres);
-          std::string b = "r2_no_" + std::to_string(mlsoft_r2_thres);
-          meas_out.add(b,r_2_thres);
-        }
-      if (mlsoft_deltas)
-        {
-          std::vector<double> delta_scores {0,0,0,0}; // delta-score , aka 1 if pred \in [truth-delta, truth+delta]
-          std::vector<double> delta_scores_thres {0,0,0,0}; // delta-score , aka 1 if pred \in [truth-delta, truth+delta]
-          std::vector<double> deltas {0.05, 0.1, 0.2, 0.5};
-          multilabel_soft_deltas(ad_res, delta_scores, deltas,-1);
-          multilabel_soft_deltas(ad_res, delta_scores_thres, deltas,mlsoft_deltas_thres);
-          for (unsigned int i=0; i<deltas.size(); ++i)
+          if (!multilabel && !segmentation && !net_meas && !bbox)
             {
-              std::ostringstream sstr;
-              sstr << "delta_score_" << deltas[i];
-              meas_out.add(sstr.str(),delta_scores[i]);
-              sstr.str("");
-              sstr << "delta_score_" << deltas[i]<<"_no_"<<mlsoft_deltas_thres;
-              meas_out.add(sstr.str(),delta_scores_thres[i]);
+              for (auto s : measures)
+                if (s.find("acc") != std::string::npos)
+                  {
+                    bacc = true;
+                    break;
+                  }
+            }
+          bool bf1 = (std::find(measures.begin(), measures.end(), "f1")
+                      != measures.end());
+          bool bf1full = (std::find(measures.begin(), measures.end(), "f1full")
+                          != measures.end());
+          bool bmcll = (std::find(measures.begin(), measures.end(), "mcll")
+                        != measures.end());
+          bool bgini = (std::find(measures.begin(), measures.end(), "gini")
+                        != measures.end());
+          bool beucll = false;
+          float beucll_thres = -1;
+          find_presence_and_thres("eucll", measures, beucll, beucll_thres);
+          bool bmcc = (std::find(measures.begin(), measures.end(), "mcc")
+                       != measures.end());
+          bool baccv = false;
+          bool mlacc = false;
+          bool mlsoft_kl = false;
+          float mlsoft_kl_thres = -1;
+          bool mlsoft_js = false;
+          float mlsoft_js_thres = -1;
+          bool mlsoft_was = false;
+          float mlsoft_was_thres = -1;
+          bool mlsoft_ks = false;
+          float mlsoft_ks_thres = -1;
+          bool mlsoft_dc = false;
+          float mlsoft_dc_thres = -1;
+          bool mlsoft_r2 = false;
+          float mlsoft_r2_thres = -1;
+          bool mlsoft_deltas = false;
+          float mlsoft_deltas_thres = -1;
+          bool raw = false;
+
+          raw = std::find(measures.begin(), measures.end(), "raw")
+                != measures.end();
+
+          if (segmentation)
+            baccv = (std::find(measures.begin(), measures.end(), "acc")
+                     != measures.end());
+          if (multilabel && !regression)
+            mlacc = (std::find(measures.begin(), measures.end(), "acc")
+                     != measures.end());
+          if (multilabel && regression)
+            {
+              bool acc = (std::find(measures.begin(), measures.end(), "acc")
+                          != measures.end());
+              if (acc)
+                {
+                  mlsoft_kl = mlsoft_js = mlsoft_was = mlsoft_ks = mlsoft_dc
+                      = mlsoft_r2 = mlsoft_deltas = true;
+                }
+              else
+                {
+                  find_presence_and_thres("kl", measures, mlsoft_kl,
+                                          mlsoft_kl_thres);
+                  find_presence_and_thres("js", measures, mlsoft_js,
+                                          mlsoft_js_thres);
+                  find_presence_and_thres("was", measures, mlsoft_was,
+                                          mlsoft_was_thres);
+                  find_presence_and_thres("ks", measures, mlsoft_ks,
+                                          mlsoft_ks_thres);
+                  find_presence_and_thres("dc", measures, mlsoft_dc,
+                                          mlsoft_dc_thres);
+                  find_presence_and_thres("r2", measures, mlsoft_r2,
+                                          mlsoft_r2_thres);
+                  find_presence_and_thres("deltas", measures, mlsoft_deltas,
+                                          mlsoft_deltas_thres);
+                }
+            }
+          if (bbox)
+            {
+              bool bbmap = (std::find(measures.begin(), measures.end(), "map")
+                            != measures.end());
+              if (bbmap)
+                {
+                  std::map<int, float> aps;
+                  double bmap = ap(ad_res, aps);
+                  meas_out.add("map", bmap);
+                  for (auto ap : aps)
+                    {
+                      std::string s = "map_" + std::to_string(ap.first);
+                      meas_out.add(s, static_cast<double>(ap.second));
+                    }
+                }
+              bool raw = (std::find(measures.begin(), measures.end(), "raw")
+                          != measures.end());
+              if (raw)
+                {
+                  std::vector<std::string> clnames
+                      = ad_res.get("clnames").get<std::vector<std::string>>();
+                  APIData ap = raw_detection_results(ad_res, clnames);
+                  meas_out.add("raw", ap);
+                }
+            }
+          if (net_meas) // measure is coming from the net directly
+            {
+              double acc = straight_meas(ad_res);
+              meas_out.add("acc", acc);
+            }
+          if (bauc) // XXX: applies two binary classification problems only
+            {
+              double mauc = auc(ad_res);
+              meas_out.add("auc", mauc);
+            }
+          if (bacc)
+            {
+              std::map<std::string, double> accs = acc(ad_res, measures);
+              auto mit = accs.begin();
+              while (mit != accs.end())
+                {
+                  meas_out.add((*mit).first, (*mit).second);
+                  ++mit;
+                }
+            }
+          if (baccv)
+            {
+              double meanacc, meaniou;
+              std::vector<double> clacc;
+              std::vector<double> cliou;
+              double accs = acc_v(ad_res, meanacc, meaniou, clacc, cliou);
+              meas_out.add("acc", accs);
+              meas_out.add("meanacc", meanacc);
+              meas_out.add("meaniou", meaniou);
+              meas_out.add("clacc", clacc);
+              meas_out.add("cliou", cliou);
+            }
+          if (mlacc)
+            {
+              double f1, sensitivity, specificity, harmmean, precision;
+              multilabel_acc(ad_res, sensitivity, specificity, harmmean,
+                             precision, f1);
+              meas_out.add("f1", f1);
+              meas_out.add("precision", precision);
+              meas_out.add("sensitivity", sensitivity);
+              meas_out.add("specificity", specificity);
+              meas_out.add("harmmean", harmmean);
+            }
+          if (mlsoft_kl)
+            {
+              double kl_divergence = multilabel_soft_kl(
+                  ad_res, -1); // kl: amount of lost info if using pred instead
+                               // of truth
+              meas_out.add("kl_divergence", kl_divergence);
+              double kl_divergence_thres
+                  = multilabel_soft_kl(ad_res, mlsoft_kl_thres);
+              std::string b
+                  = "kl_divergence_no_" + std::to_string(mlsoft_kl_thres);
+              meas_out.add(b, kl_divergence_thres);
+            }
+          if (mlsoft_js)
+            {
+              double js_divergence = multilabel_soft_js(
+                  ad_res, -1); // jsd: symetrized version of kl
+              meas_out.add("js_divergence", js_divergence);
+              double js_divergence_thres
+                  = multilabel_soft_js(ad_res, mlsoft_js_thres);
+              std::string b
+                  = "js_divergence_no_" + std::to_string(mlsoft_js_thres);
+              meas_out.add(b, js_divergence_thres);
+            }
+          if (mlsoft_was)
+            {
+              double wasserstein
+                  = multilabel_soft_was(ad_res, -1); // wasserstein distance
+              meas_out.add("wasserstein", wasserstein);
+              double wasserstein_thres
+                  = multilabel_soft_was(ad_res, mlsoft_was_thres);
+              std::string b
+                  = "wasserstein_no_" + std::to_string(mlsoft_was_thres);
+              meas_out.add(b, wasserstein_thres);
+            }
+          if (mlsoft_ks)
+            {
+              double kolmogorov_smirnov = multilabel_soft_ks(
+                  ad_res,
+                  -1); // kolmogorov-smirnov test aka max individual error
+              meas_out.add("kolmogorov_smirnov", kolmogorov_smirnov);
+              double kolmogorov_smirnov_thres
+                  = multilabel_soft_ks(ad_res, mlsoft_ks_thres);
+              std::string b = "kolmogorov_smirnov_no_"
+                              + std::to_string(kolmogorov_smirnov_thres);
+              meas_out.add(b, kolmogorov_smirnov_thres);
+            }
+          if (mlsoft_dc)
+            {
+              double distance_correlation = multilabel_soft_dc(
+                  ad_res,
+                  -1); // distance correlation , same as brownian correlation
+              meas_out.add("distance_correlation", distance_correlation);
+              double distance_correlation_thres
+                  = multilabel_soft_dc(ad_res, mlsoft_dc_thres);
+              std::string b = "distance_correlation_no_"
+                              + std::to_string(mlsoft_dc_thres);
+              meas_out.add(b, distance_correlation_thres);
+            }
+          if (mlsoft_r2)
+            {
+              double r_2 = multilabel_soft_r2(
+                  ad_res, -1); // r_2 score: best  is 1, min is 0
+              meas_out.add("r2", r_2);
+              double r_2_thres = multilabel_soft_r2(ad_res, mlsoft_r2_thres);
+              std::string b = "r2_no_" + std::to_string(mlsoft_r2_thres);
+              meas_out.add(b, r_2_thres);
+            }
+          if (mlsoft_deltas)
+            {
+              std::vector<double> delta_scores{
+                0, 0, 0, 0
+              }; // delta-score , aka 1 if pred \in [truth-delta, truth+delta]
+              std::vector<double> delta_scores_thres{
+                0, 0, 0, 0
+              }; // delta-score , aka 1 if pred \in [truth-delta, truth+delta]
+              std::vector<double> deltas{ 0.05, 0.1, 0.2, 0.5 };
+              multilabel_soft_deltas(ad_res, delta_scores, deltas, -1);
+              multilabel_soft_deltas(ad_res, delta_scores_thres, deltas,
+                                     mlsoft_deltas_thres);
+              for (unsigned int i = 0; i < deltas.size(); ++i)
+                {
+                  std::ostringstream sstr;
+                  sstr << "delta_score_" << deltas[i];
+                  meas_out.add(sstr.str(), delta_scores[i]);
+                  sstr.str("");
+                  sstr << "delta_score_" << deltas[i] << "_no_"
+                       << mlsoft_deltas_thres;
+                  meas_out.add(sstr.str(), delta_scores_thres[i]);
+                }
+            }
+
+          if (!multilabel && !segmentation && !bbox && (bf1 || bf1full))
+            {
+              double f1, precision, recall, acc;
+              dMat conf_diag, conf_matrix;
+              dVec precisionV, recallV, f1V;
+              f1 = mf1(ad_res, precision, recall, acc, precisionV, recallV,
+                       f1V, conf_diag, conf_matrix);
+              meas_out.add("f1", f1);
+              meas_out.add("precision", precision);
+              meas_out.add("recall", recall);
+              meas_out.add("accp", acc);
+              if (std::find(measures.begin(), measures.end(), "f1full")
+                  != measures.end())
+                {
+                  std::vector<double> allPrecisions;
+                  std::vector<double> allRecalls;
+                  std::vector<double> allF1s;
+                  for (int i = 0; i < precisionV.size(); ++i)
+                    {
+                      allPrecisions.push_back(precisionV(i));
+                      allRecalls.push_back(recallV(i));
+                      allF1s.push_back(f1V(i));
+                    }
+                  meas_out.add("precisions", allPrecisions);
+                  meas_out.add("recalls", allRecalls);
+                  meas_out.add("f1s", allF1s);
+                  if (std::find(measures.begin(), measures.end(), "cmdiag")
+                      == measures.end())
+                    meas_out.add(
+                        "labels",
+                        ad_res.get("clnames").get<std::vector<std::string>>());
+                }
+
+              if (std::find(measures.begin(), measures.end(), "cmdiag")
+                  != measures.end())
+
+                {
+                  std::vector<double> cmdiagv;
+                  for (int i = 0; i < conf_diag.rows(); i++)
+                    cmdiagv.push_back(conf_diag(i, 0));
+                  meas_out.add("cmdiag", cmdiagv);
+                  meas_out.add(
+                      "labels",
+                      ad_res.get("clnames").get<std::vector<std::string>>());
+                }
+              if (std::find(measures.begin(), measures.end(), "cmfull")
+                  != measures.end())
+                {
+                  std::vector<std::string> clnames
+                      = ad_res.get("clnames").get<std::vector<std::string>>();
+                  std::vector<APIData> cmdata;
+                  for (int i = 0; i < conf_matrix.cols(); i++)
+                    {
+                      std::vector<double> cmrow;
+                      for (int j = 0; j < conf_matrix.rows(); j++)
+                        cmrow.push_back(conf_matrix(j, i));
+                      APIData adrow;
+                      adrow.add(clnames.at(i), cmrow);
+                      cmdata.push_back(adrow);
+                    }
+                  meas_out.add("cmfull", cmdata);
+                }
+            }
+          if (!multilabel && !segmentation && !bbox && bmcll)
+            {
+              double mmcll = mcll(ad_res);
+              meas_out.add("mcll", mmcll);
+            }
+          if (bgini)
+            {
+              double mgini = gini(ad_res, regression);
+              meas_out.add("gini", mgini);
+            }
+          if (beucll)
+            {
+              double meucll = eucll(ad_res, -1);
+              meas_out.add("eucll", meucll);
+              double meucll_thres = eucll(ad_res, beucll_thres);
+              std::string b = "eucll_no_" + std::to_string(beucll_thres);
+              meas_out.add(b, meucll_thres);
+            }
+          if (bmcc)
+            {
+              double mmcc = mcc(ad_res);
+              meas_out.add("mcc", mmcc);
+            }
+          if (raw && !bbox)
+            {
+              APIData raw_res = raw_results(
+                  ad_res,
+                  ad_res.get("clnames").get<std::vector<std::string>>());
+              meas_out.add("raw", raw_res);
+            }
+          if (timeserie)
+            {
+              // we have timeseries outputs (flattened / interleaved in preds!)
+              std::vector<double> max_errors(timeseries);
+              std::vector<int> indexes_max_error(timeseries);
+              std::vector<double> mean_errors(timeseries);
+              double max_error;
+              double mean_error;
+
+              bool L1 = false;
+              bool L2 = false;
+              if (ad_out.has("measure"))
+                {
+                  std::vector<std::string> measures
+                      = ad_out.get("measure").get<std::vector<std::string>>();
+                  L1 = (std::find(measures.begin(), measures.end(), "L1")
+                        != measures.end());
+                  L2 = (std::find(measures.begin(), measures.end(), "L2")
+                        != measures.end());
+                }
+
+              if (!L1 && !L2)
+                L1 = true;
+
+              if (L1)
+                {
+                  timeSeriesErrors(ad_res, timeseries, &max_errors[0],
+                                   &indexes_max_error[0], &mean_errors[0],
+                                   max_error, mean_error, true);
+                  for (int i = 0; i < timeseries; ++i)
+                    {
+                      meas_out.add("L1_max_error_" + std::to_string(i),
+                                   max_errors[i]);
+                      meas_out.add("L1_max_error_" + std::to_string(i)
+                                       + "_date",
+                                   (double)(indexes_max_error[i]));
+                      meas_out.add("L1_mean_error_" + std::to_string(i),
+                                   mean_errors[i]);
+                    }
+                  meas_out.add("L1_max_error", max_error);
+                  meas_out.add("L1_mean_error", mean_error);
+                  if (!L2)
+                    meas_out.add("eucll", mean_error);
+                }
+              if (L2)
+                {
+                  timeSeriesErrors(ad_res, timeseries, &max_errors[0],
+                                   &indexes_max_error[0], &mean_errors[0],
+                                   max_error, mean_error, false);
+                  for (int i = 0; i < timeseries; ++i)
+                    {
+                      meas_out.add("L2_max_error_" + std::to_string(i),
+                                   max_errors[i]);
+                      meas_out.add("L2_max_error_" + std::to_string(i)
+                                       + "_date",
+                                   (double)(indexes_max_error[i]));
+                      meas_out.add("L2_mean_error_" + std::to_string(i),
+                                   mean_errors[i]);
+                    }
+                  meas_out.add("L2_max_error", max_error);
+                  meas_out.add("L2_mean_error", mean_error);
+                  meas_out.add("eucll", mean_error);
+                }
             }
         }
-
-	  if (!multilabel && !segmentation && !bbox && (bf1 || bf1full))
-	    {
-	      double f1,precision,recall,acc;
-	      dMat conf_diag,conf_matrix;
-		  dVec precisionV, recallV, f1V;
-	      f1 = mf1(ad_res,precision,recall,acc,precisionV, recallV, f1V, conf_diag,conf_matrix);
-	      meas_out.add("f1",f1);
-	      meas_out.add("precision",precision);
-	      meas_out.add("recall",recall);
-	      meas_out.add("accp",acc);
-		  if (std::find(measures.begin(), measures.end(), "f1full") != measures.end())
-			{
-			  std::vector<double> allPrecisions;
-			  std::vector<double> allRecalls;
-			  std::vector<double> allF1s;
-			  for (int i=0; i<precisionV.size(); ++i)
-				{
-				  allPrecisions.push_back(precisionV(i));
-				  allRecalls.push_back(recallV(i));
-				  allF1s.push_back(f1V(i));
-				}
-			  meas_out.add("precisions", allPrecisions);
-			  meas_out.add("recalls", allRecalls);
-			  meas_out.add("f1s", allF1s);
-			  if (std::find(measures.begin(),measures.end(),"cmdiag")==measures.end())
-				meas_out.add("labels",ad_res.get("clnames").get<std::vector<std::string>>());
-			}
-
-		  if (std::find(measures.begin(),measures.end(),"cmdiag")!=measures.end())
-
-		{
-		  std::vector<double> cmdiagv;
-		  for (int i=0;i<conf_diag.rows();i++)
-		    cmdiagv.push_back(conf_diag(i,0));
-		  meas_out.add("cmdiag",cmdiagv);
-		  meas_out.add("labels",ad_res.get("clnames").get<std::vector<std::string>>());
-		}
-	      if (std::find(measures.begin(),measures.end(),"cmfull")!=measures.end())
-		{
-		  std::vector<std::string> clnames = ad_res.get("clnames").get<std::vector<std::string>>();
-		  std::vector<APIData> cmdata;
-		  for (int i=0;i<conf_matrix.cols();i++)
-		    {
-		      std::vector<double> cmrow;
-		      for (int j=0;j<conf_matrix.rows();j++)
-			cmrow.push_back(conf_matrix(j,i));
-		      APIData adrow;
-		      adrow.add(clnames.at(i),cmrow);
-		      cmdata.push_back(adrow);
-		    }
-		  meas_out.add("cmfull",cmdata);
-		}
-	    }
-	  if (!multilabel && !segmentation && !bbox && bmcll)
-	    {
-	      double mmcll = mcll(ad_res);
-	      meas_out.add("mcll",mmcll);
-	    }
-	  if (bgini)
-	    {
-	      double mgini = gini(ad_res,regression);
-	      meas_out.add("gini",mgini);
-	    }
-	  if (beucll)
-	    {
-	      double meucll = eucll(ad_res,-1);
-	      meas_out.add("eucll",meucll);
-          double meucll_thres = eucll(ad_res,beucll_thres);
-          std::string b = "eucll_no_" + std::to_string(beucll_thres);
-          meas_out.add(b,meucll_thres);
-	    }
-	  if (bmcc)
-	    {
-	      double mmcc = mcc(ad_res);
-	      meas_out.add("mcc",mmcc);
-	      
-	    }
-      if (raw && !bbox)
-        {
-          APIData raw_res = raw_results(ad_res,ad_res.get("clnames").get<std::vector<std::string>>());
-          meas_out.add("raw",raw_res);
-        }
-         if (timeserie)
-           {
-             // we have timeseries outputs (flattened / interleaved in preds!)
-             std::vector<double> max_errors(timeseries);
-             std::vector<int> indexes_max_error(timeseries);
-             std::vector<double> mean_errors(timeseries);
-             double max_error;
-             double mean_error;
-
-             bool L1 = false;
-             bool L2 = false;
-             if (ad_out.has("measure"))
-               {
-                 std::vector<std::string> measures = ad_out.get("measure").get<std::vector<std::string>>();
-                 L1 = (std::find(measures.begin(),measures.end(),"L1")!=measures.end());
-                 L2 = (std::find(measures.begin(),measures.end(),"L2")!=measures.end());
-               }
-
-             if (!L1 && !L2)
-               L1 = true;
-
-             if (L1)
-               {
-                 timeSeriesErrors(ad_res, timeseries, &max_errors[0], &indexes_max_error[0], &mean_errors[0], max_error, mean_error, true);
-                 for (int i=0; i<timeseries; ++i)
-                   {
-                     meas_out.add("L1_max_error_" + std::to_string(i),max_errors[i]);
-                     meas_out.add("L1_max_error_" + std::to_string(i) + "_date" ,(double)(indexes_max_error[i]));
-                     meas_out.add("L1_mean_error_" + std::to_string(i),mean_errors[i]);
-                   }
-                 meas_out.add("L1_max_error", max_error);
-                 meas_out.add("L1_mean_error", mean_error);
-                 if (!L2)
-                   meas_out.add("eucll", mean_error);
-               }
-             if (L2)
-               {
-                 timeSeriesErrors(ad_res, timeseries, &max_errors[0], &indexes_max_error[0], &mean_errors[0], max_error, mean_error, false);
-                 for (int i=0; i<timeseries; ++i)
-                   {
-                     meas_out.add("L2_max_error_" + std::to_string(i),max_errors[i]);
-                     meas_out.add("L2_max_error_" + std::to_string(i) + "_date" ,(double)(indexes_max_error[i]));
-                     meas_out.add("L2_mean_error_" + std::to_string(i),mean_errors[i]);
-                   }
-                 meas_out.add("L2_max_error", max_error);
-                 meas_out.add("L2_mean_error", mean_error);
-                 meas_out.add("eucll", mean_error);
-               }
-           }
-	}
-	if (loss)
-	  meas_out.add("loss",ad_res.get("loss").get<double>()); // 'universal', comes from algorithm
-	if (tloss)
-	  meas_out.add("train_loss",ad_res.get("train_loss").get<double>());
-	if (iter)
-	  meas_out.add("iteration",ad_res.get("iteration").get<double>());
-    if (lr)
-      meas_out.add("learning_rate",ad_res.get("learning_rate").get<double>());
-	out.add("measure",meas_out);
+      if (loss)
+        meas_out.add("loss",
+                     ad_res.get("loss")
+                         .get<double>()); // 'universal', comes from algorithm
+      if (tloss)
+        meas_out.add("train_loss", ad_res.get("train_loss").get<double>());
+      if (iter)
+        meas_out.add("iteration", ad_res.get("iteration").get<double>());
+      if (lr)
+        meas_out.add("learning_rate",
+                     ad_res.get("learning_rate").get<double>());
+      out.add("measure", meas_out);
     }
 
     static void timeSeriesErrors(const APIData &ad, const int timeseries,
-                                 double * const max_errors, int * const indexes_max_error,
-                                 double * const mean_errors, double& max_error,
-                                 double& mean_error, bool L1)
+                                 double *const max_errors,
+                                 int *const indexes_max_error,
+                                 double *const mean_errors, double &max_error,
+                                 double &mean_error, bool L1)
     {
       Eigen::Map<dVec> mean_error_vector = dVec::Map(mean_errors, timeseries);
-      Eigen::Map<Eigen::VectorXi> idxmxerrors = Eigen::VectorXi::Map(indexes_max_error,timeseries);
+      Eigen::Map<Eigen::VectorXi> idxmxerrors
+          = Eigen::VectorXi::Map(indexes_max_error, timeseries);
       mean_error_vector.setZero();
-      Eigen::Map<dVec> max = dVec::Map(max_errors,timeseries);
+      Eigen::Map<dVec> max = dVec::Map(max_errors, timeseries);
       double nts = 0;
       int batch_size = ad.get("batch_size").get<int>();
-      for (int i=0;i<batch_size;i++)
+      for (int i = 0; i < batch_size; i++)
         {
           APIData bad = ad.getobj(std::to_string(i));
-          std::vector<double> targets = bad.get("target").get<std::vector<double>>();
+          std::vector<double> targets
+              = bad.get("target").get<std::vector<double>>();
           /* std::cout << "targets: " ; */
           /* for (double d: targets) */
           /*   std::cout << d << " "; */
           /* std::cout << std::endl; */
-          std::vector<double> predictions = bad.get("pred").get<std::vector<double>>();
+          std::vector<double> predictions
+              = bad.get("pred").get<std::vector<double>>();
           /* std::cout << "predictions: "; */
           /* for (double d : predictions) */
           /*   std::cout << d << " "; */
           /* std::cout << std::endl; */
-          nts+=targets.size();
+          nts += targets.size();
 
           int dataduration = targets.size() / timeseries;
-          typedef Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> Mdat;
+          typedef Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic,
+                                Eigen::RowMajor>
+              Mdat;
           Mdat dpred = Mdat::Map(&predictions.at(0), dataduration, timeseries);
           Mdat dtarg = Mdat::Map(&targets.at(0), dataduration, timeseries);
           // now can access dpred(timestep_number, serie_number)
@@ -1014,21 +1193,21 @@ namespace dd
           //          std::cout << "error: " << error << std::endl;
           dVec batchmax = error.colwise().maxCoeff();
           std::vector<int> batch_max_indexes(timeseries);
-          for (int j =0; j<timeseries; ++j)
-              error.col(j).maxCoeff(&(batch_max_indexes[j]));
+          for (int j = 0; j < timeseries; ++j)
+            error.col(j).maxCoeff(&(batch_max_indexes[j]));
 
           mean_error_vector += error.colwise().sum();
           if (!L1)
             mean_error_vector = mean_error_vector.array().sqrt();
-          if (i==0)
+          if (i == 0)
             {
               max = batchmax;
-              for (int j =0; j<timeseries; ++j)
+              for (int j = 0; j < timeseries; ++j)
                 idxmxerrors(j) = batch_max_indexes[j];
             }
           else
             {
-              for (int j =0; j<timeseries; ++j)
+              for (int j = 0; j < timeseries; ++j)
                 {
                   if (batchmax(j) > max(j))
                     {
@@ -1038,12 +1217,12 @@ namespace dd
                 }
             }
         }
-      mean_error_vector /= static_cast<float>(nts) ;
+      mean_error_vector /= static_cast<float>(nts);
       mean_error_vector *= timeseries;
 
       max_error = max_errors[0];
       mean_error = mean_errors[0];
-      for (int i =1; i<timeseries; ++i)
+      for (int i = 1; i < timeseries; ++i)
         {
           if (max_errors[i] > max_error)
             max_error = max_errors[i];
@@ -1052,15 +1231,15 @@ namespace dd
       mean_error /= timeseries;
     }
 
-
-
-    static void find_presence_and_thres(std::string meas, std::vector<std::string> measures, bool& do_meas, float& meas_thres)
+    static void find_presence_and_thres(std::string meas,
+                                        std::vector<std::string> measures,
+                                        bool &do_meas, float &meas_thres)
     {
-      for(auto s: measures)
-        if (s.find(meas)!=std::string::npos)
+      for (auto s : measures)
+        if (s.find(meas) != std::string::npos)
           {
             do_meas = true;
-            std::vector<std::string> sv = dd_utils::split(s,'-');
+            std::vector<std::string> sv = dd_utils::split(s, '-');
             if (sv.size() == 2)
               {
                 meas_thres = std::atof(sv.at(1).c_str());
@@ -1070,151 +1249,174 @@ namespace dd
           }
     }
 
-
     static double straight_meas(const APIData &ad)
     {
       APIData bad = ad.getobj("0");
       std::vector<double> acc = bad.get("pred").get<std::vector<double>>();
       if (acc.empty())
-	return 0.0;
-      else return acc.at(0);
+        return 0.0;
+      else
+        return acc.at(0);
     }
-    
+
     // measure: ACC
-    static std::map<std::string,double> acc(const APIData &ad,
-					    const std::vector<std::string> &measures)
+    static std::map<std::string, double>
+    acc(const APIData &ad, const std::vector<std::string> &measures)
     {
       struct acc_comp
       {
-        acc_comp(const std::vector<double> &v)
-	:_v(v) {}
-	bool operator()(double a, double b) { return _v[a] > _v[b]; }
-	const std::vector<double> _v;
+        acc_comp(const std::vector<double> &v) : _v(v)
+        {
+        }
+        bool operator()(double a, double b)
+        {
+          return _v[a] > _v[b];
+        }
+        const std::vector<double> _v;
       };
-      std::map<std::string,double> accs;
+      std::map<std::string, double> accs;
       std::vector<int> vacck;
-      for(auto s: measures)
-	if (s.find("acc")!=std::string::npos)
-	  {
-	    std::vector<std::string> sv = dd_utils::split(s,'-');
-	    if (sv.size() == 2)
-	      {
-		vacck.push_back(std::atoi(sv.at(1).c_str()));
-	      }
-	    else vacck.push_back(1);
-	  }
-      
+      for (auto s : measures)
+        if (s.find("acc") != std::string::npos)
+          {
+            std::vector<std::string> sv = dd_utils::split(s, '-');
+            if (sv.size() == 2)
+              {
+                vacck.push_back(std::atoi(sv.at(1).c_str()));
+              }
+            else
+              vacck.push_back(1);
+          }
+
       int batch_size = ad.get("batch_size").get<int>();
-      for (auto k: vacck)
-	{
-	  double acc = 0.0;
-	  for (int i=0;i<batch_size;i++)
-	    {
-	      APIData bad = ad.getobj(std::to_string(i));
-	      std::vector<double> predictions = bad.get("pred").get<std::vector<double>>();
-	      if (k-1 >= static_cast<int>(predictions.size()))
-		continue; // ignore instead of error
-	      std::vector<int> predk(predictions.size());
-	      for (size_t j=0;j<predictions.size();j++)
-		predk[j] = j;
-	      std::partial_sort(predk.begin(),predk.begin()+k-1,predk.end(),acc_comp(predictions));
-	      for (int l=0;l<k;l++)
-		if (predk.at(l) == bad.get("target").get<double>())
-		  {
-		    acc++;
-		    break;
-		  }
-	    }
-	  std::string key = "acc";
-	  if (k>1)
-	    key += "-" + std::to_string(k);
-	  accs.insert(std::pair<std::string,double>(key,acc / static_cast<double>(batch_size)));
-	}
+      for (auto k : vacck)
+        {
+          double acc = 0.0;
+          for (int i = 0; i < batch_size; i++)
+            {
+              APIData bad = ad.getobj(std::to_string(i));
+              std::vector<double> predictions
+                  = bad.get("pred").get<std::vector<double>>();
+              if (k - 1 >= static_cast<int>(predictions.size()))
+                continue; // ignore instead of error
+              std::vector<int> predk(predictions.size());
+              for (size_t j = 0; j < predictions.size(); j++)
+                predk[j] = j;
+              std::partial_sort(predk.begin(), predk.begin() + k - 1,
+                                predk.end(), acc_comp(predictions));
+              for (int l = 0; l < k; l++)
+                if (predk.at(l) == bad.get("target").get<double>())
+                  {
+                    acc++;
+                    break;
+                  }
+            }
+          std::string key = "acc";
+          if (k > 1)
+            key += "-" + std::to_string(k);
+          accs.insert(std::pair<std::string, double>(
+              key, acc / static_cast<double>(batch_size)));
+        }
       return accs;
     }
 
-    static double acc_v(const APIData &ad, double &meanacc, double &meaniou, std::vector<double> &clacc, std::vector<double> &cliou)
+    static double acc_v(const APIData &ad, double &meanacc, double &meaniou,
+                        std::vector<double> &clacc, std::vector<double> &cliou)
     {
       int nclasses = ad.get("nclasses").get<int>();
       int batch_size = ad.get("batch_size").get<int>();
-      std::vector<double> mean_acc(nclasses,0.0);
-      std::vector<double> mean_acc_bs(nclasses,0.0);
-      std::vector<double> mean_iou_bs(nclasses,0.0);
-      std::vector<double> mean_iou(nclasses,0.0);
+      std::vector<double> mean_acc(nclasses, 0.0);
+      std::vector<double> mean_acc_bs(nclasses, 0.0);
+      std::vector<double> mean_iou_bs(nclasses, 0.0);
+      std::vector<double> mean_iou(nclasses, 0.0);
       double acc_v = 0.0;
       meanacc = 0.0;
       meaniou = 0.0;
-      for (int i=0;i<batch_size;i++)
-	{
-	  APIData bad = ad.getobj(std::to_string(i));
-	  std::vector<double> predictions = bad.get("pred").get<std::vector<double>>(); // all best-1
-	  std::vector<double> targets = bad.get("target").get<std::vector<double>>(); // all targets against best-1
-	  dVec dpred = dVec::Map(&predictions.at(0),predictions.size());
-	  dVec dtarg = dVec::Map(&targets.at(0),targets.size());
-	  dVec ddiff = dpred - dtarg;
-	  double acc = (ddiff.cwiseAbs().array() == 0).count() / static_cast<double>(dpred.size());
-	  acc_v += acc;
-	  
-	  for (int c=0;c<nclasses;c++)
-	    {
-	      dVec dpredc = (dpred.array() == c).select(dpred,dVec::Constant(dpred.size(),-2.0));
-	      dVec dtargc = (dtarg.array() == c).select(dtarg,dVec::Constant(dtarg.size(),-1.0));
-	      dVec ddiffc = dpredc - dtargc;
-	      double c_sum = (ddiffc.cwiseAbs().array() == 0).count();
+      for (int i = 0; i < batch_size; i++)
+        {
+          APIData bad = ad.getobj(std::to_string(i));
+          std::vector<double> predictions
+              = bad.get("pred").get<std::vector<double>>(); // all best-1
+          std::vector<double> targets
+              = bad.get("target")
+                    .get<std::vector<double>>(); // all targets against best-1
+          dVec dpred = dVec::Map(&predictions.at(0), predictions.size());
+          dVec dtarg = dVec::Map(&targets.at(0), targets.size());
+          dVec ddiff = dpred - dtarg;
+          double acc = (ddiff.cwiseAbs().array() == 0).count()
+                       / static_cast<double>(dpred.size());
+          acc_v += acc;
 
-	      // mean acc over classes
-	      double c_total_targ = static_cast<double>((dtarg.array() == c).count());
-	      if (/* c_sum == 0 || */ c_total_targ == 0)
-               {
-               }
-	      else
-		{
-		  double accc = c_sum / c_total_targ;
-		  mean_acc[c] += accc;
-		  mean_acc_bs[c]++;
-              }
+          for (int c = 0; c < nclasses; c++)
+            {
+              dVec dpredc
+                  = (dpred.array() == c)
+                        .select(dpred, dVec::Constant(dpred.size(), -2.0));
+              dVec dtargc
+                  = (dtarg.array() == c)
+                        .select(dtarg, dVec::Constant(dtarg.size(), -1.0));
+              dVec ddiffc = dpredc - dtargc;
+              double c_sum = (ddiffc.cwiseAbs().array() == 0).count();
 
-           // mean intersection over union
-	      double c_false_neg = static_cast<double>((ddiffc.array() == -2-c).count());
-	      double c_false_pos = static_cast<double>((ddiffc.array() == c+1).count());
-          // below corner case where nothing is to predict : put correct to zero
-          // but do not devide by zero
-          double iou =  (c_sum == 0)? 0 : c_sum / (c_false_pos + c_sum + c_false_neg);
-	      mean_iou[c] += iou;
-          // ... and divide one time less when normalizing by batch size
-          if (c_total_targ !=0)
-            mean_iou_bs[c]++;
-          // another possible waywould be to put artificially iou to one if nothing is to be
-          // predicted for class c
+              // mean acc over classes
+              double c_total_targ
+                  = static_cast<double>((dtarg.array() == c).count());
+              if (/* c_sum == 0 || */ c_total_targ == 0)
+                {
+                }
+              else
+                {
+                  double accc = c_sum / c_total_targ;
+                  mean_acc[c] += accc;
+                  mean_acc_bs[c]++;
+                }
 
-	    }
-	}
+              // mean intersection over union
+              double c_false_neg
+                  = static_cast<double>((ddiffc.array() == -2 - c).count());
+              double c_false_pos
+                  = static_cast<double>((ddiffc.array() == c + 1).count());
+              // below corner case where nothing is to predict : put correct to
+              // zero but do not devide by zero
+              double iou = (c_sum == 0)
+                               ? 0
+                               : c_sum / (c_false_pos + c_sum + c_false_neg);
+              mean_iou[c] += iou;
+              // ... and divide one time less when normalizing by batch size
+              if (c_total_targ != 0)
+                mean_iou_bs[c]++;
+              // another possible waywould be to put artificially iou to one if
+              // nothing is to be predicted for class c
+            }
+        }
       int c_nclasses = 0;
-      for (int c=0;c<nclasses;c++)
-	{
-	  if (mean_acc_bs[c] > 0.0)
-	    {
-	      mean_acc[c] /= mean_acc_bs[c];
-	      mean_iou[c] /= mean_iou_bs[c];
-	      c_nclasses++;
-	    }
-	  meanacc += mean_acc[c];
-	  meaniou += mean_iou[c];
-	}
+      for (int c = 0; c < nclasses; c++)
+        {
+          if (mean_acc_bs[c] > 0.0)
+            {
+              mean_acc[c] /= mean_acc_bs[c];
+              mean_iou[c] /= mean_iou_bs[c];
+              c_nclasses++;
+            }
+          meanacc += mean_acc[c];
+          meaniou += mean_iou[c];
+        }
       clacc = mean_acc;
       cliou = mean_iou;
 
       // corner case where prediction is wrong
-      if (c_nclasses > 0) {
-        meanacc /= static_cast<double>(c_nclasses);
-        meaniou /= static_cast<double>(c_nclasses);
-      }
+      if (c_nclasses > 0)
+        {
+          meanacc /= static_cast<double>(c_nclasses);
+          meaniou /= static_cast<double>(c_nclasses);
+        }
       return acc_v / static_cast<double>(batch_size);
     }
 
     // multilabel measures
-    static double multilabel_acc(const APIData &ad, double &sensitivity, double &specificity,
-				 double &harmmean, double &precision, double &f1)
+    static double multilabel_acc(const APIData &ad, double &sensitivity,
+                                 double &specificity, double &harmmean,
+                                 double &precision, double &f1)
     {
       int batch_size = ad.get("batch_size").get<int>();
       double tp = 0.0;
@@ -1223,39 +1425,44 @@ namespace dd
       double fn = 0.0;
       double count_pos = 0.0;
       double count_neg = 0.0;
-      for (int i=0;i<batch_size;i++)
-	{
-	  APIData bad = ad.getobj(std::to_string(i));
-	  std::vector<double> targets = bad.get("target").get<std::vector<double>>();
-	  std::vector<double> predictions = bad.get("pred").get<std::vector<double>>();
-	  for (size_t j=0;j<predictions.size();j++)
-	    {
-	      if (targets.at(j) < 0)
-		continue;
-	      if (targets.at(j) >= 0.5)
-		{
-		  // positive accuracy
-		  if (predictions.at(j) >= 0)
-		    ++tp;
-		  else ++fn;
-		  ++count_pos;
-		}
-	      else
-		{
-		  // negative accuracy
-		  if (predictions.at(j) < 0)
-		    ++tn;
-		  else ++fp;
-		  ++count_neg;
-		}
-	    }
-	}
+      for (int i = 0; i < batch_size; i++)
+        {
+          APIData bad = ad.getobj(std::to_string(i));
+          std::vector<double> targets
+              = bad.get("target").get<std::vector<double>>();
+          std::vector<double> predictions
+              = bad.get("pred").get<std::vector<double>>();
+          for (size_t j = 0; j < predictions.size(); j++)
+            {
+              if (targets.at(j) < 0)
+                continue;
+              if (targets.at(j) >= 0.5)
+                {
+                  // positive accuracy
+                  if (predictions.at(j) >= 0)
+                    ++tp;
+                  else
+                    ++fn;
+                  ++count_pos;
+                }
+              else
+                {
+                  // negative accuracy
+                  if (predictions.at(j) < 0)
+                    ++tn;
+                  else
+                    ++fp;
+                  ++count_neg;
+                }
+            }
+        }
       sensitivity = (count_pos > 0) ? tp / count_pos : 0.0;
       specificity = (count_neg > 0) ? tn / count_neg : 0.0;
-      harmmean = ((count_pos + count_neg > 0)) ?
-	2 / (count_pos / tp + count_neg / tn) : 0.0;
-      precision = (tp > 0) ? (tp / (tp + fp)): 0.0;
-      f1 = (tp > 0) ? 2 * tp / (2 * tp + fp + fn): 0.0;
+      harmmean = ((count_pos + count_neg > 0))
+                     ? 2 / (count_pos / tp + count_neg / tn)
+                     : 0.0;
+      precision = (tp > 0) ? (tp / (tp + fp)) : 0.0;
+      f1 = (tp > 0) ? 2 * tp / (2 * tp + fp + fn) : 0.0;
       return f1;
     }
 
@@ -1264,28 +1471,31 @@ namespace dd
       double kl_divergence = 0;
       long int total_number = 0;
       int batch_size = ad.get("batch_size").get<int>();
-      for (int i=0;i<batch_size;i++)
+      for (int i = 0; i < batch_size; i++)
         {
           APIData bad = ad.getobj(std::to_string(i));
-          std::vector<double> targets = bad.get("target").get<std::vector<double>>();
-          std::vector<double> predictions = bad.get("pred").get<std::vector<double>>();
+          std::vector<double> targets
+              = bad.get("target").get<std::vector<double>>();
+          std::vector<double> predictions
+              = bad.get("pred").get<std::vector<double>>();
           dVec dpred = dVec::Map(&predictions.at(0), predictions.size());
           dVec dtarg = dVec::Map(&targets.at(0), targets.size());
           double eps = 0.00001;
           dVec dprede = (dpred.array() < eps).select(eps, dpred);
           dVec dtarge = (dtarg.array() < eps).select(eps, dtarg);
-          dVec temp = (dprede.array().inverse()*dtarge.array()).log()*dtarge.array();
+          dVec temp = (dprede.array().inverse() * dtarge.array()).log()
+                      * dtarge.array();
           if (thres >= 0)
             {
-              total_number += (dtarg.array()>thres).count();
+              total_number += (dtarg.array() > thres).count();
               temp = (dtarg.array() <= thres).select(0, temp);
             }
           else
             {
-              total_number += (dtarg.array()>=0).count();
+              total_number += (dtarg.array() >= 0).count();
               temp = (dtarg.array() < 0).select(0, temp);
             }
-          kl_divergence +=  temp.sum();
+          kl_divergence += temp.sum();
         }
       return kl_divergence / (double)total_number;
     }
@@ -1295,28 +1505,32 @@ namespace dd
       int batch_size = ad.get("batch_size").get<int>();
       double js_divergence = 0;
       long int total_number = 0;
-      for (int i=0;i<batch_size;i++)
+      for (int i = 0; i < batch_size; i++)
         {
           APIData bad = ad.getobj(std::to_string(i));
-          std::vector<double> targets = bad.get("target").get<std::vector<double>>();
-          std::vector<double> predictions = bad.get("pred").get<std::vector<double>>();
+          std::vector<double> targets
+              = bad.get("target").get<std::vector<double>>();
+          std::vector<double> predictions
+              = bad.get("pred").get<std::vector<double>>();
           dVec dpred = dVec::Map(&predictions.at(0), predictions.size());
           dVec dtarg = dVec::Map(&targets.at(0), targets.size());
           double eps = 0.00001;
           dVec dprede = (dpred.array() < eps).select(eps, dpred);
           dVec dtarge = (dtarg.array() < eps).select(eps, dtarg);
           dVec temp = (dprede + dtarge).array().inverse();
-          dVec temp2 = (temp.array()*dtarge.array()*2).log()*dtarge.array()*0.5 +
-            (temp.array()*dprede.array()*2).log()*dprede.array()*0.5;
+          dVec temp2 = (temp.array() * dtarge.array() * 2).log()
+                           * dtarge.array() * 0.5
+                       + (temp.array() * dprede.array() * 2).log()
+                             * dprede.array() * 0.5;
           if (thres >= 0)
             {
-              total_number += (dtarg.array()>thres).count();
-              temp2 = (dtarg.array()<=thres).select(0, temp2);
+              total_number += (dtarg.array() > thres).count();
+              temp2 = (dtarg.array() <= thres).select(0, temp2);
             }
           else
             {
-              total_number += (dtarg.array()>=0).count();
-              temp2 = (dtarg.array()<0).select(0, temp2);
+              total_number += (dtarg.array() >= 0).count();
+              temp2 = (dtarg.array() < 0).select(0, temp2);
             }
           js_divergence += temp2.sum();
         }
@@ -1328,28 +1542,30 @@ namespace dd
       int batch_size = ad.get("batch_size").get<int>();
       double was = 0;
       long int total_number = 0;
-      for (int i=0;i<batch_size;i++)
+      for (int i = 0; i < batch_size; i++)
         {
           APIData bad = ad.getobj(std::to_string(i));
-          std::vector<double> targets = bad.get("target").get<std::vector<double>>();
-          std::vector<double> predictions = bad.get("pred").get<std::vector<double>>();
+          std::vector<double> targets
+              = bad.get("target").get<std::vector<double>>();
+          std::vector<double> predictions
+              = bad.get("pred").get<std::vector<double>>();
           dVec dpred = dVec::Map(&predictions.at(0), predictions.size());
           dVec dtarg = dVec::Map(&targets.at(0), targets.size());
           dVec dif = dtarg - dpred;
-          if (thres >=0)
+          if (thres >= 0)
             {
               dif = (dtarg.array() <= thres).select(0, dif);
-              total_number += (dtarg.array()>thres).count();
+              total_number += (dtarg.array() > thres).count();
             }
           else
             {
               dif = (dtarg.array() < 0).select(0, dif);
-              total_number += (dtarg.array()>=0).count();
+              total_number += (dtarg.array() >= 0).count();
             }
           was += (dif.array() * dif.array()).sum();
         }
       was = sqrt(was);
-      return was/sqrt((double)total_number);
+      return was / sqrt((double)total_number);
     }
 
     static double multilabel_soft_ks(const APIData &ad, float thres)
@@ -1357,46 +1573,53 @@ namespace dd
       int batch_size = ad.get("batch_size").get<int>();
       double ks = 0;
       long int total_number = 0;
-      for (int i=0;i<batch_size;i++)
+      for (int i = 0; i < batch_size; i++)
         {
           APIData bad = ad.getobj(std::to_string(i));
-          std::vector<double> targets = bad.get("target").get<std::vector<double>>();
-          std::vector<double> predictions = bad.get("pred").get<std::vector<double>>();
+          std::vector<double> targets
+              = bad.get("target").get<std::vector<double>>();
+          std::vector<double> predictions
+              = bad.get("pred").get<std::vector<double>>();
           dVec dpred = dVec::Map(&predictions.at(0), predictions.size());
           dVec dtarg = dVec::Map(&targets.at(0), targets.size());
-          dVec dif = dtarg-dpred;
+          dVec dif = dtarg - dpred;
           if (thres >= 0)
             {
               dif = (dtarg.array() < thres).select(0, dif);
-              total_number += (dtarg.array()>thres).count();
+              total_number += (dtarg.array() > thres).count();
             }
           else
             {
               dif = (dtarg.array() < 0).select(0, dif);
-              total_number += (dtarg.array()>=0).count();
+              total_number += (dtarg.array() >= 0).count();
             }
           ks = dif.array().abs().maxCoeff();
         }
       return ks;
     }
 
-    static int dc_pt_jk(const long int j, const long int k, const std::vector<double> &targets, const std::vector<double> & predictions, double& p_jk, double &t_jk )
+    static int dc_pt_jk(const long int j, const long int k,
+                        const std::vector<double> &targets,
+                        const std::vector<double> &predictions, double &p_jk,
+                        double &t_jk)
     {
-      p_jk = fabs(predictions[j]-predictions[k]);
-      t_jk = fabs(targets[j]-targets[k]);
+      p_jk = fabs(predictions[j] - predictions[k]);
+      t_jk = fabs(targets[j] - targets[k]);
       return 1;
     }
-
 
     static double multilabel_soft_dc(const APIData &ad, float thres)
     {
       int batch_size = ad.get("batch_size").get<int>();
-      int nclasses = ad.getobj(std::to_string(0)).get("target").get<std::vector<double>>().size();
+      int nclasses = ad.getobj(std::to_string(0))
+                         .get("target")
+                         .get<std::vector<double>>()
+                         .size();
 
       double distance_correlation = 0;
 
-      std::vector<double> t_j(nclasses,0);
-      std::vector<double> p_j(nclasses,0);
+      std::vector<double> t_j(nclasses, 0);
+      std::vector<double> p_j(nclasses, 0);
       double t_ = 0;
       double p_ = 0;
 
@@ -1405,66 +1628,68 @@ namespace dd
       double dvarp = 0;
       std::vector<int> care_classes;
 
-      for (int i =0; i< batch_size; ++i) {
-        APIData badj = ad.getobj(std::to_string(i));
-        std::vector<double> targets = badj.get("target").get<std::vector<double>>();
-        std::vector<double> predictions = badj.get("pred").get<std::vector<double>>();
+      for (int i = 0; i < batch_size; ++i)
+        {
+          APIData badj = ad.getobj(std::to_string(i));
+          std::vector<double> targets
+              = badj.get("target").get<std::vector<double>>();
+          std::vector<double> predictions
+              = badj.get("pred").get<std::vector<double>>();
 
-        care_classes.clear();
-        for (int l =0; l<nclasses; ++l)
-          if (thres >= 0)
-            {
-              if (targets[l] > thres)
-                care_classes.push_back(l);
-            }
-          else
-            if (targets[l] >= 0)
+          care_classes.clear();
+          for (int l = 0; l < nclasses; ++l)
+            if (thres >= 0)
+              {
+                if (targets[l] > thres)
+                  care_classes.push_back(l);
+              }
+            else if (targets[l] >= 0)
               care_classes.push_back(l);
 
+          if (care_classes.size() == 0)
+            continue;
 
-
-        if (care_classes.size() == 0)
-          continue;
-
-        for (int l : care_classes) {
-          for (int m : care_classes) {
-            double t_lm;
-            double p_lm;
-            dc_pt_jk(l,m, targets, predictions, p_lm, t_lm);
-            t_j[l] += t_lm;
-            p_j[l] += p_lm;
-          }
-          t_j[l] /= (double)care_classes.size();
-          t_ += t_j[l];
-          p_j[l] /= (double)care_classes.size();
-          p_ += p_j[l];
-        }
-        t_ /= (double) care_classes.size();
-        p_ /= (double) care_classes.size();
-
-        for (int j : care_classes)
-          for (int k : care_classes)
+          for (int l : care_classes)
             {
-              double p_jk;
-              double t_jk;
-              dc_pt_jk(j,k, targets, predictions, p_jk, t_jk);
-              double p = p_jk - p_j[j] - p_j[k] + p_;
-              double t = t_jk - t_j[j] - t_j[k] + t_;
-              dcov += p*t;
-              dvart += t*t;
-              dvarp += p*p;
-          }
-        dcov /= care_classes.size() * care_classes.size();
-        dvart /= care_classes.size()* care_classes.size();
-        dvarp /= care_classes.size() * care_classes.size();
-        dcov = sqrt(dcov);
-        dvart = sqrt(dvart);
+              for (int m : care_classes)
+                {
+                  double t_lm;
+                  double p_lm;
+                  dc_pt_jk(l, m, targets, predictions, p_lm, t_lm);
+                  t_j[l] += t_lm;
+                  p_j[l] += p_lm;
+                }
+              t_j[l] /= (double)care_classes.size();
+              t_ += t_j[l];
+              p_j[l] /= (double)care_classes.size();
+              p_ += p_j[l];
+            }
+          t_ /= (double)care_classes.size();
+          p_ /= (double)care_classes.size();
 
-        dvarp = sqrt(dvarp);
+          for (int j : care_classes)
+            for (int k : care_classes)
+              {
+                double p_jk;
+                double t_jk;
+                dc_pt_jk(j, k, targets, predictions, p_jk, t_jk);
+                double p = p_jk - p_j[j] - p_j[k] + p_;
+                double t = t_jk - t_j[j] - t_j[k] + t_;
+                dcov += p * t;
+                dvart += t * t;
+                dvarp += p * p;
+              }
+          dcov /= care_classes.size() * care_classes.size();
+          dvart /= care_classes.size() * care_classes.size();
+          dvarp /= care_classes.size() * care_classes.size();
+          dcov = sqrt(dcov);
+          dvart = sqrt(dvart);
 
-        if (dvart != 0 && dvarp !=0)
-          distance_correlation += dcov / (sqrt(dvart * dvarp));
-      }
+          dvarp = sqrt(dvarp);
+
+          if (dvart != 0 && dvarp != 0)
+            distance_correlation += dcov / (sqrt(dvart * dvarp));
+        }
       distance_correlation /= batch_size;
       return distance_correlation;
     }
@@ -1475,41 +1700,45 @@ namespace dd
       double tmean = 0;
       long int total_number = 0;
       double ssres = 0;
-      for (int i=0;i<batch_size;i++)
+      for (int i = 0; i < batch_size; i++)
         {
           APIData bad = ad.getobj(std::to_string(i));
-          std::vector<double> targets = bad.get("target").get<std::vector<double>>();
-          std::vector<double> predictions = bad.get("pred").get<std::vector<double>>();
+          std::vector<double> targets
+              = bad.get("target").get<std::vector<double>>();
+          std::vector<double> predictions
+              = bad.get("pred").get<std::vector<double>>();
           dVec dpred = dVec::Map(&predictions.at(0), predictions.size());
           dVec dtarg = dVec::Map(&targets.at(0), targets.size());
           dVec dif = dtarg - dpred;
-          if (thres >=0)
+          if (thres >= 0)
             {
-              total_number += (dtarg.array()>thres).count();
+              total_number += (dtarg.array() > thres).count();
               tmean += ((dtarg.array() <= thres).select(0, dtarg)).sum();
               dif = (dtarg.array() <= thres).select(0, dif);
             }
           else
             {
-              total_number += (dtarg.array()>=0).count();
+              total_number += (dtarg.array() >= 0).count();
               tmean += ((dtarg.array() < 0).select(0, dtarg)).sum();
               dif = (dtarg.array() < 0).select(0, dif);
             }
-          ssres += (dif.array() * dif.array() ).sum();
+          ssres += (dif.array() * dif.array()).sum();
         }
       tmean /= (double)total_number;
 
       double sstot = 0;
 
-      for (int i=0;i<batch_size;i++)
+      for (int i = 0; i < batch_size; i++)
         {
           APIData bad = ad.getobj(std::to_string(i));
-          std::vector<double> targets = bad.get("target").get<std::vector<double>>();
-          std::vector<double> predictions = bad.get("pred").get<std::vector<double>>();
+          std::vector<double> targets
+              = bad.get("target").get<std::vector<double>>();
+          std::vector<double> predictions
+              = bad.get("pred").get<std::vector<double>>();
           dVec dpred = dVec::Map(&predictions.at(0), predictions.size());
           dVec dtarg = dVec::Map(&targets.at(0), targets.size());
           dVec temp;
-          if (thres>=0)
+          if (thres >= 0)
             {
               temp = (dtarg.array() <= thres).select(0, dtarg.array() - tmean);
             }
@@ -1519,43 +1748,50 @@ namespace dd
             }
           sstot += (temp.array() * temp.array()).sum();
         }
-      return  1.0 - ssres/sstot;
+      return 1.0 - ssres / sstot;
     }
 
-    static void multilabel_soft_deltas(const APIData &ad, std::vector<double>& delta_scores, const std::vector<double>& deltas, float thres)
+    static void multilabel_soft_deltas(const APIData &ad,
+                                       std::vector<double> &delta_scores,
+                                       const std::vector<double> &deltas,
+                                       float thres)
     {
       int batch_size = ad.get("batch_size").get<int>();
       long int total_number = 0;
-      for (unsigned int k =0; k<deltas.size(); ++k)
+      for (unsigned int k = 0; k < deltas.size(); ++k)
         delta_scores[k] = 0;
-      for (int i=0;i<batch_size;i++)
+      for (int i = 0; i < batch_size; i++)
         {
           APIData bad = ad.getobj(std::to_string(i));
-          std::vector<double> targets = bad.get("target").get<std::vector<double>>();
-          std::vector<double> predictions = bad.get("pred").get<std::vector<double>>();
+          std::vector<double> targets
+              = bad.get("target").get<std::vector<double>>();
+          std::vector<double> predictions
+              = bad.get("pred").get<std::vector<double>>();
           dVec dpred = dVec::Map(&predictions.at(0), predictions.size());
           dVec dtarg = dVec::Map(&targets.at(0), targets.size());
           dVec dif;
-          if (thres >=0)
+          if (thres >= 0)
             {
-              total_number += (dtarg.array()>thres).count();
-              dif = (dtarg.array() <= thres).select(10, (dtarg-dpred).array().abs());
+              total_number += (dtarg.array() > thres).count();
+              dif = (dtarg.array() <= thres)
+                        .select(10, (dtarg - dpred).array().abs());
             }
           else
             {
-              total_number += (dtarg.array()>=0).count();
-              dif = (dtarg.array() < 0).select(10, (dtarg-dpred).array().abs());
+              total_number += (dtarg.array() >= 0).count();
+              dif = (dtarg.array() < 0)
+                        .select(10, (dtarg - dpred).array().abs());
             }
-          for (unsigned int k=0; k<deltas.size(); ++k)
+          for (unsigned int k = 0; k < deltas.size(); ++k)
             delta_scores[k] += (dif.array() < deltas[k]).count();
         }
-      for (unsigned int k =0; k<deltas.size(); ++k)
-        delta_scores[k] /=  (double)total_number; // gives proportion of good in 0:1 at every threshold
-
+      for (unsigned int k = 0; k < deltas.size(); ++k)
+        delta_scores[k] /= (double)
+            total_number; // gives proportion of good in 0:1 at every threshold
     }
 
-
-    static APIData raw_results(const APIData &ad, std::vector<std::string> clnames)
+    static APIData raw_results(const APIData &ad,
+                               std::vector<std::string> clnames)
     {
       APIData raw_res;
       int nclasses = ad.get("nclasses").get<int>();
@@ -1564,22 +1800,30 @@ namespace dd
       std::vector<std::string> targets;
       std::vector<double> confs;
       std::vector<std::vector<double>> logits;
-      for (int i=0;i<batch_size;i++)
+      for (int i = 0; i < batch_size; i++)
         {
           APIData bad = ad.getobj(std::to_string(i));
-          std::vector<double> predictions = bad.get("pred").get<std::vector<double>>();
+          std::vector<double> predictions
+              = bad.get("pred").get<std::vector<double>>();
           double target = bad.get("target").get<double>();
           if (bad.has("logits"))
-			  logits.push_back(bad.get("logits").get<std::vector<double>>());
+            logits.push_back(bad.get("logits").get<std::vector<double>>());
           if (target < 0)
-            throw OutputConnectorBadParamException("negative supervised discrete target (e.g. wrong use of label_offset ?");
+            throw OutputConnectorBadParamException(
+                "negative supervised discrete target (e.g. wrong use of "
+                "label_offset ?");
           else if (target >= nclasses)
-            throw OutputConnectorBadParamException("target class has id " + std::to_string(target) + " is higher than the number of classes " + std::to_string(nclasses) + " (e.g. wrong number of classes specified with nclasses");
-          // TODO : find max predictions -> argmax = estimation   max = confidence
+            throw OutputConnectorBadParamException(
+                "target class has id " + std::to_string(target)
+                + " is higher than the number of classes "
+                + std::to_string(nclasses)
+                + " (e.g. wrong number of classes specified with nclasses");
+          // TODO : find max predictions -> argmax = estimation   max =
+          // confidence
           targets.push_back(clnames[static_cast<int>(target)]);
           double max_pred = predictions[0];
           int best_cat = 0;
-          for (unsigned int j=1; j<predictions.size(); ++j)
+          for (unsigned int j = 1; j < predictions.size(); ++j)
             {
               if (predictions[j] > max_pred)
                 {
@@ -1590,84 +1834,100 @@ namespace dd
           preds.push_back(clnames[static_cast<int>(best_cat)]);
           confs.push_back(max_pred);
         }
-      raw_res.add("truths",targets);
-      raw_res.add("estimations",preds);
-      raw_res.add("confidences",confs);
-      if (logits.size() >0)
+      raw_res.add("truths", targets);
+      raw_res.add("estimations", preds);
+      raw_res.add("confidences", confs);
+      if (logits.size() > 0)
         {
           std::vector<APIData> adlogit;
-          for (std::vector<double> l: logits)
+          for (std::vector<double> l : logits)
             {
               APIData lad;
-              lad.add("logits",l);
+              lad.add("logits", l);
               adlogit.push_back(lad);
             }
-          raw_res.add("all_logits",adlogit);
+          raw_res.add("all_logits", adlogit);
         }
 
       return raw_res;
     }
 
     // measure: F1
-    static double mf1(const APIData &ad, double &precision, double &recall, double &acc,
-					  dVec &precisionV, dVec &recallV, dVec &f1V, dMat &conf_diag, dMat &conf_matrix)
+    static double mf1(const APIData &ad, double &precision, double &recall,
+                      double &acc, dVec &precisionV, dVec &recallV, dVec &f1V,
+                      dMat &conf_diag, dMat &conf_matrix)
     {
       int nclasses = ad.get("nclasses").get<int>();
-      double f1=0.0;
-      conf_matrix = dMat::Zero(nclasses,nclasses);
+      double f1 = 0.0;
+      conf_matrix = dMat::Zero(nclasses, nclasses);
       int batch_size = ad.get("batch_size").get<int>();
-      for (int i=0;i<batch_size;i++)
-	{
-	  APIData bad = ad.getobj(std::to_string(i));
-	  std::vector<double> predictions = bad.get("pred").get<std::vector<double>>();
-	  int maxpr = std::distance(predictions.begin(),std::max_element(predictions.begin(),predictions.end()));
-	  double target = bad.get("target").get<double>();
-	  if (target < 0)
-	    throw OutputConnectorBadParamException("negative supervised discrete target (e.g. wrong use of label_offset ?");
-	  else if (target >= nclasses)
-	    throw OutputConnectorBadParamException("target class has id " + std::to_string(target) + " is higher than the number of classes " + std::to_string(nclasses) + " (e.g. wrong number of classes specified with nclasses");
-	  conf_matrix(maxpr,static_cast<int>(target)) += 1.0;
-	}
+      for (int i = 0; i < batch_size; i++)
+        {
+          APIData bad = ad.getobj(std::to_string(i));
+          std::vector<double> predictions
+              = bad.get("pred").get<std::vector<double>>();
+          int maxpr = std::distance(
+              predictions.begin(),
+              std::max_element(predictions.begin(), predictions.end()));
+          double target = bad.get("target").get<double>();
+          if (target < 0)
+            throw OutputConnectorBadParamException(
+                "negative supervised discrete target (e.g. wrong use of "
+                "label_offset ?");
+          else if (target >= nclasses)
+            throw OutputConnectorBadParamException(
+                "target class has id " + std::to_string(target)
+                + " is higher than the number of classes "
+                + std::to_string(nclasses)
+                + " (e.g. wrong number of classes specified with nclasses");
+          conf_matrix(maxpr, static_cast<int>(target)) += 1.0;
+        }
       conf_diag = conf_matrix.diagonal();
       dMat conf_csum = conf_matrix.colwise().sum();
       dMat conf_rsum = conf_matrix.rowwise().sum();
-      dMat eps = dMat::Constant(nclasses,1,1e-8);
+      dMat eps = dMat::Constant(nclasses, 1, 1e-8);
       acc = conf_diag.sum() / conf_matrix.sum();
-	  recallV = (conf_diag.transpose().cwiseQuotient(conf_csum + eps.transpose())).transpose();
-	  recall = recallV.sum() / static_cast<double>(nclasses);
-	  precisionV = conf_diag.cwiseQuotient(conf_rsum + eps);
+      recallV
+          = (conf_diag.transpose().cwiseQuotient(conf_csum + eps.transpose()))
+                .transpose();
+      recall = recallV.sum() / static_cast<double>(nclasses);
+      precisionV = conf_diag.cwiseQuotient(conf_rsum + eps);
       precision = precisionV.sum() / static_cast<double>(nclasses);
-	  f1V = (2.0*precisionV.cwiseProduct(recallV)).cwiseQuotient(precisionV + recallV + eps);
-	  f1 = f1V.sum() / static_cast<double>(nclasses);
-      conf_diag = conf_diag.transpose().cwiseQuotient(conf_csum+eps.transpose()).transpose();
-      for (int i=0;i<conf_matrix.cols();i++)
+      f1V = (2.0 * precisionV.cwiseProduct(recallV))
+                .cwiseQuotient(precisionV + recallV + eps);
+      f1 = f1V.sum() / static_cast<double>(nclasses);
+      conf_diag = conf_diag.transpose()
+                      .cwiseQuotient(conf_csum + eps.transpose())
+                      .transpose();
+      for (int i = 0; i < conf_matrix.cols(); i++)
         if (conf_csum(i) > 0)
           conf_matrix.col(i) /= conf_csum(i);
       return f1;
     }
 
     // measure: AP, mAP
-    static void cumsum_pair(const std::vector<std::pair<double, int> >& pairs,
-			    std::vector<int> &cumsum)
+    static void cumsum_pair(const std::vector<std::pair<double, int>> &pairs,
+                            std::vector<int> &cumsum)
     {
       // Sort the pairs based on first item of the pair.
-      std::vector<std::pair<double, int> > sort_pairs = pairs;
+      std::vector<std::pair<double, int>> sort_pairs = pairs;
       std::stable_sort(sort_pairs.begin(), sort_pairs.end(),
-		       SortScorePairDescend<int>);
+                       SortScorePairDescend<int>);
       for (size_t i = 0; i < sort_pairs.size(); ++i)
-	{
-	  if (i == 0)
-	    {
-	      cumsum.push_back(sort_pairs[i].second);
-	    }
-	  else
-	    {
-	      cumsum.push_back(cumsum.back() + sort_pairs[i].second);
-	    }
-	}
+        {
+          if (i == 0)
+            {
+              cumsum.push_back(sort_pairs[i].second);
+            }
+          else
+            {
+              cumsum.push_back(cumsum.back() + sort_pairs[i].second);
+            }
+        }
     }
 
-    static APIData raw_detection_results(const APIData &ad, std::vector<std::string> clnames)
+    static APIData raw_detection_results(const APIData &ad,
+                                         std::vector<std::string> clnames)
     {
       APIData raw_res;
       std::vector<std::string> preds;
@@ -1677,20 +1937,24 @@ namespace dd
       bool output_logits = false;
       APIData bad = ad.getobj("0");
       int pos_count = ad.get("pos_count").get<int>();
-      for (int i=0;i<pos_count;i++)
+      for (int i = 0; i < pos_count; i++)
         {
           std::vector<APIData> vbad = bad.getv(std::to_string(i));
-          for (size_t j=0;j<vbad.size();j++)
+          for (size_t j = 0; j < vbad.size(); j++)
             {
-              std::vector<double> tp_d = vbad.at(j).get("tp_d").get<std::vector<double>>();
-              std::vector<int> tp_i = vbad.at(j).get("tp_i").get<std::vector<int>>();
-              std::vector<double> fp_d = vbad.at(j).get("fp_d").get<std::vector<double>>();
-              std::vector<int> fp_i = vbad.at(j).get("fp_i").get<std::vector<int>>();
+              std::vector<double> tp_d
+                  = vbad.at(j).get("tp_d").get<std::vector<double>>();
+              std::vector<int> tp_i
+                  = vbad.at(j).get("tp_i").get<std::vector<int>>();
+              std::vector<double> fp_d
+                  = vbad.at(j).get("fp_d").get<std::vector<double>>();
+              std::vector<int> fp_i
+                  = vbad.at(j).get("fp_i").get<std::vector<int>>();
               int num_pos = vbad.at(j).get("num_pos").get<int>();
               int label = vbad.at(j).get("label").get<int>();
 
               // below true positives
-              for (unsigned int k = 0; k<tp_d.size(); ++k)
+              for (unsigned int k = 0; k < tp_d.size(); ++k)
                 {
                   if (tp_i[k] == 1)
                     {
@@ -1705,12 +1969,12 @@ namespace dd
                       confs.push_back(fp_d[k]);
                     }
                 }
-              //blow false negatives
+              // blow false negatives
               int ntp = 0;
-              for (unsigned int k = 0; k< tp_i.size(); ++k)
+              for (unsigned int k = 0; k < tp_i.size(); ++k)
                 if (tp_i[k] == 1)
                   ntp++;
-              for (int  k= 0; k<(num_pos - ntp); ++k)
+              for (int k = 0; k < (num_pos - ntp); ++k)
                 {
                   targets.push_back(clnames[label]);
                   confs.push_back(1.0);
@@ -1720,16 +1984,20 @@ namespace dd
               if (vbad.at(j).has("all_logits"))
                 {
                   output_logits = true;
-                  const std::vector<APIData>& logits = vbad.at(j).getv("all_logits");
-                  really_all_logits.insert(really_all_logits.end(),logits.begin(), logits.end());
-                  for (int  k= 0; k<(num_pos - ntp); ++k)
+                  const std::vector<APIData> &logits
+                      = vbad.at(j).getv("all_logits");
+                  really_all_logits.insert(really_all_logits.end(),
+                                           logits.begin(), logits.end());
+                  for (int k = 0; k < (num_pos - ntp); ++k)
                     {
                       APIData background_logits_ad;
                       std::vector<double> background_logits;
-                      background_logits.push_back(0.5+0.5/(float)clnames.size());
-                      for (unsigned int c = 1; c<clnames.size(); ++c)
-                        background_logits.push_back(1.0/(float)clnames.size()/2.0);
-                      background_logits_ad.add("logits",background_logits);
+                      background_logits.push_back(
+                          0.5 + 0.5 / (float)clnames.size());
+                      for (unsigned int c = 1; c < clnames.size(); ++c)
+                        background_logits.push_back(1.0 / (float)clnames.size()
+                                                    / 2.0);
+                      background_logits_ad.add("logits", background_logits);
                       really_all_logits.push_back(background_logits_ad);
                     }
                 }
@@ -1743,45 +2011,44 @@ namespace dd
       return raw_res;
     }
 
-
-    static double compute_ap(const std::vector<std::pair<double,int>> &tp,
-			     const std::vector<std::pair<double,int>> &fp,
-			     const int &num_pos)
+    static double compute_ap(const std::vector<std::pair<double, int>> &tp,
+                             const std::vector<std::pair<double, int>> &fp,
+                             const int &num_pos)
     {
       const double eps = 1e-6;
       const int num = tp.size();
       if (num == 0 || num_pos == 0)
-	return 0.0;
+        return 0.0;
       double ap = 0.0;
       std::vector<int> tp_cumsum;
       std::vector<int> fp_cumsum;
       cumsum_pair(tp, tp_cumsum); // tp cumsum
       cumsum_pair(fp, fp_cumsum); // fp cumsum
-      std::vector<double> prec; // precision
-      for (int i=0;i<num;i++)
-	prec.push_back(static_cast<double>(tp_cumsum[i])/(tp_cumsum[i] + fp_cumsum[i]));
+      std::vector<double> prec;   // precision
+      for (int i = 0; i < num; i++)
+        prec.push_back(static_cast<double>(tp_cumsum[i])
+                       / (tp_cumsum[i] + fp_cumsum[i]));
       std::vector<double> rec; // recall
-      for (int i=0;i<num;i++)
-	rec.push_back(static_cast<double>(tp_cumsum[i])/num_pos);
+      for (int i = 0; i < num; i++)
+        rec.push_back(static_cast<double>(tp_cumsum[i]) / num_pos);
 
       // voc12, ilsvrc style ap
       float cur_rec = rec.back();
       float cur_prec = prec.back();
-      for (int i=num-2; i>=0; --i)
-	{
-	  cur_prec = std::max<float>(prec[i], cur_prec);
-	  if (fabs(cur_rec - rec[i]) > eps)
-	    {
-	      ap += cur_prec * fabs(cur_rec - rec[i]);
-	    }
-	  cur_rec = rec[i];
-	}
+      for (int i = num - 2; i >= 0; --i)
+        {
+          cur_prec = std::max<float>(prec[i], cur_prec);
+          if (fabs(cur_rec - rec[i]) > eps)
+            {
+              ap += cur_prec * fabs(cur_rec - rec[i]);
+            }
+          cur_rec = rec[i];
+        }
       ap += cur_rec * cur_prec;
       return ap;
     }
 
-
-    static double ap(const APIData &ad,  std::map<int,float>& APs)
+    static double ap(const APIData &ad, std::map<int, float> &APs)
     {
       double mmAP = 0.0;
       std::map<int, int> APs_count;
@@ -1789,126 +2056,148 @@ namespace dd
       // extract tp, fp, labels
       APIData bad = ad.getobj("0");
       int pos_count = ad.get("pos_count").get<int>();
-      for (int i=0;i<pos_count;i++)
-	{
-         // do a mean over label AP per image in test set
-         double mAP = 0.0;
-	  std::vector<APIData> vbad = bad.getv(std::to_string(i));
-	  //std::cerr << "vbad size=" << vbad.size() << std::endl;
-	  for (size_t j=0;j<vbad.size();j++)
-	    {
-	      std::vector<double> tp_d = vbad.at(j).get("tp_d").get<std::vector<double>>();
-	      //std::cerr << "tp_d size=" << tp_d.size() << std::endl;
-	      std::vector<int> tp_i = vbad.at(j).get("tp_i").get<std::vector<int>>();
-	      std::vector<double> fp_d = vbad.at(j).get("fp_d").get<std::vector<double>>();
-	      std::vector<int> fp_i = vbad.at(j).get("fp_i").get<std::vector<int>>();
-	      int num_pos = vbad.at(j).get("num_pos").get<int>();
-	      //std::cerr << "num_pos=" << num_pos << std::endl;
-	      int label = vbad.at(j).get("label").get<int>();
-	      //std::cerr << "label=" << label << std::endl;
-	      std::vector<std::pair<double,int>> tp;
-	      std::vector<std::pair<double,int>> fp;
-	      
-	      //std::cerr << "fp_d size=" << fp_d.size() << std::endl;
-	      for (size_t j=0;j<tp_d.size();j++)
-		{
-		  tp.push_back(std::pair<double,int>(tp_d.at(j),tp_i.at(j)));
-		}
-	      for (size_t j=0;j<fp_d.size();j++)
-		{
-		  fp.push_back(std::pair<double,int>(fp_d.at(j),fp_i.at(j)));
-		}
+      for (int i = 0; i < pos_count; i++)
+        {
+          // do a mean over label AP per image in test set
+          double mAP = 0.0;
+          std::vector<APIData> vbad = bad.getv(std::to_string(i));
+          // std::cerr << "vbad size=" << vbad.size() << std::endl;
+          for (size_t j = 0; j < vbad.size(); j++)
+            {
+              std::vector<double> tp_d
+                  = vbad.at(j).get("tp_d").get<std::vector<double>>();
+              // std::cerr << "tp_d size=" << tp_d.size() << std::endl;
+              std::vector<int> tp_i
+                  = vbad.at(j).get("tp_i").get<std::vector<int>>();
+              std::vector<double> fp_d
+                  = vbad.at(j).get("fp_d").get<std::vector<double>>();
+              std::vector<int> fp_i
+                  = vbad.at(j).get("fp_i").get<std::vector<int>>();
+              int num_pos = vbad.at(j).get("num_pos").get<int>();
+              // std::cerr << "num_pos=" << num_pos << std::endl;
+              int label = vbad.at(j).get("label").get<int>();
+              // std::cerr << "label=" << label << std::endl;
+              std::vector<std::pair<double, int>> tp;
+              std::vector<std::pair<double, int>> fp;
 
-             double local_ap =compute_ap(tp,fp,num_pos);
-             if (APs.find(label) == APs.end())
-               {
-                 APs[label] = local_ap;
-                 APs_count[label] = 1;
-               }
-             else
-               {
-                 APs[label] += local_ap;
-                 APs_count[label] += 1;
-               }
-	      //std::cerr << "ap for label " << label << "=" << APs[label] << std::endl;
-	      mAP += local_ap;
-	    }
-	  mAP/=static_cast<double>(vbad.size());
-         // do a mean mAP over images in test set
-         mmAP += mAP;
-	}
-      for (auto ap: APs)
+              // std::cerr << "fp_d size=" << fp_d.size() << std::endl;
+              for (size_t j = 0; j < tp_d.size(); j++)
+                {
+                  tp.push_back(std::pair<double, int>(tp_d.at(j), tp_i.at(j)));
+                }
+              for (size_t j = 0; j < fp_d.size(); j++)
+                {
+                  fp.push_back(std::pair<double, int>(fp_d.at(j), fp_i.at(j)));
+                }
+
+              double local_ap = compute_ap(tp, fp, num_pos);
+              if (APs.find(label) == APs.end())
+                {
+                  APs[label] = local_ap;
+                  APs_count[label] = 1;
+                }
+              else
+                {
+                  APs[label] += local_ap;
+                  APs_count[label] += 1;
+                }
+              // std::cerr << "ap for label " << label << "=" << APs[label] <<
+              // std::endl;
+              mAP += local_ap;
+            }
+          mAP /= static_cast<double>(vbad.size());
+          // do a mean mAP over images in test set
+          mmAP += mAP;
+        }
+      for (auto ap : APs)
         {
           APs[ap.first] /= static_cast<float>(APs_count[ap.first]);
         }
-     return mmAP / static_cast<double>(pos_count);;
+      return mmAP / static_cast<double>(pos_count);
+      ;
     }
-    
+
     // measure: AUC
     static double auc(const APIData &ad)
     {
       std::vector<double> pred1;
       std::vector<double> targets;
       int batch_size = ad.get("batch_size").get<int>();
-      for (int i=0;i<batch_size;i++)
-	{
-	  APIData bad = ad.getobj(std::to_string(i));
-	  pred1.push_back(bad.get("pred").get<std::vector<double>>().at(1));
-	  targets.push_back(bad.get("target").get<double>());
-	}
-      return auc(pred1,targets);
+      for (int i = 0; i < batch_size; i++)
+        {
+          APIData bad = ad.getobj(std::to_string(i));
+          pred1.push_back(bad.get("pred").get<std::vector<double>>().at(1));
+          targets.push_back(bad.get("target").get<double>());
+        }
+      return auc(pred1, targets);
     }
-    static double auc(const std::vector<double> &pred, const std::vector<double> &targets)
+    static double auc(const std::vector<double> &pred,
+                      const std::vector<double> &targets)
     {
-      class PredictionAndAnswer {
+      class PredictionAndAnswer
+      {
       public:
-	PredictionAndAnswer(const float &f, const int &i)
-	  :prediction(f),answer(i) {}
-	~PredictionAndAnswer() {}
-	float prediction;
-	int answer; //this is either 0 or 1
+        PredictionAndAnswer(const float &f, const int &i)
+            : prediction(f), answer(i)
+        {
+        }
+        ~PredictionAndAnswer()
+        {
+        }
+        float prediction;
+        int answer; // this is either 0 or 1
       };
       std::vector<PredictionAndAnswer> p;
-      for (size_t i=0;i<pred.size();i++)
-	p.emplace_back(pred.at(i),targets.at(i));
+      for (size_t i = 0; i < pred.size(); i++)
+        p.emplace_back(pred.at(i), targets.at(i));
       int count = p.size();
-      
-      std::sort(p.begin(),p.end(),
-		[](const PredictionAndAnswer &p1, const PredictionAndAnswer &p2){return p1.prediction < p2.prediction;});
 
-      int i,truePos,tp0,accum,tn,ones=0;
-      float threshold; //predictions <= threshold are classified as zeros
+      std::sort(
+          p.begin(), p.end(),
+          [](const PredictionAndAnswer &p1, const PredictionAndAnswer &p2) {
+            return p1.prediction < p2.prediction;
+          });
 
-      for (i=0;i<count;i++) ones+=p[i].answer;
-      if (0==ones || count==ones) return 1;
+      int i, truePos, tp0, accum, tn, ones = 0;
+      float threshold; // predictions <= threshold are classified as zeros
 
-      truePos=tp0=ones; accum=tn=0; threshold=p[0].prediction;
-      for (i=0;i<count;i++) {
-        if (p[i].prediction!=threshold) { //threshold changes
-	  threshold=p[i].prediction;
-	  accum+=tn*(truePos+tp0); //2* the area of trapezoid
-	  tp0=truePos;
-	  tn=0;
+      for (i = 0; i < count; i++)
+        ones += p[i].answer;
+      if (0 == ones || count == ones)
+        return 1;
+
+      truePos = tp0 = ones;
+      accum = tn = 0;
+      threshold = p[0].prediction;
+      for (i = 0; i < count; i++)
+        {
+          if (p[i].prediction != threshold)
+            { // threshold changes
+              threshold = p[i].prediction;
+              accum += tn * (truePos + tp0); // 2* the area of trapezoid
+              tp0 = truePos;
+              tn = 0;
+            }
+          tn += 1 - p[i].answer; // x-distance between adjacent points
+          truePos -= p[i].answer;
         }
-        tn+= 1- p[i].answer; //x-distance between adjacent points
-        truePos-= p[i].answer;            
-      }
-      accum+=tn*(truePos+tp0); //2* the area of trapezoid
-      return accum/static_cast<double>((2*ones*(count-ones)));
+      accum += tn * (truePos + tp0); // 2* the area of trapezoid
+      return accum / static_cast<double>((2 * ones * (count - ones)));
     }
-    
+
     // measure: multiclass logarithmic loss
     static double mcll(const APIData &ad)
     {
-      double ll=0.0;
+      double ll = 0.0;
       int batch_size = ad.get("batch_size").get<int>();
-      for (int i=0;i<batch_size;i++)
-	{
-	  APIData bad = ad.getobj(std::to_string(i));
-	  std::vector<double> predictions = bad.get("pred").get<std::vector<double>>();
-	  double target = bad.get("target").get<double>();
-	  ll -= std::log(predictions.at(target));
-	}
+      for (int i = 0; i < batch_size; i++)
+        {
+          APIData bad = ad.getobj(std::to_string(i));
+          std::vector<double> predictions
+              = bad.get("pred").get<std::vector<double>>();
+          double target = bad.get("target").get<double>();
+          ll -= std::log(predictions.at(target));
+        }
       return ll / static_cast<double>(batch_size);
     }
 
@@ -1916,31 +2205,40 @@ namespace dd
     static double mcc(const APIData &ad)
     {
       int nclasses = ad.get("nclasses").get<int>();
-      dMat conf_matrix = dMat::Zero(nclasses,nclasses);
+      dMat conf_matrix = dMat::Zero(nclasses, nclasses);
       int batch_size = ad.get("batch_size").get<int>();
-      for (int i=0;i<batch_size;i++)
-	{
-	  APIData bad = ad.getobj(std::to_string(i));
-	  std::vector<double> predictions = bad.get("pred").get<std::vector<double>>();
-	  int maxpr = std::distance(predictions.begin(),std::max_element(predictions.begin(),predictions.end()));
-	  double target = bad.get("target").get<double>();
-	  if (target < 0)
-	    throw OutputConnectorBadParamException("negative supervised discrete target (e.g. wrong use of label_offset ?");
-	  else if (target >= nclasses)
-	    throw OutputConnectorBadParamException("target class has id " + std::to_string(target) + " is higher than the number of classes " + std::to_string(nclasses) + " (e.g. wrong number of classes specified with nclasses");
-	  conf_matrix(maxpr,static_cast<int>(target)) += 1.0;
-	}
-      double tp = conf_matrix(0,0);
-      double tn = conf_matrix(1,1);
-      double fn = conf_matrix(0,1);
-      double fp = conf_matrix(1,0);
-      double den = (tp+fp)*(tp+fn)*(tn+fp)*(tn+fn);
+      for (int i = 0; i < batch_size; i++)
+        {
+          APIData bad = ad.getobj(std::to_string(i));
+          std::vector<double> predictions
+              = bad.get("pred").get<std::vector<double>>();
+          int maxpr = std::distance(
+              predictions.begin(),
+              std::max_element(predictions.begin(), predictions.end()));
+          double target = bad.get("target").get<double>();
+          if (target < 0)
+            throw OutputConnectorBadParamException(
+                "negative supervised discrete target (e.g. wrong use of "
+                "label_offset ?");
+          else if (target >= nclasses)
+            throw OutputConnectorBadParamException(
+                "target class has id " + std::to_string(target)
+                + " is higher than the number of classes "
+                + std::to_string(nclasses)
+                + " (e.g. wrong number of classes specified with nclasses");
+          conf_matrix(maxpr, static_cast<int>(target)) += 1.0;
+        }
+      double tp = conf_matrix(0, 0);
+      double tn = conf_matrix(1, 1);
+      double fn = conf_matrix(0, 1);
+      double fp = conf_matrix(1, 0);
+      double den = (tp + fp) * (tp + fn) * (tn + fp) * (tn + fn);
       if (den == 0.0)
-	den = 1.0;
-      double mcc = (tp*tn-fp*fn) / std::sqrt(den);
+        den = 1.0;
+      double mcc = (tp * tn - fp * fn) / std::sqrt(den);
       return mcc;
     }
-    
+
     static double eucll(const APIData &ad, float thres)
     {
       double eucl = 0.0;
@@ -1951,77 +2249,93 @@ namespace dd
       if (has_ignore)
         ignore_label = ad.get("ignore_label").get<int>();
 
-      for (int i=0;i<batch_size;i++)
-	{
-	  APIData bad = ad.getobj(std::to_string(i));
-	  std::vector<double> predictions = bad.get("pred").get<std::vector<double>>();
-	  std::vector<double> target;
-	  if (predictions.size() > 1)
-	    target = bad.get("target").get<std::vector<double>>();
-	  else target.push_back(bad.get("target").get<double>());
-         double leucl = 0;
-	  for (size_t i=0;i<target.size();i++)
-           {
-             int t = target.at(i);
-             if (has_ignore && t-static_cast<double>(ignore_label) < 1E-9)
-               continue;
-             double diff = predictions.at(i)-target.at(i);
-             if (thres >= 0 )
-               {
-                 if (fabs(diff) >= thres)
-                   leucl += diff*diff;
-               }
-             else
-	      {
-               leucl += diff*diff;
-	      }
-           }
-         eucl += sqrt(leucl);
-       }
+      for (int i = 0; i < batch_size; i++)
+        {
+          APIData bad = ad.getobj(std::to_string(i));
+          std::vector<double> predictions
+              = bad.get("pred").get<std::vector<double>>();
+          std::vector<double> target;
+          if (predictions.size() > 1)
+            target = bad.get("target").get<std::vector<double>>();
+          else
+            target.push_back(bad.get("target").get<double>());
+          double leucl = 0;
+          for (size_t i = 0; i < target.size(); i++)
+            {
+              int t = target.at(i);
+              if (has_ignore && t - static_cast<double>(ignore_label) < 1E-9)
+                continue;
+              double diff = predictions.at(i) - target.at(i);
+              if (thres >= 0)
+                {
+                  if (fabs(diff) >= thres)
+                    leucl += diff * diff;
+                }
+              else
+                {
+                  leucl += diff * diff;
+                }
+            }
+          eucl += sqrt(leucl);
+        }
       return eucl / static_cast<double>(batch_size);
     }
-    
+
     // measure: gini coefficient
-    static double comp_gini(const std::vector<double> &a, const std::vector<double> &p) {
-      struct K { double a, p; };
+    static double comp_gini(const std::vector<double> &a,
+                            const std::vector<double> &p)
+    {
+      struct K
+      {
+        double a, p;
+      };
       std::vector<K> k(a.size());
-      for (size_t i = 0; i != a.size(); ++i) k[i] = {a[i], p[i]};
-      std::stable_sort(k.begin(), k.end(), [](const K &a, const K &b) {return a.p > b.p;});
-      double accPopPercSum=0, accLossPercSum=0, giniSum=0, sum=0;
-      for (auto &i: a) sum += i;
-      for (auto &i: k) 
-	{
-	  accLossPercSum += i.a/sum;
-	  accPopPercSum += 1.0/a.size();
-	  giniSum += accLossPercSum-accPopPercSum;
-	}
-      return giniSum/a.size();
+      for (size_t i = 0; i != a.size(); ++i)
+        k[i] = { a[i], p[i] };
+      std::stable_sort(k.begin(), k.end(),
+                       [](const K &a, const K &b) { return a.p > b.p; });
+      double accPopPercSum = 0, accLossPercSum = 0, giniSum = 0, sum = 0;
+      for (auto &i : a)
+        sum += i;
+      for (auto &i : k)
+        {
+          accLossPercSum += i.a / sum;
+          accPopPercSum += 1.0 / a.size();
+          giniSum += accLossPercSum - accPopPercSum;
+        }
+      return giniSum / a.size();
     }
-    static double comp_gini_normalized(const std::vector<double> &a, const std::vector<double> &p) {
-      return comp_gini(a, p)/comp_gini(a, a);
+    static double comp_gini_normalized(const std::vector<double> &a,
+                                       const std::vector<double> &p)
+    {
+      return comp_gini(a, p) / comp_gini(a, a);
     }
-    
-    static double gini(const APIData &ad,
-		       const bool &regression)
+
+    static double gini(const APIData &ad, const bool &regression)
     {
       int batch_size = ad.get("batch_size").get<int>();
       std::vector<double> a(batch_size);
       std::vector<double> p(batch_size);
-      for (int i=0;i<batch_size;i++)
-	{
-	  APIData bad = ad.getobj(std::to_string(i));
-	  a.at(i) = bad.get("target").get<double>();
-	  if (regression)
-	    p.at(i) = bad.get("pred").get<std::vector<double>>().at(0); //XXX: could be vector for multi-dimensional regression -> TODO: in supervised mode, get best pred index ?
-	  else
-	    {
-	      std::vector<double> allpreds = bad.get("pred").get<std::vector<double>>();
-	      a.at(i) = std::distance(allpreds.begin(),std::max_element(allpreds.begin(),allpreds.end()));
-	    }
-	}
-      return comp_gini_normalized(a,p);
+      for (int i = 0; i < batch_size; i++)
+        {
+          APIData bad = ad.getobj(std::to_string(i));
+          a.at(i) = bad.get("target").get<double>();
+          if (regression)
+            p.at(i) = bad.get("pred").get<std::vector<double>>().at(
+                0); // XXX: could be vector for multi-dimensional regression ->
+                    // TODO: in supervised mode, get best pred index ?
+          else
+            {
+              std::vector<double> allpreds
+                  = bad.get("pred").get<std::vector<double>>();
+              a.at(i) = std::distance(
+                  allpreds.begin(),
+                  std::max_element(allpreds.begin(), allpreds.end()));
+            }
+        }
+      return comp_gini_normalized(a, p);
     }
-    
+
     // for debugging purposes.
     /**
      * \brief print supervised output to string
@@ -2029,20 +2343,21 @@ namespace dd
     void to_str(std::string &out, const int &rmax) const
     {
       auto vit = _vcats.begin();
-      while(vit!=_vcats.end())
-	{
-	  int count = 0;
-	  out += "-------------\n";
-	  out += (*vit).first + "\n";
-	  auto mit = _vvcats.at((*vit).second)._cats.begin();
-	  while(mit!=_vvcats.at((*vit).second)._cats.end()&&count<rmax)
-	  {
-	    out += "accuracy=" + std::to_string((*mit).first) + " -- cat=" + (*mit).second + "\n";
-	    ++mit;
-	    ++count;
-	  }
-	  ++vit;
-	}
+      while (vit != _vcats.end())
+        {
+          int count = 0;
+          out += "-------------\n";
+          out += (*vit).first + "\n";
+          auto mit = _vvcats.at((*vit).second)._cats.begin();
+          while (mit != _vvcats.at((*vit).second)._cats.end() && count < rmax)
+            {
+              out += "accuracy=" + std::to_string((*mit).first)
+                     + " -- cat=" + (*mit).second + "\n";
+              ++mit;
+              ++count;
+            }
+          ++vit;
+        }
     }
 
     /**
@@ -2056,7 +2371,8 @@ namespace dd
      * @param indexed_uris list of indexed uris, if any
      */
     void to_ad(APIData &out, const bool &regression, const bool &autoencoder,
-               const bool &has_bbox, const bool &has_roi, const bool &has_mask, const bool &timeseries,
+               const bool &has_bbox, const bool &has_roi, const bool &has_mask,
+               const bool &timeseries,
                const std::unordered_set<std::string> &indexed_uris) const
     {
 #ifndef USE_SIMSEARCH
@@ -2077,136 +2393,148 @@ namespace dd
       static std::string last = "last";
       std::unordered_set<std::string>::const_iterator hit;
       std::vector<APIData> vpred;
-      for (size_t i=0;i<_vvcats.size();i++)
-	{
-	  APIData adpred;
-	  std::vector<APIData> v;
-	  auto bit = _vvcats.at(i)._bboxes.begin();
-	  auto vit = _vvcats.at(i)._vals.begin();
-	  auto mit = _vvcats.at(i)._cats.begin();
-	  auto maskit = _vvcats.at(i)._masks.begin();
-	  while(mit!=_vvcats.at(i)._cats.end())
-	    {
-	      APIData nad;
-	      if (!autoencoder)
-		nad.add(chead,(*mit).second);
-	      if (regression)
-		nad.add(vhead,(*mit).first);
-	      else if (autoencoder)
-		nad.add(ahead,(*mit).first);
-	      else nad.add(phead,(*mit).first);
-	      if (has_bbox || has_roi || has_mask)
-		{
-		  nad.add(bb,(*bit).second);
-		  ++bit;
-		}
-	      if (has_roi)
-		{
-		  /* std::vector<std::string> keys = (*vit).second.list_keys(); */
-		  /* std::copy(keys.begin(), keys.end(), std::ostream_iterator<std::string>(std::cout, "'")); */
-		  /* std::cout << std::endl; */
-		  nad.add(roi,(*vit).second.get("vals").get<std::vector<double>>());
-		  ++vit;
-		}
-	      if (has_mask)
-		{
-		  nad.add(mask,(*maskit).second);
-		  ++maskit;
-		}
-	      ++mit;
-	      if (mit == _vvcats.at(i)._cats.end())
-		nad.add(last,true);
-	      v.push_back(nad);
-	    }
-	  if (_vvcats.at(i)._loss > 0.0) // XXX: not set by Caffe in prediction mode for now
-	    adpred.add("loss",_vvcats.at(i)._loss);
-	  adpred.add("uri",_vvcats.at(i)._label);
+      for (size_t i = 0; i < _vvcats.size(); i++)
+        {
+          APIData adpred;
+          std::vector<APIData> v;
+          auto bit = _vvcats.at(i)._bboxes.begin();
+          auto vit = _vvcats.at(i)._vals.begin();
+          auto mit = _vvcats.at(i)._cats.begin();
+          auto maskit = _vvcats.at(i)._masks.begin();
+          while (mit != _vvcats.at(i)._cats.end())
+            {
+              APIData nad;
+              if (!autoencoder)
+                nad.add(chead, (*mit).second);
+              if (regression)
+                nad.add(vhead, (*mit).first);
+              else if (autoencoder)
+                nad.add(ahead, (*mit).first);
+              else
+                nad.add(phead, (*mit).first);
+              if (has_bbox || has_roi || has_mask)
+                {
+                  nad.add(bb, (*bit).second);
+                  ++bit;
+                }
+              if (has_roi)
+                {
+                  /* std::vector<std::string> keys = (*vit).second.list_keys();
+                   */
+                  /* std::copy(keys.begin(), keys.end(),
+                   * std::ostream_iterator<std::string>(std::cout, "'")); */
+                  /* std::cout << std::endl; */
+                  nad.add(
+                      roi,
+                      (*vit).second.get("vals").get<std::vector<double>>());
+                  ++vit;
+                }
+              if (has_mask)
+                {
+                  nad.add(mask, (*maskit).second);
+                  ++maskit;
+                }
+              ++mit;
+              if (mit == _vvcats.at(i)._cats.end())
+                nad.add(last, true);
+              v.push_back(nad);
+            }
+          if (_vvcats.at(i)._loss
+              > 0.0) // XXX: not set by Caffe in prediction mode for now
+            adpred.add("loss", _vvcats.at(i)._loss);
+          adpred.add("uri", _vvcats.at(i)._label);
 #ifdef USE_SIMSEARCH
-	  if (!_vvcats.at(i)._index_uri.empty())
-	    adpred.add("index_uri",_vvcats.at(i)._index_uri);
-	  if (!indexed_uris.empty() && (hit=indexed_uris.find(_vvcats.at(i)._label))!=indexed_uris.end())
-	    adpred.add("indexed",true);
-	  if (!_vvcats.at(i)._nns.empty() || !_vvcats.at(i)._bbox_nns.empty())
-	    {
-	      if (!has_roi)
-		{
-		  std::vector<APIData> ad_nns;
-		  auto nnit = _vvcats.at(i)._nns.begin();
-		  while(nnit!=_vvcats.at(i)._nns.end())
-		    {
-		      APIData ad_nn;
-		      ad_nn.add("uri",(*nnit).second._uri);
-		      ad_nn.add("dist",(*nnit).first);
-		      ad_nns.push_back(ad_nn);
-		      ++nnit;
-		    }
-		  adpred.add("nns",ad_nns);
-		}
-	      else // has_roi
-		{
-		  for (size_t bb=0;bb<_vvcats.at(i)._bbox_nns.size();bb++)
-		    {
-		      std::vector<APIData> ad_nns;
-		      auto nnit = _vvcats.at(i)._bbox_nns.at(bb).begin();
-		      while(nnit!=_vvcats.at(i)._bbox_nns.at(bb).end())
-			{
-			  APIData ad_nn;
-			  ad_nn.add("uri",(*nnit).second._uri);
-			  ad_nn.add("dist",(*nnit).first);
-			  ad_nn.add("prob",(*nnit).second._prob);
-			  ad_nn.add("cat",(*nnit).second._cat);
-			  APIData ad_bbox;
-			  ad_bbox.add("xmin",(*nnit).second._bbox.at(0));
-			  ad_bbox.add("ymin",(*nnit).second._bbox.at(1));
-			  ad_bbox.add("xmax",(*nnit).second._bbox.at(2));
-			  ad_bbox.add("ymax",(*nnit).second._bbox.at(3));
-			  ad_nn.add("bbox",ad_bbox);
-			  ad_nns.push_back(ad_nn);
-			  ++nnit;
-			}
-		      v.at(bb).add("nns",ad_nns); // v is in roi object vector
-		    }
-		}
-	    }
+          if (!_vvcats.at(i)._index_uri.empty())
+            adpred.add("index_uri", _vvcats.at(i)._index_uri);
+          if (!indexed_uris.empty()
+              && (hit = indexed_uris.find(_vvcats.at(i)._label))
+                     != indexed_uris.end())
+            adpred.add("indexed", true);
+          if (!_vvcats.at(i)._nns.empty() || !_vvcats.at(i)._bbox_nns.empty())
+            {
+              if (!has_roi)
+                {
+                  std::vector<APIData> ad_nns;
+                  auto nnit = _vvcats.at(i)._nns.begin();
+                  while (nnit != _vvcats.at(i)._nns.end())
+                    {
+                      APIData ad_nn;
+                      ad_nn.add("uri", (*nnit).second._uri);
+                      ad_nn.add("dist", (*nnit).first);
+                      ad_nns.push_back(ad_nn);
+                      ++nnit;
+                    }
+                  adpred.add("nns", ad_nns);
+                }
+              else // has_roi
+                {
+                  for (size_t bb = 0; bb < _vvcats.at(i)._bbox_nns.size();
+                       bb++)
+                    {
+                      std::vector<APIData> ad_nns;
+                      auto nnit = _vvcats.at(i)._bbox_nns.at(bb).begin();
+                      while (nnit != _vvcats.at(i)._bbox_nns.at(bb).end())
+                        {
+                          APIData ad_nn;
+                          ad_nn.add("uri", (*nnit).second._uri);
+                          ad_nn.add("dist", (*nnit).first);
+                          ad_nn.add("prob", (*nnit).second._prob);
+                          ad_nn.add("cat", (*nnit).second._cat);
+                          APIData ad_bbox;
+                          ad_bbox.add("xmin", (*nnit).second._bbox.at(0));
+                          ad_bbox.add("ymin", (*nnit).second._bbox.at(1));
+                          ad_bbox.add("xmax", (*nnit).second._bbox.at(2));
+                          ad_bbox.add("ymax", (*nnit).second._bbox.at(3));
+                          ad_nn.add("bbox", ad_bbox);
+                          ad_nns.push_back(ad_nn);
+                          ++nnit;
+                        }
+                      v.at(bb).add("nns", ad_nns); // v is in roi object vector
+                    }
+                }
+            }
 #endif
-         if (!_vvcats.at(i)._series.empty())
-           {
-             auto sit = _vvcats.at(i)._series.begin();
-             while(sit!=_vvcats.at(i)._series.end())
-               {
-                 APIData nad;
-                 nad.add("out",(*sit).second.get("out").get<std::vector<double>>());
-                 ++sit;
-                 if (sit == _vvcats.at(i)._series.end())
-                   nad.add(last,true);
-                 v.push_back(nad);
-               }
-           }
+          if (!_vvcats.at(i)._series.empty())
+            {
+              auto sit = _vvcats.at(i)._series.begin();
+              while (sit != _vvcats.at(i)._series.end())
+                {
+                  APIData nad;
+                  nad.add("out",
+                          (*sit).second.get("out").get<std::vector<double>>());
+                  ++sit;
+                  if (sit == _vvcats.at(i)._series.end())
+                    nad.add(last, true);
+                  v.push_back(nad);
+                }
+            }
 
-         if (timeseries)
-           adpred.add(series,v);
-	  else if (regression)
-	    adpred.add(ve,v);
-	  else if (autoencoder)
-	    adpred.add(ae,v);
-	  else if (has_roi)
-	    adpred.add(rois,v);
-	  else adpred.add(cl,v);
-	  vpred.push_back(adpred);
-	}
-      out.add("predictions",vpred);
+          if (timeseries)
+            adpred.add(series, v);
+          else if (regression)
+            adpred.add(ve, v);
+          else if (autoencoder)
+            adpred.add(ae, v);
+          else if (has_roi)
+            adpred.add(rois, v);
+          else
+            adpred.add(cl, v);
+          vpred.push_back(adpred);
+        }
+      out.add("predictions", vpred);
     }
-    
-    std::unordered_map<std::string,int> _vcats; /**< batch of results, per uri. */
+
+    std::unordered_map<std::string, int>
+        _vcats;                      /**< batch of results, per uri. */
     std::vector<sup_result> _vvcats; /**< ordered results, per uri. */
-    
+
     // options
     int _best = 1;
 #ifdef USE_SIMSEARCH
     int _search_nn = 10; /**< default nearest neighbors per search. */
 #endif
   };
-  
+
 }
 
 #endif

--- a/src/txtinputfileconn.h
+++ b/src/txtinputfileconn.h
@@ -35,8 +35,12 @@ namespace dd
   class DDTxt
   {
   public:
-    DDTxt() {}
-    ~DDTxt() {}
+    DDTxt()
+    {
+    }
+    ~DDTxt()
+    {
+    }
 
     int read_file(const std::string &fname);
     int read_db(const std::string &fname);
@@ -50,54 +54,80 @@ namespace dd
   class Word
   {
   public:
-    Word() {}
-    Word(const int &pos)
-      :_pos(pos) {}
-    Word(const int &pos,
-	 const int &tcount,
-	 const int &tdocs)
-      :_pos(pos),_total_count(tcount),_total_docs(tdocs) {}
-    ~Word() {}
-    
+    Word()
+    {
+    }
+    Word(const int &pos) : _pos(pos)
+    {
+    }
+    Word(const int &pos, const int &tcount, const int &tdocs)
+        : _pos(pos), _total_count(tcount), _total_docs(tdocs)
+    {
+    }
+    ~Word()
+    {
+    }
+
     int _pos = -1;
     int _total_count = 1;
     int _total_docs = 1;
   };
 
-  template<typename T> class TxtEntry
+  template <typename T> class TxtEntry
   {
   public:
-    TxtEntry() {}
-    TxtEntry(const float &target): _target(target) {}
-    virtual ~TxtEntry() {}
+    TxtEntry()
+    {
+    }
+    TxtEntry(const float &target) : _target(target)
+    {
+    }
+    virtual ~TxtEntry()
+    {
+    }
 
-    void reset() {}
-    void get_elt(std::string &key, T &val) const { (void)key; (void)val; }
-    bool has_elt() const { return false; }
-    size_t size() const { return 0; }
-    
+    void reset()
+    {
+    }
+    void get_elt(std::string &key, T &val) const
+    {
+      (void)key;
+      (void)val;
+    }
+    bool has_elt() const
+    {
+      return false;
+    }
+    size_t size() const
+    {
+      return 0;
+    }
+
     float _target = -1; /**< class target in training mode. */
     std::string _uri;
   };
-  
-  class TxtBowEntry: public TxtEntry<double>
+
+  class TxtBowEntry : public TxtEntry<double>
   {
   public:
-  TxtBowEntry():TxtEntry<double>() {};
-  TxtBowEntry(const float &target):TxtEntry<double>(target) {}
-    virtual ~TxtBowEntry() {}
-
-    void add_word(const std::string &str,
-		  const double &v,
-		  const bool &count)
+    TxtBowEntry() : TxtEntry<double>(){};
+    TxtBowEntry(const float &target) : TxtEntry<double>(target)
     {
-      std::unordered_map<std::string,double>::iterator hit;
-      if ((hit=_v.find(str))!=_v.end())
-	{
-	  if (count)
-	    (*hit).second += v;
-	}
-      else _v.insert(std::pair<std::string,double>(str,v));
+    }
+    virtual ~TxtBowEntry()
+    {
+    }
+
+    void add_word(const std::string &str, const double &v, const bool &count)
+    {
+      std::unordered_map<std::string, double>::iterator hit;
+      if ((hit = _v.find(str)) != _v.end())
+        {
+          if (count)
+            (*hit).second += v;
+        }
+      else
+        _v.insert(std::pair<std::string, double>(str, v));
     }
 
     bool has_word(const std::string &str)
@@ -112,34 +142,40 @@ namespace dd
 
     void get_next_elt(std::string &key, double &val)
     {
-      if (_vit!=_v.end())
-	{
-	  key = (*_vit).first;
-	  val = (*_vit).second;
-	  ++_vit;
-	}
+      if (_vit != _v.end())
+        {
+          key = (*_vit).first;
+          val = (*_vit).second;
+          ++_vit;
+        }
     }
 
     bool has_elt() const
     {
       return _vit != _v.end();
     }
-    
+
     size_t size() const
     {
       return _v.size();
     }
 
-    std::unordered_map<std::string,double> _v; /**< words as (<pos,val>). */
-    std::unordered_map<std::string,double>::iterator _vit;
+    std::unordered_map<std::string, double> _v; /**< words as (<pos,val>). */
+    std::unordered_map<std::string, double>::iterator _vit;
   };
 
-  class TxtCharEntry: public TxtEntry<double>
+  class TxtCharEntry : public TxtEntry<double>
   {
   public:
-  TxtCharEntry():TxtEntry<double>() {}
-  TxtCharEntry(const float &target):TxtEntry<double>(target) {}
-    virtual ~TxtCharEntry() {}
+    TxtCharEntry() : TxtEntry<double>()
+    {
+    }
+    TxtCharEntry(const float &target) : TxtEntry<double>(target)
+    {
+    }
+    virtual ~TxtCharEntry()
+    {
+    }
 
     void add_char(const uint32_t &c)
     {
@@ -153,12 +189,12 @@ namespace dd
 
     void get_next_elt(std::string &key, double &val)
     {
-      if (_vit!=_v.end())
-	{
-	  key = std::to_string((*_vit));
-	  val = 1;
-	  ++_vit;
-	}
+      if (_vit != _v.end())
+        {
+          key = std::to_string((*_vit));
+          val = 1;
+          ++_vit;
+        }
     }
 
     bool has_elt() const
@@ -166,20 +202,27 @@ namespace dd
       return _vit != _v.end();
     }
 
-    size_t size() const 
+    size_t size() const
     {
       return _v.size();
     }
-    
+
     std::vector<uint32_t> _v;
     std::vector<uint32_t>::iterator _vit;
   };
 
-  class TxtOrderedWordsEntry: public TxtEntry<double> {
+  class TxtOrderedWordsEntry : public TxtEntry<double>
+  {
   public:
-    TxtOrderedWordsEntry() :TxtEntry<double>() {}
-    TxtOrderedWordsEntry(const float &target) :TxtEntry<double>(target) {}
-    virtual ~TxtOrderedWordsEntry() {}
+    TxtOrderedWordsEntry() : TxtEntry<double>()
+    {
+    }
+    TxtOrderedWordsEntry(const float &target) : TxtEntry<double>(target)
+    {
+    }
+    virtual ~TxtOrderedWordsEntry()
+    {
+    }
 
     void add_word(const std::string &word)
     {
@@ -193,12 +236,12 @@ namespace dd
 
     void get_next_elt(std::string &key, double &val)
     {
-      if (_vit!=_v.end())
-      {
-        key = *_vit;
-        val = 1;
-        ++_vit;
-      }
+      if (_vit != _v.end())
+        {
+          key = *_vit;
+          val = 1;
+          ++_vit;
+        }
     }
 
     bool has_elt() const
@@ -206,7 +249,7 @@ namespace dd
       return _vit != _v.end();
     }
 
-    size_t size() const 
+    size_t size() const
     {
       return _v.size();
     }
@@ -217,113 +260,112 @@ namespace dd
 
   /** Tokenizer that uses greedy longest-match-first search to cut words
    * in pieces */
-  class WordPieceTokenizer {
+  class WordPieceTokenizer
+  {
   public:
-      std::vector<std::string> _tokens;
-      TxtInputFileConn *_ctfc = nullptr;
+    std::vector<std::string> _tokens;
+    TxtInputFileConn *_ctfc = nullptr;
 
-      WordPieceTokenizer() {}
+    WordPieceTokenizer()
+    {
+    }
 
-      void reset() {
-          _tokens.clear();
-      }
+    void reset()
+    {
+      _tokens.clear();
+    }
 
-      void append_input(const std::string &word);
+    void append_input(const std::string &word);
+
   public:
-      bool in_vocab(const std::string &tok);
+    bool in_vocab(const std::string &tok);
 
-      std::string _suffix_start = "##";/**< Suffix tokens in vocabulary are prefixed by this */
-      std::string _word_start = "";/**< Tokens corresponding to word or word beggining in the vocabulary are prefixed by this */
-      std::string _unk_token = "[UNK]";
+    std::string _suffix_start
+        = "##"; /**< Suffix tokens in vocabulary are prefixed by this */
+    std::string _word_start
+        = ""; /**< Tokens corresponding to word or word beggining in the
+                 vocabulary are prefixed by this */
+    std::string _unk_token = "[UNK]";
   };
 
   class TxtInputFileConn : public InputConnectorStrategy
   {
   public:
-    TxtInputFileConn()
-      :InputConnectorStrategy()
-      {
-        _wordpiece_tokenizer._ctfc = this;
-      }
+    TxtInputFileConn() : InputConnectorStrategy()
+    {
+      _wordpiece_tokenizer._ctfc = this;
+    }
     TxtInputFileConn(const TxtInputFileConn &i)
-      :InputConnectorStrategy(i),
-      _iterator(i._iterator),
-	  _test_split(i._test_split),
-      _count(i._count),
-      _tfidf(i._tfidf),
-      _min_count(i._min_count),
-      _min_word_length(i._min_word_length),
-      _sentences(i._sentences),
-      _characters(i._characters),
-      _ordered_words(i._ordered_words),
-      _lower_case(i._lower_case),
-      _wordpiece_tokens(i._wordpiece_tokens),
-      _punctuation_tokens(i._punctuation_tokens),
-      _alphabet_str(i._alphabet_str),
-      _alphabet(i._alphabet),
-      _sequence(i._sequence),
-      _seq_forward(i._seq_forward),
-      _generate_vocab(i._generate_vocab),
-      _vocab(i._vocab),
-      _vocab_sep(i._vocab_sep),
-      _wordpiece_tokenizer(i._wordpiece_tokenizer),
-      _ndbed(i._ndbed)
-      {
-        _wordpiece_tokenizer._ctfc = this;
-      }
+        : InputConnectorStrategy(i), _iterator(i._iterator),
+          _test_split(i._test_split), _count(i._count), _tfidf(i._tfidf),
+          _min_count(i._min_count), _min_word_length(i._min_word_length),
+          _sentences(i._sentences), _characters(i._characters),
+          _ordered_words(i._ordered_words), _lower_case(i._lower_case),
+          _wordpiece_tokens(i._wordpiece_tokens),
+          _punctuation_tokens(i._punctuation_tokens),
+          _alphabet_str(i._alphabet_str), _alphabet(i._alphabet),
+          _sequence(i._sequence), _seq_forward(i._seq_forward),
+          _generate_vocab(i._generate_vocab), _vocab(i._vocab),
+          _vocab_sep(i._vocab_sep),
+          _wordpiece_tokenizer(i._wordpiece_tokenizer), _ndbed(i._ndbed)
+    {
+      _wordpiece_tokenizer._ctfc = this;
+    }
     ~TxtInputFileConn()
-      {
-	destroy_txt_entries(_txt);
-	destroy_txt_entries(_test_txt);
-      }
+    {
+      destroy_txt_entries(_txt);
+      destroy_txt_entries(_test_txt);
+    }
 
     void init(const APIData &ad)
     {
       fillup_parameters(ad);
       if (!_characters && !_train)
-	deserialize_vocab(false);
+        deserialize_vocab(false);
     }
 
     void fillup_parameters(const APIData &ad_input)
     {
       if (ad_input.has("shuffle"))
-	_shuffle = ad_input.get("shuffle").get<bool>();
+        _shuffle = ad_input.get("shuffle").get<bool>();
       if (ad_input.has("seed"))
-	_seed = ad_input.get("seed").get<int>();
+        _seed = ad_input.get("seed").get<int>();
       if (ad_input.has("test_split"))
-	_test_split = ad_input.get("test_split").get<double>();
+        _test_split = ad_input.get("test_split").get<double>();
       if (ad_input.has("count"))
-	_count = ad_input.get("count").get<bool>();
+        _count = ad_input.get("count").get<bool>();
       if (ad_input.has("tfidf"))
-	_tfidf = ad_input.get("tfidf").get<bool>();
+        _tfidf = ad_input.get("tfidf").get<bool>();
       if (ad_input.has("min_count"))
-	_min_count = ad_input.get("min_count").get<int>();
+        _min_count = ad_input.get("min_count").get<int>();
       if (ad_input.has("min_word_length"))
-	_min_word_length = ad_input.get("min_word_length").get<int>();
+        _min_word_length = ad_input.get("min_word_length").get<int>();
       if (ad_input.has("sentences"))
-	_sentences = ad_input.get("sentences").get<bool>();
+        _sentences = ad_input.get("sentences").get<bool>();
       if (ad_input.has("characters"))
-	_characters = ad_input.get("characters").get<bool>();
+        _characters = ad_input.get("characters").get<bool>();
       if (ad_input.has("ordered_words"))
-	_ordered_words = ad_input.get("ordered_words").get<bool>();
+        _ordered_words = ad_input.get("ordered_words").get<bool>();
       if (ad_input.has("lower_case"))
-	_lower_case = ad_input.get("lower_case").get<bool>();
+        _lower_case = ad_input.get("lower_case").get<bool>();
       if (ad_input.has("wordpiece_tokens"))
-	_wordpiece_tokens = ad_input.get("wordpiece_tokens").get<bool>();
+        _wordpiece_tokens = ad_input.get("wordpiece_tokens").get<bool>();
       if (ad_input.has("word_start"))
-        _wordpiece_tokenizer._word_start = ad_input.get("word_start").get<std::string>();
+        _wordpiece_tokenizer._word_start
+            = ad_input.get("word_start").get<std::string>();
       if (ad_input.has("suffix_start"))
-        _wordpiece_tokenizer._suffix_start = ad_input.get("suffix_start").get<std::string>();
+        _wordpiece_tokenizer._suffix_start
+            = ad_input.get("suffix_start").get<std::string>();
       if (ad_input.has("punctuation_tokens"))
-	_punctuation_tokens = ad_input.get("punctuation_tokens").get<bool>();
+        _punctuation_tokens = ad_input.get("punctuation_tokens").get<bool>();
       if (ad_input.has("alphabet"))
-	_alphabet_str = ad_input.get("alphabet").get<std::string>();
+        _alphabet_str = ad_input.get("alphabet").get<std::string>();
       if (_characters)
-	build_alphabet();
+        build_alphabet();
       if (ad_input.has("sequence"))
-	_sequence = ad_input.get("sequence").get<int>();
+        _sequence = ad_input.get("sequence").get<int>();
       if (ad_input.has("read_forward"))
-	_seq_forward = ad_input.get("read_forward").get<bool>();
+        _seq_forward = ad_input.get("read_forward").get<bool>();
 
       // timeout
       this->set_timeout(ad_input);
@@ -349,138 +391,154 @@ namespace dd
     {
       get_data(ad);
 
-      if (ad.has("parameters")) // hotplug of parameters, overriding the defaults
-	{
-	  APIData ad_param = ad.getobj("parameters");
-	  if (ad_param.has("input"))
-	    {
-	      fillup_parameters(ad_param.getobj("input"));
-	    }
-	}
+      if (ad.has(
+              "parameters")) // hotplug of parameters, overriding the defaults
+        {
+          APIData ad_param = ad.getobj("parameters");
+          if (ad_param.has("input"))
+            {
+              fillup_parameters(ad_param.getobj("input"));
+            }
+        }
 
       if (_alphabet.empty() && _characters)
-	build_alphabet();
-      
-      if (!_characters && (!_train || _ordered_words) && _vocab.empty())
-	deserialize_vocab();
-      
-      for (std::string u: _uris)
-	{
-	  DataEl<DDTxt> dtxt(this->_input_timeout);
-	  dtxt._ctype._ctfc = this;
-	  if (dtxt.read_element(u,this->_logger) ||( _txt.empty()  && _db_fname.empty() && _ndbed == 0))
-	    {
-	      throw InputConnectorBadParamException("no data for text in " + u);
-	    }
+        build_alphabet();
 
-      if (_ndbed == 0)
+      if (!_characters && (!_train || _ordered_words) && _vocab.empty())
+        deserialize_vocab();
+
+      for (std::string u : _uris)
         {
-          if (_db_fname.empty())
-            _txt.back()->_uri = u;
-          else return; // single db
+          DataEl<DDTxt> dtxt(this->_input_timeout);
+          dtxt._ctype._ctfc = this;
+          if (dtxt.read_element(u, this->_logger)
+              || (_txt.empty() && _db_fname.empty() && _ndbed == 0))
+            {
+              throw InputConnectorBadParamException("no data for text in "
+                                                    + u);
+            }
+
+          if (_ndbed == 0)
+            {
+              if (_db_fname.empty())
+                _txt.back()->_uri = u;
+              else
+                return; // single db
+            }
         }
-	}
 
       if (_train)
-	{
-	  _shuffle = true;
-	  serialize_vocab();
-	}
+        {
+          _shuffle = true;
+          serialize_vocab();
+        }
 
       // shuffle entries if requested
-      if (_train && _shuffle && _ndbed ==0)
-	{
-	  std::mt19937 g;
-	  if (_seed >= 0)
-	    g =std::mt19937(_seed);
-	  else
-	    {
-	      std::random_device rd;
-	      g = std::mt19937(rd());
-	    }
-	  std::shuffle(_txt.begin(),_txt.end(),g);
-	}
-      
+      if (_train && _shuffle && _ndbed == 0)
+        {
+          std::mt19937 g;
+          if (_seed >= 0)
+            g = std::mt19937(_seed);
+          else
+            {
+              std::random_device rd;
+              g = std::mt19937(rd());
+            }
+          std::shuffle(_txt.begin(), _txt.end(), g);
+        }
+
       // split for test set
       if (_train && _test_split > 0 && _ndbed == 0)
-	{
-	  int split_size = std::floor(_txt.size() * (1.0-_test_split));
-	  auto chit = _txt.begin();
-	  auto dchit = chit;
-	  int cpos = 0;
-	  while(chit!=_txt.end())
-	    {
-	      if (cpos == split_size)
-		{
-		  if (dchit == _txt.begin())
-		    dchit = chit;
-		  _test_txt.push_back((*chit));
-		}
-	      else ++cpos;
-	      ++chit;
-	    }
-	  _txt.erase(dchit,_txt.end());
-        _logger->info("data split test size=" + std::to_string(_test_txt.size()) +
-                      " / remaining data size=" + std::to_string(_txt.size()));
-	}
-      if (_txt.empty() && _ndbed ==0)
-        //if _nbded != 0 _txt has be already db_ed and freed
+        {
+          int split_size = std::floor(_txt.size() * (1.0 - _test_split));
+          auto chit = _txt.begin();
+          auto dchit = chit;
+          int cpos = 0;
+          while (chit != _txt.end())
+            {
+              if (cpos == split_size)
+                {
+                  if (dchit == _txt.begin())
+                    dchit = chit;
+                  _test_txt.push_back((*chit));
+                }
+              else
+                ++cpos;
+              ++chit;
+            }
+          _txt.erase(dchit, _txt.end());
+          _logger->info(
+              "data split test size=" + std::to_string(_test_txt.size())
+              + " / remaining data size=" + std::to_string(_txt.size()));
+        }
+      if (_txt.empty() && _ndbed == 0)
+        // if _nbded != 0 _txt has be already db_ed and freed
         // and splitting / shuffling is done somewhere else
-	throw InputConnectorBadParamException("no text could be found");
+        throw InputConnectorBadParamException("no text could be found");
     }
 
     // text tokenization for BOW
     virtual void parse_content(const std::string &content,
-                               const float &target=-1,
-                               const bool &test=false);
+                               const float &target = -1,
+                               const bool &test = false);
 
     // serialization of vocabulary
     void serialize_vocab();
-    void deserialize_vocab(const bool &required=true);
+    void deserialize_vocab(const bool &required = true);
 
     // alphabet for character-level features
     void build_alphabet();
 
     // clearing up memory
-    void destroy_txt_entries(std::vector<TxtEntry<double>*> &v);
-    
+    void destroy_txt_entries(std::vector<TxtEntry<double> *> &v);
+
     // options
     std::string _iterator = "document";
     bool _shuffle = false;
     int _seed = -1;
     double _test_split = 0.0;
-    bool _count = true; /**< whether to add up word counters */
-    bool _tfidf = false; /**< whether to use TF/IDF */
-    int _min_count = 5; /**< min word occurence. */
+    bool _count = true;       /**< whether to add up word counters */
+    bool _tfidf = false;      /**< whether to use TF/IDF */
+    int _min_count = 5;       /**< min word occurence. */
     int _min_word_length = 5; /**< min word length. */
-    bool _sentences = false; /**< whether to consider every sentence (\n separated) as a document. */
-    bool _characters = false; /**< whether to use character-level input features. */
-    bool _ordered_words = false; /**< whether to consider the position of each words in the sentence. */
-    bool _lower_case = true; /**< whether the input should be lower cased before processing */
-    bool _wordpiece_tokens = false; /**< whether to try to match word pieces from the vocabulary. */
+    bool _sentences = false;  /**< whether to consider every sentence (\n
+                                 separated) as a document. */
+    bool _characters
+        = false; /**< whether to use character-level input features. */
+    bool _ordered_words = false; /**< whether to consider the position of each
+                                    words in the sentence. */
+    bool _lower_case = true;     /**< whether the input should be lower cased
+                                    before processing */
+    bool _wordpiece_tokens = false;   /**< whether to try to match word pieces
+                                         from the vocabulary. */
     bool _punctuation_tokens = false; /**< accept punctuation tokens. */
-    std::string _alphabet_str = "abcdefghijklmnopqrstuvwxyz0123456789,;.!?:'\"/\\|_@#$%^&*~`+-=<>()[]{}";
-    std::unordered_map<uint32_t,int> _alphabet; /**< character-level alphabet. */
-    int _sequence = 60; /**< sequence size when using character-level features. */
-    bool _seq_forward = false; /**< whether to read character-based sequences forward. */
-    
+    std::string _alphabet_str = "abcdefghijklmnopqrstuvwxyz0123456789,;.!?:'"
+                                "\"/\\|_@#$%^&*~`+-=<>()[]{}";
+    std::unordered_map<uint32_t, int>
+        _alphabet; /**< character-level alphabet. */
+    int _sequence
+        = 60; /**< sequence size when using character-level features. */
+    bool _seq_forward
+        = false; /**< whether to read character-based sequences forward. */
+
     // internals
     bool _generate_vocab = true;
-    std::unordered_map<std::string,Word> _vocab; /**< string to word stats, including word */
+    std::unordered_map<std::string, Word>
+        _vocab; /**< string to word stats, including word */
     std::string _vocabfname = "vocab.dat";
     std::string _correspname = "corresp.txt";
     char _vocab_sep = ','; /**< vocabulary separator */
-    int _dirs = 0; /**< directories as input. */
+    int _dirs = 0;         /**< directories as input. */
     WordPieceTokenizer _wordpiece_tokenizer;
-    
+
     // data
-    std::vector<TxtEntry<double>*> _txt;
-    std::vector<TxtEntry<double>*> _test_txt;
+    std::vector<TxtEntry<double> *> _txt;
+    std::vector<TxtEntry<double> *> _test_txt;
     std::string _db_fname;
 
     int64_t _ndbed = 0;
   };
-  
+
 }
 
 #endif

--- a/src/unsupervisedoutputconnector.h
+++ b/src/unsupervisedoutputconnector.h
@@ -28,112 +28,115 @@ namespace dd
   class unsup_result
   {
   public:
-    unsup_result(const std::string &uri,
-		 const std::vector<double> &vals,
-                 const APIData &extra=APIData(),
-		 const std::string &meta_uri="")
-      :_uri(uri),_vals(vals),_extra(extra), _meta_uri(meta_uri) {
+    unsup_result(const std::string &uri, const std::vector<double> &vals,
+                 const APIData &extra = APIData(),
+                 const std::string &meta_uri = "")
+        : _uri(uri), _vals(vals), _extra(extra), _meta_uri(meta_uri)
+    {
     }
 
-    ~unsup_result() {}
+    ~unsup_result()
+    {
+    }
 
     void binarized()
     {
-      for (size_t i=0;i<_vals.size();i++)
-	_vals.at(i) = _vals.at(i) <= 0.0 ? 0.0 : 1.0;
+      for (size_t i = 0; i < _vals.size(); i++)
+        _vals.at(i) = _vals.at(i) <= 0.0 ? 0.0 : 1.0;
     }
-    
+
     void bool_binarized()
     {
-      for (size_t i=0;i<_vals.size();i++)
-	_bvals.push_back(_vals.at(i) <= 0.0 ? false : true);
+      for (size_t i = 0; i < _vals.size(); i++)
+        _bvals.push_back(_vals.at(i) <= 0.0 ? false : true);
       _vals.clear();
     }
 
     void string_binarized()
     {
-       for (size_t i=0;i<_vals.size();i++)
-	_str += _vals.at(i) <= 0.0 ? "0" : "1";
+      for (size_t i = 0; i < _vals.size(); i++)
+        _str += _vals.at(i) <= 0.0 ? "0" : "1";
       _vals.clear();
     }
 
 #ifdef USE_SIMSEARCH
     void add_nn(const double dist, const std::string &uri)
     {
-      _nns.insert(std::pair<double,std::string>(dist,uri));
+      _nns.insert(std::pair<double, std::string>(dist, uri));
     }
 #endif
-    
+
     std::string _uri;
     std::vector<double> _vals;
     std::vector<bool> _bvals;
     std::string _str;
 #ifdef USE_SIMSEARCH
     bool _indexed = false;
-    std::multimap<double,std::string> _nns; /**< nearest neigbors. */
+    std::multimap<double, std::string> _nns; /**< nearest neigbors. */
 #endif
-    APIData _extra; /**< other metadata, e.g. image size.*/
+    APIData _extra;        /**< other metadata, e.g. image size.*/
     std::string _meta_uri; // used for indexing from a chain
   };
-  
+
   /**
    * \brief supervised machine learning output connector class
    */
   class UnsupervisedOutput : public OutputConnectorStrategy
   {
   public:
-    UnsupervisedOutput()
-      :OutputConnectorStrategy()
-      {
-      }
+    UnsupervisedOutput() : OutputConnectorStrategy()
+    {
+    }
 
     UnsupervisedOutput(const UnsupervisedOutput &uout)
-      :OutputConnectorStrategy(uout)
-      {
-      }
+        : OutputConnectorStrategy(uout)
+    {
+    }
 
-    ~UnsupervisedOutput() {}
+    ~UnsupervisedOutput()
+    {
+    }
 
     void init(const APIData &ad)
     {
       APIData ad_out = ad.getobj("parameters").getobj("output");
       if (ad_out.has("binarized"))
-	_binarized = ad_out.get("binarized").get<bool>();
+        _binarized = ad_out.get("binarized").get<bool>();
       else if (ad_out.has("bool_binarized"))
-	_bool_binarized = ad_out.get("bool_binarized").get<bool>();
+        _bool_binarized = ad_out.get("bool_binarized").get<bool>();
       else if (ad_out.has("string_binarized"))
-	_string_binarized = ad_out.get("string_binarized").get<bool>();
+        _string_binarized = ad_out.get("string_binarized").get<bool>();
     }
-    
+
     void add_results(const std::vector<APIData> &vrad)
     {
-      std::unordered_map<std::string,int>::iterator hit;
-      for (APIData ad: vrad)
-	{
-	  std::string uri = ad.get("uri").get<std::string>();
-      if (!ad.has("vals"))
+      std::unordered_map<std::string, int>::iterator hit;
+      for (APIData ad : vrad)
         {
-          this->_logger->error("unsupervised output needs mllib.extract_layer param");
-          return;
+          std::string uri = ad.get("uri").get<std::string>();
+          if (!ad.has("vals"))
+            {
+              this->_logger->error(
+                  "unsupervised output needs mllib.extract_layer param");
+              return;
+            }
+          std::vector<double> vals = ad.get("vals").get<std::vector<double>>();
+          if ((hit = _vres.find(uri)) == _vres.end())
+            {
+              _vres.insert(std::pair<std::string, int>(uri, _vvres.size()));
+              APIData extra;
+              if (ad.has("imgsize"))
+                extra.add("imgsize", ad.getobj("imgsize"));
+              if (ad.has("confidences"))
+                extra.add("confidences", ad.getobj("confidences"));
+              std::string meta_uri;
+              if (ad.has("index_uri"))
+                meta_uri = ad.get("index_uri").get<std::string>();
+              else if (ad.has("meta_uri"))
+                meta_uri = ad.get("meta_uri").get<std::string>();
+              _vvres.push_back(unsup_result(uri, vals, extra, meta_uri));
+            }
         }
-	  std::vector<double> vals = ad.get("vals").get<std::vector<double>>();
-	  if ((hit=_vres.find(uri))==_vres.end())
-	    {
-	      _vres.insert(std::pair<std::string,int>(uri,_vvres.size()));
-             APIData extra;
-             if (ad.has("imgsize"))
-               extra.add("imgsize",ad.getobj("imgsize"));
-             if (ad.has("confidences"))
-               extra.add("confidences",ad.getobj("confidences"));
-	     std::string meta_uri;
-	     if (ad.has("index_uri"))
-	       meta_uri = ad.get("index_uri").get<std::string>();
-	     else if (ad.has("meta_uri"))
-	       meta_uri = ad.get("meta_uri").get<std::string>();
-	     _vvres.push_back(unsup_result(uri,vals,extra,meta_uri));
-	    }
-	  
-	}
     }
 
     void finalize(const APIData &ad_in, APIData &ad_out, MLModel *mlm)
@@ -142,155 +145,173 @@ namespace dd
       (void)mlm;
 #endif
       if (ad_in.has("binarized"))
-	_binarized = ad_in.get("binarized").get<bool>();
+        _binarized = ad_in.get("binarized").get<bool>();
       else if (ad_in.has("bool_binarized"))
-	_bool_binarized = ad_in.get("bool_binarized").get<bool>();
+        _bool_binarized = ad_in.get("bool_binarized").get<bool>();
       else if (ad_in.has("string_binarized"))
-	_string_binarized = ad_in.get("string_binarized").get<bool>();
+        _string_binarized = ad_in.get("string_binarized").get<bool>();
       if (_binarized)
-	{
-	  for (size_t i=0;i<_vvres.size();i++)
-	    {
-	      _vvres.at(i).binarized();
-	    }
-	}
+        {
+          for (size_t i = 0; i < _vvres.size(); i++)
+            {
+              _vvres.at(i).binarized();
+            }
+        }
       else if (_bool_binarized)
-	{
-	  for (size_t i=0;i<_vvres.size();i++)
-	    {
-	      _vvres.at(i).bool_binarized();
-	    }
-	}
+        {
+          for (size_t i = 0; i < _vvres.size(); i++)
+            {
+              _vvres.at(i).bool_binarized();
+            }
+        }
       else if (_string_binarized)
-	{
-	  for (size_t i=0;i<_vvres.size();i++)
-	    {
-	      _vvres.at(i).string_binarized();
-	    }
-	}
+        {
+          for (size_t i = 0; i < _vvres.size(); i++)
+            {
+              _vvres.at(i).string_binarized();
+            }
+        }
 
       std::unordered_set<std::string> indexed_uris;
 #ifdef USE_SIMSEARCH
       if (ad_in.has("index") && ad_in.get("index").get<bool>())
-	{
-	  // check whether index has been created
-	  if (!mlm->_se)
-	    {
-	      int index_dim = _vvres.at(0)._vals.size(); //XXX: lookup to the batch's first output, as they should all have the same size
-	      mlm->create_sim_search(index_dim,ad_in);
-	    }
-	      
-	  // index output content -> vector (XXX: will need to flatten in case of multiple vectors)
+        {
+          // check whether index has been created
+          if (!mlm->_se)
+            {
+              int index_dim
+                  = _vvres.at(0)._vals.size(); // XXX: lookup to the batch's
+                                               // first output, as they should
+                                               // all have the same size
+              mlm->create_sim_search(index_dim, ad_in);
+            }
+
+            // index output content -> vector (XXX: will need to flatten in
+            // case of multiple vectors)
 #ifdef USE_FAISS
-      std::vector<URIData> urids;
-      std::vector<std::vector<double>> vvals;
+          std::vector<URIData> urids;
+          std::vector<std::vector<double>> vvals;
 #endif
-	  for (size_t i=0;i<_vvres.size();i++)
-	    {
-	      URIData urid;
-	      if (_vvres.at(i)._meta_uri.empty())
-		urid = URIData(_vvres.at(i)._uri);
-	      else urid = URIData(_vvres.at(i)._meta_uri);
+          for (size_t i = 0; i < _vvres.size(); i++)
+            {
+              URIData urid;
+              if (_vvres.at(i)._meta_uri.empty())
+                urid = URIData(_vvres.at(i)._uri);
+              else
+                urid = URIData(_vvres.at(i)._meta_uri);
 #ifdef USE_FAISS
-          urids.push_back(urid);
-          vvals.push_back(_vvres.at(i)._vals);
+              urids.push_back(urid);
+              vvals.push_back(_vvres.at(i)._vals);
 #else
-	      mlm->_se->index(urid,_vvres.at(i)._vals);
+              mlm->_se->index(urid, _vvres.at(i)._vals);
 #endif
-	      indexed_uris.insert(urid._uri);
-	    }
+              indexed_uris.insert(urid._uri);
+            }
 #ifdef USE_FAISS
-      mlm->_se->index(urids,vvals);
+          mlm->_se->index(urids, vvals);
 #endif
-	}
+        }
       if (ad_in.has("build_index") && ad_in.get("build_index").get<bool>())
-	{
-	  if (mlm->_se)
-	    mlm->build_index();
-	  else throw SimIndexException("Cannot build index if not created");
-	}
+        {
+          if (mlm->_se)
+            mlm->build_index();
+          else
+            throw SimIndexException("Cannot build index if not created");
+        }
 
       if (ad_in.has("search") && ad_in.get("search").get<bool>())
-	{
-	  if (!mlm->_se)
-	    {
-	      int index_dim = _vvres.at(0)._vals.size(); //XXX: lookup to the batch's first output, as they should all have the same size
-	      mlm->create_sim_search(index_dim,ad_in);
-	    }
-	  
-	  int search_nn = _search_nn;
-	  if (ad_in.has("search_nn"))
-	    search_nn = ad_in.get("search_nn").get<int>();
+        {
+          if (!mlm->_se)
+            {
+              int index_dim
+                  = _vvres.at(0)._vals.size(); // XXX: lookup to the batch's
+                                               // first output, as they should
+                                               // all have the same size
+              mlm->create_sim_search(index_dim, ad_in);
+            }
+
+          int search_nn = _search_nn;
+          if (ad_in.has("search_nn"))
+            search_nn = ad_in.get("search_nn").get<int>();
 #ifdef USE_FAISS
-      if (ad_in.has("nprobe"))
-        mlm->_se->_tse->_nprobe = ad_in.get("nprobe").get<int>();
+          if (ad_in.has("nprobe"))
+            mlm->_se->_tse->_nprobe = ad_in.get("nprobe").get<int>();
 #endif
-	  for (size_t i=0;i<_vvres.size();i++)
-	    {
-	      std::vector<URIData> nn_uris;
-	      std::vector<double> nn_distances;
-	      mlm->_se->search(_vvres.at(i)._vals,search_nn,nn_uris,nn_distances);
-	      for (size_t j=0;j<nn_uris.size();j++)
-		{
-		  _vvres.at(i).add_nn(nn_distances.at(j),nn_uris.at(j)._uri);
-		}
-	    }
-	}
+          for (size_t i = 0; i < _vvres.size(); i++)
+            {
+              std::vector<URIData> nn_uris;
+              std::vector<double> nn_distances;
+              mlm->_se->search(_vvres.at(i)._vals, search_nn, nn_uris,
+                               nn_distances);
+              for (size_t j = 0; j < nn_uris.size(); j++)
+                {
+                  _vvres.at(i).add_nn(nn_distances.at(j), nn_uris.at(j)._uri);
+                }
+            }
+        }
 #endif
-      
-      to_ad(ad_out,indexed_uris);
+
+      to_ad(ad_out, indexed_uris);
     }
 
-    void to_ad(APIData &out, const std::unordered_set<std::string> &indexed_uris) const
+    void to_ad(APIData &out,
+               const std::unordered_set<std::string> &indexed_uris) const
     {
 #ifndef USE_SIMSEARCH
       (void)indexed_uris;
 #endif
       std::unordered_set<std::string>::const_iterator hit;
       std::vector<APIData> vpred;
-      for (size_t i=0;i<_vvres.size();i++)
-	{
-	  APIData adpred;
-	  adpred.add("uri",_vvres.at(i)._uri);
-	  if (_bool_binarized)
-	    adpred.add("vals",_vvres.at(i)._bvals);
-	  else if (_string_binarized)
-	    adpred.add("vals",_vvres.at(i)._str);
-	  else adpred.add("vals",_vvres.at(i)._vals);
-	  if (_vvres.at(i)._extra.has("imgsize"))
-	    adpred.add("imgsize",_vvres.at(i)._extra.getobj("imgsize"));
-	  if (_vvres.at(i)._extra.has("confidences"))
-	    adpred.add("confidences",_vvres.at(i)._extra.getobj("confidences"));
-	  if (i == _vvres.size()-1)
-	    adpred.add("last",true);
+      for (size_t i = 0; i < _vvres.size(); i++)
+        {
+          APIData adpred;
+          adpred.add("uri", _vvres.at(i)._uri);
+          if (_bool_binarized)
+            adpred.add("vals", _vvres.at(i)._bvals);
+          else if (_string_binarized)
+            adpred.add("vals", _vvres.at(i)._str);
+          else
+            adpred.add("vals", _vvres.at(i)._vals);
+          if (_vvres.at(i)._extra.has("imgsize"))
+            adpred.add("imgsize", _vvres.at(i)._extra.getobj("imgsize"));
+          if (_vvres.at(i)._extra.has("confidences"))
+            adpred.add("confidences",
+                       _vvres.at(i)._extra.getobj("confidences"));
+          if (i == _vvres.size() - 1)
+            adpred.add("last", true);
 #ifdef USE_SIMSEARCH
-	  if (!indexed_uris.empty() && (hit=indexed_uris.find(_vvres.at(i)._uri))!=indexed_uris.end())
-	    adpred.add("indexed",true);
-	  if (!_vvres.at(i)._nns.empty())
-	    {
-	      std::vector<APIData> ad_nns;
-	      auto mit = _vvres.at(i)._nns.begin();
-	      while(mit!=_vvres.at(i)._nns.end())
-		{
-		  APIData ad_nn;
-		  ad_nn.add("uri",(*mit).second);
-		  ad_nn.add("dist",(*mit).first);
-		  ad_nns.push_back(ad_nn);
-		  ++mit;
-		}
-	      adpred.add("nns",ad_nns);
-	    }
+          if (!indexed_uris.empty()
+              && (hit = indexed_uris.find(_vvres.at(i)._uri))
+                     != indexed_uris.end())
+            adpred.add("indexed", true);
+          if (!_vvres.at(i)._nns.empty())
+            {
+              std::vector<APIData> ad_nns;
+              auto mit = _vvres.at(i)._nns.begin();
+              while (mit != _vvres.at(i)._nns.end())
+                {
+                  APIData ad_nn;
+                  ad_nn.add("uri", (*mit).second);
+                  ad_nn.add("dist", (*mit).first);
+                  ad_nns.push_back(ad_nn);
+                  ++mit;
+                }
+              adpred.add("nns", ad_nns);
+            }
 #endif
-	  vpred.push_back(adpred);
-	}
-      out.add("predictions",vpred);
+          vpred.push_back(adpred);
+        }
+      out.add("predictions", vpred);
     }
-    
-    std::unordered_map<std::string,int> _vres; /**< batch of results index, per uri. */
+
+    std::unordered_map<std::string, int>
+        _vres;                        /**< batch of results index, per uri. */
     std::vector<unsup_result> _vvres; /**< ordered results, per uri. */
     bool _binarized = false; /**< binary representation of output values. */
-    bool _bool_binarized = false; /**< boolean binary representation of output values. */
-    bool _string_binarized = false; /**< boolean string as binary representation of output values. */
+    bool _bool_binarized
+        = false; /**< boolean binary representation of output values. */
+    bool _string_binarized = false; /**< boolean string as binary
+                                       representation of output values. */
 #ifdef USE_SIMSEARCH
     int _search_nn = 10; /**< default nearest neighbors per search. */
 #endif

--- a/src/utils/apitools.h
+++ b/src/utils/apitools.h
@@ -24,63 +24,80 @@
 
 #include "apidata.h"
 
-namespace dd {
-  namespace apitools {
+namespace dd
+{
+  namespace apitools
+  {
 
     template <typename T>
     inline bool get_variant(const ad_variant_type &adv,
-			    const std::function<void(const T&)> &f) {
-      if (!adv.is<T>()) {
-	return false;
-      }
+                            const std::function<void(const T &)> &f)
+    {
+      if (!adv.is<T>())
+        {
+          return false;
+        }
       f(adv.get<T>());
       return true;
     }
 
-    // Simple way to retrieve a value from an APIData when the type is uncertain
+    // Simple way to retrieve a value from an APIData when the type is
+    // uncertain
     template <typename T1, typename T2>
     inline void test_variants(const APIData &ad, const std::string &name,
-			      const std::function<void(const T1&)> &f1,
-			      const std::function<void(const T2&)> &f2) {
+                              const std::function<void(const T1 &)> &f1,
+                              const std::function<void(const T2 &)> &f2)
+    {
       const ad_variant_type &adv = ad.get(name);
-      if (get_variant<T1>(adv, f1));
-      else if (get_variant<T2>(adv, f2));
-      else throw std::runtime_error("Invalid type for '" + std::string(name) + "'");
+      if (get_variant<T1>(adv, f1))
+        ;
+      else if (get_variant<T2>(adv, f2))
+        ;
+      else
+        throw std::runtime_error("Invalid type for '" + std::string(name)
+                                 + "'");
     }
 
     // Try to cast a single value
     template <typename T1, typename T2, typename Out>
-    inline void get_with_cast(const APIData &ad, const std::string &name, Out &out) {
-      test_variants<T1, T2>
-	(ad, name,
-	 [&](const T1 &v){out = static_cast<Out>(v);},
-	 [&](const T2 &v){out = static_cast<Out>(v);});
+    inline void get_with_cast(const APIData &ad, const std::string &name,
+                              Out &out)
+    {
+      test_variants<T1, T2>(
+          ad, name, [&](const T1 &v) { out = static_cast<Out>(v); },
+          [&](const T2 &v) { out = static_cast<Out>(v); });
     }
 
     // Try to cast a vector
     template <typename T1, typename T2, typename Out>
-    inline void get_with_cast(const APIData &ad, const std::string &name, std::vector<Out> &out) {
-      test_variants<std::vector<T1>, std::vector<T2>>
-	(ad, name,
-	 [&](const std::vector<T1> &v){out.assign(v.begin(), v.end());},
-	 [&](const std::vector<T2> &v){out.assign(v.begin(), v.end());});
+    inline void get_with_cast(const APIData &ad, const std::string &name,
+                              std::vector<Out> &out)
+    {
+      test_variants<std::vector<T1>, std::vector<T2>>(
+          ad, name,
+          [&](const std::vector<T1> &v) { out.assign(v.begin(), v.end()); },
+          [&](const std::vector<T2> &v) { out.assign(v.begin(), v.end()); });
     }
 
     // Floats can be fetched from doubles and integers
-    inline void get_float(const APIData &ad, const std::string &name, float &v) {
+    inline void get_float(const APIData &ad, const std::string &name, float &v)
+    {
       get_with_cast<double, int, float>(ad, name, v);
     }
-    inline void get_floats(const APIData &ad, const std::string &name, std::vector<float> &v) {
+    inline void get_floats(const APIData &ad, const std::string &name,
+                           std::vector<float> &v)
+    {
       get_with_cast<double, int, float>(ad, name, v);
     }
 
     // Try as one or several values
-    template<typename Out>
-    inline void get_vector(const APIData &ad, const std::string &name, std::vector<Out> &out) {
-      test_variants<Out, std::vector<Out>>
-	(ad, name,
-	 [&](const Out &v){out = {v};},
-	 [&](const std::vector<Out> &v){out = v;});
+    template <typename Out>
+    inline void get_vector(const APIData &ad, const std::string &name,
+                           std::vector<Out> &out)
+    {
+      test_variants<Out, std::vector<Out>>(
+          ad, name, [&](const Out &v) { out = { v }; },
+          [&](const std::vector<Out> &v) { out = v; });
     }
 
   }

--- a/src/utils/fileops.hpp
+++ b/src/utils/fileops.hpp
@@ -30,10 +30,10 @@
 #include <boost/filesystem.hpp>
 
 #if !defined(WIN32)
-  #include <dirent.h>
-  #include <unistd.h>
-  #include <archive.h>
-  #include <archive_entry.h>
+#include <dirent.h>
+#include <unistd.h>
+#include <archive.h>
+#include <archive_entry.h>
 #endif
 
 namespace dd
@@ -41,93 +41,94 @@ namespace dd
   class fileops
   {
   public:
-
 #if defined(WIN32)
     static bool create_dir(const std::string &dirName, int mode)
-	{
-        assert(false);
-        return false;
+    {
+      assert(false);
+      return false;
     }
 
     static bool file_exists(const std::string &fname)
     {
-        boost::filesystem::path p(fname);
+      boost::filesystem::path p(fname);
 
-        return boost::filesystem::exists(p);
+      return boost::filesystem::exists(p);
     }
 
     static bool file_exists(const std::string &fname, bool &directory)
     {
-        boost::filesystem::path p(fname);
+      boost::filesystem::path p(fname);
 
-        directory = boost::filesystem::is_directory(p);
-        return boost::filesystem::exists(p);
+      directory = boost::filesystem::is_directory(p);
+      return boost::filesystem::exists(p);
     }
 
     static bool is_db(const std::string &fname)
     {
-        const std::vector<std::string> db_exts = { ".lmdb" }; // add more here
-        for (auto e : db_exts)
-            if (fname.find(e) != std::string::npos)
-                return true;
-        return false;
+      const std::vector<std::string> db_exts = { ".lmdb" }; // add more here
+      for (auto e : db_exts)
+        if (fname.find(e) != std::string::npos)
+          return true;
+      return false;
     }
 
     static long int file_last_modif(const std::string &fname)
     {
-        boost::filesystem::path p(fname);
+      boost::filesystem::path p(fname);
 
-        return boost::filesystem::last_write_time(p);
+      return boost::filesystem::last_write_time(p);
     }
-
 
     static int clear_directory(const std::string &repo)
     {
-        assert(false);
-        return -1;
+      assert(false);
+      return -1;
     }
 
     static int remove_dir(const std::string &d)
     {
-        assert(false);
-        return -1;
+      assert(false);
+      return -1;
     }
 
-    static int uncompress(const std::string &fc,
-        const std::string &repo)
+    static int uncompress(const std::string &fc, const std::string &repo)
     {
-        assert(false);
-        return -1;
+      assert(false);
+      return -1;
     }
 
 #else
     static bool create_dir(const std::string &dirName, mode_t mode)
     {
       std::string s = dirName;
-      size_t pre=0,pos;
+      size_t pre = 0, pos;
       std::string dir;
       int mdret = 0;
 
-      if(s[s.size()-1]!='/'){
-        // force trailing / so we can handle everything in loop
-        s+='/';
-      }
-
-      while((pos=s.find_first_of('/',pre))!=std::string::npos){
-        dir=s.substr(0,pos++);
-        pre=pos;
-        if(dir.size()==0) continue; // if leading / first time is 0 length
-        if((mdret=mkdir(dir.c_str(),mode)) && errno!=EEXIST){
-          return mdret;
+      if (s[s.size() - 1] != '/')
+        {
+          // force trailing / so we can handle everything in loop
+          s += '/';
         }
-      }
+
+      while ((pos = s.find_first_of('/', pre)) != std::string::npos)
+        {
+          dir = s.substr(0, pos++);
+          pre = pos;
+          if (dir.size() == 0)
+            continue; // if leading / first time is 0 length
+          if ((mdret = mkdir(dir.c_str(), mode)) && errno != EEXIST)
+            {
+              return mdret;
+            }
+        }
       return mdret;
     }
 
     static bool file_exists(const std::string &fname)
     {
       struct stat bstat;
-      return (stat(fname.c_str(),&bstat)==0);
+      return (stat(fname.c_str(), &bstat) == 0);
     }
 
     static bool dir_exists(const std::string &fname)
@@ -137,73 +138,75 @@ namespace dd
       return exists && dir;
     }
 
-    static bool file_exists(const std::string &fname,
-			    bool &directory)
+    static bool file_exists(const std::string &fname, bool &directory)
     {
       struct stat bstat;
-      int r = stat(fname.c_str(),&bstat);
+      int r = stat(fname.c_str(), &bstat);
       if (r != 0)
-	{
-	  directory = false;
-	  return false;
-	}
+        {
+          directory = false;
+          return false;
+        }
       if (S_ISDIR(bstat.st_mode))
-	directory = true;
-      else directory = false;
-      return r == 0; 
+        directory = true;
+      else
+        directory = false;
+      return r == 0;
     }
 
     static bool is_db(const std::string &fname)
     {
-      const std::vector<std::string> db_exts = {".lmdb"}; // add more here
-      for (auto e: db_exts)
-	if (fname.find(e) != std::string::npos)
-	  return true;
+      const std::vector<std::string> db_exts = { ".lmdb" }; // add more here
+      for (auto e : db_exts)
+        if (fname.find(e) != std::string::npos)
+          return true;
       return false;
     }
-    
+
     static long int file_last_modif(const std::string &fname)
     {
       struct stat bstat;
-      if (stat(fname.c_str(),&bstat)==0)
-	return bstat.st_mtim.tv_sec;
-      else return -1;
+      if (stat(fname.c_str(), &bstat) == 0)
+        return bstat.st_mtim.tv_sec;
+      else
+        return -1;
     }
 
-    static int list_directory(const std::string &repo,
-        const bool &files,
-        const bool &dirs,
-        const bool &sub_files,
-        std::unordered_set<std::string> &lfiles)
+    static int list_directory(const std::string &repo, const bool &files,
+                              const bool &dirs, const bool &sub_files,
+                              std::unordered_set<std::string> &lfiles)
     {
-        boost::filesystem::path p(repo);
+      boost::filesystem::path p(repo);
 
-        if (!boost::filesystem::is_directory(p))
-            return 1;
+      if (!boost::filesystem::is_directory(p))
+        return 1;
 
-        boost::filesystem::directory_iterator dir_iter(p);
-        boost::filesystem::directory_iterator end_iter;
-        for (; dir_iter != end_iter; ++dir_iter)
+      boost::filesystem::directory_iterator dir_iter(p);
+      boost::filesystem::directory_iterator end_iter;
+      for (; dir_iter != end_iter; ++dir_iter)
         {
-            if ((dirs && boost::filesystem::is_directory(dir_iter->status())) ||
-                (files && boost::filesystem::is_regular_file(dir_iter->status())) ||
-                ((dirs||files) && boost::filesystem::is_symlink(dir_iter->status())))
-                lfiles.insert(dir_iter->path().string());
+          if ((dirs && boost::filesystem::is_directory(dir_iter->status()))
+              || (files
+                  && boost::filesystem::is_regular_file(dir_iter->status()))
+              || ((dirs || files)
+                  && boost::filesystem::is_symlink(dir_iter->status())))
+            lfiles.insert(dir_iter->path().string());
 
-            if (sub_files &&
-                (boost::filesystem::is_directory(dir_iter->status()) ||
-                    boost::filesystem::is_symlink(dir_iter->status())))
-                list_directory(dir_iter->path().string(), files, dirs, sub_files, lfiles);
+          if (sub_files
+              && (boost::filesystem::is_directory(dir_iter->status())
+                  || boost::filesystem::is_symlink(dir_iter->status())))
+            list_directory(dir_iter->path().string(), files, dirs, sub_files,
+                           lfiles);
         }
 
-        return 0;
+      return 0;
     }
 
     // remove everything, including first level directories within directory
     static int clear_directory(const std::string &repo)
     {
       boost::system::error_code ercode;
-      boost::filesystem::directory_iterator dir_iter(repo,ercode);
+      boost::filesystem::directory_iterator dir_iter(repo, ercode);
       boost::filesystem::directory_iterator end_iter;
       int err = ercode.value();
       if (ercode.value() != 0)
@@ -212,7 +215,7 @@ namespace dd
       err = 0;
       for (; dir_iter != end_iter; ++dir_iter)
         {
-          boost::filesystem::remove_all(*dir_iter,ercode);
+          boost::filesystem::remove_all(*dir_iter, ercode);
           if (ercode.value() == ENOENT || ercode.value() == EACCES)
             err++;
         }
@@ -220,11 +223,12 @@ namespace dd
     }
 
     // empty extensions means a wildcard
-    static int remove_directory_files(const std::string &repo,
-				      const std::vector<std::string> &extensions)
+    static int
+    remove_directory_files(const std::string &repo,
+                           const std::vector<std::string> &extensions)
     {
       boost::system::error_code ercode;
-      boost::filesystem::directory_iterator dir_iter(repo,ercode);
+      boost::filesystem::directory_iterator dir_iter(repo, ercode);
       boost::filesystem::directory_iterator end_iter;
       int err = ercode.value();
       if (ercode.value() != 0)
@@ -235,7 +239,7 @@ namespace dd
         {
           if (extensions.empty())
             {
-              boost::filesystem::remove_all(*dir_iter,ercode);
+              boost::filesystem::remove_all(*dir_iter, ercode);
               if (ercode.value() == ENOENT || ercode.value() == EACCES)
                 err++;
             }
@@ -244,7 +248,7 @@ namespace dd
               for (std::string s : extensions)
                 if (dir_iter->path().native().find(s) != std::string::npos)
                   {
-                    boost::filesystem::remove(*dir_iter,ercode);
+                    boost::filesystem::remove(*dir_iter, ercode);
                     if (ercode.value() == ENOENT || ercode.value() == EACCES)
                       err++;
                   }
@@ -253,27 +257,25 @@ namespace dd
       return err;
     }
 
-    static int copy_file(const std::string &fin,
-			 const std::string &fout)
+    static int copy_file(const std::string &fin, const std::string &fout)
     {
-      std::ifstream src(fin,std::ios::binary);
+      std::ifstream src(fin, std::ios::binary);
       if (!src.is_open())
-	return 1;
-      std::ofstream dst(fout,std::ios::binary);
+        return 1;
+      std::ofstream dst(fout, std::ios::binary);
       if (!dst.is_open())
-	return 2;
+        return 2;
       dst << src.rdbuf();
       src.close();
       dst.close();
       return 0;
     }
 
-    static int remove_file(const std::string &repo,
-			   const std::string &f)
+    static int remove_file(const std::string &repo, const std::string &f)
     {
       std::string fn = repo + "/" + f;
       if (remove(fn.c_str()))
-	return -1; // error.
+        return -1; // error.
       return 0;
     }
 
@@ -291,22 +293,24 @@ namespace dd
       size_t size;
       int64_t offset;
 
-      for (;;) {
-	r = archive_read_data_block(ar, &buff, &size, &offset);
-	if (r == ARCHIVE_EOF)
-	  return (ARCHIVE_OK);
-	if (r < ARCHIVE_OK)
-	  return (r);
-	r = archive_write_data_block(aw, buff, size, offset);
-	if (r < ARCHIVE_OK) {
-	  std::cerr << "archive error: " << archive_error_string(aw) << std::endl;
-	  return r;
-	}
-      }
+      for (;;)
+        {
+          r = archive_read_data_block(ar, &buff, &size, &offset);
+          if (r == ARCHIVE_EOF)
+            return (ARCHIVE_OK);
+          if (r < ARCHIVE_OK)
+            return (r);
+          r = archive_write_data_block(aw, buff, size, offset);
+          if (r < ARCHIVE_OK)
+            {
+              std::cerr << "archive error: " << archive_error_string(aw)
+                        << std::endl;
+              return r;
+            }
+        }
     }
-    
-    static int uncompress(const std::string &fc,
-			  const std::string &repo)
+
+    static int uncompress(const std::string &fc, const std::string &repo)
     {
       struct archive *a;
       struct archive *ext;
@@ -315,51 +319,61 @@ namespace dd
       int r;
 
       flags = ARCHIVE_EXTRACT_TIME;
-      //flags |= ARCHIVE_EXTRACT_PERM;
-      //flags |= ARCHIVE_EXTRACT_ACL;
+      // flags |= ARCHIVE_EXTRACT_PERM;
+      // flags |= ARCHIVE_EXTRACT_ACL;
       flags |= ARCHIVE_EXTRACT_FFLAGS;
-      
+
       a = archive_read_new();
       archive_read_support_format_all(a);
       archive_read_support_filter_all(a);
       ext = archive_write_disk_new();
       archive_write_disk_set_options(ext, flags);
       archive_write_disk_set_standard_lookup(ext);
-      if ((r = archive_read_open_filename(a, fc.c_str(), 10240))) // 10240 is block_size
-	return r;
-      for (;;) {
-	r = archive_read_next_header(a, &entry);
-	if (r == ARCHIVE_EOF)
-	  break;
-	if (r < ARCHIVE_OK)
-	  std::cerr <<  "archive error: " << archive_error_string(a) << std::endl;
-	if (r < ARCHIVE_WARN) {
-	  std::cerr << "archive error, aborting\n";
-	  return 1;
-	}
-	const char * compressed_head = archive_entry_pathname(entry);
-	const std::string full_outpath = repo + "/" + compressed_head;
-	archive_entry_set_pathname(entry,full_outpath.c_str());
-	r = archive_write_header(ext, entry);
-	if (r < ARCHIVE_OK)
-	  std::cerr << "archive error: " << archive_error_string(ext) << std::endl;
-	else if (archive_entry_size(entry) > 0) {
-	  r = copy_uncompressed_data(a, ext);
-	  if (r < ARCHIVE_OK)
-	    std::cerr << "error writing uncompressed data: " << archive_error_string(ext) << std::endl;
-	  if (r < ARCHIVE_WARN) {
-	    std::cerr << "archive error, aborting\n";
-	    return 2;
-	  }
-	}
-	r = archive_write_finish_entry(ext);
-	if (r < ARCHIVE_OK)
-	  std::cerr << "error finishing uncompressed data entry: " << archive_error_string(ext) << std::endl;
-	if (r < ARCHIVE_WARN) {
-	  std::cerr << "archive error, aborting\n";
-	  return 3;
-	}
-      }
+      if ((r = archive_read_open_filename(a, fc.c_str(),
+                                          10240))) // 10240 is block_size
+        return r;
+      for (;;)
+        {
+          r = archive_read_next_header(a, &entry);
+          if (r == ARCHIVE_EOF)
+            break;
+          if (r < ARCHIVE_OK)
+            std::cerr << "archive error: " << archive_error_string(a)
+                      << std::endl;
+          if (r < ARCHIVE_WARN)
+            {
+              std::cerr << "archive error, aborting\n";
+              return 1;
+            }
+          const char *compressed_head = archive_entry_pathname(entry);
+          const std::string full_outpath = repo + "/" + compressed_head;
+          archive_entry_set_pathname(entry, full_outpath.c_str());
+          r = archive_write_header(ext, entry);
+          if (r < ARCHIVE_OK)
+            std::cerr << "archive error: " << archive_error_string(ext)
+                      << std::endl;
+          else if (archive_entry_size(entry) > 0)
+            {
+              r = copy_uncompressed_data(a, ext);
+              if (r < ARCHIVE_OK)
+                std::cerr << "error writing uncompressed data: "
+                          << archive_error_string(ext) << std::endl;
+              if (r < ARCHIVE_WARN)
+                {
+                  std::cerr << "archive error, aborting\n";
+                  return 2;
+                }
+            }
+          r = archive_write_finish_entry(ext);
+          if (r < ARCHIVE_OK)
+            std::cerr << "error finishing uncompressed data entry: "
+                      << archive_error_string(ext) << std::endl;
+          if (r < ARCHIVE_WARN)
+            {
+              std::cerr << "archive error, aborting\n";
+              return 3;
+            }
+        }
       archive_read_close(a);
       archive_read_free(a);
       archive_write_close(ext);
@@ -368,7 +382,7 @@ namespace dd
       return 0;
     }
 #endif
-  };  
+  };
 }
 
 #endif

--- a/src/utils/httpclient.hpp
+++ b/src/utils/httpclient.hpp
@@ -31,16 +31,15 @@ namespace dd
 {
 
   static int _default_timeout = 600; // 10 mins
-  static int _max_timeout = 36000; // 10 hours
-  
+  static int _max_timeout = 36000;   // 10 hours
+
   class httpclient
   {
   public:
     static void get_call(const std::string &url,
-			 const std::string &http_method,
-			 int &outcode,
-			 std::string &outstr,
-			 const int &timeout=_default_timeout)
+                         const std::string &http_method, int &outcode,
+                         std::string &outstr,
+                         const int &timeout = _default_timeout)
     {
       std::ostringstream os;
       curlpp::Easy request;
@@ -51,22 +50,23 @@ namespace dd
       request.setOpt(pr);
       request.setOpt(cURLpp::Options::FollowLocation(true));
       if (timeout > _max_timeout)
-	{
-	  outcode = 400;
-	  throw std::runtime_error("timeout value is above max default timeout (" + std::to_string(_max_timeout) + ")");
-	}
+        {
+          outcode = 400;
+          throw std::runtime_error(
+              "timeout value is above max default timeout ("
+              + std::to_string(_max_timeout) + ")");
+        }
       request.setOpt(cURLpp::Options::Timeout(timeout));
       request.perform();
       outstr = os.str();
       outcode = curlpp::infos::ResponseCode::get(request);
     }
-    
-    static void post_call(const std::string &url,
-			  const std::string &jcontent,
-			  const std::string &http_method,
-			  int &outcode,
-			  std::string &outstr,
-			  const std::string &content_type="Content-Type: application/json")
+
+    static void post_call(const std::string &url, const std::string &jcontent,
+                          const std::string &http_method, int &outcode,
+                          std::string &outstr,
+                          const std::string &content_type
+                          = "Content-Type: application/json")
     {
       std::ostringstream os;
       curlpp::Easy request_put;
@@ -82,11 +82,11 @@ namespace dd
       request_put.setOpt(curlpp::options::PostFieldSize(jcontent.length()));
       request_put.perform();
       outstr = os.str();
-      //std::cout << "outstr=" << outstr << std::endl;
+      // std::cout << "outstr=" << outstr << std::endl;
       outcode = curlpp::infos::ResponseCode::get(request_put);
     }
   };
-  
+
 }
 
 #endif

--- a/src/utils/optional.hpp
+++ b/src/utils/optional.hpp
@@ -1,74 +1,97 @@
 #ifndef MAPBOX_UTIL_OPTIONAL_HPP
 #define MAPBOX_UTIL_OPTIONAL_HPP
 
-#pragma message("This implementation of optional is deprecated. See https://github.com/mapbox/variant/issues/64.")
+#pragma message(                                                              \
+    "This implementation of optional is deprecated. See https://github.com/mapbox/variant/issues/64.")
 
 #include <type_traits>
 #include <utility>
 
 #include <variant.hpp>
 
-namespace mapbox {
-namespace util {
-
-template <typename T>
-class optional
+namespace mapbox
 {
-    static_assert(!std::is_reference<T>::value, "optional doesn't support references");
+  namespace util
+  {
 
-    struct none_type
+    template <typename T> class optional
     {
-    };
+      static_assert(!std::is_reference<T>::value,
+                    "optional doesn't support references");
 
-    variant<none_type, T> variant_;
+      struct none_type
+      {
+      };
 
-public:
-    optional() = default;
+      variant<none_type, T> variant_;
 
-    optional(optional const& rhs)
-    {
+    public:
+      optional() = default;
+
+      optional(optional const &rhs)
+      {
         if (this != &rhs)
-        { // protect against invalid self-assignment
+          { // protect against invalid self-assignment
             variant_ = rhs.variant_;
-        }
-    }
+          }
+      }
 
-    optional(T const& v) { variant_ = v; }
+      optional(T const &v)
+      {
+        variant_ = v;
+      }
 
-    explicit operator bool() const noexcept { return variant_.template is<T>(); }
+      explicit operator bool() const noexcept
+      {
+        return variant_.template is<T>();
+      }
 
-    T const& get() const { return variant_.template get<T>(); }
-    T& get() { return variant_.template get<T>(); }
+      T const &get() const
+      {
+        return variant_.template get<T>();
+      }
+      T &get()
+      {
+        return variant_.template get<T>();
+      }
 
-    T const& operator*() const { return this->get(); }
-    T operator*() { return this->get(); }
+      T const &operator*() const
+      {
+        return this->get();
+      }
+      T operator*()
+      {
+        return this->get();
+      }
 
-    optional& operator=(T const& v)
-    {
+      optional &operator=(T const &v)
+      {
         variant_ = v;
         return *this;
-    }
+      }
 
-    optional& operator=(optional const& rhs)
-    {
+      optional &operator=(optional const &rhs)
+      {
         if (this != &rhs)
-        {
+          {
             variant_ = rhs.variant_;
-        }
+          }
         return *this;
-    }
+      }
 
-    template <typename... Args>
-    void emplace(Args&&... args)
-    {
-        variant_ = T{std::forward<Args>(args)...};
-    }
+      template <typename... Args> void emplace(Args &&... args)
+      {
+        variant_ = T{ std::forward<Args>(args)... };
+      }
 
-    void reset() { variant_ = none_type{}; }
+      void reset()
+      {
+        variant_ = none_type{};
+      }
 
-}; // class optional
+    }; // class optional
 
-} // namespace util
+  } // namespace util
 } // namespace mapbox
 
 #endif // MAPBOX_UTIL_OPTIONAL_HPP

--- a/src/utils/recursive_wrapper.hpp
+++ b/src/utils/recursive_wrapper.hpp
@@ -15,108 +15,132 @@
 #include <cassert>
 #include <utility>
 
-namespace mapbox {
-namespace util {
-
-template <typename T>
-class recursive_wrapper
+namespace mapbox
 {
+  namespace util
+  {
 
-    T* p_;
-
-    void assign(T const& rhs)
+    template <typename T> class recursive_wrapper
     {
+
+      T *p_;
+
+      void assign(T const &rhs)
+      {
         this->get() = rhs;
-    }
+      }
 
-public:
-    using type = T;
+    public:
+      using type = T;
 
-    /**
-     * Default constructor default initializes the internally stored value.
-     * For POD types this means nothing is done and the storage is
-     * uninitialized.
-     *
-     * @throws std::bad_alloc if there is insufficient memory for an object
-     *         of type T.
-     * @throws any exception thrown by the default constructur of T.
-     */
-    recursive_wrapper()
-        : p_(new T){}
+      /**
+       * Default constructor default initializes the internally stored value.
+       * For POD types this means nothing is done and the storage is
+       * uninitialized.
+       *
+       * @throws std::bad_alloc if there is insufficient memory for an object
+       *         of type T.
+       * @throws any exception thrown by the default constructur of T.
+       */
+      recursive_wrapper() : p_(new T)
+      {
+      }
 
-    ~recursive_wrapper() noexcept { delete p_; }
+      ~recursive_wrapper() noexcept
+      {
+        delete p_;
+      }
 
-    recursive_wrapper(recursive_wrapper const& operand)
-        : p_(new T(operand.get())) {}
+      recursive_wrapper(recursive_wrapper const &operand)
+          : p_(new T(operand.get()))
+      {
+      }
 
-    recursive_wrapper(T const& operand)
-        : p_(new T(operand)) {}
+      recursive_wrapper(T const &operand) : p_(new T(operand))
+      {
+      }
 
-    recursive_wrapper(recursive_wrapper&& operand)
-        : p_(new T(std::move(operand.get()))) {}
+      recursive_wrapper(recursive_wrapper &&operand)
+          : p_(new T(std::move(operand.get())))
+      {
+      }
 
-    recursive_wrapper(T&& operand)
-        : p_(new T(std::move(operand))) {}
+      recursive_wrapper(T &&operand) : p_(new T(std::move(operand)))
+      {
+      }
 
-    inline recursive_wrapper& operator=(recursive_wrapper const& rhs)
-    {
+      inline recursive_wrapper &operator=(recursive_wrapper const &rhs)
+      {
         assign(rhs.get());
         return *this;
-    }
+      }
 
-    inline recursive_wrapper& operator=(T const& rhs)
-    {
+      inline recursive_wrapper &operator=(T const &rhs)
+      {
         assign(rhs);
         return *this;
-    }
+      }
 
-    inline void swap(recursive_wrapper& operand) noexcept
-    {
-        T* temp = operand.p_;
+      inline void swap(recursive_wrapper &operand) noexcept
+      {
+        T *temp = operand.p_;
         operand.p_ = p_;
         p_ = temp;
-    }
+      }
 
-    recursive_wrapper& operator=(recursive_wrapper&& rhs) noexcept
-    {
+      recursive_wrapper &operator=(recursive_wrapper &&rhs) noexcept
+      {
         swap(rhs);
         return *this;
-    }
+      }
 
-    recursive_wrapper& operator=(T&& rhs)
-    {
+      recursive_wrapper &operator=(T &&rhs)
+      {
         get() = std::move(rhs);
         return *this;
-    }
+      }
 
-    T& get()
-    {
+      T &get()
+      {
         assert(p_);
         return *get_pointer();
-    }
+      }
 
-    T const& get() const
-    {
+      T const &get() const
+      {
         assert(p_);
         return *get_pointer();
+      }
+
+      T *get_pointer()
+      {
+        return p_;
+      }
+
+      const T *get_pointer() const
+      {
+        return p_;
+      }
+
+      operator T const &() const
+      {
+        return this->get();
+      }
+
+      operator T &()
+      {
+        return this->get();
+      }
+
+    }; // class recursive_wrapper
+
+    template <typename T>
+    inline void swap(recursive_wrapper<T> &lhs,
+                     recursive_wrapper<T> &rhs) noexcept
+    {
+      lhs.swap(rhs);
     }
-
-    T* get_pointer() { return p_; }
-
-    const T* get_pointer() const { return p_; }
-
-    operator T const&() const { return this->get(); }
-
-    operator T&() { return this->get(); }
-
-}; // class recursive_wrapper
-
-template <typename T>
-inline void swap(recursive_wrapper<T>& lhs, recursive_wrapper<T>& rhs) noexcept
-{
-    lhs.swap(rhs);
-}
-} // namespace util
+  } // namespace util
 } // namespace mapbox
 
 #endif // MAPBOX_UTIL_RECURSIVE_WRAPPER_HPP

--- a/src/utils/utils.hpp
+++ b/src/utils/utils.hpp
@@ -34,21 +34,22 @@ namespace dd
       std::vector<std::string> elems;
       std::stringstream ss(s);
       std::string item;
-      while (std::getline(ss, item, delim)) {
-	if (!item.empty())
-	  elems.push_back(item);
-      }
+      while (std::getline(ss, item, delim))
+        {
+          if (!item.empty())
+            elems.push_back(item);
+        }
       return elems;
     }
-    
-    static bool iequals(const std::string& a, const std::string& b)
+
+    static bool iequals(const std::string &a, const std::string &b)
     {
       unsigned int sz = a.size();
       if (b.size() != sz)
-	return false;
+        return false;
       for (unsigned int i = 0; i < sz; ++i)
-	if (std::tolower(a[i]) != std::tolower(b[i]))
-	  return false;
+        if (std::tolower(a[i]) != std::tolower(b[i]))
+          return false;
       return true;
     }
 
@@ -62,11 +63,11 @@ namespace dd
 #else
     static int my_hardware_concurrency()
     {
-        std::ifstream cpuinfo("/proc/cpuinfo");
+      std::ifstream cpuinfo("/proc/cpuinfo");
 
-        return std::count(std::istream_iterator<std::string>(cpuinfo),
-			  std::istream_iterator<std::string>(),
-			  std::string("processor"));
+      return std::count(std::istream_iterator<std::string>(cpuinfo),
+                        std::istream_iterator<std::string>(),
+                        std::string("processor"));
     }
 #endif
   };

--- a/src/utils/variant.hpp
+++ b/src/utils/variant.hpp
@@ -45,7 +45,7 @@
 // clang-format on
 
 // Exceptions
-#if defined( __EXCEPTIONS) || defined( _MSC_VER)
+#if defined(__EXCEPTIONS) || defined(_MSC_VER)
 #define HAS_EXCEPTIONS
 #endif
 
@@ -53,922 +53,1075 @@
 #define VARIANT_MINOR_VERSION 1
 #define VARIANT_PATCH_VERSION 0
 
-#define VARIANT_VERSION (VARIANT_MAJOR_VERSION * 100000) + (VARIANT_MINOR_VERSION * 100) + (VARIANT_PATCH_VERSION)
+#define VARIANT_VERSION                                                       \
+  (VARIANT_MAJOR_VERSION * 100000) + (VARIANT_MINOR_VERSION * 100)            \
+      + (VARIANT_PATCH_VERSION)
 
-namespace mapbox {
-namespace util {
-
-// XXX This should derive from std::logic_error instead of std::runtime_error.
-//     See https://github.com/mapbox/variant/issues/48 for details.
-class bad_variant_access : public std::runtime_error
+namespace mapbox
 {
+  namespace util
+  {
 
-public:
-    explicit bad_variant_access(const std::string& what_arg)
-        : runtime_error(what_arg) {}
+    // XXX This should derive from std::logic_error instead of
+    // std::runtime_error.
+    //     See https://github.com/mapbox/variant/issues/48 for details.
+    class bad_variant_access : public std::runtime_error
+    {
 
-    explicit bad_variant_access(const char* what_arg)
-        : runtime_error(what_arg) {}
+    public:
+      explicit bad_variant_access(const std::string &what_arg)
+          : runtime_error(what_arg)
+      {
+      }
 
-}; // class bad_variant_access
+      explicit bad_variant_access(const char *what_arg)
+          : runtime_error(what_arg)
+      {
+      }
 
-template <typename R = void>
-struct MAPBOX_VARIANT_DEPRECATED static_visitor
-{
-    using result_type = R;
+    }; // class bad_variant_access
 
-protected:
-    static_visitor() {}
-    ~static_visitor() {}
-};
+    template <typename R = void>
+    struct MAPBOX_VARIANT_DEPRECATED static_visitor
+    {
+      using result_type = R;
 
-namespace detail {
+    protected:
+      static_visitor()
+      {
+      }
+      ~static_visitor()
+      {
+      }
+    };
 
-static constexpr std::size_t invalid_value = std::size_t(-1);
+    namespace detail
+    {
 
-template <typename T, typename... Types>
-struct direct_type;
+      static constexpr std::size_t invalid_value = std::size_t(-1);
 
-template <typename T, typename First, typename... Types>
-struct direct_type<T, First, Types...>
-{
-    static constexpr std::size_t index = std::is_same<T, First>::value
-        ? sizeof...(Types)
-        : direct_type<T, Types...>::index;
-};
+      template <typename T, typename... Types> struct direct_type;
 
-template <typename T>
-struct direct_type<T>
-{
-    static constexpr std::size_t index = invalid_value;
-};
+      template <typename T, typename First, typename... Types>
+      struct direct_type<T, First, Types...>
+      {
+        static constexpr std::size_t index
+            = std::is_same<T, First>::value ? sizeof...(Types)
+                                            : direct_type<T, Types...>::index;
+      };
+
+      template <typename T> struct direct_type<T>
+      {
+        static constexpr std::size_t index = invalid_value;
+      };
 
 #if __cpp_lib_logical_traits >= 201510L
 
-using std::disjunction;
+      using std::disjunction;
 
 #else
 
-template <typename...>
-struct disjunction : std::false_type {};
+      template <typename...> struct disjunction : std::false_type
+      {
+      };
 
-template <typename B1>
-struct disjunction<B1> : B1 {};
+      template <typename B1> struct disjunction<B1> : B1
+      {
+      };
 
-template <typename B1, typename B2>
-struct disjunction<B1, B2> : std::conditional<B1::value, B1, B2>::type {};
+      template <typename B1, typename B2>
+      struct disjunction<B1, B2> : std::conditional<B1::value, B1, B2>::type
+      {
+      };
 
-template <typename B1, typename... Bs>
-struct disjunction<B1, Bs...> : std::conditional<B1::value, B1, disjunction<Bs...>>::type {};
+      template <typename B1, typename... Bs>
+      struct disjunction<B1, Bs...>
+          : std::conditional<B1::value, B1, disjunction<Bs...>>::type
+      {
+      };
 
 #endif
 
-template <typename T, typename... Types>
-struct convertible_type;
+      template <typename T, typename... Types> struct convertible_type;
 
-template <typename T, typename First, typename... Types>
-struct convertible_type<T, First, Types...>
-{
-    static constexpr std::size_t index = std::is_convertible<T, First>::value
-        ? disjunction<std::is_convertible<T, Types>...>::value ? invalid_value : sizeof...(Types)
-        : convertible_type<T, Types...>::index;
-};
+      template <typename T, typename First, typename... Types>
+      struct convertible_type<T, First, Types...>
+      {
+        static constexpr std::size_t index
+            = std::is_convertible<T, First>::value
+                  ? disjunction<std::is_convertible<T, Types>...>::value
+                        ? invalid_value
+                        : sizeof...(Types)
+                  : convertible_type<T, Types...>::index;
+      };
 
-template <typename T>
-struct convertible_type<T>
-{
-    static constexpr std::size_t index = invalid_value;
-};
+      template <typename T> struct convertible_type<T>
+      {
+        static constexpr std::size_t index = invalid_value;
+      };
 
-template <typename T, typename... Types>
-struct value_traits
-{
-    using value_type = typename std::remove_const<typename std::remove_reference<T>::type>::type;
-    static constexpr std::size_t direct_index = direct_type<value_type, Types...>::index;
-    static constexpr bool is_direct = direct_index != invalid_value;
-    static constexpr std::size_t index = is_direct ? direct_index : convertible_type<value_type, Types...>::index;
-    static constexpr bool is_valid = index != invalid_value;
-    static constexpr std::size_t tindex = is_valid ? sizeof...(Types)-index : 0;
-    using target_type = typename std::tuple_element<tindex, std::tuple<void, Types...>>::type;
-};
+      template <typename T, typename... Types> struct value_traits
+      {
+        using value_type = typename std::remove_const<
+            typename std::remove_reference<T>::type>::type;
+        static constexpr std::size_t direct_index
+            = direct_type<value_type, Types...>::index;
+        static constexpr bool is_direct = direct_index != invalid_value;
+        static constexpr std::size_t index
+            = is_direct ? direct_index
+                        : convertible_type<value_type, Types...>::index;
+        static constexpr bool is_valid = index != invalid_value;
+        static constexpr std::size_t tindex
+            = is_valid ? sizeof...(Types) - index : 0;
+        using target_type =
+            typename std::tuple_element<tindex,
+                                        std::tuple<void, Types...>>::type;
+      };
 
-template <typename T, typename R = void>
-struct enable_if_type
-{
-    using type = R;
-};
+      template <typename T, typename R = void> struct enable_if_type
+      {
+        using type = R;
+      };
 
-template <typename F, typename V, typename Enable = void>
-struct result_of_unary_visit
-{
-    using type = typename std::result_of<F(V&)>::type;
-};
+      template <typename F, typename V, typename Enable = void>
+      struct result_of_unary_visit
+      {
+        using type = typename std::result_of<F(V &)>::type;
+      };
 
-template <typename F, typename V>
-struct result_of_unary_visit<F, V, typename enable_if_type<typename F::result_type>::type>
-{
-    using type = typename F::result_type;
-};
+      template <typename F, typename V>
+      struct result_of_unary_visit<
+          F, V, typename enable_if_type<typename F::result_type>::type>
+      {
+        using type = typename F::result_type;
+      };
 
-template <typename F, typename V, typename Enable = void>
-struct result_of_binary_visit
-{
-    using type = typename std::result_of<F(V&, V&)>::type;
-};
+      template <typename F, typename V, typename Enable = void>
+      struct result_of_binary_visit
+      {
+        using type = typename std::result_of<F(V &, V &)>::type;
+      };
 
-template <typename F, typename V>
-struct result_of_binary_visit<F, V, typename enable_if_type<typename F::result_type>::type>
-{
-    using type = typename F::result_type;
-};
+      template <typename F, typename V>
+      struct result_of_binary_visit<
+          F, V, typename enable_if_type<typename F::result_type>::type>
+      {
+        using type = typename F::result_type;
+      };
 
-template <std::size_t arg1, std::size_t... others>
-struct static_max;
+      template <std::size_t arg1, std::size_t... others> struct static_max;
 
-template <std::size_t arg>
-struct static_max<arg>
-{
-    static const std::size_t value = arg;
-};
+      template <std::size_t arg> struct static_max<arg>
+      {
+        static const std::size_t value = arg;
+      };
 
-template <std::size_t arg1, std::size_t arg2, std::size_t... others>
-struct static_max<arg1, arg2, others...>
-{
-    static const std::size_t value = arg1 >= arg2 ? static_max<arg1, others...>::value : static_max<arg2, others...>::value;
-};
+      template <std::size_t arg1, std::size_t arg2, std::size_t... others>
+      struct static_max<arg1, arg2, others...>
+      {
+        static const std::size_t value
+            = arg1 >= arg2 ? static_max<arg1, others...>::value
+                           : static_max<arg2, others...>::value;
+      };
 
-template <typename... Types>
-struct variant_helper;
+      template <typename... Types> struct variant_helper;
 
-template <typename T, typename... Types>
-struct variant_helper<T, Types...>
-{
-    VARIANT_INLINE static void destroy(const std::size_t type_index, void* data)
-    {
-        if (type_index == sizeof...(Types))
+      template <typename T, typename... Types>
+      struct variant_helper<T, Types...>
+      {
+        VARIANT_INLINE static void destroy(const std::size_t type_index,
+                                           void *data)
         {
-            reinterpret_cast<T*>(data)->~T();
-        }
-        else
-        {
-            variant_helper<Types...>::destroy(type_index, data);
-        }
-    }
-
-    VARIANT_INLINE static void move(const std::size_t old_type_index, void* old_value, void* new_value)
-    {
-        if (old_type_index == sizeof...(Types))
-        {
-            new (new_value) T(std::move(*reinterpret_cast<T*>(old_value)));
-        }
-        else
-        {
-            variant_helper<Types...>::move(old_type_index, old_value, new_value);
-        }
-    }
-
-    VARIANT_INLINE static void copy(const std::size_t old_type_index, const void* old_value, void* new_value)
-    {
-        if (old_type_index == sizeof...(Types))
-        {
-            new (new_value) T(*reinterpret_cast<const T*>(old_value));
-        }
-        else
-        {
-            variant_helper<Types...>::copy(old_type_index, old_value, new_value);
-        }
-    }
-};
-
-template <>
-struct variant_helper<>
-{
-    VARIANT_INLINE static void destroy(const std::size_t, void*) {}
-    VARIANT_INLINE static void move(const std::size_t, void*, void*) {}
-    VARIANT_INLINE static void copy(const std::size_t, const void*, void*) {}
-};
-
-template <typename T>
-struct unwrapper
-{
-    static T const& apply_const(T const& obj) { return obj; }
-    static T& apply(T& obj) { return obj; }
-};
-
-template <typename T>
-struct unwrapper<recursive_wrapper<T>>
-{
-    static auto apply_const(recursive_wrapper<T> const& obj)
-        -> typename recursive_wrapper<T>::type const&
-    {
-        return obj.get();
-    }
-    static auto apply(recursive_wrapper<T>& obj)
-        -> typename recursive_wrapper<T>::type&
-    {
-        return obj.get();
-    }
-};
-
-template <typename T>
-struct unwrapper<std::reference_wrapper<T>>
-{
-    static auto apply_const(std::reference_wrapper<T> const& obj)
-        -> typename std::reference_wrapper<T>::type const&
-    {
-        return obj.get();
-    }
-    static auto apply(std::reference_wrapper<T>& obj)
-        -> typename std::reference_wrapper<T>::type&
-    {
-        return obj.get();
-    }
-};
-
-template <typename F, typename V, typename R, typename... Types>
-struct dispatcher;
-
-template <typename F, typename V, typename R, typename T, typename... Types>
-struct dispatcher<F, V, R, T, Types...>
-{
-    VARIANT_INLINE static R apply_const(V const& v, F&& f)
-    {
-        if (v.template is<T>())
-        {
-            return f(unwrapper<T>::apply_const(v.template get_unchecked<T>()));
-        }
-        else
-        {
-            return dispatcher<F, V, R, Types...>::apply_const(v, std::forward<F>(f));
-        }
-    }
-
-    VARIANT_INLINE static R apply(V& v, F&& f)
-    {
-        if (v.template is<T>())
-        {
-            return f(unwrapper<T>::apply(v.template get_unchecked<T>()));
-        }
-        else
-        {
-            return dispatcher<F, V, R, Types...>::apply(v, std::forward<F>(f));
-        }
-    }
-};
-
-template <typename F, typename V, typename R, typename T>
-struct dispatcher<F, V, R, T>
-{
-    VARIANT_INLINE static R apply_const(V const& v, F&& f)
-    {
-        return f(unwrapper<T>::apply_const(v.template get_unchecked<T>()));
-    }
-
-    VARIANT_INLINE static R apply(V& v, F&& f)
-    {
-        return f(unwrapper<T>::apply(v.template get_unchecked<T>()));
-    }
-};
-
-template <typename F, typename V, typename R, typename T, typename... Types>
-struct binary_dispatcher_rhs;
-
-template <typename F, typename V, typename R, typename T0, typename T1, typename... Types>
-struct binary_dispatcher_rhs<F, V, R, T0, T1, Types...>
-{
-    VARIANT_INLINE static R apply_const(V const& lhs, V const& rhs, F&& f)
-    {
-        if (rhs.template is<T1>()) // call binary functor
-        {
-            return f(unwrapper<T0>::apply_const(lhs.template get_unchecked<T0>()),
-                     unwrapper<T1>::apply_const(rhs.template get_unchecked<T1>()));
-        }
-        else
-        {
-            return binary_dispatcher_rhs<F, V, R, T0, Types...>::apply_const(lhs, rhs, std::forward<F>(f));
-        }
-    }
-
-    VARIANT_INLINE static R apply(V& lhs, V& rhs, F&& f)
-    {
-        if (rhs.template is<T1>()) // call binary functor
-        {
-            return f(unwrapper<T0>::apply(lhs.template get_unchecked<T0>()),
-                     unwrapper<T1>::apply(rhs.template get_unchecked<T1>()));
-        }
-        else
-        {
-            return binary_dispatcher_rhs<F, V, R, T0, Types...>::apply(lhs, rhs, std::forward<F>(f));
-        }
-    }
-};
-
-template <typename F, typename V, typename R, typename T0, typename T1>
-struct binary_dispatcher_rhs<F, V, R, T0, T1>
-{
-    VARIANT_INLINE static R apply_const(V const& lhs, V const& rhs, F&& f)
-    {
-        return f(unwrapper<T0>::apply_const(lhs.template get_unchecked<T0>()),
-                 unwrapper<T1>::apply_const(rhs.template get_unchecked<T1>()));
-    }
-
-    VARIANT_INLINE static R apply(V& lhs, V& rhs, F&& f)
-    {
-        return f(unwrapper<T0>::apply(lhs.template get_unchecked<T0>()),
-                 unwrapper<T1>::apply(rhs.template get_unchecked<T1>()));
-    }
-};
-
-template <typename F, typename V, typename R, typename T, typename... Types>
-struct binary_dispatcher_lhs;
-
-template <typename F, typename V, typename R, typename T0, typename T1, typename... Types>
-struct binary_dispatcher_lhs<F, V, R, T0, T1, Types...>
-{
-    VARIANT_INLINE static R apply_const(V const& lhs, V const& rhs, F&& f)
-    {
-        if (lhs.template is<T1>()) // call binary functor
-        {
-            return f(unwrapper<T1>::apply_const(lhs.template get_unchecked<T1>()),
-                     unwrapper<T0>::apply_const(rhs.template get_unchecked<T0>()));
-        }
-        else
-        {
-            return binary_dispatcher_lhs<F, V, R, T0, Types...>::apply_const(lhs, rhs, std::forward<F>(f));
-        }
-    }
-
-    VARIANT_INLINE static R apply(V& lhs, V& rhs, F&& f)
-    {
-        if (lhs.template is<T1>()) // call binary functor
-        {
-            return f(unwrapper<T1>::apply(lhs.template get_unchecked<T1>()),
-                     unwrapper<T0>::apply(rhs.template get_unchecked<T0>()));
-        }
-        else
-        {
-            return binary_dispatcher_lhs<F, V, R, T0, Types...>::apply(lhs, rhs, std::forward<F>(f));
-        }
-    }
-};
-
-template <typename F, typename V, typename R, typename T0, typename T1>
-struct binary_dispatcher_lhs<F, V, R, T0, T1>
-{
-    VARIANT_INLINE static R apply_const(V const& lhs, V const& rhs, F&& f)
-    {
-        return f(unwrapper<T1>::apply_const(lhs.template get_unchecked<T1>()),
-                 unwrapper<T0>::apply_const(rhs.template get_unchecked<T0>()));
-    }
-
-    VARIANT_INLINE static R apply(V& lhs, V& rhs, F&& f)
-    {
-        return f(unwrapper<T1>::apply(lhs.template get_unchecked<T1>()),
-                 unwrapper<T0>::apply(rhs.template get_unchecked<T0>()));
-    }
-};
-
-template <typename F, typename V, typename R, typename... Types>
-struct binary_dispatcher;
-
-template <typename F, typename V, typename R, typename T, typename... Types>
-struct binary_dispatcher<F, V, R, T, Types...>
-{
-    VARIANT_INLINE static R apply_const(V const& v0, V const& v1, F&& f)
-    {
-        if (v0.template is<T>())
-        {
-            if (v1.template is<T>())
+          if (type_index == sizeof...(Types))
             {
-                return f(unwrapper<T>::apply_const(v0.template get_unchecked<T>()),
-                         unwrapper<T>::apply_const(v1.template get_unchecked<T>())); // call binary functor
+              reinterpret_cast<T *>(data)->~T();
             }
-            else
+          else
             {
-                return binary_dispatcher_rhs<F, V, R, T, Types...>::apply_const(v0, v1, std::forward<F>(f));
+              variant_helper<Types...>::destroy(type_index, data);
             }
         }
-        else if (v1.template is<T>())
-        {
-            return binary_dispatcher_lhs<F, V, R, T, Types...>::apply_const(v0, v1, std::forward<F>(f));
-        }
-        return binary_dispatcher<F, V, R, Types...>::apply_const(v0, v1, std::forward<F>(f));
-    }
 
-    VARIANT_INLINE static R apply(V& v0, V& v1, F&& f)
-    {
-        if (v0.template is<T>())
+        VARIANT_INLINE static void move(const std::size_t old_type_index,
+                                        void *old_value, void *new_value)
         {
-            if (v1.template is<T>())
+          if (old_type_index == sizeof...(Types))
             {
-                return f(unwrapper<T>::apply(v0.template get_unchecked<T>()),
-                         unwrapper<T>::apply(v1.template get_unchecked<T>())); // call binary functor
+              new (new_value) T(std::move(*reinterpret_cast<T *>(old_value)));
             }
-            else
+          else
             {
-                return binary_dispatcher_rhs<F, V, R, T, Types...>::apply(v0, v1, std::forward<F>(f));
+              variant_helper<Types...>::move(old_type_index, old_value,
+                                             new_value);
             }
         }
-        else if (v1.template is<T>())
+
+        VARIANT_INLINE static void copy(const std::size_t old_type_index,
+                                        const void *old_value, void *new_value)
         {
-            return binary_dispatcher_lhs<F, V, R, T, Types...>::apply(v0, v1, std::forward<F>(f));
+          if (old_type_index == sizeof...(Types))
+            {
+              new (new_value) T(*reinterpret_cast<const T *>(old_value));
+            }
+          else
+            {
+              variant_helper<Types...>::copy(old_type_index, old_value,
+                                             new_value);
+            }
         }
-        return binary_dispatcher<F, V, R, Types...>::apply(v0, v1, std::forward<F>(f));
-    }
-};
+      };
 
-template <typename F, typename V, typename R, typename T>
-struct binary_dispatcher<F, V, R, T>
-{
-    VARIANT_INLINE static R apply_const(V const& v0, V const& v1, F&& f)
+      template <> struct variant_helper<>
+      {
+        VARIANT_INLINE static void destroy(const std::size_t, void *)
+        {
+        }
+        VARIANT_INLINE static void move(const std::size_t, void *, void *)
+        {
+        }
+        VARIANT_INLINE static void copy(const std::size_t, const void *,
+                                        void *)
+        {
+        }
+      };
+
+      template <typename T> struct unwrapper
+      {
+        static T const &apply_const(T const &obj)
+        {
+          return obj;
+        }
+        static T &apply(T &obj)
+        {
+          return obj;
+        }
+      };
+
+      template <typename T> struct unwrapper<recursive_wrapper<T>>
+      {
+        static auto apply_const(recursive_wrapper<T> const &obj) ->
+            typename recursive_wrapper<T>::type const &
+        {
+          return obj.get();
+        }
+        static auto apply(recursive_wrapper<T> &obj) ->
+            typename recursive_wrapper<T>::type &
+        {
+          return obj.get();
+        }
+      };
+
+      template <typename T> struct unwrapper<std::reference_wrapper<T>>
+      {
+        static auto apply_const(std::reference_wrapper<T> const &obj) ->
+            typename std::reference_wrapper<T>::type const &
+        {
+          return obj.get();
+        }
+        static auto apply(std::reference_wrapper<T> &obj) ->
+            typename std::reference_wrapper<T>::type &
+        {
+          return obj.get();
+        }
+      };
+
+      template <typename F, typename V, typename R, typename... Types>
+      struct dispatcher;
+
+      template <typename F, typename V, typename R, typename T,
+                typename... Types>
+      struct dispatcher<F, V, R, T, Types...>
+      {
+        VARIANT_INLINE static R apply_const(V const &v, F &&f)
+        {
+          if (v.template is<T>())
+            {
+              return f(
+                  unwrapper<T>::apply_const(v.template get_unchecked<T>()));
+            }
+          else
+            {
+              return dispatcher<F, V, R, Types...>::apply_const(
+                  v, std::forward<F>(f));
+            }
+        }
+
+        VARIANT_INLINE static R apply(V &v, F &&f)
+        {
+          if (v.template is<T>())
+            {
+              return f(unwrapper<T>::apply(v.template get_unchecked<T>()));
+            }
+          else
+            {
+              return dispatcher<F, V, R, Types...>::apply(v,
+                                                          std::forward<F>(f));
+            }
+        }
+      };
+
+      template <typename F, typename V, typename R, typename T>
+      struct dispatcher<F, V, R, T>
+      {
+        VARIANT_INLINE static R apply_const(V const &v, F &&f)
+        {
+          return f(unwrapper<T>::apply_const(v.template get_unchecked<T>()));
+        }
+
+        VARIANT_INLINE static R apply(V &v, F &&f)
+        {
+          return f(unwrapper<T>::apply(v.template get_unchecked<T>()));
+        }
+      };
+
+      template <typename F, typename V, typename R, typename T,
+                typename... Types>
+      struct binary_dispatcher_rhs;
+
+      template <typename F, typename V, typename R, typename T0, typename T1,
+                typename... Types>
+      struct binary_dispatcher_rhs<F, V, R, T0, T1, Types...>
+      {
+        VARIANT_INLINE static R apply_const(V const &lhs, V const &rhs, F &&f)
+        {
+          if (rhs.template is<T1>()) // call binary functor
+            {
+              return f(
+                  unwrapper<T0>::apply_const(lhs.template get_unchecked<T0>()),
+                  unwrapper<T1>::apply_const(
+                      rhs.template get_unchecked<T1>()));
+            }
+          else
+            {
+              return binary_dispatcher_rhs<F, V, R, T0, Types...>::apply_const(
+                  lhs, rhs, std::forward<F>(f));
+            }
+        }
+
+        VARIANT_INLINE static R apply(V &lhs, V &rhs, F &&f)
+        {
+          if (rhs.template is<T1>()) // call binary functor
+            {
+              return f(unwrapper<T0>::apply(lhs.template get_unchecked<T0>()),
+                       unwrapper<T1>::apply(rhs.template get_unchecked<T1>()));
+            }
+          else
+            {
+              return binary_dispatcher_rhs<F, V, R, T0, Types...>::apply(
+                  lhs, rhs, std::forward<F>(f));
+            }
+        }
+      };
+
+      template <typename F, typename V, typename R, typename T0, typename T1>
+      struct binary_dispatcher_rhs<F, V, R, T0, T1>
+      {
+        VARIANT_INLINE static R apply_const(V const &lhs, V const &rhs, F &&f)
+        {
+          return f(
+              unwrapper<T0>::apply_const(lhs.template get_unchecked<T0>()),
+              unwrapper<T1>::apply_const(rhs.template get_unchecked<T1>()));
+        }
+
+        VARIANT_INLINE static R apply(V &lhs, V &rhs, F &&f)
+        {
+          return f(unwrapper<T0>::apply(lhs.template get_unchecked<T0>()),
+                   unwrapper<T1>::apply(rhs.template get_unchecked<T1>()));
+        }
+      };
+
+      template <typename F, typename V, typename R, typename T,
+                typename... Types>
+      struct binary_dispatcher_lhs;
+
+      template <typename F, typename V, typename R, typename T0, typename T1,
+                typename... Types>
+      struct binary_dispatcher_lhs<F, V, R, T0, T1, Types...>
+      {
+        VARIANT_INLINE static R apply_const(V const &lhs, V const &rhs, F &&f)
+        {
+          if (lhs.template is<T1>()) // call binary functor
+            {
+              return f(
+                  unwrapper<T1>::apply_const(lhs.template get_unchecked<T1>()),
+                  unwrapper<T0>::apply_const(
+                      rhs.template get_unchecked<T0>()));
+            }
+          else
+            {
+              return binary_dispatcher_lhs<F, V, R, T0, Types...>::apply_const(
+                  lhs, rhs, std::forward<F>(f));
+            }
+        }
+
+        VARIANT_INLINE static R apply(V &lhs, V &rhs, F &&f)
+        {
+          if (lhs.template is<T1>()) // call binary functor
+            {
+              return f(unwrapper<T1>::apply(lhs.template get_unchecked<T1>()),
+                       unwrapper<T0>::apply(rhs.template get_unchecked<T0>()));
+            }
+          else
+            {
+              return binary_dispatcher_lhs<F, V, R, T0, Types...>::apply(
+                  lhs, rhs, std::forward<F>(f));
+            }
+        }
+      };
+
+      template <typename F, typename V, typename R, typename T0, typename T1>
+      struct binary_dispatcher_lhs<F, V, R, T0, T1>
+      {
+        VARIANT_INLINE static R apply_const(V const &lhs, V const &rhs, F &&f)
+        {
+          return f(
+              unwrapper<T1>::apply_const(lhs.template get_unchecked<T1>()),
+              unwrapper<T0>::apply_const(rhs.template get_unchecked<T0>()));
+        }
+
+        VARIANT_INLINE static R apply(V &lhs, V &rhs, F &&f)
+        {
+          return f(unwrapper<T1>::apply(lhs.template get_unchecked<T1>()),
+                   unwrapper<T0>::apply(rhs.template get_unchecked<T0>()));
+        }
+      };
+
+      template <typename F, typename V, typename R, typename... Types>
+      struct binary_dispatcher;
+
+      template <typename F, typename V, typename R, typename T,
+                typename... Types>
+      struct binary_dispatcher<F, V, R, T, Types...>
+      {
+        VARIANT_INLINE static R apply_const(V const &v0, V const &v1, F &&f)
+        {
+          if (v0.template is<T>())
+            {
+              if (v1.template is<T>())
+                {
+                  return f(unwrapper<T>::apply_const(
+                               v0.template get_unchecked<T>()),
+                           unwrapper<T>::apply_const(
+                               v1.template get_unchecked<T>())); // call binary
+                                                                 // functor
+                }
+              else
+                {
+                  return binary_dispatcher_rhs<
+                      F, V, R, T, Types...>::apply_const(v0, v1,
+                                                         std::forward<F>(f));
+                }
+            }
+          else if (v1.template is<T>())
+            {
+              return binary_dispatcher_lhs<F, V, R, T, Types...>::apply_const(
+                  v0, v1, std::forward<F>(f));
+            }
+          return binary_dispatcher<F, V, R, Types...>::apply_const(
+              v0, v1, std::forward<F>(f));
+        }
+
+        VARIANT_INLINE static R apply(V &v0, V &v1, F &&f)
+        {
+          if (v0.template is<T>())
+            {
+              if (v1.template is<T>())
+                {
+                  return f(unwrapper<T>::apply(v0.template get_unchecked<T>()),
+                           unwrapper<T>::apply(
+                               v1.template get_unchecked<T>())); // call binary
+                                                                 // functor
+                }
+              else
+                {
+                  return binary_dispatcher_rhs<F, V, R, T, Types...>::apply(
+                      v0, v1, std::forward<F>(f));
+                }
+            }
+          else if (v1.template is<T>())
+            {
+              return binary_dispatcher_lhs<F, V, R, T, Types...>::apply(
+                  v0, v1, std::forward<F>(f));
+            }
+          return binary_dispatcher<F, V, R, Types...>::apply(
+              v0, v1, std::forward<F>(f));
+        }
+      };
+
+      template <typename F, typename V, typename R, typename T>
+      struct binary_dispatcher<F, V, R, T>
+      {
+        VARIANT_INLINE static R apply_const(V const &v0, V const &v1, F &&f)
+        {
+          return f(unwrapper<T>::apply_const(v0.template get_unchecked<T>()),
+                   unwrapper<T>::apply_const(
+                       v1.template get_unchecked<T>())); // call binary functor
+        }
+
+        VARIANT_INLINE static R apply(V &v0, V &v1, F &&f)
+        {
+          return f(unwrapper<T>::apply(v0.template get_unchecked<T>()),
+                   unwrapper<T>::apply(
+                       v1.template get_unchecked<T>())); // call binary functor
+        }
+      };
+
+      // comparator functors
+      struct equal_comp
+      {
+        template <typename T> bool operator()(T const &lhs, T const &rhs) const
+        {
+          return lhs == rhs;
+        }
+      };
+
+      struct less_comp
+      {
+        template <typename T> bool operator()(T const &lhs, T const &rhs) const
+        {
+          return lhs < rhs;
+        }
+      };
+
+      template <typename Variant, typename Comp> class comparer
+      {
+      public:
+        explicit comparer(Variant const &lhs) noexcept : lhs_(lhs)
+        {
+        }
+        comparer &operator=(comparer const &) = delete;
+        // visitor
+        template <typename T> bool operator()(T const &rhs_content) const
+        {
+          T const &lhs_content = lhs_.template get_unchecked<T>();
+          return Comp()(lhs_content, rhs_content);
+        }
+
+      private:
+        Variant const &lhs_;
+      };
+
+    } // namespace detail
+
+    struct no_init
     {
-        return f(unwrapper<T>::apply_const(v0.template get_unchecked<T>()),
-                 unwrapper<T>::apply_const(v1.template get_unchecked<T>())); // call binary functor
-    }
+    };
 
-    VARIANT_INLINE static R apply(V& v0, V& v1, F&& f)
+    template <typename... Types> class variant
     {
-        return f(unwrapper<T>::apply(v0.template get_unchecked<T>()),
-                 unwrapper<T>::apply(v1.template get_unchecked<T>())); // call binary functor
-    }
-};
+      static_assert(
+          sizeof...(Types) > 0,
+          "Template parameter type list of variant can not be empty");
+      static_assert(!detail::disjunction<std::is_reference<Types>...>::value,
+                    "Variant can not hold reference types. Maybe use "
+                    "std::reference_wrapper?");
 
-// comparator functors
-struct equal_comp
-{
-    template <typename T>
-    bool operator()(T const& lhs, T const& rhs) const
-    {
-        return lhs == rhs;
-    }
-};
+    private:
+      static const std::size_t data_size
+          = detail::static_max<sizeof(Types)...>::value;
+      static const std::size_t data_align
+          = detail::static_max<alignof(Types)...>::value;
 
-struct less_comp
-{
-    template <typename T>
-    bool operator()(T const& lhs, T const& rhs) const
-    {
-        return lhs < rhs;
-    }
-};
+    public:
+      struct adapted_variant_tag;
+      using types = std::tuple<Types...>;
 
-template <typename Variant, typename Comp>
-class comparer
-{
-public:
-    explicit comparer(Variant const& lhs) noexcept
-        : lhs_(lhs) {}
-    comparer& operator=(comparer const&) = delete;
-    // visitor
-    template <typename T>
-    bool operator()(T const& rhs_content) const
-    {
-        T const& lhs_content = lhs_.template get_unchecked<T>();
-        return Comp()(lhs_content, rhs_content);
-    }
+    private:
+      using first_type = typename std::tuple_element<0, types>::type;
+      using data_type =
+          typename std::aligned_storage<data_size, data_align>::type;
+      using helper_type = detail::variant_helper<Types...>;
 
-private:
-    Variant const& lhs_;
-};
+      std::size_t type_index;
+      data_type data;
 
-} // namespace detail
-
-struct no_init
-{
-};
-
-template <typename... Types>
-class variant
-{
-    static_assert(sizeof...(Types) > 0, "Template parameter type list of variant can not be empty");
-    static_assert(!detail::disjunction<std::is_reference<Types>...>::value, "Variant can not hold reference types. Maybe use std::reference_wrapper?");
-
-private:
-    static const std::size_t data_size = detail::static_max<sizeof(Types)...>::value;
-    static const std::size_t data_align = detail::static_max<alignof(Types)...>::value;
-public:
-    struct adapted_variant_tag;
-    using types = std::tuple<Types...>;
-private:
-    using first_type = typename std::tuple_element<0, types>::type;
-    using data_type = typename std::aligned_storage<data_size, data_align>::type;
-    using helper_type = detail::variant_helper<Types...>;
-
-    std::size_t type_index;
-    data_type data;
-
-public:
-    VARIANT_INLINE variant() noexcept(std::is_nothrow_default_constructible<first_type>::value)
-        : type_index(sizeof...(Types)-1)
-    {
-        static_assert(std::is_default_constructible<first_type>::value, "First type in variant must be default constructible to allow default construction of variant");
+    public:
+      VARIANT_INLINE variant() noexcept(
+          std::is_nothrow_default_constructible<first_type>::value)
+          : type_index(sizeof...(Types) - 1)
+      {
+        static_assert(std::is_default_constructible<first_type>::value,
+                      "First type in variant must be default constructible to "
+                      "allow default construction of variant");
         new (&data) first_type();
-    }
+      }
 
-    VARIANT_INLINE variant(no_init) noexcept
-        : type_index(detail::invalid_value) {}
+      VARIANT_INLINE variant(no_init) noexcept
+          : type_index(detail::invalid_value)
+      {
+      }
 
-    // http://isocpp.org/blog/2012/11/universal-references-in-c11-scott-meyers
-    template <typename T, typename Traits = detail::value_traits<T, Types...>,
-              typename Enable = typename std::enable_if<Traits::is_valid && !std::is_same<variant<Types...>, typename Traits::value_type>::value>::type >
-    VARIANT_INLINE variant(T&& val) noexcept(std::is_nothrow_constructible<typename Traits::target_type, T&&>::value)
-        : type_index(Traits::index)
-    {
+      // http://isocpp.org/blog/2012/11/universal-references-in-c11-scott-meyers
+      template <
+          typename T, typename Traits = detail::value_traits<T, Types...>,
+          typename Enable = typename std::enable_if<
+              Traits::is_valid
+              && !std::is_same<variant<Types...>,
+                               typename Traits::value_type>::value>::type>
+      VARIANT_INLINE variant(T &&val) noexcept(
+          std::is_nothrow_constructible<typename Traits::target_type,
+                                        T &&>::value)
+          : type_index(Traits::index)
+      {
         new (&data) typename Traits::target_type(std::forward<T>(val));
-    }
+      }
 
-    VARIANT_INLINE variant(variant<Types...> const& old)
-        : type_index(old.type_index)
-    {
+      VARIANT_INLINE variant(variant<Types...> const &old)
+          : type_index(old.type_index)
+      {
         helper_type::copy(old.type_index, &old.data, &data);
-    }
+      }
 
-    VARIANT_INLINE variant(variant<Types...>&& old) noexcept(std::is_nothrow_move_constructible<types>::value)
-        : type_index(old.type_index)
-    {
+      VARIANT_INLINE variant(variant<Types...> &&old) noexcept(
+          std::is_nothrow_move_constructible<types>::value)
+          : type_index(old.type_index)
+      {
         helper_type::move(old.type_index, &old.data, &data);
-    }
+      }
 
-private:
-    VARIANT_INLINE void copy_assign(variant<Types...> const& rhs)
-    {
+    private:
+      VARIANT_INLINE void copy_assign(variant<Types...> const &rhs)
+      {
         helper_type::destroy(type_index, &data);
         type_index = detail::invalid_value;
         helper_type::copy(rhs.type_index, &rhs.data, &data);
         type_index = rhs.type_index;
-    }
+      }
 
-    VARIANT_INLINE void move_assign(variant<Types...>&& rhs)
-    {
+      VARIANT_INLINE void move_assign(variant<Types...> &&rhs)
+      {
         helper_type::destroy(type_index, &data);
         type_index = detail::invalid_value;
         helper_type::move(rhs.type_index, &rhs.data, &data);
         type_index = rhs.type_index;
-    }
+      }
 
-public:
-    VARIANT_INLINE variant<Types...>& operator=(variant<Types...>&& other)
-    {
+    public:
+      VARIANT_INLINE variant<Types...> &operator=(variant<Types...> &&other)
+      {
         move_assign(std::move(other));
         return *this;
-    }
+      }
 
-    VARIANT_INLINE variant<Types...>& operator=(variant<Types...> const& other)
-    {
+      VARIANT_INLINE variant<Types...> &
+      operator=(variant<Types...> const &other)
+      {
         copy_assign(other);
         return *this;
-    }
+      }
 
-    // conversions
-    // move-assign
-    template <typename T>
-    VARIANT_INLINE variant<Types...>& operator=(T&& rhs) noexcept
-    {
+      // conversions
+      // move-assign
+      template <typename T>
+      VARIANT_INLINE variant<Types...> &operator=(T &&rhs) noexcept
+      {
         variant<Types...> temp(std::forward<T>(rhs));
         move_assign(std::move(temp));
         return *this;
-    }
+      }
 
-    // copy-assign
-    template <typename T>
-    VARIANT_INLINE variant<Types...>& operator=(T const& rhs)
-    {
+      // copy-assign
+      template <typename T>
+      VARIANT_INLINE variant<Types...> &operator=(T const &rhs)
+      {
         variant<Types...> temp(rhs);
         copy_assign(temp);
         return *this;
-    }
+      }
 
-    template <typename T, typename std::enable_if<
-                          (detail::direct_type<T, Types...>::index != detail::invalid_value)>::type* = nullptr>
-    VARIANT_INLINE bool is() const
-    {
+      template <typename T, typename std::enable_if<
+                                (detail::direct_type<T, Types...>::index
+                                 != detail::invalid_value)>::type * = nullptr>
+      VARIANT_INLINE bool is() const
+      {
         return type_index == detail::direct_type<T, Types...>::index;
-    }
+      }
 
-    template <typename T,typename std::enable_if<
-                         (detail::direct_type<recursive_wrapper<T>, Types...>::index != detail::invalid_value)>::type* = nullptr>
-    VARIANT_INLINE bool is() const
-    {
-        return type_index == detail::direct_type<recursive_wrapper<T>, Types...>::index;
-    }
+      template <typename T,
+                typename std::enable_if<
+                    (detail::direct_type<recursive_wrapper<T>, Types...>::index
+                     != detail::invalid_value)>::type * = nullptr>
+      VARIANT_INLINE bool is() const
+      {
+        return type_index
+               == detail::direct_type<recursive_wrapper<T>, Types...>::index;
+      }
 
-    VARIANT_INLINE bool valid() const
-    {
+      VARIANT_INLINE bool valid() const
+      {
         return type_index != detail::invalid_value;
-    }
+      }
 
-    template <typename T, typename... Args>
-    VARIANT_INLINE void set(Args&&... args)
-    {
+      template <typename T, typename... Args>
+      VARIANT_INLINE void set(Args &&... args)
+      {
         helper_type::destroy(type_index, &data);
         type_index = detail::invalid_value;
         new (&data) T(std::forward<Args>(args)...);
         type_index = detail::direct_type<T, Types...>::index;
-    }
+      }
 
-    // get_unchecked<T>()
-    template <typename T, typename std::enable_if<
-                          (detail::direct_type<T, Types...>::index != detail::invalid_value)>::type* = nullptr>
-    VARIANT_INLINE T& get_unchecked()
-    {
-        return *reinterpret_cast<T*>(&data);
-    }
+      // get_unchecked<T>()
+      template <typename T, typename std::enable_if<
+                                (detail::direct_type<T, Types...>::index
+                                 != detail::invalid_value)>::type * = nullptr>
+      VARIANT_INLINE T &get_unchecked()
+      {
+        return *reinterpret_cast<T *>(&data);
+      }
 
 #ifdef HAS_EXCEPTIONS
-    // get<T>()
-    template <typename T, typename std::enable_if<
-                          (detail::direct_type<T, Types...>::index != detail::invalid_value)>::type* = nullptr>
-    VARIANT_INLINE T& get()
-    {
+      // get<T>()
+      template <typename T, typename std::enable_if<
+                                (detail::direct_type<T, Types...>::index
+                                 != detail::invalid_value)>::type * = nullptr>
+      VARIANT_INLINE T &get()
+      {
         if (type_index == detail::direct_type<T, Types...>::index)
-        {
-            return *reinterpret_cast<T*>(&data);
-        }
+          {
+            return *reinterpret_cast<T *>(&data);
+          }
         else
-        {
+          {
             throw bad_variant_access("in get<T>()");
-        }
-    }
+          }
+      }
 #endif
 
-    template <typename T, typename std::enable_if<
-                          (detail::direct_type<T, Types...>::index != detail::invalid_value)>::type* = nullptr>
-    VARIANT_INLINE T const& get_unchecked() const
-    {
-        return *reinterpret_cast<T const*>(&data);
-    }
+      template <typename T, typename std::enable_if<
+                                (detail::direct_type<T, Types...>::index
+                                 != detail::invalid_value)>::type * = nullptr>
+      VARIANT_INLINE T const &get_unchecked() const
+      {
+        return *reinterpret_cast<T const *>(&data);
+      }
 
 #ifdef HAS_EXCEPTIONS
-    template <typename T, typename std::enable_if<
-                          (detail::direct_type<T, Types...>::index != detail::invalid_value)>::type* = nullptr>
-    VARIANT_INLINE T const& get() const
-    {
+      template <typename T, typename std::enable_if<
+                                (detail::direct_type<T, Types...>::index
+                                 != detail::invalid_value)>::type * = nullptr>
+      VARIANT_INLINE T const &get() const
+      {
         if (type_index == detail::direct_type<T, Types...>::index)
-        {
-            return *reinterpret_cast<T const*>(&data);
-        }
+          {
+            return *reinterpret_cast<T const *>(&data);
+          }
         else
-        {
+          {
             throw bad_variant_access("in get<T>()");
-        }
-    }
+          }
+      }
 #endif
 
-    // get_unchecked<T>() - T stored as recursive_wrapper<T>
-    template <typename T, typename std::enable_if<
-                          (detail::direct_type<recursive_wrapper<T>, Types...>::index != detail::invalid_value)>::type* = nullptr>
-    VARIANT_INLINE T& get_unchecked()
-    {
-        return (*reinterpret_cast<recursive_wrapper<T>*>(&data)).get();
-    }
+      // get_unchecked<T>() - T stored as recursive_wrapper<T>
+      template <typename T,
+                typename std::enable_if<
+                    (detail::direct_type<recursive_wrapper<T>, Types...>::index
+                     != detail::invalid_value)>::type * = nullptr>
+      VARIANT_INLINE T &get_unchecked()
+      {
+        return (*reinterpret_cast<recursive_wrapper<T> *>(&data)).get();
+      }
 
 #ifdef HAS_EXCEPTIONS
-    // get<T>() - T stored as recursive_wrapper<T>
-    template <typename T, typename std::enable_if<
-                          (detail::direct_type<recursive_wrapper<T>, Types...>::index != detail::invalid_value)>::type* = nullptr>
-    VARIANT_INLINE T& get()
-    {
-        if (type_index == detail::direct_type<recursive_wrapper<T>, Types...>::index)
-        {
-            return (*reinterpret_cast<recursive_wrapper<T>*>(&data)).get();
-        }
+      // get<T>() - T stored as recursive_wrapper<T>
+      template <typename T,
+                typename std::enable_if<
+                    (detail::direct_type<recursive_wrapper<T>, Types...>::index
+                     != detail::invalid_value)>::type * = nullptr>
+      VARIANT_INLINE T &get()
+      {
+        if (type_index
+            == detail::direct_type<recursive_wrapper<T>, Types...>::index)
+          {
+            return (*reinterpret_cast<recursive_wrapper<T> *>(&data)).get();
+          }
         else
-        {
+          {
             throw bad_variant_access("in get<T>()");
-        }
-    }
+          }
+      }
 #endif
 
-    template <typename T, typename std::enable_if<
-                          (detail::direct_type<recursive_wrapper<T>, Types...>::index != detail::invalid_value)>::type* = nullptr>
-    VARIANT_INLINE T const& get_unchecked() const
-    {
-        return (*reinterpret_cast<recursive_wrapper<T> const*>(&data)).get();
-    }
+      template <typename T,
+                typename std::enable_if<
+                    (detail::direct_type<recursive_wrapper<T>, Types...>::index
+                     != detail::invalid_value)>::type * = nullptr>
+      VARIANT_INLINE T const &get_unchecked() const
+      {
+        return (*reinterpret_cast<recursive_wrapper<T> const *>(&data)).get();
+      }
 
 #ifdef HAS_EXCEPTIONS
-    template <typename T, typename std::enable_if<
-                          (detail::direct_type<recursive_wrapper<T>, Types...>::index != detail::invalid_value)>::type* = nullptr>
-    VARIANT_INLINE T const& get() const
-    {
-        if (type_index == detail::direct_type<recursive_wrapper<T>, Types...>::index)
-        {
-            return (*reinterpret_cast<recursive_wrapper<T> const*>(&data)).get();
-        }
+      template <typename T,
+                typename std::enable_if<
+                    (detail::direct_type<recursive_wrapper<T>, Types...>::index
+                     != detail::invalid_value)>::type * = nullptr>
+      VARIANT_INLINE T const &get() const
+      {
+        if (type_index
+            == detail::direct_type<recursive_wrapper<T>, Types...>::index)
+          {
+            return (*reinterpret_cast<recursive_wrapper<T> const *>(&data))
+                .get();
+          }
         else
-        {
+          {
             throw bad_variant_access("in get<T>()");
-        }
-    }
+          }
+      }
 #endif
 
-    // get_unchecked<T>() - T stored as std::reference_wrapper<T>
-    template <typename T, typename std::enable_if<
-                          (detail::direct_type<std::reference_wrapper<T>, Types...>::index != detail::invalid_value)>::type* = nullptr>
-    VARIANT_INLINE T& get_unchecked()
-    {
-        return (*reinterpret_cast<std::reference_wrapper<T>*>(&data)).get();
-    }
+      // get_unchecked<T>() - T stored as std::reference_wrapper<T>
+      template <
+          typename T,
+          typename std::enable_if<
+              (detail::direct_type<std::reference_wrapper<T>, Types...>::index
+               != detail::invalid_value)>::type * = nullptr>
+      VARIANT_INLINE T &get_unchecked()
+      {
+        return (*reinterpret_cast<std::reference_wrapper<T> *>(&data)).get();
+      }
 
 #ifdef HAS_EXCEPTIONS
-    // get<T>() - T stored as std::reference_wrapper<T>
-    template <typename T, typename std::enable_if<
-                          (detail::direct_type<std::reference_wrapper<T>, Types...>::index != detail::invalid_value)>::type* = nullptr>
-    VARIANT_INLINE T& get()
-    {
-        if (type_index == detail::direct_type<std::reference_wrapper<T>, Types...>::index)
-        {
-            return (*reinterpret_cast<std::reference_wrapper<T>*>(&data)).get();
-        }
+      // get<T>() - T stored as std::reference_wrapper<T>
+      template <
+          typename T,
+          typename std::enable_if<
+              (detail::direct_type<std::reference_wrapper<T>, Types...>::index
+               != detail::invalid_value)>::type * = nullptr>
+      VARIANT_INLINE T &get()
+      {
+        if (type_index
+            == detail::direct_type<std::reference_wrapper<T>, Types...>::index)
+          {
+            return (*reinterpret_cast<std::reference_wrapper<T> *>(&data))
+                .get();
+          }
         else
-        {
+          {
             throw bad_variant_access("in get<T>()");
-        }
-    }
+          }
+      }
 #endif
 
-    template <typename T, typename std::enable_if<
-                          (detail::direct_type<std::reference_wrapper<T const>, Types...>::index != detail::invalid_value)>::type* = nullptr>
-    VARIANT_INLINE T const& get_unchecked() const
-    {
-        return (*reinterpret_cast<std::reference_wrapper<T const> const*>(&data)).get();
-    }
+      template <typename T,
+                typename std::enable_if<
+                    (detail::direct_type<std::reference_wrapper<T const>,
+                                         Types...>::index
+                     != detail::invalid_value)>::type * = nullptr>
+      VARIANT_INLINE T const &get_unchecked() const
+      {
+        return (*reinterpret_cast<std::reference_wrapper<T const> const *>(
+                    &data))
+            .get();
+      }
 
 #ifdef HAS_EXCEPTIONS
-    template <typename T, typename std::enable_if<
-                          (detail::direct_type<std::reference_wrapper<T const>, Types...>::index != detail::invalid_value)>::type* = nullptr>
-    VARIANT_INLINE T const& get() const
-    {
-        if (type_index == detail::direct_type<std::reference_wrapper<T const>, Types...>::index)
-        {
-            return (*reinterpret_cast<std::reference_wrapper<T const> const*>(&data)).get();
-        }
+      template <typename T,
+                typename std::enable_if<
+                    (detail::direct_type<std::reference_wrapper<T const>,
+                                         Types...>::index
+                     != detail::invalid_value)>::type * = nullptr>
+      VARIANT_INLINE T const &get() const
+      {
+        if (type_index
+            == detail::direct_type<std::reference_wrapper<T const>,
+                                   Types...>::index)
+          {
+            return (*reinterpret_cast<std::reference_wrapper<T const> const *>(
+                        &data))
+                .get();
+          }
         else
-        {
+          {
             throw bad_variant_access("in get<T>()");
-        }
-    }
+          }
+      }
 #endif
 
-    // This function is deprecated because it returns an internal index field.
-    // Use which() instead.
-    MAPBOX_VARIANT_DEPRECATED VARIANT_INLINE std::size_t get_type_index() const
-    {
+      // This function is deprecated because it returns an internal index
+      // field. Use which() instead.
+      MAPBOX_VARIANT_DEPRECATED VARIANT_INLINE std::size_t
+      get_type_index() const
+      {
         return type_index;
-    }
+      }
 
-    VARIANT_INLINE int which() const noexcept
-    {
-        return static_cast<int>(sizeof...(Types)-type_index - 1);
-    }
+      VARIANT_INLINE int which() const noexcept
+      {
+        return static_cast<int>(sizeof...(Types) - type_index - 1);
+      }
 
-    template <typename T, typename std::enable_if<
-                          (detail::direct_type<T, Types...>::index != detail::invalid_value)>::type* = nullptr>
-    VARIANT_INLINE static constexpr int which() noexcept
-    {
-        return static_cast<int>(sizeof...(Types)-detail::direct_type<T, Types...>::index - 1);
-    }
+      template <typename T, typename std::enable_if<
+                                (detail::direct_type<T, Types...>::index
+                                 != detail::invalid_value)>::type * = nullptr>
+      VARIANT_INLINE static constexpr int which() noexcept
+      {
+        return static_cast<int>(sizeof...(Types)
+                                - detail::direct_type<T, Types...>::index - 1);
+      }
 
-    // visitor
-    // unary
-    template <typename F, typename V, typename R = typename detail::result_of_unary_visit<F, first_type>::type>
-    auto VARIANT_INLINE static visit(V const& v, F&& f)
-        -> decltype(detail::dispatcher<F, V, R, Types...>::apply_const(v, std::forward<F>(f)))
-    {
-        return detail::dispatcher<F, V, R, Types...>::apply_const(v, std::forward<F>(f));
-    }
-    // non-const
-    template <typename F, typename V, typename R = typename detail::result_of_unary_visit<F, first_type>::type>
-    auto VARIANT_INLINE static visit(V& v, F&& f)
-        -> decltype(detail::dispatcher<F, V, R, Types...>::apply(v, std::forward<F>(f)))
-    {
-        return detail::dispatcher<F, V, R, Types...>::apply(v, std::forward<F>(f));
-    }
+      // visitor
+      // unary
+      template <typename F, typename V,
+                typename R
+                = typename detail::result_of_unary_visit<F, first_type>::type>
+      auto VARIANT_INLINE static visit(V const &v, F &&f)
+          -> decltype(detail::dispatcher<F, V, R, Types...>::apply_const(
+              v, std::forward<F>(f)))
+      {
+        return detail::dispatcher<F, V, R, Types...>::apply_const(
+            v, std::forward<F>(f));
+      }
+      // non-const
+      template <typename F, typename V,
+                typename R
+                = typename detail::result_of_unary_visit<F, first_type>::type>
+      auto VARIANT_INLINE static visit(V &v, F &&f) -> decltype(
+          detail::dispatcher<F, V, R, Types...>::apply(v, std::forward<F>(f)))
+      {
+        return detail::dispatcher<F, V, R, Types...>::apply(
+            v, std::forward<F>(f));
+      }
 
-    // binary
-    // const
-    template <typename F, typename V, typename R = typename detail::result_of_binary_visit<F, first_type>::type>
-    auto VARIANT_INLINE static binary_visit(V const& v0, V const& v1, F&& f)
-        -> decltype(detail::binary_dispatcher<F, V, R, Types...>::apply_const(v0, v1, std::forward<F>(f)))
-    {
-        return detail::binary_dispatcher<F, V, R, Types...>::apply_const(v0, v1, std::forward<F>(f));
-    }
-    // non-const
-    template <typename F, typename V, typename R = typename detail::result_of_binary_visit<F, first_type>::type>
-    auto VARIANT_INLINE static binary_visit(V& v0, V& v1, F&& f)
-        -> decltype(detail::binary_dispatcher<F, V, R, Types...>::apply(v0, v1, std::forward<F>(f)))
-    {
-        return detail::binary_dispatcher<F, V, R, Types...>::apply(v0, v1, std::forward<F>(f));
-    }
+      // binary
+      // const
+      template <typename F, typename V,
+                typename R
+                = typename detail::result_of_binary_visit<F, first_type>::type>
+      auto VARIANT_INLINE static binary_visit(V const &v0, V const &v1, F &&f)
+          -> decltype(
+              detail::binary_dispatcher<F, V, R, Types...>::apply_const(
+                  v0, v1, std::forward<F>(f)))
+      {
+        return detail::binary_dispatcher<F, V, R, Types...>::apply_const(
+            v0, v1, std::forward<F>(f));
+      }
+      // non-const
+      template <typename F, typename V,
+                typename R
+                = typename detail::result_of_binary_visit<F, first_type>::type>
+      auto VARIANT_INLINE static binary_visit(V &v0, V &v1, F &&f)
+          -> decltype(detail::binary_dispatcher<F, V, R, Types...>::apply(
+              v0, v1, std::forward<F>(f)))
+      {
+        return detail::binary_dispatcher<F, V, R, Types...>::apply(
+            v0, v1, std::forward<F>(f));
+      }
 
-    ~variant() noexcept // no-throw destructor
-    {
+      ~variant() noexcept // no-throw destructor
+      {
         helper_type::destroy(type_index, &data);
-    }
+      }
 
-    // comparison operators
-    // equality
-    VARIANT_INLINE bool operator==(variant const& rhs) const
-    {
+      // comparison operators
+      // equality
+      VARIANT_INLINE bool operator==(variant const &rhs) const
+      {
         assert(valid() && rhs.valid());
         if (this->which() != rhs.which())
-        {
+          {
             return false;
-        }
+          }
         detail::comparer<variant, detail::equal_comp> visitor(*this);
         return visit(rhs, visitor);
-    }
+      }
 
-    VARIANT_INLINE bool operator!=(variant const& rhs) const
-    {
+      VARIANT_INLINE bool operator!=(variant const &rhs) const
+      {
         return !(*this == rhs);
-    }
+      }
 
-    // less than
-    VARIANT_INLINE bool operator<(variant const& rhs) const
-    {
+      // less than
+      VARIANT_INLINE bool operator<(variant const &rhs) const
+      {
         assert(valid() && rhs.valid());
         if (this->which() != rhs.which())
-        {
+          {
             return this->which() < rhs.which();
-        }
+          }
         detail::comparer<variant, detail::less_comp> visitor(*this);
         return visit(rhs, visitor);
-    }
-    VARIANT_INLINE bool operator>(variant const& rhs) const
-    {
+      }
+      VARIANT_INLINE bool operator>(variant const &rhs) const
+      {
         return rhs < *this;
-    }
-    VARIANT_INLINE bool operator<=(variant const& rhs) const
-    {
+      }
+      VARIANT_INLINE bool operator<=(variant const &rhs) const
+      {
         return !(*this > rhs);
-    }
-    VARIANT_INLINE bool operator>=(variant const& rhs) const
-    {
+      }
+      VARIANT_INLINE bool operator>=(variant const &rhs) const
+      {
         return !(*this < rhs);
+      }
+    };
+
+    // unary visitor interface
+    // const
+    template <typename F, typename V>
+    auto VARIANT_INLINE apply_visitor(F &&f, V const &v)
+        -> decltype(V::visit(v, std::forward<F>(f)))
+    {
+      return V::visit(v, std::forward<F>(f));
     }
-};
 
-// unary visitor interface
-// const
-template <typename F, typename V>
-auto VARIANT_INLINE apply_visitor(F&& f, V const& v) -> decltype(V::visit(v, std::forward<F>(f)))
-{
-    return V::visit(v, std::forward<F>(f));
-}
+    // non-const
+    template <typename F, typename V>
+    auto VARIANT_INLINE apply_visitor(F &&f, V &v)
+        -> decltype(V::visit(v, std::forward<F>(f)))
+    {
+      return V::visit(v, std::forward<F>(f));
+    }
 
-// non-const
-template <typename F, typename V>
-auto VARIANT_INLINE apply_visitor(F&& f, V& v) -> decltype(V::visit(v, std::forward<F>(f)))
-{
-    return V::visit(v, std::forward<F>(f));
-}
+    // binary visitor interface
+    // const
+    template <typename F, typename V>
+    auto VARIANT_INLINE apply_visitor(F &&f, V const &v0, V const &v1)
+        -> decltype(V::binary_visit(v0, v1, std::forward<F>(f)))
+    {
+      return V::binary_visit(v0, v1, std::forward<F>(f));
+    }
 
-// binary visitor interface
-// const
-template <typename F, typename V>
-auto VARIANT_INLINE apply_visitor(F&& f, V const& v0, V const& v1) -> decltype(V::binary_visit(v0, v1, std::forward<F>(f)))
-{
-    return V::binary_visit(v0, v1, std::forward<F>(f));
-}
+    // non-const
+    template <typename F, typename V>
+    auto VARIANT_INLINE apply_visitor(F &&f, V &v0, V &v1)
+        -> decltype(V::binary_visit(v0, v1, std::forward<F>(f)))
+    {
+      return V::binary_visit(v0, v1, std::forward<F>(f));
+    }
 
-// non-const
-template <typename F, typename V>
-auto VARIANT_INLINE apply_visitor(F&& f, V& v0, V& v1) -> decltype(V::binary_visit(v0, v1, std::forward<F>(f)))
-{
-    return V::binary_visit(v0, v1, std::forward<F>(f));
-}
-
-// getter interface
+    // getter interface
 
 #ifdef HAS_EXCEPTIONS
-template <typename ResultType, typename T>
-auto get(T& var)->decltype(var.template get<ResultType>())
-{
-    return var.template get<ResultType>();
-}
+    template <typename ResultType, typename T>
+    auto get(T &var) -> decltype(var.template get<ResultType>())
+    {
+      return var.template get<ResultType>();
+    }
 #endif
 
-template <typename ResultType, typename T>
-ResultType& get_unchecked(T& var)
-{
-    return var.template get_unchecked<ResultType>();
-}
+    template <typename ResultType, typename T>
+    ResultType &get_unchecked(T &var)
+    {
+      return var.template get_unchecked<ResultType>();
+    }
 
 #ifdef HAS_EXCEPTIONS
-template <typename ResultType, typename T>
-auto get(T const& var)->decltype(var.template get<ResultType>())
-{
-    return var.template get<ResultType>();
-}
+    template <typename ResultType, typename T>
+    auto get(T const &var) -> decltype(var.template get<ResultType>())
+    {
+      return var.template get<ResultType>();
+    }
 #endif
 
-template <typename ResultType, typename T>
-ResultType const& get_unchecked(T const& var)
-{
-    return var.template get_unchecked<ResultType>();
-}
-} // namespace util
+    template <typename ResultType, typename T>
+    ResultType const &get_unchecked(T const &var)
+    {
+      return var.template get_unchecked<ResultType>();
+    }
+  } // namespace util
 } // namespace mapbox
 
 #endif // MAPBOX_UTIL_VARIANT_HPP

--- a/src/utils/variant_io.hpp
+++ b/src/utils/variant_io.hpp
@@ -5,41 +5,44 @@
 
 #include <mapbox/variant.hpp>
 
-namespace mapbox {
-namespace util {
-
-namespace detail {
-// operator<< helper
-template <typename Out>
-class printer
+namespace mapbox
 {
-public:
-    explicit printer(Out& out)
-        : out_(out) {}
-    printer& operator=(printer const&) = delete;
+  namespace util
+  {
 
-    // visitor
-    template <typename T>
-    void operator()(T const& operand) const
+    namespace detail
     {
-        out_ << operand;
+      // operator<< helper
+      template <typename Out> class printer
+      {
+      public:
+        explicit printer(Out &out) : out_(out)
+        {
+        }
+        printer &operator=(printer const &) = delete;
+
+        // visitor
+        template <typename T> void operator()(T const &operand) const
+        {
+          out_ << operand;
+        }
+
+      private:
+        Out &out_;
+      };
     }
 
-private:
-    Out& out_;
-};
-}
-
-// operator<<
-template <typename CharT, typename Traits, typename... Types>
-VARIANT_INLINE std::basic_ostream<CharT, Traits>&
-operator<<(std::basic_ostream<CharT, Traits>& out, variant<Types...> const& rhs)
-{
-    detail::printer<std::basic_ostream<CharT, Traits>> visitor(out);
-    apply_visitor(visitor, rhs);
-    return out;
-}
-} // namespace util
+    // operator<<
+    template <typename CharT, typename Traits, typename... Types>
+    VARIANT_INLINE std::basic_ostream<CharT, Traits> &
+    operator<<(std::basic_ostream<CharT, Traits> &out,
+               variant<Types...> const &rhs)
+    {
+      detail::printer<std::basic_ostream<CharT, Traits>> visitor(out);
+      apply_visitor(visitor, rhs);
+      return out;
+    }
+  } // namespace util
 } // namespace mapbox
 
 #endif // MAPBOX_UTIL_VARIANT_IO_HPP

--- a/tests/opencv_tensor.cc
+++ b/tests/opencv_tensor.cc
@@ -1,11 +1,10 @@
 
 /*
-  Following file take opencv mat file as an input and convert it to proper tensor object 
-  Created by : Kumar Shubham
-  Date : 27-03-2016
+  Following file take opencv mat file as an input and convert it to proper
+  tensor object Created by : Kumar Shubham Date : 27-03-2016
 */
 
-//Loading Opencv fIles for processing
+// Loading Opencv fIles for processing
 
 #include <opencv2/opencv.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
@@ -18,9 +17,9 @@
 #include "tensorflow/core/framework/tensor.h"
 #include <fstream>
 
-int main(int argc, char** argv)
+int main(int argc, char **argv)
 {
-  
+
   // Loading the file path provided in the arg into a mat objects
   std::string path = argv[1];
   cv::Mat readImage = cv::imread(path);
@@ -32,66 +31,78 @@ int main(int argc, char** argv)
   int mean = 128;
   int std = 128;
 
-  cv::Size s(height,width);
+  cv::Size s(height, width);
   cv::Mat Image;
   std::cerr << "resizing\n";
-  cv::resize(readImage,Image,s,0,0,cv::INTER_CUBIC);
+  cv::resize(readImage, Image, s, 0, 0, cv::INTER_CUBIC);
   std::cerr << "success resizing\n";
 
   int depth = Image.channels();
 
-  //std::cerr << "height=" << height << " / width=" << width << " / depth=" << depth << std::endl;
-  
+  // std::cerr << "height=" << height << " / width=" << width << " / depth=" <<
+  // depth << std::endl;
+
   // creating a Tensor for storing the data
-  tensorflow::Tensor input_tensor(tensorflow::DT_FLOAT, tensorflow::TensorShape({1,height,width,depth}));
+  tensorflow::Tensor input_tensor(
+      tensorflow::DT_FLOAT,
+      tensorflow::TensorShape({ 1, height, width, depth }));
   auto input_tensor_mapped = input_tensor.tensor<float, 4>();
-  
+
   cv::Mat Image2;
   Image.convertTo(Image2, CV_32FC1);
   Image = Image2;
-  Image = Image-mean;
-  Image = Image/std;
-  const float * source_data = (float*) Image.data;
-  
-  // copying the data into the corresponding tensor
-  for (int y = 0; y < height; ++y) {
-    const float* source_row = source_data + (y * width * depth);
-    for (int x = 0; x < width; ++x) {
-      const float* source_pixel = source_row + (x * depth);
-      for (int c = 0; c < depth; ++c) {
-  const float* source_value = source_pixel + c;
-  input_tensor_mapped(0, y, x, c) = *source_value;
-      }
-    }
-  }
+  Image = Image - mean;
+  Image = Image / std;
+  const float *source_data = (float *)Image.data;
 
-  // initializing the graph 
+  // copying the data into the corresponding tensor
+  for (int y = 0; y < height; ++y)
+    {
+      const float *source_row = source_data + (y * width * depth);
+      for (int x = 0; x < width; ++x)
+        {
+          const float *source_pixel = source_row + (x * depth);
+          for (int c = 0; c < depth; ++c)
+            {
+              const float *source_value = source_pixel + c;
+              input_tensor_mapped(0, y, x, c) = *source_value;
+            }
+        }
+    }
+
+  // initializing the graph
   tensorflow::GraphDef graph_def;
 
   // Name of the folder in which inception graph is present
   std::string graphFile = "../../model/tensorflow_inception_graph.pb";
 
   // Loading the graph to the given variable
-  tensorflow::Status graphLoadedStatus = ReadBinaryProto(tensorflow::Env::Default(),graphFile,&graph_def);
-  if (!graphLoadedStatus.ok()){
-    std::cout << graphLoadedStatus.ToString()<<std::endl;
-    return 1;
-  }
+  tensorflow::Status graphLoadedStatus
+      = ReadBinaryProto(tensorflow::Env::Default(), graphFile, &graph_def);
+  if (!graphLoadedStatus.ok())
+    {
+      std::cout << graphLoadedStatus.ToString() << std::endl;
+      return 1;
+    }
 
   // creating a session with the grap
-  std::unique_ptr<tensorflow::Session> session_inception(tensorflow::NewSession(tensorflow::SessionOptions()));
-  //session->reset(tensorflow::NewSession(tensorflow::SessionOptions()));
-  tensorflow::Status session_create_status = session_inception->Create(graph_def);
-  
-  if (!session_create_status.ok()){
-    return 1;
-  }
-  // running the loaded graph 
+  std::unique_ptr<tensorflow::Session> session_inception(
+      tensorflow::NewSession(tensorflow::SessionOptions()));
+  // session->reset(tensorflow::NewSession(tensorflow::SessionOptions()));
+  tensorflow::Status session_create_status
+      = session_inception->Create(graph_def);
+
+  if (!session_create_status.ok())
+    {
+      return 1;
+    }
+  // running the loaded graph
   std::vector<tensorflow::Tensor> finalOutput;
 
   std::string InputName = "Mul";
   std::string OutputName = "softmax";
-  tensorflow::Status run_status  = session_inception->Run({{InputName,input_tensor}},{OutputName},{},&finalOutput);
+  tensorflow::Status run_status = session_inception->Run(
+      { { InputName, input_tensor } }, { OutputName }, {}, &finalOutput);
 
   // finding the labels for prediction
   std::cerr << "final output size=" << finalOutput.size() << std::endl;
@@ -103,26 +114,30 @@ int main(int argc, char** argv)
   std::string labelfile = "../../model/imagenet_comp_graph_label_strings.txt";
   std::ifstream label(labelfile);
   std::string line;
-  
+
   // sorting the file to find the top labels
-  std::vector<std::pair<float,std::string>> sorted;
+  std::vector<std::pair<float, std::string>> sorted;
 
-  for (unsigned int i =0; i<=1000 ;++i){
-    std::getline(label,line);
-    sorted.emplace_back(scores(i),line);
-    //std::cout << scores(i) << " / line=" << line << std::endl;
-  }
+  for (unsigned int i = 0; i <= 1000; ++i)
+    {
+      std::getline(label, line);
+      sorted.emplace_back(scores(i), line);
+      // std::cout << scores(i) << " / line=" << line << std::endl;
+    }
 
-  std::sort(sorted.begin(),sorted.end());
-  std::reverse(sorted.begin(),sorted.end());
-  std::cout << "size of the sorted file is "<<sorted.size()<< std::endl;
-  for(unsigned int i =0 ; i< 5;++i){
+  std::sort(sorted.begin(), sorted.end());
+  std::reverse(sorted.begin(), sorted.end());
+  std::cout << "size of the sorted file is " << sorted.size() << std::endl;
+  for (unsigned int i = 0; i < 5; ++i)
+    {
 
-    std::cout << "The output of the current graph has category  " << sorted[i].second << " with probability "<< sorted[i].first << std::endl; 
-  }
-  
+      std::cout << "The output of the current graph has category  "
+                << sorted[i].second << " with probability " << sorted[i].first
+                << std::endl;
+    }
+
   /*cv::namedWindow("imageOpencv",CV_WINDOW_KEEPRATIO);
   cv::imshow("imgOpencv",Image);
-  
+
   */
 }

--- a/tests/test-server.cc
+++ b/tests/test-server.cc
@@ -6,24 +6,26 @@ namespace http = boost::network::http;
 struct handler;
 typedef http::server<handler> http_server;
 
-struct handler {
-  void operator() (http_server::request const &request,
-		   http_server::response &response) {
+struct handler
+{
+  void operator()(http_server::request const &request,
+                  http_server::response &response)
+  {
     (void)request;
-    response = http_server::response::stock_reply(
-						  http_server::response::ok, "Hello, world!");
+    response = http_server::response::stock_reply(http_server::response::ok,
+                                                  "Hello, world!");
   }
 
-  void log(http_server::string_type const &info) {
+  void log(http_server::string_type const &info)
+  {
     std::cerr << "ERROR: " << info << '\n';
   }
 };
 
-int main() {
+int main()
+{
   handler handler_;
   http_server::options options(handler_);
-  http_server server_(
-		      options.address("0.0.0.0")
-		      .port("8000"));
+  http_server server_(options.address("0.0.0.0").port("8000"));
   server_.run();
 }

--- a/tests/ut-apidata.cc
+++ b/tests/ut-apidata.cc
@@ -26,35 +26,35 @@
 
 using namespace dd;
 
-TEST(apidata,visitor_vad)
+TEST(apidata, visitor_vad)
 {
   double loss = 1.17;
   double prob1 = 0.67;
   double prob2 = 0.29;
-  
+
   APIData ad;
   std::vector<APIData> vad;
   APIData ivad1;
-  ivad1.add("cat",std::string("car"));
-  ivad1.add("prob",prob1);
+  ivad1.add("cat", std::string("car"));
+  ivad1.add("prob", prob1);
   vad.push_back(ivad1);
   APIData ivad2;
-  ivad2.add("cat",std::string("wolf"));
-  ivad2.add("prob",prob2);
+  ivad2.add("cat", std::string("wolf"));
+  ivad2.add("prob", prob2);
   vad.push_back(ivad2);
-  ad.add("classes",vad);
-  ad.add("loss",loss);
+  ad.add("classes", vad);
+  ad.add("loss", loss);
   APIData tad;
-  tad.add("test",1);
-  ad.add("tad",tad);
+  tad.add("test", 1);
+  ad.add("tad", tad);
 
   std::vector<APIData> ad_cl = ad.getv("classes");
   std::cout << "prob=" << ad_cl.at(0).get("prob").get<double>() << std::endl;
-  ASSERT_EQ(prob1,ad_cl.at(0).get("prob").get<double>());
-  ASSERT_EQ(1,ad.getobj("tad").get("test").get<int>());
+  ASSERT_EQ(prob1, ad_cl.at(0).get("prob").get<double>());
+  ASSERT_EQ(1, ad.getobj("tad").get("test").get<int>());
 }
 
-TEST(apidata,to_from_json)
+TEST(apidata, to_from_json)
 {
   double prob1 = 0.67;
   double prob2 = 0.29;
@@ -63,68 +63,66 @@ TEST(apidata,to_from_json)
 
   // to JSON
   APIData ad;
-  ad.add("string",std::string("string"));
-  ad.add("double",2.3);
-  ad.add("int",3);
-  ad.add("bool",true);
-  std::vector<double> vd = {1.1,2.2,3.3};
-  ad.add("vdouble",vd);
-  std::vector<std::string> vs = {"one","two","three"};
-  ad.add("vstring",vs);
+  ad.add("string", std::string("string"));
+  ad.add("double", 2.3);
+  ad.add("int", 3);
+  ad.add("bool", true);
+  std::vector<double> vd = { 1.1, 2.2, 3.3 };
+  ad.add("vdouble", vd);
+  std::vector<std::string> vs = { "one", "two", "three" };
+  ad.add("vstring", vs);
   std::vector<APIData> vad;
   APIData ivad1;
-  ivad1.add("cat",std::string("car"));
-  ivad1.add("prob",prob1);
+  ivad1.add("cat", std::string("car"));
+  ivad1.add("prob", prob1);
   vad.push_back(ivad1);
   APIData ivad2;
-  ivad2.add("cat",std::string("wolf"));
-  ivad2.add("prob",prob2);
+  ivad2.add("cat", std::string("wolf"));
+  ivad2.add("prob", prob2);
   vad.push_back(ivad2);
-  ad.add("classes",vad);
+  ad.add("classes", vad);
   APIData tad;
-  tad.add("test",1);
-  ad.add("tad",tad);
+  tad.add("test", 1);
+  ad.add("tad", tad);
   ad.toJDoc(jd);
   JsonAPI japi;
   std::string jrstr = japi.jrender(jd);
   std::cout << jrstr << std::endl;
-  ASSERT_TRUE(jd["string"].GetString()==std::string("string"));
-  ASSERT_EQ(2.3,jd["double"]);
-  ASSERT_EQ(3,jd["int"]);
-  ASSERT_EQ(true,jd["bool"]);
+  ASSERT_TRUE(jd["string"].GetString() == std::string("string"));
+  ASSERT_EQ(2.3, jd["double"]);
+  ASSERT_EQ(3, jd["int"]);
+  ASSERT_EQ(true, jd["bool"]);
   ASSERT_TRUE(jd["vdouble"].IsArray());
-  ASSERT_EQ(1.1,jd["vdouble"][0]);
+  ASSERT_EQ(1.1, jd["vdouble"][0]);
   ASSERT_TRUE(jd["vstring"].IsArray());
-  ASSERT_TRUE(jd["vstring"][1].GetString()==std::string("two"));
+  ASSERT_TRUE(jd["vstring"][1].GetString() == std::string("two"));
   ASSERT_TRUE(jd["classes"].IsArray());
-  ASSERT_TRUE(jd["classes"][0]["cat"].GetString()==std::string("car"));
-  ASSERT_EQ(prob1,jd["classes"][0]["prob"].GetDouble());
+  ASSERT_TRUE(jd["classes"][0]["cat"].GetString() == std::string("car"));
+  ASSERT_EQ(prob1, jd["classes"][0]["prob"].GetDouble());
 
   // to APIData
   APIData nad(jd);
-  ASSERT_EQ("string",nad.get("string").get<std::string>());
-  ASSERT_EQ(2.3,nad.get("double").get<double>());
-  ASSERT_EQ(true,nad.get("bool").get<bool>());
-  ASSERT_EQ(3,nad.get("vdouble").get<std::vector<double>>().size());
-  ASSERT_EQ(2.2,nad.get("vdouble").get<std::vector<double>>().at(1));
-  ASSERT_EQ(3,nad.get("vstring").get<std::vector<std::string>>().size());
-  ASSERT_EQ("two",nad.get("vstring").get<std::vector<std::string>>().at(1));
-  
+  ASSERT_EQ("string", nad.get("string").get<std::string>());
+  ASSERT_EQ(2.3, nad.get("double").get<double>());
+  ASSERT_EQ(true, nad.get("bool").get<bool>());
+  ASSERT_EQ(3, nad.get("vdouble").get<std::vector<double>>().size());
+  ASSERT_EQ(2.2, nad.get("vdouble").get<std::vector<double>>().at(1));
+  ASSERT_EQ(3, nad.get("vstring").get<std::vector<std::string>>().size());
+  ASSERT_EQ("two", nad.get("vstring").get<std::vector<std::string>>().at(1));
+
   // and back to JSON for comparison
   JDoc njd;
   njd.SetObject();
   nad.toJDoc(njd);
-  ASSERT_TRUE(njd["string"].GetString()==std::string("string"));
-  ASSERT_EQ(2.3,njd["double"]);
-  ASSERT_EQ(3,njd["int"]);
-  ASSERT_EQ(true,njd["bool"]);
+  ASSERT_TRUE(njd["string"].GetString() == std::string("string"));
+  ASSERT_EQ(2.3, njd["double"]);
+  ASSERT_EQ(3, njd["int"]);
+  ASSERT_EQ(true, njd["bool"]);
   ASSERT_TRUE(njd["vdouble"].IsArray());
-  ASSERT_EQ(1.1,njd["vdouble"][0]);
+  ASSERT_EQ(1.1, njd["vdouble"][0]);
   ASSERT_TRUE(njd["vstring"].IsArray());
-  ASSERT_TRUE(njd["vstring"][1].GetString()==std::string("two"));
+  ASSERT_TRUE(njd["vstring"][1].GetString() == std::string("two"));
   ASSERT_TRUE(njd["classes"].IsArray());
-  ASSERT_TRUE(njd["classes"][0]["cat"].GetString()==std::string("car"));
-  ASSERT_EQ(prob1,njd["classes"][0]["prob"].GetDouble());
+  ASSERT_TRUE(njd["classes"][0]["cat"].GetString() == std::string("car"));
+  ASSERT_EQ(prob1, njd["classes"][0]["prob"].GetDouble());
 }
-
-

--- a/tests/ut-caffe-mlp.cc
+++ b/tests/ut-caffe-mlp.cc
@@ -32,603 +32,661 @@ static std::string dnet_file = "../templates/caffe/mlp/deploy.prototxt";
 static std::string onet_file = "nmlp.prototxt";
 static std::string donet_file = "nmlp_deploy.prototxt";
 
-static std::string convnet_file = "../templates/caffe/convnet/convnet.prototxt";
-static std::string dconvnet_file = "../templates/caffe/convnet/deploy.prototxt";
+static std::string convnet_file
+    = "../templates/caffe/convnet/convnet.prototxt";
+static std::string dconvnet_file
+    = "../templates/caffe/convnet/deploy.prototxt";
 static std::string oconvnet_file = "nconvnet.prototxt";
 static std::string doconvnet_file = "nconvnet_deploy.prototxt";
 static std::string oresnet_file = "nresnet.prototxt";
 static std::string doresnet_file = "nresnet_deploy.prototxt";
 
-TEST(caffelib,configure_mlp_template_1_nt)
+TEST(caffelib, configure_mlp_template_1_nt)
 {
   int nclasses = 7;
   caffe::NetParameter net_param, deploy_net_param;
 
-  std::vector<int> layers = {200};
+  std::vector<int> layers = { 200 };
   APIData ad;
-  ad.add("layers",layers);
-  ad.add("activation",std::string("prelu"));
-  ad.add("dropout",0.6);
-  ad.add("nclasses",nclasses);
-  
-  CaffeLib<CSVCaffeInputFileConn,SupervisedOutput,CaffeModel> *caff = new CaffeLib<CSVCaffeInputFileConn,SupervisedOutput,CaffeModel>(CaffeModel());
-  caff->configure_mlp_template(ad,CSVCaffeInputFileConn(),net_param,deploy_net_param);
+  ad.add("layers", layers);
+  ad.add("activation", std::string("prelu"));
+  ad.add("dropout", 0.6);
+  ad.add("nclasses", nclasses);
 
-  caffe::WriteProtoToTextFile(net_param,onet_file.c_str());
-  caffe::WriteProtoToTextFile(deploy_net_param,donet_file);
-  
-  ASSERT_EQ(8,net_param.layer_size());
+  CaffeLib<CSVCaffeInputFileConn, SupervisedOutput, CaffeModel> *caff
+      = new CaffeLib<CSVCaffeInputFileConn, SupervisedOutput, CaffeModel>(
+          CaffeModel());
+  caff->configure_mlp_template(ad, CSVCaffeInputFileConn(), net_param,
+                               deploy_net_param);
+
+  caffe::WriteProtoToTextFile(net_param, onet_file.c_str());
+  caffe::WriteProtoToTextFile(deploy_net_param, donet_file);
+
+  ASSERT_EQ(8, net_param.layer_size());
   caffe::LayerParameter *lparam = net_param.mutable_layer(2);
-  ASSERT_EQ("InnerProduct",lparam->type());
-  ASSERT_EQ(layers.at(0),lparam->mutable_inner_product_param()->num_output());
+  ASSERT_EQ("InnerProduct", lparam->type());
+  ASSERT_EQ(layers.at(0), lparam->mutable_inner_product_param()->num_output());
   lparam = net_param.mutable_layer(3);
-  ASSERT_EQ("PReLU",lparam->type());
+  ASSERT_EQ("PReLU", lparam->type());
   lparam = net_param.mutable_layer(4);
-  ASSERT_EQ("Dropout",lparam->type());
-  ASSERT_NEAR(0.6,lparam->mutable_dropout_param()->dropout_ratio(),1e-5); // near as there seems to be a slight conversion issue from protobufs
+  ASSERT_EQ("Dropout", lparam->type());
+  ASSERT_NEAR(0.6, lparam->mutable_dropout_param()->dropout_ratio(),
+              1e-5); // near as there seems to be a slight conversion issue
+                     // from protobufs
   lparam = net_param.mutable_layer(5);
-  ASSERT_EQ("InnerProduct",lparam->type());
-  ASSERT_EQ(nclasses,lparam->mutable_inner_product_param()->num_output());
-  
-  ASSERT_EQ(5,deploy_net_param.layer_size());
+  ASSERT_EQ("InnerProduct", lparam->type());
+  ASSERT_EQ(nclasses, lparam->mutable_inner_product_param()->num_output());
+
+  ASSERT_EQ(5, deploy_net_param.layer_size());
   caffe::LayerParameter *dlparam = deploy_net_param.mutable_layer(1);
-  ASSERT_EQ("InnerProduct",dlparam->type());
-  ASSERT_EQ(layers.at(0),dlparam->mutable_inner_product_param()->num_output());
+  ASSERT_EQ("InnerProduct", dlparam->type());
+  ASSERT_EQ(layers.at(0),
+            dlparam->mutable_inner_product_param()->num_output());
   dlparam = deploy_net_param.mutable_layer(2);
-  ASSERT_EQ("PReLU",dlparam->type());
+  ASSERT_EQ("PReLU", dlparam->type());
   dlparam = deploy_net_param.mutable_layer(3);
-  ASSERT_EQ("InnerProduct",dlparam->type());
-  ASSERT_EQ(nclasses,dlparam->mutable_inner_product_param()->num_output());
+  ASSERT_EQ("InnerProduct", dlparam->type());
+  ASSERT_EQ(nclasses, dlparam->mutable_inner_product_param()->num_output());
 
   delete caff;
 }
 
-TEST(caffelib,configure_mlp_template_1_db)
+TEST(caffelib, configure_mlp_template_1_db)
 {
   int nclasses = 7;
   caffe::NetParameter net_param, deploy_net_param;
-  
-  std::vector<int> layers = {200};
+
+  std::vector<int> layers = { 200 };
   APIData ad;
-  ad.add("layers",layers);
-  ad.add("activation",std::string("prelu"));
-  ad.add("dropout",0.2);
-  ad.add("db",true);
-  ad.add("nclasses",nclasses);
-  
-  CaffeLib<CSVCaffeInputFileConn,SupervisedOutput,CaffeModel> *caff = new CaffeLib<CSVCaffeInputFileConn,SupervisedOutput,CaffeModel>(CaffeModel());
-  caff->configure_mlp_template(ad,CSVCaffeInputFileConn(),net_param,deploy_net_param);
+  ad.add("layers", layers);
+  ad.add("activation", std::string("prelu"));
+  ad.add("dropout", 0.2);
+  ad.add("db", true);
+  ad.add("nclasses", nclasses);
 
-  caffe::WriteProtoToTextFile(net_param,onet_file);
-  caffe::WriteProtoToTextFile(deploy_net_param,donet_file);
+  CaffeLib<CSVCaffeInputFileConn, SupervisedOutput, CaffeModel> *caff
+      = new CaffeLib<CSVCaffeInputFileConn, SupervisedOutput, CaffeModel>(
+          CaffeModel());
+  caff->configure_mlp_template(ad, CSVCaffeInputFileConn(), net_param,
+                               deploy_net_param);
 
-  ASSERT_EQ(8,net_param.layer_size());
+  caffe::WriteProtoToTextFile(net_param, onet_file);
+  caffe::WriteProtoToTextFile(deploy_net_param, donet_file);
+
+  ASSERT_EQ(8, net_param.layer_size());
   caffe::LayerParameter *lparam = net_param.mutable_layer(0);
-  ASSERT_EQ("Data",lparam->type());
-  ASSERT_EQ("train.lmdb",lparam->mutable_data_param()->source());
-  ASSERT_EQ(caffe::DataParameter_DB_LMDB,lparam->mutable_data_param()->backend());
+  ASSERT_EQ("Data", lparam->type());
+  ASSERT_EQ("train.lmdb", lparam->mutable_data_param()->source());
+  ASSERT_EQ(caffe::DataParameter_DB_LMDB,
+            lparam->mutable_data_param()->backend());
   lparam = net_param.mutable_layer(2);
-  ASSERT_EQ("InnerProduct",lparam->type());
-  ASSERT_EQ(layers.at(0),lparam->mutable_inner_product_param()->num_output());
+  ASSERT_EQ("InnerProduct", lparam->type());
+  ASSERT_EQ(layers.at(0), lparam->mutable_inner_product_param()->num_output());
   lparam = net_param.mutable_layer(3);
-  ASSERT_EQ("PReLU",lparam->type());
+  ASSERT_EQ("PReLU", lparam->type());
   lparam = net_param.mutable_layer(4);
-  ASSERT_EQ("Dropout",lparam->type());
-  ASSERT_NEAR(0.2,lparam->mutable_dropout_param()->dropout_ratio(),1e-5); // near as there seems to be a slight conversion issue from protobufs
+  ASSERT_EQ("Dropout", lparam->type());
+  ASSERT_NEAR(0.2, lparam->mutable_dropout_param()->dropout_ratio(),
+              1e-5); // near as there seems to be a slight conversion issue
+                     // from protobufs
   lparam = net_param.mutable_layer(5);
-  ASSERT_EQ("InnerProduct",lparam->type());
-  ASSERT_EQ(nclasses,lparam->mutable_inner_product_param()->num_output());
-  
-  ASSERT_EQ(5,deploy_net_param.layer_size());
+  ASSERT_EQ("InnerProduct", lparam->type());
+  ASSERT_EQ(nclasses, lparam->mutable_inner_product_param()->num_output());
+
+  ASSERT_EQ(5, deploy_net_param.layer_size());
   caffe::LayerParameter *dlparam = deploy_net_param.mutable_layer(1);
-  ASSERT_EQ("InnerProduct",dlparam->type());
-  ASSERT_EQ(layers.at(0),dlparam->mutable_inner_product_param()->num_output());
+  ASSERT_EQ("InnerProduct", dlparam->type());
+  ASSERT_EQ(layers.at(0),
+            dlparam->mutable_inner_product_param()->num_output());
   dlparam = deploy_net_param.mutable_layer(2);
-  ASSERT_EQ("PReLU",dlparam->type());
+  ASSERT_EQ("PReLU", dlparam->type());
   dlparam = deploy_net_param.mutable_layer(3);
-  ASSERT_EQ("InnerProduct",dlparam->type());
-  ASSERT_EQ(nclasses,dlparam->mutable_inner_product_param()->num_output());
+  ASSERT_EQ("InnerProduct", dlparam->type());
+  ASSERT_EQ(nclasses, dlparam->mutable_inner_product_param()->num_output());
 
   delete caff;
 }
 
-TEST(caffelib,configure_mlp_template_n_nt)
+TEST(caffelib, configure_mlp_template_n_nt)
 {
   int nclasses = 7;
   caffe::NetParameter net_param, deploy_net_param;
-    
-  std::vector<int> layers = {200,150,75};
-  APIData ad;
-  ad.add("layers",layers);
-  ad.add("activation",std::string("prelu"));
-  ad.add("dropout",0.6);
-  ad.add("nclasses",nclasses);
 
-  CaffeLib<CSVCaffeInputFileConn,SupervisedOutput,CaffeModel> *caff = new CaffeLib<CSVCaffeInputFileConn,SupervisedOutput,CaffeModel>(CaffeModel());
-  caff->configure_mlp_template(ad,CSVCaffeInputFileConn(),net_param,deploy_net_param);
-    
-  caffe::WriteProtoToTextFile(net_param,onet_file);
-  caffe::WriteProtoToTextFile(deploy_net_param,donet_file);
-  
-  ASSERT_EQ(14,net_param.layer_size());
-  ASSERT_EQ(9,deploy_net_param.layer_size());
+  std::vector<int> layers = { 200, 150, 75 };
+  APIData ad;
+  ad.add("layers", layers);
+  ad.add("activation", std::string("prelu"));
+  ad.add("dropout", 0.6);
+  ad.add("nclasses", nclasses);
+
+  CaffeLib<CSVCaffeInputFileConn, SupervisedOutput, CaffeModel> *caff
+      = new CaffeLib<CSVCaffeInputFileConn, SupervisedOutput, CaffeModel>(
+          CaffeModel());
+  caff->configure_mlp_template(ad, CSVCaffeInputFileConn(), net_param,
+                               deploy_net_param);
+
+  caffe::WriteProtoToTextFile(net_param, onet_file);
+  caffe::WriteProtoToTextFile(deploy_net_param, donet_file);
+
+  ASSERT_EQ(14, net_param.layer_size());
+  ASSERT_EQ(9, deploy_net_param.layer_size());
   int rl = 1;
   caffe::LayerParameter *lparam;
-  for (size_t l=0;l<layers.size();l++)
+  for (size_t l = 0; l < layers.size(); l++)
     {
       lparam = net_param.mutable_layer(++rl);
-      ASSERT_EQ("InnerProduct",lparam->type());
-      ASSERT_EQ(layers.at(l),lparam->mutable_inner_product_param()->num_output());
+      ASSERT_EQ("InnerProduct", lparam->type());
+      ASSERT_EQ(layers.at(l),
+                lparam->mutable_inner_product_param()->num_output());
       lparam = net_param.mutable_layer(++rl);
-      ASSERT_EQ("PReLU",lparam->type());
+      ASSERT_EQ("PReLU", lparam->type());
       lparam = net_param.mutable_layer(++rl);
-      ASSERT_EQ("Dropout",lparam->type());
-      ASSERT_NEAR(0.6,lparam->mutable_dropout_param()->dropout_ratio(),1e-5); // near as there seems to be a slight conversion issue from protobufs
+      ASSERT_EQ("Dropout", lparam->type());
+      ASSERT_NEAR(0.6, lparam->mutable_dropout_param()->dropout_ratio(),
+                  1e-5); // near as there seems to be a slight conversion issue
+                         // from protobufs
     }
   int drl = 0;
   caffe::LayerParameter *dlparam;
-  for (size_t l=0;l<layers.size();l++)
+  for (size_t l = 0; l < layers.size(); l++)
     {
       dlparam = deploy_net_param.mutable_layer(++drl);
-      ASSERT_EQ("InnerProduct",dlparam->type());
-      ASSERT_EQ(layers.at(l),dlparam->mutable_inner_product_param()->num_output());
+      ASSERT_EQ("InnerProduct", dlparam->type());
+      ASSERT_EQ(layers.at(l),
+                dlparam->mutable_inner_product_param()->num_output());
       dlparam = deploy_net_param.mutable_layer(++drl);
-      ASSERT_EQ("PReLU",dlparam->type());
+      ASSERT_EQ("PReLU", dlparam->type());
     }
-  lparam = net_param.mutable_layer(rl+1);
-  ASSERT_EQ("InnerProduct",lparam->type());
-  ASSERT_EQ(nclasses,lparam->mutable_inner_product_param()->num_output());
-  dlparam = deploy_net_param.mutable_layer(drl+1);
-  ASSERT_EQ("InnerProduct",dlparam->type());
-  ASSERT_EQ(nclasses,dlparam->mutable_inner_product_param()->num_output());
+  lparam = net_param.mutable_layer(rl + 1);
+  ASSERT_EQ("InnerProduct", lparam->type());
+  ASSERT_EQ(nclasses, lparam->mutable_inner_product_param()->num_output());
+  dlparam = deploy_net_param.mutable_layer(drl + 1);
+  ASSERT_EQ("InnerProduct", dlparam->type());
+  ASSERT_EQ(nclasses, dlparam->mutable_inner_product_param()->num_output());
   delete caff;
 }
 
-TEST(caffelib,configure_mlp_template_n_mt)
+TEST(caffelib, configure_mlp_template_n_mt)
 {
   int ntargets = 3;
   caffe::NetParameter net_param, deploy_net_param;
-  
-  std::vector<int> layers = {200,150,75};
+
+  std::vector<int> layers = { 200, 150, 75 };
   APIData ad;
-  ad.add("layers",layers);
-  ad.add("activation",std::string("prelu"));
-  ad.add("dropout",0.6);
-  ad.add("ntargets",ntargets);
+  ad.add("layers", layers);
+  ad.add("activation", std::string("prelu"));
+  ad.add("dropout", 0.6);
+  ad.add("ntargets", ntargets);
 
-  CaffeLib<CSVCaffeInputFileConn,SupervisedOutput,CaffeModel> *caff = new CaffeLib<CSVCaffeInputFileConn,SupervisedOutput,CaffeModel>(CaffeModel());
-  caff->configure_mlp_template(ad,CSVCaffeInputFileConn(),net_param,deploy_net_param);
+  CaffeLib<CSVCaffeInputFileConn, SupervisedOutput, CaffeModel> *caff
+      = new CaffeLib<CSVCaffeInputFileConn, SupervisedOutput, CaffeModel>(
+          CaffeModel());
+  caff->configure_mlp_template(ad, CSVCaffeInputFileConn(), net_param,
+                               deploy_net_param);
 
-  caffe::WriteProtoToTextFile(net_param,onet_file);
-  caffe::WriteProtoToTextFile(deploy_net_param,donet_file);
-  
-  ASSERT_EQ(15,net_param.layer_size());
-  ASSERT_EQ(10,deploy_net_param.layer_size());
+  caffe::WriteProtoToTextFile(net_param, onet_file);
+  caffe::WriteProtoToTextFile(deploy_net_param, donet_file);
+
+  ASSERT_EQ(15, net_param.layer_size());
+  ASSERT_EQ(10, deploy_net_param.layer_size());
   int rl = 1;
   caffe::LayerParameter *lparam;
   lparam = net_param.mutable_layer(++rl);
-  ASSERT_EQ("Slice",lparam->type());
-  ASSERT_EQ(1,lparam->mutable_slice_param()->slice_point(0)); // 1 is a dummy slice point
-  for (size_t l=0;l<layers.size();l++)
+  ASSERT_EQ("Slice", lparam->type());
+  ASSERT_EQ(1, lparam->mutable_slice_param()->slice_point(
+                   0)); // 1 is a dummy slice point
+  for (size_t l = 0; l < layers.size(); l++)
     {
       lparam = net_param.mutable_layer(++rl);
-      ASSERT_EQ("InnerProduct",lparam->type());
-      ASSERT_EQ(layers.at(l),lparam->mutable_inner_product_param()->num_output());
+      ASSERT_EQ("InnerProduct", lparam->type());
+      ASSERT_EQ(layers.at(l),
+                lparam->mutable_inner_product_param()->num_output());
       lparam = net_param.mutable_layer(++rl);
-      ASSERT_EQ("PReLU",lparam->type());
+      ASSERT_EQ("PReLU", lparam->type());
       lparam = net_param.mutable_layer(++rl);
-      ASSERT_EQ("Dropout",lparam->type());
-      ASSERT_NEAR(0.6,lparam->mutable_dropout_param()->dropout_ratio(),1e-5); // near as there seems to be a slight conversion issue from protobufs
+      ASSERT_EQ("Dropout", lparam->type());
+      ASSERT_NEAR(0.6, lparam->mutable_dropout_param()->dropout_ratio(),
+                  1e-5); // near as there seems to be a slight conversion issue
+                         // from protobufs
     }
   int drl = 0;
   caffe::LayerParameter *dlparam;
   dlparam = deploy_net_param.mutable_layer(++drl);
-  ASSERT_EQ("Slice",dlparam->type());
-  ASSERT_EQ(1,dlparam->mutable_slice_param()->slice_point(0)); // 1 is a dummy slice point
-  for (size_t l=0;l<layers.size();l++)
+  ASSERT_EQ("Slice", dlparam->type());
+  ASSERT_EQ(1, dlparam->mutable_slice_param()->slice_point(
+                   0)); // 1 is a dummy slice point
+  for (size_t l = 0; l < layers.size(); l++)
     {
       dlparam = deploy_net_param.mutable_layer(++drl);
-      ASSERT_EQ("InnerProduct",dlparam->type());
-      ASSERT_EQ(layers.at(l),dlparam->mutable_inner_product_param()->num_output());
+      ASSERT_EQ("InnerProduct", dlparam->type());
+      ASSERT_EQ(layers.at(l),
+                dlparam->mutable_inner_product_param()->num_output());
       dlparam = deploy_net_param.mutable_layer(++drl);
-      ASSERT_EQ("PReLU",dlparam->type());
+      ASSERT_EQ("PReLU", dlparam->type());
     }
-  lparam = net_param.mutable_layer(rl+1);
-  ASSERT_EQ("InnerProduct",lparam->type());
-  ASSERT_EQ(ntargets,lparam->mutable_inner_product_param()->num_output());
-  dlparam = deploy_net_param.mutable_layer(drl+1);
-  ASSERT_EQ("InnerProduct",dlparam->type());
-  ASSERT_EQ(ntargets,dlparam->mutable_inner_product_param()->num_output());
+  lparam = net_param.mutable_layer(rl + 1);
+  ASSERT_EQ("InnerProduct", lparam->type());
+  ASSERT_EQ(ntargets, lparam->mutable_inner_product_param()->num_output());
+  dlparam = deploy_net_param.mutable_layer(drl + 1);
+  ASSERT_EQ("InnerProduct", dlparam->type());
+  ASSERT_EQ(ntargets, dlparam->mutable_inner_product_param()->num_output());
   delete caff;
 }
 
-TEST(caffelib,configure_convnet_template_1)
+TEST(caffelib, configure_convnet_template_1)
 {
   int nclasses = 18;
   caffe::NetParameter net_param, deploy_net_param;
- 
-  std::vector<std::string> layers = {"1CR64"};
+
+  std::vector<std::string> layers = { "1CR64" };
   APIData ad;
-  ad.add("layers",layers);
-  ad.add("activation",std::string("prelu"));
-  ad.add("dropout",0.2);
-  ad.add("nclasses",nclasses);
+  ad.add("layers", layers);
+  ad.add("activation", std::string("prelu"));
+  ad.add("dropout", 0.2);
+  ad.add("nclasses", nclasses);
 
-  CaffeLib<ImgCaffeInputFileConn,SupervisedOutput,CaffeModel> *caff = new CaffeLib<ImgCaffeInputFileConn,SupervisedOutput,CaffeModel>(CaffeModel());
-  caff->configure_convnet_template(ad,ImgCaffeInputFileConn(),net_param,deploy_net_param);
+  CaffeLib<ImgCaffeInputFileConn, SupervisedOutput, CaffeModel> *caff
+      = new CaffeLib<ImgCaffeInputFileConn, SupervisedOutput, CaffeModel>(
+          CaffeModel());
+  caff->configure_convnet_template(ad, ImgCaffeInputFileConn(), net_param,
+                                   deploy_net_param);
 
-  caffe::WriteProtoToTextFile(net_param,oconvnet_file);
-  caffe::WriteProtoToTextFile(deploy_net_param,doconvnet_file);
- 
-  ASSERT_EQ(8,net_param.layer_size());
+  caffe::WriteProtoToTextFile(net_param, oconvnet_file);
+  caffe::WriteProtoToTextFile(deploy_net_param, doconvnet_file);
+
+  ASSERT_EQ(8, net_param.layer_size());
   caffe::LayerParameter *lparam = net_param.mutable_layer(2);
-  ASSERT_EQ("Convolution",lparam->type());
-  ASSERT_EQ(64,lparam->mutable_convolution_param()->num_output());
+  ASSERT_EQ("Convolution", lparam->type());
+  ASSERT_EQ(64, lparam->mutable_convolution_param()->num_output());
   lparam = net_param.mutable_layer(3);
-  ASSERT_EQ("PReLU",lparam->type());
+  ASSERT_EQ("PReLU", lparam->type());
   lparam = net_param.mutable_layer(4);
-  ASSERT_EQ("Pooling",lparam->type());
+  ASSERT_EQ("Pooling", lparam->type());
   lparam = net_param.mutable_layer(5);
-  ASSERT_EQ("InnerProduct",lparam->type());
-  ASSERT_EQ(nclasses,lparam->mutable_inner_product_param()->num_output());
-  ASSERT_EQ("ip0_conv_0",lparam->bottom(0));
+  ASSERT_EQ("InnerProduct", lparam->type());
+  ASSERT_EQ(nclasses, lparam->mutable_inner_product_param()->num_output());
+  ASSERT_EQ("ip0_conv_0", lparam->bottom(0));
 
-  //ASSERT_EQ(6,deploy_net_param.layer_size());
+  // ASSERT_EQ(6,deploy_net_param.layer_size());
   caffe::LayerParameter *dlparam = deploy_net_param.mutable_layer(1);
-  ASSERT_EQ("Convolution",dlparam->type());
-  ASSERT_EQ(64,dlparam->mutable_convolution_param()->num_output());
+  ASSERT_EQ("Convolution", dlparam->type());
+  ASSERT_EQ(64, dlparam->mutable_convolution_param()->num_output());
   dlparam = deploy_net_param.mutable_layer(2);
-  ASSERT_EQ("PReLU",dlparam->type());
+  ASSERT_EQ("PReLU", dlparam->type());
   dlparam = deploy_net_param.mutable_layer(3);
-  ASSERT_EQ("Pooling",dlparam->type());
+  ASSERT_EQ("Pooling", dlparam->type());
   dlparam = deploy_net_param.mutable_layer(4);
-  ASSERT_EQ("InnerProduct",dlparam->type());
-  ASSERT_EQ(nclasses,dlparam->mutable_inner_product_param()->num_output());
-  ASSERT_EQ("ip0_conv_0",dlparam->bottom(0));
+  ASSERT_EQ("InnerProduct", dlparam->type());
+  ASSERT_EQ(nclasses, dlparam->mutable_inner_product_param()->num_output());
+  ASSERT_EQ("ip0_conv_0", dlparam->bottom(0));
   delete caff;
 }
 
-TEST(caffelib,configure_convnet_template_1_db)
+TEST(caffelib, configure_convnet_template_1_db)
 {
   int nclasses = 18;
   caffe::NetParameter net_param, deploy_net_param;
- 
-  std::vector<std::string> layers = {"1CR64"};
+
+  std::vector<std::string> layers = { "1CR64" };
   APIData ad;
-  ad.add("layers",layers);
-  ad.add("activation",std::string("prelu"));
-  ad.add("dropout",0.2);
-  ad.add("db",true);
-  ad.add("nclasses",nclasses);
+  ad.add("layers", layers);
+  ad.add("activation", std::string("prelu"));
+  ad.add("dropout", 0.2);
+  ad.add("db", true);
+  ad.add("nclasses", nclasses);
 
-  CaffeLib<ImgCaffeInputFileConn,SupervisedOutput,CaffeModel> *caff = new CaffeLib<ImgCaffeInputFileConn,SupervisedOutput,CaffeModel>(CaffeModel());
-  caff->configure_convnet_template(ad,ImgCaffeInputFileConn(),net_param,deploy_net_param);
+  CaffeLib<ImgCaffeInputFileConn, SupervisedOutput, CaffeModel> *caff
+      = new CaffeLib<ImgCaffeInputFileConn, SupervisedOutput, CaffeModel>(
+          CaffeModel());
+  caff->configure_convnet_template(ad, ImgCaffeInputFileConn(), net_param,
+                                   deploy_net_param);
 
-  caffe::WriteProtoToTextFile(net_param,oconvnet_file);
-  caffe::WriteProtoToTextFile(deploy_net_param,doconvnet_file);
-  
-  ASSERT_EQ(8,net_param.layer_size());
+  caffe::WriteProtoToTextFile(net_param, oconvnet_file);
+  caffe::WriteProtoToTextFile(deploy_net_param, doconvnet_file);
+
+  ASSERT_EQ(8, net_param.layer_size());
   caffe::LayerParameter *lparam = net_param.mutable_layer(0);
-  ASSERT_EQ("Data",lparam->type());
-  ASSERT_EQ("train.lmdb",lparam->mutable_data_param()->source());
-  ASSERT_EQ(caffe::DataParameter_DB_LMDB,lparam->mutable_data_param()->backend());
+  ASSERT_EQ("Data", lparam->type());
+  ASSERT_EQ("train.lmdb", lparam->mutable_data_param()->source());
+  ASSERT_EQ(caffe::DataParameter_DB_LMDB,
+            lparam->mutable_data_param()->backend());
   lparam = net_param.mutable_layer(2);
-  ASSERT_EQ("Convolution",lparam->type());
-  ASSERT_EQ(64,lparam->mutable_convolution_param()->num_output());
+  ASSERT_EQ("Convolution", lparam->type());
+  ASSERT_EQ(64, lparam->mutable_convolution_param()->num_output());
   lparam = net_param.mutable_layer(3);
-  ASSERT_EQ("PReLU",lparam->type());
+  ASSERT_EQ("PReLU", lparam->type());
   lparam = net_param.mutable_layer(4);
-  ASSERT_EQ("Pooling",lparam->type());
+  ASSERT_EQ("Pooling", lparam->type());
   lparam = net_param.mutable_layer(5);
-  ASSERT_EQ("InnerProduct",lparam->type());
-  ASSERT_EQ(nclasses,lparam->mutable_inner_product_param()->num_output());
-  ASSERT_EQ("ip0_conv_0",lparam->bottom(0));
+  ASSERT_EQ("InnerProduct", lparam->type());
+  ASSERT_EQ(nclasses, lparam->mutable_inner_product_param()->num_output());
+  ASSERT_EQ("ip0_conv_0", lparam->bottom(0));
 
-  ASSERT_EQ(6,deploy_net_param.layer_size());
+  ASSERT_EQ(6, deploy_net_param.layer_size());
   caffe::LayerParameter *dlparam = deploy_net_param.mutable_layer(1);
-  ASSERT_EQ("Convolution",dlparam->type());
-  ASSERT_EQ(64,dlparam->mutable_convolution_param()->num_output());
+  ASSERT_EQ("Convolution", dlparam->type());
+  ASSERT_EQ(64, dlparam->mutable_convolution_param()->num_output());
   dlparam = deploy_net_param.mutable_layer(2);
-  ASSERT_EQ("PReLU",dlparam->type());
+  ASSERT_EQ("PReLU", dlparam->type());
   dlparam = deploy_net_param.mutable_layer(3);
-  ASSERT_EQ("Pooling",dlparam->type());
+  ASSERT_EQ("Pooling", dlparam->type());
   dlparam = deploy_net_param.mutable_layer(4);
-  ASSERT_EQ("InnerProduct",dlparam->type());
-  ASSERT_EQ(nclasses,dlparam->mutable_inner_product_param()->num_output());
-  ASSERT_EQ("ip0_conv_0",dlparam->bottom(0));
+  ASSERT_EQ("InnerProduct", dlparam->type());
+  ASSERT_EQ(nclasses, dlparam->mutable_inner_product_param()->num_output());
+  ASSERT_EQ("ip0_conv_0", dlparam->bottom(0));
   delete caff;
 }
 
-TEST(caffelib,configure_convnet_template_2)
+TEST(caffelib, configure_convnet_template_2)
 {
   int nclasses = 18;
   caffe::NetParameter net_param, deploy_net_param;
-  
-  std::vector<std::string> layers = {"1CR64","1CR128","1000"};
+
+  std::vector<std::string> layers = { "1CR64", "1CR128", "1000" };
   APIData ad;
-  ad.add("layers",layers);
-  ad.add("activation",std::string("prelu"));
-  ad.add("dropout",0.2);
-  ad.add("nclasses",nclasses);
+  ad.add("layers", layers);
+  ad.add("activation", std::string("prelu"));
+  ad.add("dropout", 0.2);
+  ad.add("nclasses", nclasses);
 
-  CaffeLib<ImgCaffeInputFileConn,SupervisedOutput,CaffeModel> *caff = new CaffeLib<ImgCaffeInputFileConn,SupervisedOutput,CaffeModel>(CaffeModel());
-  caff->configure_convnet_template(ad,ImgCaffeInputFileConn(),net_param,deploy_net_param);
+  CaffeLib<ImgCaffeInputFileConn, SupervisedOutput, CaffeModel> *caff
+      = new CaffeLib<ImgCaffeInputFileConn, SupervisedOutput, CaffeModel>(
+          CaffeModel());
+  caff->configure_convnet_template(ad, ImgCaffeInputFileConn(), net_param,
+                                   deploy_net_param);
 
-  caffe::WriteProtoToTextFile(net_param,oconvnet_file);
-  caffe::WriteProtoToTextFile(deploy_net_param,doconvnet_file);
-  
-  ASSERT_EQ(14,net_param.layer_size());
+  caffe::WriteProtoToTextFile(net_param, oconvnet_file);
+  caffe::WriteProtoToTextFile(deploy_net_param, doconvnet_file);
+
+  ASSERT_EQ(14, net_param.layer_size());
   caffe::LayerParameter *lparam = net_param.mutable_layer(2);
-  ASSERT_EQ("Convolution",lparam->type());
-  ASSERT_EQ(64,lparam->mutable_convolution_param()->num_output());
+  ASSERT_EQ("Convolution", lparam->type());
+  ASSERT_EQ(64, lparam->mutable_convolution_param()->num_output());
   lparam = net_param.mutable_layer(3);
-  ASSERT_EQ("PReLU",lparam->type());
+  ASSERT_EQ("PReLU", lparam->type());
   lparam = net_param.mutable_layer(4);
-  ASSERT_EQ("Pooling",lparam->type());
+  ASSERT_EQ("Pooling", lparam->type());
   lparam = net_param.mutable_layer(5);
-  ASSERT_EQ("Convolution",lparam->type());
-  ASSERT_EQ(128,lparam->mutable_convolution_param()->num_output());
+  ASSERT_EQ("Convolution", lparam->type());
+  ASSERT_EQ(128, lparam->mutable_convolution_param()->num_output());
   lparam = net_param.mutable_layer(6);
-  ASSERT_EQ("PReLU",lparam->type());
+  ASSERT_EQ("PReLU", lparam->type());
   lparam = net_param.mutable_layer(7);
-  ASSERT_EQ("Pooling",lparam->type());
+  ASSERT_EQ("Pooling", lparam->type());
   lparam = net_param.mutable_layer(8);
-  ASSERT_EQ("InnerProduct",lparam->type());
-  ASSERT_EQ(1000,lparam->mutable_inner_product_param()->num_output());
-  ASSERT_EQ("ip1_conv_0",lparam->bottom(0));
+  ASSERT_EQ("InnerProduct", lparam->type());
+  ASSERT_EQ(1000, lparam->mutable_inner_product_param()->num_output());
+  ASSERT_EQ("ip1_conv_0", lparam->bottom(0));
   lparam = net_param.mutable_layer(9);
-  ASSERT_EQ("PReLU",lparam->type());
+  ASSERT_EQ("PReLU", lparam->type());
   lparam = net_param.mutable_layer(10);
-  ASSERT_EQ("Dropout",lparam->type());
-  ASSERT_NEAR(0.2,lparam->mutable_dropout_param()->dropout_ratio(),1e-5);
+  ASSERT_EQ("Dropout", lparam->type());
+  ASSERT_NEAR(0.2, lparam->mutable_dropout_param()->dropout_ratio(), 1e-5);
   lparam = net_param.mutable_layer(11);
-  ASSERT_EQ("InnerProduct",lparam->type());
-  ASSERT_EQ(nclasses,lparam->mutable_inner_product_param()->num_output());
-  ASSERT_EQ("fc1000_0",lparam->bottom(0));
-  ASSERT_EQ("ip_losst",lparam->top(0));
+  ASSERT_EQ("InnerProduct", lparam->type());
+  ASSERT_EQ(nclasses, lparam->mutable_inner_product_param()->num_output());
+  ASSERT_EQ("fc1000_0", lparam->bottom(0));
+  ASSERT_EQ("ip_losst", lparam->top(0));
 
-  ASSERT_EQ(11,deploy_net_param.layer_size());
+  ASSERT_EQ(11, deploy_net_param.layer_size());
   caffe::LayerParameter *dlparam = deploy_net_param.mutable_layer(1);
-  ASSERT_EQ("Convolution",dlparam->type());
-  ASSERT_EQ(64,dlparam->mutable_convolution_param()->num_output());
+  ASSERT_EQ("Convolution", dlparam->type());
+  ASSERT_EQ(64, dlparam->mutable_convolution_param()->num_output());
   dlparam = deploy_net_param.mutable_layer(2);
-  ASSERT_EQ("PReLU",dlparam->type());
+  ASSERT_EQ("PReLU", dlparam->type());
   dlparam = deploy_net_param.mutable_layer(3);
-  ASSERT_EQ("Pooling",dlparam->type());
+  ASSERT_EQ("Pooling", dlparam->type());
   dlparam = deploy_net_param.mutable_layer(4);
-  ASSERT_EQ("Convolution",dlparam->type());
-  ASSERT_EQ(128,dlparam->mutable_convolution_param()->num_output());
+  ASSERT_EQ("Convolution", dlparam->type());
+  ASSERT_EQ(128, dlparam->mutable_convolution_param()->num_output());
   dlparam = deploy_net_param.mutable_layer(5);
-  ASSERT_EQ("PReLU",dlparam->type());
+  ASSERT_EQ("PReLU", dlparam->type());
   dlparam = deploy_net_param.mutable_layer(6);
-  ASSERT_EQ("Pooling",dlparam->type());
+  ASSERT_EQ("Pooling", dlparam->type());
   dlparam = deploy_net_param.mutable_layer(7);
-  ASSERT_EQ("InnerProduct",dlparam->type());
-  ASSERT_EQ(1000,dlparam->mutable_inner_product_param()->num_output());
-  ASSERT_EQ("ip1_conv_0",dlparam->bottom(0));
+  ASSERT_EQ("InnerProduct", dlparam->type());
+  ASSERT_EQ(1000, dlparam->mutable_inner_product_param()->num_output());
+  ASSERT_EQ("ip1_conv_0", dlparam->bottom(0));
   dlparam = deploy_net_param.mutable_layer(8);
-  ASSERT_EQ("PReLU",dlparam->type());
+  ASSERT_EQ("PReLU", dlparam->type());
   dlparam = deploy_net_param.mutable_layer(9);
-  ASSERT_EQ("InnerProduct",dlparam->type());
-  ASSERT_EQ(nclasses,dlparam->mutable_inner_product_param()->num_output());
-  ASSERT_EQ("fc1000_0",dlparam->bottom(0)); 
-  ASSERT_EQ("ip_loss",dlparam->top(0));
+  ASSERT_EQ("InnerProduct", dlparam->type());
+  ASSERT_EQ(nclasses, dlparam->mutable_inner_product_param()->num_output());
+  ASSERT_EQ("fc1000_0", dlparam->bottom(0));
+  ASSERT_EQ("ip_loss", dlparam->top(0));
   delete caff;
 }
 
-TEST(caffelib,configure_convnet_template_3)
+TEST(caffelib, configure_convnet_template_3)
 {
   int nclasses = 18;
   caffe::NetParameter net_param, deploy_net_param;
-  
-  std::vector<std::string> layers = {"2CR64"};
+
+  std::vector<std::string> layers = { "2CR64" };
   APIData ad;
-  ad.add("layers",layers);
-  ad.add("activation",std::string("prelu"));
-  ad.add("dropout",0.2);
-  ad.add("nclasses",nclasses);
+  ad.add("layers", layers);
+  ad.add("activation", std::string("prelu"));
+  ad.add("dropout", 0.2);
+  ad.add("nclasses", nclasses);
 
-  CaffeLib<ImgCaffeInputFileConn,SupervisedOutput,CaffeModel> *caff = new CaffeLib<ImgCaffeInputFileConn,SupervisedOutput,CaffeModel>(CaffeModel());
-  caff->configure_convnet_template(ad,ImgCaffeInputFileConn(),net_param,deploy_net_param);
+  CaffeLib<ImgCaffeInputFileConn, SupervisedOutput, CaffeModel> *caff
+      = new CaffeLib<ImgCaffeInputFileConn, SupervisedOutput, CaffeModel>(
+          CaffeModel());
+  caff->configure_convnet_template(ad, ImgCaffeInputFileConn(), net_param,
+                                   deploy_net_param);
 
-  caffe::WriteProtoToTextFile(net_param,oconvnet_file);
-  caffe::WriteProtoToTextFile(deploy_net_param,doconvnet_file);
+  caffe::WriteProtoToTextFile(net_param, oconvnet_file);
+  caffe::WriteProtoToTextFile(deploy_net_param, doconvnet_file);
 
-  ASSERT_EQ(10,net_param.layer_size());
+  ASSERT_EQ(10, net_param.layer_size());
   caffe::LayerParameter *lparam = net_param.mutable_layer(2);
-  ASSERT_EQ("Convolution",lparam->type());
-  ASSERT_EQ(64,lparam->mutable_convolution_param()->num_output());
+  ASSERT_EQ("Convolution", lparam->type());
+  ASSERT_EQ(64, lparam->mutable_convolution_param()->num_output());
   lparam = net_param.mutable_layer(3);
-  ASSERT_EQ("PReLU",lparam->type());
+  ASSERT_EQ("PReLU", lparam->type());
   lparam = net_param.mutable_layer(4);
-  ASSERT_EQ("Convolution",lparam->type());
-  ASSERT_EQ(64,lparam->mutable_convolution_param()->num_output());
+  ASSERT_EQ("Convolution", lparam->type());
+  ASSERT_EQ(64, lparam->mutable_convolution_param()->num_output());
   lparam = net_param.mutable_layer(5);
-  ASSERT_EQ("PReLU",lparam->type());
+  ASSERT_EQ("PReLU", lparam->type());
   lparam = net_param.mutable_layer(6);
-  ASSERT_EQ("Pooling",lparam->type());
+  ASSERT_EQ("Pooling", lparam->type());
   lparam = net_param.mutable_layer(7);
-  ASSERT_EQ("InnerProduct",lparam->type());
-  ASSERT_EQ(nclasses,lparam->mutable_inner_product_param()->num_output());
-  ASSERT_EQ("ip0_conv_1",lparam->bottom(0));
-  
-  ASSERT_EQ(8,deploy_net_param.layer_size());
+  ASSERT_EQ("InnerProduct", lparam->type());
+  ASSERT_EQ(nclasses, lparam->mutable_inner_product_param()->num_output());
+  ASSERT_EQ("ip0_conv_1", lparam->bottom(0));
+
+  ASSERT_EQ(8, deploy_net_param.layer_size());
   caffe::LayerParameter *dlparam = deploy_net_param.mutable_layer(1);
-  ASSERT_EQ("Convolution",dlparam->type());
-  ASSERT_EQ(64,dlparam->mutable_convolution_param()->num_output());
+  ASSERT_EQ("Convolution", dlparam->type());
+  ASSERT_EQ(64, dlparam->mutable_convolution_param()->num_output());
   dlparam = deploy_net_param.mutable_layer(2);
-  ASSERT_EQ("PReLU",dlparam->type());
+  ASSERT_EQ("PReLU", dlparam->type());
   dlparam = deploy_net_param.mutable_layer(3);
-  ASSERT_EQ("Convolution",dlparam->type());
-  ASSERT_EQ(64,dlparam->mutable_convolution_param()->num_output());
+  ASSERT_EQ("Convolution", dlparam->type());
+  ASSERT_EQ(64, dlparam->mutable_convolution_param()->num_output());
   dlparam = deploy_net_param.mutable_layer(4);
-  ASSERT_EQ("PReLU",dlparam->type());
+  ASSERT_EQ("PReLU", dlparam->type());
   dlparam = deploy_net_param.mutable_layer(5);
-  ASSERT_EQ("Pooling",dlparam->type());
+  ASSERT_EQ("Pooling", dlparam->type());
   dlparam = deploy_net_param.mutable_layer(6);
-  ASSERT_EQ("InnerProduct",dlparam->type());
-  ASSERT_EQ(nclasses,dlparam->mutable_inner_product_param()->num_output());
-  ASSERT_EQ("ip0_conv_1",dlparam->bottom(0));
+  ASSERT_EQ("InnerProduct", dlparam->type());
+  ASSERT_EQ(nclasses, dlparam->mutable_inner_product_param()->num_output());
+  ASSERT_EQ("ip0_conv_1", dlparam->bottom(0));
   delete caff;
 }
 
-TEST(caffelib,configure_convnet_template_n)
+TEST(caffelib, configure_convnet_template_n)
 {
   int nclasses = 18;
   caffe::NetParameter net_param, deploy_net_param;
-  
-  std::vector<std::string> layers = {"2CR32","2CR64","2CR128","4096","1024"};
+
+  std::vector<std::string> layers
+      = { "2CR32", "2CR64", "2CR128", "4096", "1024" };
   APIData ad;
-  ad.add("layers",layers);
-  ad.add("activation",std::string("prelu"));
-  ad.add("dropout",0.2);
-  ad.add("nclasses",nclasses);
-  ad.add("db",true);
+  ad.add("layers", layers);
+  ad.add("activation", std::string("prelu"));
+  ad.add("dropout", 0.2);
+  ad.add("nclasses", nclasses);
+  ad.add("db", true);
 
-  CaffeLib<ImgCaffeInputFileConn,SupervisedOutput,CaffeModel> *caff = new CaffeLib<ImgCaffeInputFileConn,SupervisedOutput,CaffeModel>(CaffeModel());
-  caff->configure_convnet_template(ad,ImgCaffeInputFileConn(),net_param,deploy_net_param);
+  CaffeLib<ImgCaffeInputFileConn, SupervisedOutput, CaffeModel> *caff
+      = new CaffeLib<ImgCaffeInputFileConn, SupervisedOutput, CaffeModel>(
+          CaffeModel());
+  caff->configure_convnet_template(ad, ImgCaffeInputFileConn(), net_param,
+                                   deploy_net_param);
 
-  caffe::WriteProtoToTextFile(net_param,oconvnet_file);
-  caffe::WriteProtoToTextFile(deploy_net_param,doconvnet_file);
-  
-  ASSERT_EQ(26,net_param.layer_size());
+  caffe::WriteProtoToTextFile(net_param, oconvnet_file);
+  caffe::WriteProtoToTextFile(deploy_net_param, doconvnet_file);
+
+  ASSERT_EQ(26, net_param.layer_size());
   caffe::LayerParameter *lparam = net_param.mutable_layer(0);
-  ASSERT_EQ("Data",lparam->type());
-  //ASSERT_EQ("mean.binaryproto",lparam->mutable_transform_param()->mean_file());
-  ASSERT_EQ(22,deploy_net_param.layer_size());
+  ASSERT_EQ("Data", lparam->type());
+  // ASSERT_EQ("mean.binaryproto",lparam->mutable_transform_param()->mean_file());
+  ASSERT_EQ(22, deploy_net_param.layer_size());
   delete caff;
 }
 
-TEST(caffelib,configure_convnet_template_n_1D)
+TEST(caffelib, configure_convnet_template_n_1D)
 {
   int nclasses = 18;
   caffe::NetParameter net_param, deploy_net_param;
-  
-  std::vector<std::string> layers = {"1CR256","1CR256","4CR256","1024","1024"};
+
+  std::vector<std::string> layers
+      = { "1CR256", "1CR256", "4CR256", "1024", "1024" };
   APIData ad;
-  ad.add("layers",layers);
-  ad.add("activation",std::string("prelu"));
-  ad.add("dropout",0.2);
-  ad.add("db",true);
-  ad.add("nclasses",nclasses);
-  
+  ad.add("layers", layers);
+  ad.add("activation", std::string("prelu"));
+  ad.add("dropout", 0.2);
+  ad.add("db", true);
+  ad.add("nclasses", nclasses);
+
   TxtCaffeInputFileConn tcif;
   tcif._characters = true;
   tcif._flat1dconv = true;
   tcif._db = true;
   tcif.build_alphabet();
   tcif._sequence = 1014;
-  CaffeLib<TxtCaffeInputFileConn,SupervisedOutput,CaffeModel> *caff = new CaffeLib<TxtCaffeInputFileConn,SupervisedOutput,CaffeModel>(CaffeModel());
-  caff->configure_convnet_template(ad,tcif,net_param,deploy_net_param);
+  CaffeLib<TxtCaffeInputFileConn, SupervisedOutput, CaffeModel> *caff
+      = new CaffeLib<TxtCaffeInputFileConn, SupervisedOutput, CaffeModel>(
+          CaffeModel());
+  caff->configure_convnet_template(ad, tcif, net_param, deploy_net_param);
 
-  caffe::WriteProtoToTextFile(net_param,oconvnet_file);
-  caffe::WriteProtoToTextFile(deploy_net_param,doconvnet_file);
-  
-  ASSERT_EQ(27,net_param.layer_size());
+  caffe::WriteProtoToTextFile(net_param, oconvnet_file);
+  caffe::WriteProtoToTextFile(deploy_net_param, doconvnet_file);
+
+  ASSERT_EQ(27, net_param.layer_size());
   caffe::LayerParameter *lparam = net_param.mutable_layer(0);
-  ASSERT_EQ("Data",lparam->type());
+  ASSERT_EQ("Data", lparam->type());
   ASSERT_TRUE(lparam->mutable_transform_param()->mean_file().empty());
   lparam = net_param.mutable_layer(1);
-  ASSERT_EQ("MemoryData",lparam->type());
-  ASSERT_EQ(1,lparam->mutable_memory_data_param()->channels());
-  ASSERT_EQ(tcif._sequence,lparam->mutable_memory_data_param()->height());
-  ASSERT_EQ(tcif._alphabet.size(),lparam->mutable_memory_data_param()->width());
+  ASSERT_EQ("MemoryData", lparam->type());
+  ASSERT_EQ(1, lparam->mutable_memory_data_param()->channels());
+  ASSERT_EQ(tcif._sequence, lparam->mutable_memory_data_param()->height());
+  ASSERT_EQ(tcif._alphabet.size(),
+            lparam->mutable_memory_data_param()->width());
   lparam = net_param.mutable_layer(2);
-  ASSERT_EQ("Convolution",lparam->type());
-  ASSERT_EQ(256,lparam->mutable_convolution_param()->num_output());
-  ASSERT_EQ(7,lparam->mutable_convolution_param()->kernel_h());
-  ASSERT_EQ(69,lparam->mutable_convolution_param()->kernel_w());
+  ASSERT_EQ("Convolution", lparam->type());
+  ASSERT_EQ(256, lparam->mutable_convolution_param()->num_output());
+  ASSERT_EQ(7, lparam->mutable_convolution_param()->kernel_h());
+  ASSERT_EQ(69, lparam->mutable_convolution_param()->kernel_w());
   lparam = net_param.mutable_layer(4);
-  ASSERT_EQ("Pooling",lparam->type());
-  ASSERT_EQ(3,lparam->mutable_pooling_param()->stride_h());
-  ASSERT_EQ(1,lparam->mutable_pooling_param()->stride_w());
-  ASSERT_EQ(3,lparam->mutable_pooling_param()->kernel_h());
-  ASSERT_EQ(1,lparam->mutable_pooling_param()->kernel_w());
+  ASSERT_EQ("Pooling", lparam->type());
+  ASSERT_EQ(3, lparam->mutable_pooling_param()->stride_h());
+  ASSERT_EQ(1, lparam->mutable_pooling_param()->stride_w());
+  ASSERT_EQ(3, lparam->mutable_pooling_param()->kernel_h());
+  ASSERT_EQ(1, lparam->mutable_pooling_param()->kernel_w());
   lparam = net_param.mutable_layer(8);
-  ASSERT_EQ("Convolution",lparam->type());
-  ASSERT_EQ(256,lparam->mutable_convolution_param()->num_output());
-  ASSERT_EQ(3,lparam->mutable_convolution_param()->kernel_h());
-  ASSERT_EQ(1,lparam->mutable_convolution_param()->kernel_w());
-  
-  ASSERT_EQ(23,deploy_net_param.layer_size());
+  ASSERT_EQ("Convolution", lparam->type());
+  ASSERT_EQ(256, lparam->mutable_convolution_param()->num_output());
+  ASSERT_EQ(3, lparam->mutable_convolution_param()->kernel_h());
+  ASSERT_EQ(1, lparam->mutable_convolution_param()->kernel_w());
+
+  ASSERT_EQ(23, deploy_net_param.layer_size());
   lparam = deploy_net_param.mutable_layer(0);
-  ASSERT_EQ("MemoryData",lparam->type());
-  ASSERT_EQ(1,lparam->mutable_memory_data_param()->channels());
-  ASSERT_EQ(tcif._sequence,lparam->mutable_memory_data_param()->height());
-  ASSERT_EQ(tcif._alphabet.size(),lparam->mutable_memory_data_param()->width());
+  ASSERT_EQ("MemoryData", lparam->type());
+  ASSERT_EQ(1, lparam->mutable_memory_data_param()->channels());
+  ASSERT_EQ(tcif._sequence, lparam->mutable_memory_data_param()->height());
+  ASSERT_EQ(tcif._alphabet.size(),
+            lparam->mutable_memory_data_param()->width());
   lparam = deploy_net_param.mutable_layer(1);
-  ASSERT_EQ("Convolution",lparam->type());
-  ASSERT_EQ(256,lparam->mutable_convolution_param()->num_output());
-  ASSERT_EQ(7,lparam->mutable_convolution_param()->kernel_h());
-  ASSERT_EQ(69,lparam->mutable_convolution_param()->kernel_w());
+  ASSERT_EQ("Convolution", lparam->type());
+  ASSERT_EQ(256, lparam->mutable_convolution_param()->num_output());
+  ASSERT_EQ(7, lparam->mutable_convolution_param()->kernel_h());
+  ASSERT_EQ(69, lparam->mutable_convolution_param()->kernel_w());
   lparam = deploy_net_param.mutable_layer(3);
-  ASSERT_EQ("Pooling",lparam->type());
-  ASSERT_EQ(3,lparam->mutable_pooling_param()->stride_h());
-  ASSERT_EQ(1,lparam->mutable_pooling_param()->stride_w());
-  ASSERT_EQ(3,lparam->mutable_pooling_param()->kernel_h());
-  ASSERT_EQ(1,lparam->mutable_pooling_param()->kernel_w());
+  ASSERT_EQ("Pooling", lparam->type());
+  ASSERT_EQ(3, lparam->mutable_pooling_param()->stride_h());
+  ASSERT_EQ(1, lparam->mutable_pooling_param()->stride_w());
+  ASSERT_EQ(3, lparam->mutable_pooling_param()->kernel_h());
+  ASSERT_EQ(1, lparam->mutable_pooling_param()->kernel_w());
   lparam = deploy_net_param.mutable_layer(7);
-  ASSERT_EQ("Convolution",lparam->type());
-  ASSERT_EQ(256,lparam->mutable_convolution_param()->num_output());
-  ASSERT_EQ(3,lparam->mutable_convolution_param()->kernel_h());
-  ASSERT_EQ(1,lparam->mutable_convolution_param()->kernel_w());
+  ASSERT_EQ("Convolution", lparam->type());
+  ASSERT_EQ(256, lparam->mutable_convolution_param()->num_output());
+  ASSERT_EQ(3, lparam->mutable_convolution_param()->kernel_h());
+  ASSERT_EQ(1, lparam->mutable_convolution_param()->kernel_w());
   delete caff;
 }
 
-//TODO: lregression template
+// TODO: lregression template
 
-//TODO: regression one target template
+// TODO: regression one target template
 
-//TODO: resnets
+// TODO: resnets
 
-TEST(caffelib,configure_resnet_template_n_nt)
+TEST(caffelib, configure_resnet_template_n_nt)
 {
   int nclasses = 7;
   caffe::NetParameter net_param, deploy_net_param;
-  std::vector<std::string> layers = {"Res50"};
+  std::vector<std::string> layers = { "Res50" };
   APIData ad;
-  ad.add("layers",layers);
-  ad.add("activation",std::string("relu"));
-  //ad.add("dropout",0.6);
-  ad.add("nclasses",nclasses);
-  
-  CaffeLib<ImgCaffeInputFileConn,SupervisedOutput,CaffeModel> *caff = new CaffeLib<ImgCaffeInputFileConn,SupervisedOutput,CaffeModel>(CaffeModel());
+  ad.add("layers", layers);
+  ad.add("activation", std::string("relu"));
+  // ad.add("dropout",0.6);
+  ad.add("nclasses", nclasses);
+
+  CaffeLib<ImgCaffeInputFileConn, SupervisedOutput, CaffeModel> *caff
+      = new CaffeLib<ImgCaffeInputFileConn, SupervisedOutput, CaffeModel>(
+          CaffeModel());
   caff->_logger = spdlog::stdout_logger_mt("test");
-  caff->configure_resnet_template(ad,ImgCaffeInputFileConn(),net_param,deploy_net_param);
-  
-  caffe::WriteProtoToTextFile(net_param,oresnet_file);
-  caffe::WriteProtoToTextFile(deploy_net_param,doresnet_file);
-  bool succ = caffe::ReadProtoFromTextFile(oresnet_file,&net_param);
+  caff->configure_resnet_template(ad, ImgCaffeInputFileConn(), net_param,
+                                  deploy_net_param);
+
+  caffe::WriteProtoToTextFile(net_param, oresnet_file);
+  caffe::WriteProtoToTextFile(deploy_net_param, doresnet_file);
+  bool succ = caffe::ReadProtoFromTextFile(oresnet_file, &net_param);
   ASSERT_TRUE(succ);
 
-  ASSERT_EQ(278,net_param.layer_size());
-  ASSERT_EQ(276,deploy_net_param.layer_size());
+  ASSERT_EQ(278, net_param.layer_size());
+  ASSERT_EQ(276, deploy_net_param.layer_size());
   delete caff;
 }
 
 TEST(caffelib, configure_deeplabvgg16_diceloss)
 {
   APIData ad;
-  ad.add("template",std::string("deeplab_vgg16"));
-  ad.add("loss",std::string("dice"));
+  ad.add("template", std::string("deeplab_vgg16"));
+  ad.add("loss", std::string("dice"));
   APIData dice_param;
   APIData dice_class_weighting;
-  dice_class_weighting.add("compute_on",std::string("batch"));
-  dice_class_weighting.add("weight",std::string("equalize_classes"));
-  dice_param.add("class_weighting",dice_class_weighting);
+  dice_class_weighting.add("compute_on", std::string("batch"));
+  dice_class_weighting.add("weight", std::string("equalize_classes"));
+  dice_param.add("class_weighting", dice_class_weighting);
   // contour should not been used until fixed
   // APIData dice_contour;
   // dice_contour.add("shape",std::string("simple"));
   // dice_contour.add("size",3);
   // dice_contour.add("amplitude",20.5);
   // dice_param.add("contour",dice_contour);
-  ad.add("dice_param",dice_param);
-  ad.add("ignore_label",0);
-  ad.add("templates",std::string("../templates/caffe"));
-  ad.add("repository",std::string("./"));
-  ad.add("nclasses",2);
-  ad.add("segmentation",true);
-  CaffeLib<ImgCaffeInputFileConn,SupervisedOutput,CaffeModel> *caff = new CaffeLib<ImgCaffeInputFileConn,SupervisedOutput,CaffeModel>(CaffeModel(ad));
+  ad.add("dice_param", dice_param);
+  ad.add("ignore_label", 0);
+  ad.add("templates", std::string("../templates/caffe"));
+  ad.add("repository", std::string("./"));
+  ad.add("nclasses", 2);
+  ad.add("segmentation", true);
+  CaffeLib<ImgCaffeInputFileConn, SupervisedOutput, CaffeModel> *caff
+      = new CaffeLib<ImgCaffeInputFileConn, SupervisedOutput, CaffeModel>(
+          CaffeModel(ad));
   caff->_logger = spdlog::stdout_logger_mt("UT-deeplab_vgg16");
   caff->_inputc.init(ad);
   caff->init_mllib(ad);
@@ -636,13 +694,14 @@ TEST(caffelib, configure_deeplabvgg16_diceloss)
   caff->_loss = 1;
 
   caffe::NetParameter net_param, deploy_net_param;
-  bool succ = caffe::ReadProtoFromTextFile("./deeplab_vgg16.prototxt",&net_param);
+  bool succ
+      = caffe::ReadProtoFromTextFile("./deeplab_vgg16.prototxt", &net_param);
   ASSERT_TRUE(succ);
 
   bool found = false;
   int k = net_param.layer_size();
   caffe::LayerParameter *lparam;
-  for (int l=k-1;l>0;l--)
+  for (int l = k - 1; l > 0; l--)
     {
       lparam = net_param.mutable_layer(l);
       if (lparam->type() == "DiceCoefLoss")
@@ -654,79 +713,83 @@ TEST(caffelib, configure_deeplabvgg16_diceloss)
   ASSERT_TRUE(found);
 
   const caffe::DiceCoefLossParameter &clp = lparam->dice_coef_loss_param();
-  ASSERT_TRUE(clp.generalization() == caffe::DiceCoefLossParameter::MULTICLASS_WEIGHTED_BATCH);
+  ASSERT_TRUE(clp.generalization()
+              == caffe::DiceCoefLossParameter::MULTICLASS_WEIGHTED_BATCH);
 
-  //ASSERT_TRUE(clp.contour_shape() == caffe::DiceCoefLossParameter::SIMPLE);
+  // ASSERT_TRUE(clp.contour_shape() == caffe::DiceCoefLossParameter::SIMPLE);
   // since 2020 05 20, contour is forced to no, because of an unfound bug
   ASSERT_TRUE(clp.contour_shape() == caffe::DiceCoefLossParameter::NO);
-  //ASSERT_TRUE(clp.contour_size() == 3);
-  //ASSERT_TRUE(clp.contour_amplitude() == 20.5);
-
+  // ASSERT_TRUE(clp.contour_size() == 3);
+  // ASSERT_TRUE(clp.contour_amplitude() == 20.5);
 
   remove("./deeplab_vgg16.prototxt");
   remove("./deeplab_vgg16_solver.prototxt");
   remove("./deploy.prototxt");
 }
 
-TEST(caffelib,configure_service_images_autoenc_geometry)
+TEST(caffelib, configure_service_images_autoenc_geometry)
 {
   APIData adg;
-  adg.add("all_effects",false);
-  adg.add("persp_horizontal",true);
-  adg.add("persp_vertical",false);
-  adg.add("zoom_in",true);
-  adg.add("zoom_out",true);
-  adg.add("pad_mode",std::string("mirrored"));
-  adg.add("prob",0.1);
+  adg.add("all_effects", false);
+  adg.add("persp_horizontal", true);
+  adg.add("persp_vertical", false);
+  adg.add("zoom_in", true);
+  adg.add("zoom_out", true);
+  adg.add("pad_mode", std::string("mirrored"));
+  adg.add("prob", 0.1);
   APIData ad;
-  ad.add("template",std::string("convnet"));
-  std::vector<std::string> net = {"1CR32","1CR64","1CR128","DR128","1CR128","DR64","1CR64","DR32","1CR32"};
+  ad.add("template", std::string("convnet"));
+  std::vector<std::string> net
+      = { "1CR32", "1CR64", "1CR128", "DR128", "1CR128",
+          "DR64",  "1CR64", "DR32",   "1CR32" };
   ad.add("layers", net);
-  ad.add("activation",std::string("relu"));
-  ad.add("autoencoder",true);
-  ad.add("geometry",adg);
-  ad.add("templates",std::string("../templates/caffe"));
-  ad.add("repository",std::string("./"));
-  ad.add("width",224);
-  ad.add("height",224);
+  ad.add("activation", std::string("relu"));
+  ad.add("autoencoder", true);
+  ad.add("geometry", adg);
+  ad.add("templates", std::string("../templates/caffe"));
+  ad.add("repository", std::string("./"));
+  ad.add("width", 224);
+  ad.add("height", 224);
 
-  CaffeLib<ImgCaffeInputFileConn,SupervisedOutput,CaffeModel> *caff = new CaffeLib<ImgCaffeInputFileConn,SupervisedOutput,CaffeModel>(CaffeModel(ad));
+  CaffeLib<ImgCaffeInputFileConn, SupervisedOutput, CaffeModel> *caff
+      = new CaffeLib<ImgCaffeInputFileConn, SupervisedOutput, CaffeModel>(
+          CaffeModel(ad));
   caff->_logger = spdlog::stdout_logger_mt("UT-geom");
   caff->_inputc.init(ad);
-  //caff->init_mllib(ad);
+  // caff->init_mllib(ad);
   caff->instantiate_template(ad);
 
-
   caffe::NetParameter net_param;
-  std::string prototxt = "convnet.prototxt";;
-  bool succ = caffe::ReadProtoFromTextFile(prototxt,&net_param);
+  std::string prototxt = "convnet.prototxt";
+  ;
+  bool succ = caffe::ReadProtoFromTextFile(prototxt, &net_param);
   ASSERT_TRUE(succ);
-
 
   caffe::LayerParameter *lparam = net_param.mutable_layer(0);
   caffe::GeometryParameter gparam = lparam->transform_param().geometry_param();
   ASSERT_FLOAT_EQ(gparam.prob(), 0.1);
-  ASSERT_EQ(gparam.persp_horizontal(),true);
-  ASSERT_EQ(gparam.persp_vertical(),false);
-  ASSERT_EQ(gparam.zoom_out(),true);
-  ASSERT_EQ(gparam.zoom_in(),true);
-  ASSERT_EQ(gparam.pad_mode(),caffe::GeometryParameter_Pad_mode_MIRRORED);
+  ASSERT_EQ(gparam.persp_horizontal(), true);
+  ASSERT_EQ(gparam.persp_vertical(), false);
+  ASSERT_EQ(gparam.zoom_out(), true);
+  ASSERT_EQ(gparam.zoom_in(), true);
+  ASSERT_EQ(gparam.pad_mode(), caffe::GeometryParameter_Pad_mode_MIRRORED);
   remove("./convnet.prototxt");
   remove("./convnet_solver.prototxt");
   remove("./deploy.prototxt");
-
 }
 
 TEST(caffelib, configure_unet_diceloss)
 {
   APIData ad;
-  ad.add("template",std::string("unet"));
-  ad.add("loss",std::string("dice"));
-  ad.add("templates",std::string("../templates/caffe"));
-  ad.add("repository",std::string("./"));
-  ad.add("nclasses",2);
-  ad.add("segmentation",true);
-  CaffeLib<ImgCaffeInputFileConn,SupervisedOutput,CaffeModel> *caff = new CaffeLib<ImgCaffeInputFileConn,SupervisedOutput,CaffeModel>(CaffeModel(ad));
+  ad.add("template", std::string("unet"));
+  ad.add("loss", std::string("dice"));
+  ad.add("templates", std::string("../templates/caffe"));
+  ad.add("repository", std::string("./"));
+  ad.add("nclasses", 2);
+  ad.add("segmentation", true);
+  CaffeLib<ImgCaffeInputFileConn, SupervisedOutput, CaffeModel> *caff
+      = new CaffeLib<ImgCaffeInputFileConn, SupervisedOutput, CaffeModel>(
+          CaffeModel(ad));
   caff->_logger = spdlog::stdout_logger_mt("UT-unet");
   caff->_inputc.init(ad);
   caff->init_mllib(ad);
@@ -734,18 +797,17 @@ TEST(caffelib, configure_unet_diceloss)
   caff->_loss = 1;
 
   caffe::NetParameter net_param, deploy_net_param;
-  bool succ = caffe::ReadProtoFromTextFile("./unet.prototxt",&net_param);
+  bool succ = caffe::ReadProtoFromTextFile("./unet.prototxt", &net_param);
   ASSERT_TRUE(succ);
 
   bool found = false;
   int k = net_param.layer_size();
 
-  for (int l=k-1;l>0;l--)
+  for (int l = k - 1; l > 0; l--)
     {
       caffe::LayerParameter *lparam = net_param.mutable_layer(l);
       if (lparam->type() == "DiceCoefLoss")
         found = true;
     }
   ASSERT_TRUE(found);
-
 }

--- a/tests/ut-caffe2api.cc
+++ b/tests/ut-caffe2api.cc
@@ -32,133 +32,115 @@ using namespace dd;
 
 #define TO_STRING(...) #__VA_ARGS__
 
-#define RESPONSE(code, msg) TO_STRING({"status":{"code":code,"msg":msg}})
+#define RESPONSE(code, msg)                                                   \
+  TO_STRING({ "status" : { "code" : code, "msg" : msg } })
 
-#define _CREATE(type, repo, weights, std, mllib...) TO_STRING({	\
-      "mllib": "caffe2",				\
-      "description": "my classifier",			\
-      "type": type,					\
-      "model": {					\
-	"templates": "../templates/caffe2",		\
-	"repository": repo,				\
-	"weights": weights				\
-      },						\
-      "parameters": {					\
-	"input": {					\
-	  "connector": "image",				\
-	  "height": 224,				\
-	  "width": 224,					\
-	  "std": std					\
-	},						\
-	"mllib": {					\
-	  mllib						\
-	}						\
-      }							\
-    })
+#define _CREATE(type, repo, weights, std, mllib...)                           \
+  TO_STRING({                                                                 \
+    "mllib" : "caffe2",                                                       \
+    "description" : "my classifier",                                          \
+    "type" : type,                                                            \
+    "model" : {                                                               \
+      "templates" : "../templates/caffe2",                                    \
+      "repository" : repo,                                                    \
+      "weights" : weights                                                     \
+    },                                                                        \
+    "parameters" : {                                                          \
+      "input" : {                                                             \
+        "connector" : "image",                                                \
+        "height" : 224,                                                       \
+        "width" : 224,                                                        \
+        "std" : std                                                           \
+      },                                                                      \
+      "mllib" : { mllib }                                                     \
+    }                                                                         \
+  })
 
-#define CREATE_DETECTRON(repo, input...) TO_STRING({	\
-      "mllib": "caffe2",				\
-      "description": "my classifier",			\
-      "type": "supervised",				\
-      "model": {					\
-	"repository": repo				\
-      },						\
-      "parameters": {					\
-	"input": {					\
-	  "connector": "image",				\
-	  "mean": [102.9801, 115.9465, 122.7717],	\
-	  input						\
-	},						\
-        "mllib": {					\
-	  "gpuid": [0]					\
-	}						\
-      }							\
-    })
+#define CREATE_DETECTRON(repo, input...)                                      \
+  TO_STRING({                                                                 \
+    "mllib" : "caffe2",                                                       \
+    "description" : "my classifier",                                          \
+    "type" : "supervised",                                                    \
+    "model" : { "repository" : repo },                                        \
+    "parameters" : {                                                          \
+      "input" : {                                                             \
+        "connector" : "image",                                                \
+        "mean" : [ 102.9801, 115.9465, 122.7717 ],                            \
+        input                                                                 \
+      },                                                                      \
+      "mllib" : { "gpuid" : [0] }                                             \
+    }                                                                         \
+  })
 
-#define CREATE_DETECTRON_MASK(repo, mask, input...) TO_STRING({	\
-      "mllib": "caffe2",				\
-      "description": "my classifier",			\
-      "type": "supervised",				\
-      "model": {					\
-	"repository": repo,				\
-	  "extensions": [{				\
-	    "repository": mask,				\
-	    "type": "mask"				\
-	  }]	        				\
-      },						\
-      "parameters": {					\
-	"input": {					\
-	  "connector": "image",				\
-	  "mean": [102.9801, 115.9465, 122.7717],	\
-	  input						\
-	},						\
-        "mllib": {					\
-	  "gpuid": [0]					\
-	}						\
-      }							\
-    })
+#define CREATE_DETECTRON_MASK(repo, mask, input...)                           \
+  TO_STRING({                                                                 \
+    "mllib" : "caffe2",                                                       \
+    "description" : "my classifier",                                          \
+    "type" : "supervised",                                                    \
+    "model" : {                                                               \
+      "repository" : repo,                                                    \
+      "extensions" : [ { "repository" : mask, "type" : "mask" } ]             \
+    },                                                                        \
+    "parameters" : {                                                          \
+      "input" : {                                                             \
+        "connector" : "image",                                                \
+        "mean" : [ 102.9801, 115.9465, 122.7717 ],                            \
+        input                                                                 \
+      },                                                                      \
+      "mllib" : { "gpuid" : [0] }                                             \
+    }                                                                         \
+  })
 
-#define CREATE(t, r, s) _CREATE(t, r, "", s, "gpuid": [0])
-#define CREATE_TEMPLATE(t, r, s, tname, nclasses)			\
-  _CREATE(t, r, "", s, "gpuid": [0], "template": tname, "nclasses": nclasses)
-#define CREATE_FINETUNE(t, r, s, tname, nclasses, weights)		\
-  _CREATE(t, r, weights, s, "gpuid": [0], "template": tname, "nclasses": nclasses, "finetune": true)
+#define CREATE(t, r, s) _CREATE(t, r, "", s, "gpuid" : [0])
+#define CREATE_TEMPLATE(t, r, s, tname, nclasses)                             \
+  _CREATE(t, r, "", s, "gpuid"                                                \
+          : [0], "template"                                                   \
+          : tname, "nclasses"                                                 \
+          : nclasses)
+#define CREATE_FINETUNE(t, r, s, tname, nclasses, weights)                    \
+  _CREATE(t, r, weights, s, "gpuid"                                           \
+          : [0], "template"                                                   \
+          : tname, "nclasses"                                                 \
+          : nclasses, "finetune"                                              \
+          : true)
 
-#define PREDICT(service, extraction, data...) TO_STRING({	\
-      "service": service,					\
-      "parameters": {						\
-	extraction						\
-      },							\
-      "data": [ data ]						\
-    })
-#define PREDICT_SUPERVISED(service, best, data...)	\
-  PREDICT(service,					\
-	  "output": {					\
-	    "best": best				\
-	  },						\
-	  data)
-#define PREDICT_UNSUPERVISED(service, layer, data...)	\
-  PREDICT(service,					\
-	  "mllib": {					\
-	    "extract_layer": layer			\
-	  },						\
-	  data)
-#define PREDICT_TEST(service, batch, data, measures...) TO_STRING({	\
-      "service": service,						\
-      "parameters": {							\
-	"mllib": {							\
-	  "net": {							\
-	    "batch_size": batch						\
-	   }								\
-	},								\
-	"output": {							\
-	  "measure": [ measures ]					\
-	}								\
-      },								\
-      "data": [ data ]							\
-    })
-#define PREDICT_BBOX(service, threshold, data...) TO_STRING({		\
-      "service": service,						\
-      "parameters": {							\
-	"output": {							\
-	  "bbox": true,							\
-	  "best": 1,							\
-	  "confidence_threshold": threshold				\
-	}								\
-      },								\
-      "data": [ data ]							\
-    })
-#define PREDICT_MASK(service, threshold, data...) TO_STRING({		\
-      "service": service,						\
-      "parameters": {							\
-	"output": {							\
-	  "mask": true,							\
-	  "best": 1,							\
-	  "confidence_threshold": threshold				\
-	}								\
-      },								\
-      "data": [ data ]							\
-    })
+#define PREDICT(service, extraction, data...)                                 \
+  TO_STRING({                                                                 \
+    "service" : service,                                                      \
+    "parameters" : { extraction },                                            \
+    "data" : [data]                                                           \
+  })
+#define PREDICT_SUPERVISED(service, best, data...)                            \
+  PREDICT(service, "output" : { "best" : best }, data)
+#define PREDICT_UNSUPERVISED(service, layer, data...)                         \
+  PREDICT(service, "mllib" : { "extract_layer" : layer }, data)
+#define PREDICT_TEST(service, batch, data, measures...)                       \
+  TO_STRING({                                                                 \
+    "service" : service,                                                      \
+    "parameters" : {                                                          \
+      "mllib" : { "net" : { "batch_size" : batch } },                         \
+      "output" : { "measure" : [measures] }                                   \
+    },                                                                        \
+    "data" : [data]                                                           \
+  })
+#define PREDICT_BBOX(service, threshold, data...)                             \
+  TO_STRING({                                                                 \
+    "service" : service,                                                      \
+    "parameters" : {                                                          \
+      "output" :                                                              \
+          { "bbox" : true, "best" : 1, "confidence_threshold" : threshold }   \
+    },                                                                        \
+    "data" : [data]                                                           \
+  })
+#define PREDICT_MASK(service, threshold, data...)                             \
+  TO_STRING({                                                                 \
+    "service" : service,                                                      \
+    "parameters" : {                                                          \
+      "output" :                                                              \
+          { "mask" : true, "best" : 1, "confidence_threshold" : threshold }   \
+    },                                                                        \
+    "data" : [data]                                                           \
+  })
 
 #define SERVICE "imgserv"
 
@@ -169,17 +151,20 @@ static const std::string not_found_str = RESPONSE(404, "NotFound");
 
 // Json management
 
-inline void create(JsonAPI &japi, const std::string &json) {
+inline void create(JsonAPI &japi, const std::string &json)
+{
   ASSERT_EQ(created_str, japi.jrender(japi.service_create(SERVICE, json)));
 }
 
-inline void predict(JsonAPI &japi, JDoc &jd, const std::string &json) {
+inline void predict(JsonAPI &japi, JDoc &jd, const std::string &json)
+{
   jd.Parse(japi.jrender(japi.service_predict(json)).c_str());
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_EQ(200, jd["status"]["code"]);
 }
 
-inline void train(JsonAPI &japi, JDoc &jd, const std::string &json) {
+inline void train(JsonAPI &japi, JDoc &jd, const std::string &json)
+{
   jd.Parse(japi.jrender(japi.service_train(json)).c_str());
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_EQ(201, jd["status"]["code"].GetInt());
@@ -187,7 +172,9 @@ inline void train(JsonAPI &japi, JDoc &jd, const std::string &json) {
   ASSERT_TRUE(jd["head"]["time"].GetDouble() >= 0);
 }
 
-void assert_predictions(const JDoc &jd, std::vector<std::pair<std::string, double>> preds) {
+void assert_predictions(const JDoc &jd,
+                        std::vector<std::pair<std::string, double>> preds)
+{
 
   // Check array
   size_t nb_pred = preds.size();
@@ -195,27 +182,31 @@ void assert_predictions(const JDoc &jd, std::vector<std::pair<std::string, doubl
   ASSERT_TRUE(jd["body"]["predictions"].IsArray());
 
   // Check elements
-  for (size_t i = 0; i < nb_pred; ++i) {
-    const auto &prediction = predictions[i]["classes"][0];
-    std::string cat = prediction["cat"].GetString();
-    double prob = prediction["prob"].GetDouble();
+  for (size_t i = 0; i < nb_pred; ++i)
+    {
+      const auto &prediction = predictions[i]["classes"][0];
+      std::string cat = prediction["cat"].GetString();
+      double prob = prediction["prob"].GetDouble();
 
-    // Find a matching prediction
-    auto pred = preds.begin();
-    while (true) {
-      ASSERT_TRUE(pred != preds.end());
-      if (cat == pred->first && prob > pred->second) {
-	break;
-      }
-      ++pred;
+      // Find a matching prediction
+      auto pred = preds.begin();
+      while (true)
+        {
+          ASSERT_TRUE(pred != preds.end());
+          if (cat == pred->first && prob > pred->second)
+            {
+              break;
+            }
+          ++pred;
+        }
+      preds.erase(pred);
     }
-    preds.erase(pred);
-  }
 }
 
-void assert_bboxes_and_masks(const JDoc &jd,
-			     std::map<std::string, std::map<std::string, int>> preds,
-			     bool has_mask) {
+void assert_bboxes_and_masks(
+    const JDoc &jd, std::map<std::string, std::map<std::string, int>> preds,
+    bool has_mask)
+{
 
   // Check array
   size_t nb_pred = preds.size();
@@ -223,69 +214,82 @@ void assert_bboxes_and_masks(const JDoc &jd,
   ASSERT_TRUE(jd["body"]["predictions"].IsArray());
 
   // Check elements
-  for (size_t i = 0; i < nb_pred; ++i) {
-    const auto &prediction = predictions[i];
-    auto &cmp = preds[prediction["uri"].GetString()];
+  for (size_t i = 0; i < nb_pred; ++i)
+    {
+      const auto &prediction = predictions[i];
+      auto &cmp = preds[prediction["uri"].GetString()];
 
-    // Check BBoxes
-    size_t nb_classes = prediction["classes"].Size();
-    for (size_t j = 0; j < nb_classes; ++j) {
-      const auto &cls = prediction["classes"][j];
-      ASSERT_TRUE(cls.HasMember("bbox"));
-      auto it = cmp.find(cls["cat"].GetString());
-      if (it != cmp.end()) {
-	it->second--;
-      }
+      // Check BBoxes
+      size_t nb_classes = prediction["classes"].Size();
+      for (size_t j = 0; j < nb_classes; ++j)
+        {
+          const auto &cls = prediction["classes"][j];
+          ASSERT_TRUE(cls.HasMember("bbox"));
+          auto it = cmp.find(cls["cat"].GetString());
+          if (it != cmp.end())
+            {
+              it->second--;
+            }
 
-      // Check Masks
-      if (has_mask) {
-	ASSERT_TRUE(cls.HasMember("mask"));
-	const auto &bbox = cls["bbox"];
-	const auto &mask = cls["mask"];
-	size_t height = mask["height"].GetInt();
-	size_t width = mask["width"].GetInt();
-	size_t xmin = static_cast<size_t>(bbox["xmin"].GetDouble());
-	size_t ymin = static_cast<size_t>(bbox["ymin"].GetDouble());
-	size_t xmax = static_cast<size_t>(bbox["xmax"].GetDouble());
-	size_t ymax = static_cast<size_t>(bbox["ymax"].GetDouble());
-	ASSERT_TRUE(width == xmax - xmin + 1);
-	ASSERT_TRUE(height == ymax - ymin + 1);
-	ASSERT_TRUE(mask.HasMember("format"));
-	ASSERT_TRUE(mask["data"].Size() == width * height);
-      }
+          // Check Masks
+          if (has_mask)
+            {
+              ASSERT_TRUE(cls.HasMember("mask"));
+              const auto &bbox = cls["bbox"];
+              const auto &mask = cls["mask"];
+              size_t height = mask["height"].GetInt();
+              size_t width = mask["width"].GetInt();
+              size_t xmin = static_cast<size_t>(bbox["xmin"].GetDouble());
+              size_t ymin = static_cast<size_t>(bbox["ymin"].GetDouble());
+              size_t xmax = static_cast<size_t>(bbox["xmax"].GetDouble());
+              size_t ymax = static_cast<size_t>(bbox["ymax"].GetDouble());
+              ASSERT_TRUE(width == xmax - xmin + 1);
+              ASSERT_TRUE(height == ymax - ymin + 1);
+              ASSERT_TRUE(mask.HasMember("format"));
+              ASSERT_TRUE(mask["data"].Size() == width * height);
+            }
+        }
+
+      // Check count
+      for (auto it : cmp)
+        {
+          ASSERT_TRUE(it.second <= 0);
+        }
     }
-
-    // Check count
-    for (auto it : cmp) {
-      ASSERT_TRUE(it.second <= 0);
-    }
-  }
 }
 
-void clean_repository(const std::string &repo) {
-  ASSERT_TRUE(!fileops::remove_directory_files(repo, { ".json", ".txt", ".pb" }));
-  std::set<std::string> dbs({repo + "/train.lmdb", repo + "/test.lmdb"});
-  for (const std::string &db : dbs) {
-    fileops::clear_directory(db);
-    rmdir(db.c_str());
-  }
+void clean_repository(const std::string &repo)
+{
+  ASSERT_TRUE(
+      !fileops::remove_directory_files(repo, { ".json", ".txt", ".pb" }));
+  std::set<std::string> dbs({ repo + "/train.lmdb", repo + "/test.lmdb" });
+  for (const std::string &db : dbs)
+    {
+      fileops::clear_directory(db);
+      rmdir(db.c_str());
+    }
 }
 
-inline void assert_accuracy(const JDoc &jd, double d) {
+inline void assert_accuracy(const JDoc &jd, double d)
+{
   ASSERT_TRUE(fabs(jd["body"]["measure"]["acc"].GetDouble()) > d);
 }
 
-inline void assert_loss(const JDoc &jd, double d) {
+inline void assert_loss(const JDoc &jd, double d)
+{
   ASSERT_TRUE(fabs(jd["body"]["measure"]["train_loss"].GetDouble()) < d);
 }
 
-inline void assert_first_test_at(const JDoc &jd, double d) {
+inline void assert_first_test_at(const JDoc &jd, double d)
+{
   ASSERT_EQ(jd["body"]["measure_hist"]["iteration_hist"][0].GetDouble(), d);
 }
 
-inline void assert_last_test_at(const JDoc &jd, double d) {
-  size_t len_hist = jd["body"]["measure_hist"]["iteration_hist"].Size()-1;
-  ASSERT_EQ(jd["body"]["measure_hist"]["iteration_hist"][len_hist].GetDouble(), d);
+inline void assert_last_test_at(const JDoc &jd, double d)
+{
+  size_t len_hist = jd["body"]["measure_hist"]["iteration_hist"].Size() - 1;
+  ASSERT_EQ(jd["body"]["measure_hist"]["iteration_hist"][len_hist].GetDouble(),
+            d);
 }
 
 // Paths
@@ -307,118 +311,116 @@ inline void assert_last_test_at(const JDoc &jd, double d) {
 
 static const std::string supervised = CREATE("supervised", TRAINED, 128.0);
 static const std::string unsupervised = CREATE("unsupervised", TRAINED, 128.0);
-static const std::string trainable = CREATE_TEMPLATE("supervised", BC_REPO, 128.0, "resnet_50", 2);
-static const std::string finetunable = CREATE_FINETUNE("supervised", BC_REPO, 128.0, "resnet_50", 2,
-						       WEIGHTS);
-static const std::string detectron = CREATE_DETECTRON(DTTRON, "scale_min": 800, "scale_max": 1333);
-static const std::string detectron_mask =
-  CREATE_DETECTRON_MASK(DTTRON_MASK, DTTRON_MASK_EXT, "height": 800, "width": 1216);
+static const std::string trainable
+    = CREATE_TEMPLATE("supervised", BC_REPO, 128.0, "resnet_50", 2);
+static const std::string finetunable
+    = CREATE_FINETUNE("supervised", BC_REPO, 128.0, "resnet_50", 2, WEIGHTS);
+static const std::string detectron
+    = CREATE_DETECTRON(DTTRON, "scale_min" : 800, "scale_max" : 1333);
+static const std::string detectron_mask = CREATE_DETECTRON_MASK(
+    DTTRON_MASK, DTTRON_MASK_EXT, "height" : 800, "width" : 1216);
 
 // Json predict
 
 static const std::string predict_cat = PREDICT_SUPERVISED(SERVICE, 3, IMG_CAT);
-static const std::string predict_cat_and_amb = PREDICT_SUPERVISED(SERVICE, 3, IMG_CAT, IMG_AMB);
-static const std::string test_accuracy = PREDICT_TEST(SERVICE, 6, DB_FISH, "acc");
-static const std::string extract_conv1 = PREDICT_UNSUPERVISED(SERVICE, "conv1", IMG_CAT);
-static const std::string predict_bbox_boats_and_dogs =
-  PREDICT_BBOX(SERVICE, 0.8, DTTRON_BOATS, DTTRON_DOGS);
-static const std::string predict_mask_boats_and_dogs =
-  PREDICT_MASK(SERVICE, 0.8, DTTRON_BOATS, DTTRON_DOGS);
-static const std::string predict_mask_no_result =
-  PREDICT_MASK(SERVICE, 0.999, DTTRON_BOATS);
+static const std::string predict_cat_and_amb
+    = PREDICT_SUPERVISED(SERVICE, 3, IMG_CAT, IMG_AMB);
+static const std::string test_accuracy
+    = PREDICT_TEST(SERVICE, 6, DB_FISH, "acc");
+static const std::string extract_conv1
+    = PREDICT_UNSUPERVISED(SERVICE, "conv1", IMG_CAT);
+static const std::string predict_bbox_boats_and_dogs
+    = PREDICT_BBOX(SERVICE, 0.8, DTTRON_BOATS, DTTRON_DOGS);
+static const std::string predict_mask_boats_and_dogs
+    = PREDICT_MASK(SERVICE, 0.8, DTTRON_BOATS, DTTRON_DOGS);
+static const std::string predict_mask_no_result
+    = PREDICT_MASK(SERVICE, 0.999, DTTRON_BOATS);
 
 // Json train & test
 
 // 1 epoch = 1200 imgs / 32 batch size = 37.5 iters
-#define TRAIN_BC(service, iter, resume, data...) TO_STRING({	\
-      "service": service,					\
-      "async": false,						\
-      "parameters": {						\
-	"input": {						\
-	  "test_split": 0.1,					\
-	  "shuffle": true,					\
-	  "img_aug": {						\
-	    "mirror": true,					\
-	    "color_jitter": true,				\
-	    "img_brightness": 0.5				\
-	  }							\
-	},							\
-	"output": {						\
-	  "measure_hist": true,					\
-	  "measure": ["acc"]					\
-	},							\
-	"mllib": {						\
-	  "resume": resume,					\
-	  "net": {						\
-	    "batch_size": 32,					\
-	    "test_batch_size": 32				\
-	   },							\
-	  "solver": {						\
-	    "iterations": iter,					\
-	    "test_interval": 200,				\
-	    "lr_policy": "step",				\
-	    "base_lr": 0.01,					\
-	    "stepsize": 375,					\
-	    "gamma": 0.1,					\
-	    "solver_type": "sgd"				\
-	  }							\
-	}							\
-      },							\
-      "data": [ data ]						\
-})
-static const std::string train_boats_and_cars = TRAIN_BC(SERVICE, 1000, false, BC_IMGS);
-static const std::string train_boats_and_cars_resume = TRAIN_BC(SERVICE, 1300, true, BC_IMGS);
+#define TRAIN_BC(service, iter, resume, data...)                              \
+  TO_STRING({                                                                 \
+    "service" : service,                                                      \
+    "async" : false,                                                          \
+    "parameters" : {                                                          \
+      "input" : {                                                             \
+        "test_split" : 0.1,                                                   \
+        "shuffle" : true,                                                     \
+        "img_aug" : {                                                         \
+          "mirror" : true,                                                    \
+          "color_jitter" : true,                                              \
+          "img_brightness" : 0.5                                              \
+        }                                                                     \
+      },                                                                      \
+      "output" : { "measure_hist" : true, "measure" : ["acc"] },              \
+      "mllib" : {                                                             \
+        "resume" : resume,                                                    \
+        "net" : { "batch_size" : 32, "test_batch_size" : 32 },                \
+        "solver" : {                                                          \
+          "iterations" : iter,                                                \
+          "test_interval" : 200,                                              \
+          "lr_policy" : "step",                                               \
+          "base_lr" : 0.01,                                                   \
+          "stepsize" : 375,                                                   \
+          "gamma" : 0.1,                                                      \
+          "solver_type" : "sgd"                                               \
+        }                                                                     \
+      }                                                                       \
+    },                                                                        \
+    "data" : [data]                                                           \
+  })
+static const std::string train_boats_and_cars
+    = TRAIN_BC(SERVICE, 1000, false, BC_IMGS);
+static const std::string train_boats_and_cars_resume
+    = TRAIN_BC(SERVICE, 1300, true, BC_IMGS);
 
 // Finetune
 
-#define FINETUNE_BC(service, iter, data...) TO_STRING({		\
-      "service": service,					\
-      "async": false,						\
-      "parameters": {						\
-	"input": {						\
-	  "test_split": 0.1,					\
-	  "shuffle": true					\
-	},							\
-	"output": {						\
-	  "measure_hist": true,					\
-	  "measure": ["acc"]					\
-	},							\
-	"mllib": {						\
-	  "net": {						\
-	    "batch_size": 32,					\
-	    "test_batch_size": 32				\
-	   },							\
-	  "solver": {						\
-	    "iterations": iter,					\
-	    "test_interval": 40,				\
-	    "lr_policy": "step",				\
-	    "base_lr": 0.01,					\
-	    "stepsize": 1,					\
-	    "gamma": 0.99,					\
-	    "solver_type": "sgd"				\
-	  }							\
-	}							\
-      },							\
-      "data": [ data ]						\
-})
-static const std::string finetune_boats_and_cars = FINETUNE_BC(SERVICE, 200, BC_IMGS);
+#define FINETUNE_BC(service, iter, data...)                                   \
+  TO_STRING({                                                                 \
+    "service" : service,                                                      \
+    "async" : false,                                                          \
+    "parameters" : {                                                          \
+      "input" : { "test_split" : 0.1, "shuffle" : true },                     \
+      "output" : { "measure_hist" : true, "measure" : ["acc"] },              \
+      "mllib" : {                                                             \
+        "net" : { "batch_size" : 32, "test_batch_size" : 32 },                \
+        "solver" : {                                                          \
+          "iterations" : iter,                                                \
+          "test_interval" : 40,                                               \
+          "lr_policy" : "step",                                               \
+          "base_lr" : 0.01,                                                   \
+          "stepsize" : 1,                                                     \
+          "gamma" : 0.99,                                                     \
+          "solver_type" : "sgd"                                               \
+        }                                                                     \
+      }                                                                       \
+    },                                                                        \
+    "data" : [data]                                                           \
+  })
+static const std::string finetune_boats_and_cars
+    = FINETUNE_BC(SERVICE, 200, BC_IMGS);
 
 // Tests
 
-TEST(caffe2api, service_predict_supervised) {
+TEST(caffe2api, service_predict_supervised)
+{
 
   JsonAPI japi;
   JDoc jd;
   create(japi, supervised);
 
   predict(japi, jd, predict_cat);
-  assert_predictions(jd, { {"tabby, tabby cat", 0.8} });
+  assert_predictions(jd, { { "tabby, tabby cat", 0.8 } });
 
   predict(japi, jd, predict_cat_and_amb);
-  assert_predictions(jd, { {"tabby, tabby cat", 0.8}, {"ambulance", 0.8} });
+  assert_predictions(jd,
+                     { { "tabby, tabby cat", 0.8 }, { "ambulance", 0.8 } });
 }
 
-TEST(caffe2api, service_predict_test) {
+TEST(caffe2api, service_predict_test)
+{
 
   JsonAPI japi;
   JDoc jd;
@@ -428,7 +430,8 @@ TEST(caffe2api, service_predict_test) {
   assert_accuracy(jd, 0.7);
 }
 
-TEST(caffe2api, service_predict_extract_layer) {
+TEST(caffe2api, service_predict_extract_layer)
+{
 
   JsonAPI japi;
   JDoc jd;
@@ -438,7 +441,8 @@ TEST(caffe2api, service_predict_extract_layer) {
   ASSERT_EQ(802816, jd["body"]["predictions"][0]["vals"].Size());
 }
 
-TEST(caffe2api, service_train) {
+TEST(caffe2api, service_train)
+{
 
   // Remove old data
   clean_repository(BC_REPO);
@@ -451,7 +455,8 @@ TEST(caffe2api, service_train) {
   train(japi, jd, train_boats_and_cars);
   assert_accuracy(jd, 0.7);
   assert_loss(jd, 0.2);
-  assert_first_test_at(jd, 200); // 1000 iterations (0, 999), tests at 200, 400, 600, 800
+  assert_first_test_at(
+      jd, 200); // 1000 iterations (0, 999), tests at 200, 400, 600, 800
 
   // Test resume
   train(japi, jd, train_boats_and_cars_resume);
@@ -463,7 +468,8 @@ TEST(caffe2api, service_train) {
   clean_repository(BC_REPO);
 }
 
-TEST(caffe2api, service_finetune) {
+TEST(caffe2api, service_finetune)
+{
 
   // Remove old data
   clean_repository(BC_REPO);
@@ -478,31 +484,36 @@ TEST(caffe2api, service_finetune) {
   clean_repository(BC_REPO);
 }
 
-TEST(caffe2api, detectron_bbox_predict) {
+TEST(caffe2api, detectron_bbox_predict)
+{
   JsonAPI japi;
   JDoc jd;
   create(japi, detectron);
 
   predict(japi, jd, predict_bbox_boats_and_dogs);
-  assert_bboxes_and_masks(jd, {
-      { DTTRON_BOATS, {{"boat", 2}, {"person", 35}} },
-      { DTTRON_DOGS, {{"dog", 2}, {"person", 2}} }
-  }, false);
+  assert_bboxes_and_masks(
+      jd,
+      { { DTTRON_BOATS, { { "boat", 2 }, { "person", 35 } } },
+        { DTTRON_DOGS, { { "dog", 2 }, { "person", 2 } } } },
+      false);
 }
 
-TEST(caffe2api, detectron_mask_predict) {
+TEST(caffe2api, detectron_mask_predict)
+{
   JsonAPI japi;
   JDoc jd;
   create(japi, detectron_mask);
 
   predict(japi, jd, predict_mask_boats_and_dogs);
-  assert_bboxes_and_masks(jd, {
-      { DTTRON_BOATS, {{"boat", 2}, {"person", 25}} },
-      { DTTRON_DOGS, {{"dog", 2}, {"person", 2}} }
-  }, true);
+  assert_bboxes_and_masks(
+      jd,
+      { { DTTRON_BOATS, { { "boat", 2 }, { "person", 25 } } },
+        { DTTRON_DOGS, { { "dog", 2 }, { "person", 2 } } } },
+      true);
 }
 
-TEST(caffe2api, detectron_mask_predict_empty) {
+TEST(caffe2api, detectron_mask_predict_empty)
+{
   JsonAPI japi;
   JDoc jd;
   create(japi, detectron_mask);

--- a/tests/ut-caffeapi.cc
+++ b/tests/ut-caffeapi.cc
@@ -31,9 +31,12 @@
 using namespace dd;
 
 static std::string ok_str = "{\"status\":{\"code\":200,\"msg\":\"OK\"}}";
-static std::string created_str = "{\"status\":{\"code\":201,\"msg\":\"Created\"}}";
-static std::string bad_param_str = "{\"status\":{\"code\":400,\"msg\":\"BadRequest\"}}";
-static std::string not_found_str = "{\"status\":{\"code\":404,\"msg\":\"NotFound\"}}";
+static std::string created_str
+    = "{\"status\":{\"code\":201,\"msg\":\"Created\"}}";
+static std::string bad_param_str
+    = "{\"status\":{\"code\":400,\"msg\":\"BadRequest\"}}";
+static std::string not_found_str
+    = "{\"status\":{\"code\":404,\"msg\":\"NotFound\"}}";
 
 static std::string mnist_repo = "../examples/caffe/mnist/";
 static std::string forest_repo = "../examples/all/forest_type/";
@@ -70,27 +73,36 @@ static std::string iterations_lstm = "20";
 
 static std::string gpuid = "0"; // change as needed
 
-TEST(caffeapi,service_train)
+TEST(caffeapi, service_train)
 {
-// create service
+  // create service
   JsonAPI japi;
   std::string sname = "my_service";
-  std::string jstr = "{\"mllib\":\"caffe\",\"description\":\"my classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\"" +  mnist_repo + "\"},\"parameters\":{\"input\":{\"connector\":\"image\"},\"mllib\":{\"nclasses\":10}}}";
-  std::string joutstr = japi.jrender(japi.service_create(sname,jstr));
-  ASSERT_EQ(created_str,joutstr);
+  std::string jstr
+      = "{\"mllib\":\"caffe\",\"description\":\"my "
+        "classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\""
+        + mnist_repo
+        + "\"},\"parameters\":{\"input\":{\"connector\":\"image\"},\"mllib\":{"
+          "\"nclasses\":10}}}";
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
 
   // train
-  std::string jtrainstr = "{\"service\":\"" + sname + "\",\"async\":false,\"parameters\":{\"mllib\":{\"gpu\":true,\"gpuid\":"+gpuid+",\"solver\":{\"iterations\":" + iterations_mnist + "}}}}";
+  std::string jtrainstr
+      = "{\"service\":\"" + sname
+        + "\",\"async\":false,\"parameters\":{\"mllib\":{\"gpu\":true,"
+          "\"gpuid\":"
+        + gpuid + ",\"solver\":{\"iterations\":" + iterations_mnist + "}}}}";
   joutstr = japi.jrender(japi.service_train(jtrainstr));
   std::cout << "joutstr=" << joutstr << std::endl;
   JDoc jd;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_TRUE(jd.HasMember("status"));
-  ASSERT_EQ(201,jd["status"]["code"].GetInt());
-  ASSERT_EQ("Created",jd["status"]["msg"]);
+  ASSERT_EQ(201, jd["status"]["code"].GetInt());
+  ASSERT_EQ("Created", jd["status"]["msg"]);
   ASSERT_TRUE(jd.HasMember("head"));
-  ASSERT_EQ("/train",jd["head"]["method"]);
+  ASSERT_EQ("/train", jd["head"]["method"]);
   ASSERT_TRUE(jd["head"]["time"].GetDouble() >= 0);
   ASSERT_TRUE(jd.HasMember("body"));
   ASSERT_TRUE(jd["body"]["measure"].HasMember("train_loss"));
@@ -98,51 +110,61 @@ TEST(caffeapi,service_train)
 
   // remove service
   jstr = "{\"clear\":\"lib\"}";
-  joutstr = japi.jrender(japi.service_delete(sname,jstr));
-  ASSERT_EQ(ok_str,joutstr);
+  joutstr = japi.jrender(japi.service_delete(sname, jstr));
+  ASSERT_EQ(ok_str, joutstr);
   ASSERT_TRUE(!fileops::file_exists(mnist_repo + "model_iter_250.caffemodel"));
-  ASSERT_TRUE(!fileops::file_exists(mnist_repo + "model_iter_250.solverstate"));
-  }
+  ASSERT_TRUE(
+      !fileops::file_exists(mnist_repo + "model_iter_250.solverstate"));
+}
 
-TEST(caffeapi,service_train_async_status_delete)
+TEST(caffeapi, service_train_async_status_delete)
 {
   // create service
   JsonAPI japi;
   std::string sname = "my_service";
-  std::string jstr = "{\"mllib\":\"caffe\",\"description\":\"my classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\"" +  mnist_repo + "\"},\"parameters\":{\"input\":{\"connector\":\"image\"},\"mllib\":{\"nclasses\":10}}}";
-  std::string joutstr = japi.jrender(japi.service_create(sname,jstr));
-  ASSERT_EQ(created_str,joutstr);
+  std::string jstr
+      = "{\"mllib\":\"caffe\",\"description\":\"my "
+        "classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\""
+        + mnist_repo
+        + "\"},\"parameters\":{\"input\":{\"connector\":\"image\"},\"mllib\":{"
+          "\"nclasses\":10}}}";
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
 
   // train
-  std::string jtrainstr = "{\"service\":\"" + sname + "\",\"async\":true,\"parameters\":{\"mllib\":{\"gpu\":true,\"gpuid\":"+gpuid+",\"solver\":{\"iterations\":10000}}}}";
+  std::string jtrainstr = "{\"service\":\"" + sname
+                          + "\",\"async\":true,\"parameters\":{\"mllib\":{"
+                            "\"gpu\":true,\"gpuid\":"
+                          + gpuid + ",\"solver\":{\"iterations\":10000}}}}";
   joutstr = japi.jrender(japi.service_train(jtrainstr));
   std::cout << "joutstr=" << joutstr << std::endl;
   JDoc jd;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_TRUE(jd.HasMember("status"));
-  ASSERT_EQ(201,jd["status"]["code"]);
-  ASSERT_EQ("Created",jd["status"]["msg"]);
+  ASSERT_EQ(201, jd["status"]["code"]);
+  ASSERT_EQ("Created", jd["status"]["msg"]);
   ASSERT_TRUE(jd.HasMember("head"));
-  ASSERT_EQ("/train",jd["head"]["method"]);
-  ASSERT_EQ(1,jd["head"]["job"].GetInt());
-  ASSERT_EQ("running",jd["head"]["status"]);
-  
+  ASSERT_EQ("/train", jd["head"]["method"]);
+  ASSERT_EQ(1, jd["head"]["job"].GetInt());
+  ASSERT_EQ("running", jd["head"]["status"]);
+
   // status.
-  std::string jstatusstr = "{\"service\":\"" + sname + "\",\"job\":1,\"timeout\":5}";
+  std::string jstatusstr
+      = "{\"service\":\"" + sname + "\",\"job\":1,\"timeout\":5}";
   joutstr = japi.jrender(japi.service_train_status(jstatusstr));
   std::cout << "status joutstr=" << joutstr << std::endl;
   JDoc jd2;
   jd2.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd2.HasParseError());
   ASSERT_TRUE(jd2.HasMember("status"));
-  ASSERT_EQ(200,jd2["status"]["code"]);
-  ASSERT_EQ("OK",jd2["status"]["msg"]);
+  ASSERT_EQ(200, jd2["status"]["code"]);
+  ASSERT_EQ("OK", jd2["status"]["msg"]);
   ASSERT_TRUE(jd2.HasMember("head"));
-  ASSERT_EQ("/train",jd2["head"]["method"]);
-  ASSERT_EQ(5.0,jd2["head"]["time"].GetDouble());
-  ASSERT_EQ("running",jd2["head"]["status"]);
-  ASSERT_EQ(1,jd2["head"]["job"]);
+  ASSERT_EQ("/train", jd2["head"]["method"]);
+  ASSERT_EQ(5.0, jd2["head"]["time"].GetDouble());
+  ASSERT_EQ("running", jd2["head"]["status"]);
+  ASSERT_EQ(1, jd2["head"]["job"]);
   ASSERT_TRUE(jd2.HasMember("body"));
   ASSERT_TRUE(jd2["body"]["measure"].HasMember("train_loss"));
   ASSERT_TRUE(fabs(jd2["body"]["measure"]["train_loss"].GetDouble()) > 0);
@@ -155,177 +177,225 @@ TEST(caffeapi,service_train_async_status_delete)
   jd3.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd3.HasParseError());
   ASSERT_TRUE(jd3.HasMember("status"));
-  ASSERT_EQ(200,jd3["status"]["code"]);
-  ASSERT_EQ("OK",jd3["status"]["msg"]);
+  ASSERT_EQ(200, jd3["status"]["code"]);
+  ASSERT_EQ("OK", jd3["status"]["msg"]);
   ASSERT_TRUE(jd3.HasMember("head"));
-  ASSERT_EQ("/train",jd3["head"]["method"]);
+  ASSERT_EQ("/train", jd3["head"]["method"]);
   ASSERT_TRUE(jd3["head"]["time"].GetDouble() >= 0);
-  ASSERT_EQ("terminated",jd3["head"]["status"]);
-  ASSERT_EQ(1,jd3["head"]["job"].GetInt());
+  ASSERT_EQ("terminated", jd3["head"]["status"]);
+  ASSERT_EQ(1, jd3["head"]["job"].GetInt());
 
   // remove service
   jstr = "{\"clear\":\"lib\"}";
-  joutstr = japi.jrender(japi.service_delete(sname,jstr));
-  ASSERT_EQ(ok_str,joutstr);
+  joutstr = japi.jrender(japi.service_delete(sname, jstr));
+  ASSERT_EQ(ok_str, joutstr);
 }
 
-TEST(caffeapi,service_train_async_final_status)
+TEST(caffeapi, service_train_async_final_status)
 {
   // create service
   JsonAPI japi;
   std::string sname = "my_service";
-  std::string jstr = "{\"mllib\":\"caffe\",\"description\":\"my classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\"" +  mnist_repo + "\"},\"parameters\":{\"input\":{\"connector\":\"image\"},\"mllib\":{\"nclasses\":10}}}";
-  std::string joutstr = japi.jrender(japi.service_create(sname,jstr));
-  ASSERT_EQ(created_str,joutstr);
+  std::string jstr
+      = "{\"mllib\":\"caffe\",\"description\":\"my "
+        "classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\""
+        + mnist_repo
+        + "\"},\"parameters\":{\"input\":{\"connector\":\"image\"},\"mllib\":{"
+          "\"nclasses\":10}}}";
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
 
   // train
-  std::string jtrainstr = "{\"service\":\"" + sname + "\",\"async\":true,\"parameters\":{\"mllib\":{\"gpu\":true,\"gpuid\":"+gpuid+",\"solver\":{\"iterations\":" + iterations_mnist + "}}}}";
+  std::string jtrainstr
+      = "{\"service\":\"" + sname
+        + "\",\"async\":true,\"parameters\":{\"mllib\":{\"gpu\":true,"
+          "\"gpuid\":"
+        + gpuid + ",\"solver\":{\"iterations\":" + iterations_mnist + "}}}}";
   joutstr = japi.jrender(japi.service_train(jtrainstr));
   std::cout << "joutstr=" << joutstr << std::endl;
   JDoc jd;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_TRUE(jd.HasMember("status"));
-  ASSERT_EQ(201,jd["status"]["code"]);
-  ASSERT_EQ("Created",jd["status"]["msg"]);
+  ASSERT_EQ(201, jd["status"]["code"]);
+  ASSERT_EQ("Created", jd["status"]["msg"]);
   ASSERT_TRUE(jd.HasMember("head"));
-  ASSERT_EQ("/train",jd["head"]["method"]);
-  ASSERT_EQ(1,jd["head"]["job"].GetInt());
-  ASSERT_EQ("running",jd["head"]["status"]);
-  
+  ASSERT_EQ("/train", jd["head"]["method"]);
+  ASSERT_EQ(1, jd["head"]["job"].GetInt());
+  ASSERT_EQ("running", jd["head"]["status"]);
+
   // status.
   bool running = true;
-  while(running)
+  while (running)
     {
-      //sleep(1);
-      std::string jstatusstr = "{\"service\":\"" + sname + "\",\"job\":1,\"timeout\":1}";
+      // sleep(1);
+      std::string jstatusstr
+          = "{\"service\":\"" + sname + "\",\"job\":1,\"timeout\":1}";
       joutstr = japi.jrender(japi.service_train_status(jstatusstr));
       std::cout << "joutstr=" << joutstr << std::endl;
       running = joutstr.find("running") != std::string::npos;
       if (!running)
-	{
-	  JDoc jd2;
-	  jd2.Parse(joutstr.c_str());
-	  ASSERT_TRUE(!jd2.HasParseError());
-	  ASSERT_TRUE(jd2.HasMember("status"));
-	  ASSERT_EQ(200,jd2["status"]["code"]);
-	  ASSERT_EQ("OK",jd2["status"]["msg"]);
-	  ASSERT_TRUE(jd2.HasMember("head"));
-	  ASSERT_EQ("/train",jd2["head"]["method"]);
-	  ASSERT_TRUE(jd2["head"]["time"].GetDouble() >= 0);
-	  ASSERT_EQ("finished",jd2["head"]["status"]);
-	  ASSERT_EQ(1,jd2["head"]["job"]);
-	  ASSERT_TRUE(jd2.HasMember("body"));
-	  ASSERT_TRUE(jd2["body"]["measure"].HasMember("train_loss"));
-	  ASSERT_TRUE(fabs(jd2["body"]["measure"]["train_loss"].GetDouble()) > 0);
-	  ASSERT_TRUE(jd2["body"]["measure"].HasMember("iteration"));
-	  ASSERT_TRUE(jd2["body"]["measure"]["iteration"].GetDouble() > 0);
-	}
+        {
+          JDoc jd2;
+          jd2.Parse(joutstr.c_str());
+          ASSERT_TRUE(!jd2.HasParseError());
+          ASSERT_TRUE(jd2.HasMember("status"));
+          ASSERT_EQ(200, jd2["status"]["code"]);
+          ASSERT_EQ("OK", jd2["status"]["msg"]);
+          ASSERT_TRUE(jd2.HasMember("head"));
+          ASSERT_EQ("/train", jd2["head"]["method"]);
+          ASSERT_TRUE(jd2["head"]["time"].GetDouble() >= 0);
+          ASSERT_EQ("finished", jd2["head"]["status"]);
+          ASSERT_EQ(1, jd2["head"]["job"]);
+          ASSERT_TRUE(jd2.HasMember("body"));
+          ASSERT_TRUE(jd2["body"]["measure"].HasMember("train_loss"));
+          ASSERT_TRUE(fabs(jd2["body"]["measure"]["train_loss"].GetDouble())
+                      > 0);
+          ASSERT_TRUE(jd2["body"]["measure"].HasMember("iteration"));
+          ASSERT_TRUE(jd2["body"]["measure"]["iteration"].GetDouble() > 0);
+        }
     }
 
-   // remove service
+  // remove service
   jstr = "{\"clear\":\"lib\"}";
-  joutstr = japi.jrender(japi.service_delete(sname,jstr));
-  ASSERT_EQ(ok_str,joutstr);
+  joutstr = japi.jrender(japi.service_delete(sname, jstr));
+  ASSERT_EQ(ok_str, joutstr);
 }
 
 // predict while training
-TEST(caffeapi,service_train_async_and_predict)
+TEST(caffeapi, service_train_async_and_predict)
 {
   // create service
   JsonAPI japi;
   std::string sname = "my_service";
-  std::string jstr = "{\"mllib\":\"caffe\",\"description\":\"my classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\"" +  mnist_repo + "\"},\"parameters\":{\"input\":{\"connector\":\"image\"},\"mllib\":{\"nclasses\":10}}}";
-  std::string joutstr = japi.jrender(japi.service_create(sname,jstr));
-  ASSERT_EQ(created_str,joutstr);
+  std::string jstr
+      = "{\"mllib\":\"caffe\",\"description\":\"my "
+        "classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\""
+        + mnist_repo
+        + "\"},\"parameters\":{\"input\":{\"connector\":\"image\"},\"mllib\":{"
+          "\"nclasses\":10}}}";
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
 
   // train
   std::string iterations = iterations_mnist;
 #ifndef CPU_ONLY
   iterations = "1500";
 #endif
-  std::string jtrainstr = "{\"service\":\"" + sname + "\",\"async\":true,\"parameters\":{\"mllib\":{\"gpu\":true,\"gpuid\":"+gpuid+",\"solver\":{\"iterations\":" + iterations + "}}}}";
+  std::string jtrainstr = "{\"service\":\"" + sname
+                          + "\",\"async\":true,\"parameters\":{\"mllib\":{"
+                            "\"gpu\":true,\"gpuid\":"
+                          + gpuid + ",\"solver\":{\"iterations\":" + iterations
+                          + "}}}}";
   joutstr = japi.jrender(japi.service_train(jtrainstr));
   std::cout << "joutstr=" << joutstr << std::endl;
   JDoc jd;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_TRUE(jd.HasMember("status"));
-  ASSERT_EQ(201,jd["status"]["code"]);
-  ASSERT_EQ("Created",jd["status"]["msg"]);
+  ASSERT_EQ(201, jd["status"]["code"]);
+  ASSERT_EQ("Created", jd["status"]["msg"]);
   ASSERT_TRUE(jd.HasMember("head"));
-  ASSERT_EQ("/train",jd["head"]["method"]);
-  ASSERT_EQ(1,jd["head"]["job"].GetInt());
-  ASSERT_EQ("running",jd["head"]["status"]);
-  
+  ASSERT_EQ("/train", jd["head"]["method"]);
+  ASSERT_EQ(1, jd["head"]["job"].GetInt());
+  ASSERT_EQ("running", jd["head"]["status"]);
+
   // status
-  std::string jstatusstr = "{\"service\":\"" + sname + "\",\"job\":1,\"timeout\":2}";
+  std::string jstatusstr
+      = "{\"service\":\"" + sname + "\",\"job\":1,\"timeout\":2}";
   joutstr = japi.jrender(japi.service_train_status(jstatusstr));
   std::cout << "joutstr=" << joutstr << std::endl;
-    
+
   // predict call
-  std::string jpredictstr = "{\"service\":\""+ sname + "\",\"parameters\":{\"input\":{\"bw\":true,\"width\":28,\"height\":28}},\"data\":[\"" + mnist_repo + "/sample_digit.png\"]}";
+  std::string jpredictstr = "{\"service\":\"" + sname
+                            + "\",\"parameters\":{\"input\":{\"bw\":true,"
+                              "\"width\":28,\"height\":28}},\"data\":[\""
+                            + mnist_repo + "/sample_digit.png\"]}";
   joutstr = japi.jrender(japi.service_predict(jpredictstr));
   std::cout << "joutstr=" << joutstr << std::endl;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
-  ASSERT_EQ(409,jd["status"]["code"]);
-  ASSERT_EQ(1008,jd["status"]["dd_code"]);
-  
+  ASSERT_EQ(409, jd["status"]["code"]);
+  ASSERT_EQ(1008, jd["status"]["dd_code"]);
+
   // remove service
   jstr = "{\"clear\":\"lib\"}";
-  joutstr = japi.jrender(japi.service_delete(sname,jstr));
-  ASSERT_EQ(ok_str,joutstr);
+  joutstr = japi.jrender(japi.service_delete(sname, jstr));
+  ASSERT_EQ(ok_str, joutstr);
 }
 
-TEST(caffeapi,service_predict)
+TEST(caffeapi, service_predict)
 {
   // create service
   JsonAPI japi;
   std::string sname = "my_service";
-  std::string jstr = "{\"mllib\":\"caffe\",\"description\":\"my classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\"" +  mnist_repo + "\"},\"parameters\":{\"input\":{\"connector\":\"image\"},\"mllib\":{\"nclasses\":10}}}";
-  std::string joutstr = japi.jrender(japi.service_create(sname,jstr));
-  ASSERT_EQ(created_str,joutstr);
+  std::string jstr
+      = "{\"mllib\":\"caffe\",\"description\":\"my "
+        "classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\""
+        + mnist_repo
+        + "\"},\"parameters\":{\"input\":{\"connector\":\"image\"},\"mllib\":{"
+          "\"nclasses\":10}}}";
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
 
   // train
-  std::string jtrainstr = "{\"service\":\"" + sname + "\",\"async\":false,\"parameters\":{\"mllib\":{\"gpu\":true,\"gpuid\":"+gpuid+",\"solver\":{\"iterations\":" + iterations_mnist + ",\"snapshot\":200,\"snapshot_prefix\":\"" + mnist_repo + "/mylenet\",\"test_interval\":2}},\"output\":{\"measure_hist\":true,\"measure\":[\"f1\"]}}}";
+  std::string jtrainstr
+      = "{\"service\":\"" + sname
+        + "\",\"async\":false,\"parameters\":{\"mllib\":{\"gpu\":true,"
+          "\"gpuid\":"
+        + gpuid + ",\"solver\":{\"iterations\":" + iterations_mnist
+        + ",\"snapshot\":200,\"snapshot_prefix\":\"" + mnist_repo
+        + "/mylenet\",\"test_interval\":2}},\"output\":{\"measure_hist\":true,"
+          "\"measure\":[\"f1\"]}}}";
   joutstr = japi.jrender(japi.service_train(jtrainstr));
   std::cout << "joutstr=" << joutstr << std::endl;
   JDoc jd;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_TRUE(jd.HasMember("status"));
-  ASSERT_EQ(201,jd["status"]["code"].GetInt());
-  ASSERT_EQ("Created",jd["status"]["msg"]);
+  ASSERT_EQ(201, jd["status"]["code"].GetInt());
+  ASSERT_EQ("Created", jd["status"]["msg"]);
   ASSERT_TRUE(jd.HasMember("head"));
-  ASSERT_EQ("/train",jd["head"]["method"]);
+  ASSERT_EQ("/train", jd["head"]["method"]);
   ASSERT_TRUE(jd["head"]["time"].GetDouble() >= 0);
   ASSERT_TRUE(jd.HasMember("body"));
   ASSERT_TRUE(jd["body"].HasMember("measure"));
   ASSERT_TRUE(fabs(jd["body"]["measure"]["train_loss"].GetDouble()) > 0);
-  ASSERT_EQ(jd["body"]["measure_hist"]["iteration_hist"].Size(),jd["body"]["measure_hist"]["f1_hist"].Size());
+  ASSERT_EQ(jd["body"]["measure_hist"]["iteration_hist"].Size(),
+            jd["body"]["measure_hist"]["f1_hist"].Size());
 
   // predict
-  std::string jpredictstr = "{\"service\":\""+ sname + "\",\"parameters\":{\"input\":{\"bw\":true}},\"data\":[\"" + mnist_repo + "/sample_digit.png\"]}";
+  std::string jpredictstr
+      = "{\"service\":\"" + sname
+        + "\",\"parameters\":{\"input\":{\"bw\":true}},\"data\":[\""
+        + mnist_repo + "/sample_digit.png\"]}";
   joutstr = japi.jrender(japi.service_predict(jpredictstr));
   std::cout << "joutstr predict=" << joutstr << std::endl;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
-  ASSERT_EQ(500,jd["status"]["code"]);
-  ASSERT_EQ(1007,jd["status"]["dd_code"]);
-  
+  ASSERT_EQ(500, jd["status"]["code"]);
+  ASSERT_EQ(1007, jd["status"]["dd_code"]);
+
   // predict with image size (could be set at service creation)
-  jpredictstr = "{\"service\":\""+ sname + "\",\"parameters\":{\"input\":{\"bw\":true,\"width\":28,\"height\":28},\"output\":{\"best\":3}},\"data\":[\"" + mnist_repo + "/sample_digit.png\",\"" + mnist_repo + "/sample_digit2.png\"]}";
+  jpredictstr = "{\"service\":\"" + sname
+                + "\",\"parameters\":{\"input\":{\"bw\":true,\"width\":28,"
+                  "\"height\":28},\"output\":{\"best\":3}},\"data\":[\""
+                + mnist_repo + "/sample_digit.png\",\"" + mnist_repo
+                + "/sample_digit2.png\"]}";
   joutstr = japi.jrender(japi.service_predict(jpredictstr));
   std::cout << "joutstr=" << joutstr << std::endl;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
-  ASSERT_EQ(200,jd["status"]["code"]);
+  ASSERT_EQ(200, jd["status"]["code"]);
   ASSERT_TRUE(jd["body"]["predictions"].IsArray());
-  ASSERT_TRUE((mnist_repo + "/sample_digit.png"==jd["body"]["predictions"][0]["uri"].GetString())
-	      ||(mnist_repo + "/sample_digit2.png"==jd["body"]["predictions"][0]["uri"].GetString()));
-  ASSERT_TRUE(jd["body"]["predictions"][0]["classes"][0]["prob"].GetDouble() > 0);
-  ASSERT_TRUE(jd["body"]["predictions"][1]["classes"][0]["prob"].GetDouble() > 0);
+  ASSERT_TRUE((mnist_repo + "/sample_digit.png"
+               == jd["body"]["predictions"][0]["uri"].GetString())
+              || (mnist_repo + "/sample_digit2.png"
+                  == jd["body"]["predictions"][0]["uri"].GetString()));
+  ASSERT_TRUE(jd["body"]["predictions"][0]["classes"][0]["prob"].GetDouble()
+              > 0);
+  ASSERT_TRUE(jd["body"]["predictions"][1]["classes"][0]["prob"].GetDouble()
+              > 0);
 
   // base64 predict
   std::string img_str;
@@ -334,73 +404,102 @@ TEST(caffeapi,service_predict)
   buffer << fimg.rdbuf();
   img_str = buffer.str();
   std::string b64_str;
-  Base64::Encode(img_str,&b64_str);
-  jpredictstr = "{\"service\":\""+ sname + "\",\"parameters\":{\"input\":{\"bw\":true,\"width\":28,\"height\":28},\"output\":{\"best\":3}},\"data\":[\"" + b64_str + "\"]}";
+  Base64::Encode(img_str, &b64_str);
+  jpredictstr = "{\"service\":\"" + sname
+                + "\",\"parameters\":{\"input\":{\"bw\":true,\"width\":28,"
+                  "\"height\":28},\"output\":{\"best\":3}},\"data\":[\""
+                + b64_str + "\"]}";
   joutstr = japi.jrender(japi.service_predict(jpredictstr));
   std::cout << "joutstr=" << joutstr << std::endl;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
-  ASSERT_EQ(200,jd["status"]["code"]);
+  ASSERT_EQ(200, jd["status"]["code"]);
   std::string uri = jd["body"]["predictions"][0]["uri"].GetString();
   std::cerr << "uri=" << uri << std::endl;
-  ASSERT_EQ("0",uri);
+  ASSERT_EQ("0", uri);
 
   // predict non existing image
-  jpredictstr = "{\"service\":\""+ sname + "\",\"parameters\":{\"input\":{\"bw\":true,\"width\":28,\"height\":28},\"output\":{\"best\":3}},\"data\":[\"http://example.com/my_image.png\"]}";
+  jpredictstr = "{\"service\":\"" + sname
+                + "\",\"parameters\":{\"input\":{\"bw\":true,\"width\":28,"
+                  "\"height\":28},\"output\":{\"best\":3}},\"data\":[\"http://"
+                  "example.com/my_image.png\"]}";
   joutstr = japi.jrender(japi.service_predict(jpredictstr));
   std::cout << "joutstr=" << joutstr << std::endl;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
-  ASSERT_EQ(400,jd["status"]["code"]);
+  ASSERT_EQ(400, jd["status"]["code"]);
 
   // lmdb predict
-  jpredictstr = "{\"service\":\""+ sname + "\",\"parameters\":{\"input\":{\"bw\":true,\"width\":28,\"height\":28},\"output\":{\"measure\":[\"f1\"]},\"mllib\":{\"net\":{\"test_batch_size\":100}}},\"data\":[\"" + mnist_repo + "/test.lmdb\"]}";
+  jpredictstr = "{\"service\":\"" + sname
+                + "\",\"parameters\":{\"input\":{\"bw\":true,\"width\":28,"
+                  "\"height\":28},\"output\":{\"measure\":[\"f1\"]},\"mllib\":"
+                  "{\"net\":{\"test_batch_size\":100}}},\"data\":[\""
+                + mnist_repo + "/test.lmdb\"]}";
   joutstr = japi.jrender(japi.service_predict(jpredictstr));
   std::cout << "joutstr=" << joutstr << std::endl;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
-  ASSERT_EQ(200,jd["status"]["code"]);
+  ASSERT_EQ(200, jd["status"]["code"]);
   ASSERT_TRUE(jd["body"]["measure"]["f1"].GetDouble() > 0.0);
 
-  jpredictstr = "{\"service\":\""+ sname + "\",\"parameters\":{\"input\":{\"bw\":true,\"width\":28,\"height\":28},\"output\":{},\"mllib\":{\"net\":{\"test_batch_size\":100}}},\"data\":[\"" + mnist_repo + "/test.lmdb\"]}";
+  jpredictstr = "{\"service\":\"" + sname
+                + "\",\"parameters\":{\"input\":{\"bw\":true,\"width\":28,"
+                  "\"height\":28},\"output\":{},\"mllib\":{\"net\":{\"test_"
+                  "batch_size\":100}}},\"data\":[\""
+                + mnist_repo + "/test.lmdb\"]}";
   joutstr = japi.jrender(japi.service_predict(jpredictstr));
   std::cout << "joutstr=" << joutstr << std::endl;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
-  ASSERT_EQ(200,jd["status"]["code"]);
+  ASSERT_EQ(200, jd["status"]["code"]);
   uri = jd["body"]["predictions"][0]["uri"].GetString();
-  ASSERT_EQ(uri,"00000000");
+  ASSERT_EQ(uri, "00000000");
 
   // remove service
   jstr = "{\"clear\":\"lib\"}";
-  joutstr = japi.jrender(japi.service_delete(sname,jstr));
-  ASSERT_EQ(ok_str,joutstr);
+  joutstr = japi.jrender(japi.service_delete(sname, jstr));
+  ASSERT_EQ(ok_str, joutstr);
 }
 
-TEST(caffeapi,service_train_csv)
+TEST(caffeapi, service_train_csv)
 {
   // create service
   JsonAPI japi;
   std::string sname = "my_service";
-  std::string jstr = "{\"mllib\":\"caffe\",\"description\":\"my classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\"" +  forest_repo + "\",\"templates\":\"" + model_templates_repo  + "\"},\"parameters\":{\"input\":{\"connector\":\"csv\"},\"mllib\":{\"template\":\"mlp\",\"nclasses\":7,\"activation\":\"prelu\"}}}";
-  std::string joutstr = japi.jrender(japi.service_create(sname,jstr));
-  ASSERT_EQ(created_str,joutstr);
+  std::string jstr
+      = "{\"mllib\":\"caffe\",\"description\":\"my "
+        "classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\""
+        + forest_repo + "\",\"templates\":\"" + model_templates_repo
+        + "\"},\"parameters\":{\"input\":{\"connector\":\"csv\"},\"mllib\":{"
+          "\"template\":\"mlp\",\"nclasses\":7,\"activation\":\"prelu\"}}}";
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
 
   // assert json blob file
-  ASSERT_TRUE(fileops::file_exists(forest_repo + "/" + JsonAPI::_json_blob_fname));
-  
+  ASSERT_TRUE(
+      fileops::file_exists(forest_repo + "/" + JsonAPI::_json_blob_fname));
+
   // train
-  std::string jtrainstr = "{\"service\":\"" + sname + "\",\"async\":false,\"parameters\":{\"input\":{\"label\":\"Cover_Type\",\"id\":\"Id\",\"scale\":true,\"test_split\":0.1,\"label_offset\":-1,\"shuffle\":true},\"mllib\":{\"gpu\":true,\"gpuid\":"+gpuid+",\"solver\":{\"iterations\":" + iterations_forest + ",\"base_lr\":0.05},\"net\":{\"batch_size\":512}},\"output\":{\"measure\":[\"acc\",\"mcll\",\"f1\",\"cmdiag\",\"cmfull\"]}},\"data\":[\"" + forest_repo + "train.csv\"]}";
+  std::string jtrainstr
+      = "{\"service\":\"" + sname
+        + "\",\"async\":false,\"parameters\":{\"input\":{\"label\":\"Cover_"
+          "Type\",\"id\":\"Id\",\"scale\":true,\"test_split\":0.1,\"label_"
+          "offset\":-1,\"shuffle\":true},\"mllib\":{\"gpu\":true,\"gpuid\":"
+        + gpuid + ",\"solver\":{\"iterations\":" + iterations_forest
+        + ",\"base_lr\":0.05},\"net\":{\"batch_size\":512}},\"output\":{"
+          "\"measure\":[\"acc\",\"mcll\",\"f1\",\"cmdiag\",\"cmfull\"]}},"
+          "\"data\":[\""
+        + forest_repo + "train.csv\"]}";
   joutstr = japi.jrender(japi.service_train(jtrainstr));
   std::cout << "joutstr=" << joutstr << std::endl;
   JDoc jd;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_TRUE(jd.HasMember("status"));
-  ASSERT_EQ(201,jd["status"]["code"].GetInt());
-  ASSERT_EQ("Created",jd["status"]["msg"]);
+  ASSERT_EQ(201, jd["status"]["code"].GetInt());
+  ASSERT_EQ("Created", jd["status"]["msg"]);
   ASSERT_TRUE(jd.HasMember("head"));
-  ASSERT_EQ("/train",jd["head"]["method"]);
+  ASSERT_EQ("/train", jd["head"]["method"]);
   ASSERT_TRUE(jd["head"]["time"].GetDouble() >= 0);
   ASSERT_TRUE(jd.HasMember("body"));
   ASSERT_TRUE(jd["body"]["measure"].HasMember("train_loss"));
@@ -411,100 +510,158 @@ TEST(caffeapi,service_train_csv)
 #else
   ASSERT_TRUE(jd["body"]["measure"]["f1"].GetDouble() > 0.5);
 #endif
-  ASSERT_EQ(jd["body"]["measure"]["accp"].GetDouble(),jd["body"]["measure"]["acc"].GetDouble());
+  ASSERT_EQ(jd["body"]["measure"]["accp"].GetDouble(),
+            jd["body"]["measure"]["acc"].GetDouble());
   ASSERT_TRUE(jd["body"].HasMember("parameters"));
   ASSERT_TRUE(jd["body"]["parameters"].HasMember("input"));
   ASSERT_TRUE(jd["body"]["parameters"]["input"].HasMember("min_vals"));
   ASSERT_TRUE(jd["body"]["parameters"]["input"].HasMember("max_vals"));
   ASSERT_TRUE(jd["body"]["measure"].HasMember("cmdiag"));
-  ASSERT_EQ(7,jd["body"]["measure"]["cmdiag"].Size());
+  ASSERT_EQ(7, jd["body"]["measure"]["cmdiag"].Size());
   ASSERT_TRUE(jd["body"]["measure"]["cmdiag"][0].GetDouble() >= 0);
-  ASSERT_TRUE(jd["body"]["measure"]["cmfull"].Size()); //TODO: update
-  ASSERT_EQ(56,jd["body"]["parameters"]["input"]["min_vals"].Size());
-  ASSERT_EQ(56,jd["body"]["parameters"]["input"]["max_vals"].Size());
-  ASSERT_EQ(504,jd["body"]["parameters"]["mllib"]["batch_size"].GetInt());
+  ASSERT_TRUE(jd["body"]["measure"]["cmfull"].Size()); // TODO: update
+  ASSERT_EQ(56, jd["body"]["parameters"]["input"]["min_vals"].Size());
+  ASSERT_EQ(56, jd["body"]["parameters"]["input"]["max_vals"].Size());
+  ASSERT_EQ(504, jd["body"]["parameters"]["mllib"]["batch_size"].GetInt());
 
-  std::string str_min_vals = japi.jrender(jd["body"]["parameters"]["input"]["min_vals"]);
-  std::string str_max_vals = japi.jrender(jd["body"]["parameters"]["input"]["max_vals"]);
+  std::string str_min_vals
+      = japi.jrender(jd["body"]["parameters"]["input"]["min_vals"]);
+  std::string str_max_vals
+      = japi.jrender(jd["body"]["parameters"]["input"]["max_vals"]);
   std::cerr << "str_min_vals=" << str_min_vals << std::endl;
   std::cerr << "str_max_vals=" << str_max_vals << std::endl;
-  
+
   // predict from data, with header and id
-  std::string mem_data_head = "Id,Elevation,Aspect,Slope,Horizontal_Distance_To_Hydrology,Vertical_Distance_To_Hydrology,Horizontal_Distance_To_Roadways,Hillshade_9am,Hillshade_Noon,Hillshade_3pm,Horizontal_Distance_To_Fire_Points,Wilderness_Area1,Wilderness_Area2,Wilderness_Area3,Wilderness_Area4,Soil_Type1,Soil_Type2,Soil_Type3,Soil_Type4,Soil_Type5,Soil_Type6,Soil_Type7,Soil_Type8,Soil_Type9,Soil_Type10,Soil_Type11,Soil_Type12,Soil_Type13,Soil_Type14,Soil_Type15,Soil_Type16,Soil_Type17,Soil_Type18,Soil_Type19,Soil_Type20,Soil_Type21,Soil_Type22,Soil_Type23,Soil_Type24,Soil_Type25,Soil_Type26,Soil_Type27,Soil_Type28,Soil_Type29,Soil_Type30,Soil_Type31,Soil_Type32,Soil_Type33,Soil_Type34,Soil_Type35,Soil_Type36,Soil_Type37,Soil_Type38,Soil_Type39,Soil_Type40";
-  std::string mem_data = "0,2499,326,7,300,88,480,202,232,169,1676,0,0,0,1,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0";
-  std::string jpredictstr = "{\"service\":\""+ sname + "\",\"parameters\":{\"input\":{\"connector\":\"csv\",\"id\":\"Id\",\"scale\":true,\"min_vals\":" + str_min_vals + ",\"max_vals\":" + str_max_vals + "},\"output\":{\"best\":3}},\"data\":[\"" + mem_data_head + "\",\"" + mem_data + "\"]}";
+  std::string mem_data_head
+      = "Id,Elevation,Aspect,Slope,Horizontal_Distance_To_Hydrology,Vertical_"
+        "Distance_To_Hydrology,Horizontal_Distance_To_Roadways,Hillshade_9am,"
+        "Hillshade_Noon,Hillshade_3pm,Horizontal_Distance_To_Fire_Points,"
+        "Wilderness_Area1,Wilderness_Area2,Wilderness_Area3,Wilderness_Area4,"
+        "Soil_Type1,Soil_Type2,Soil_Type3,Soil_Type4,Soil_Type5,Soil_Type6,"
+        "Soil_Type7,Soil_Type8,Soil_Type9,Soil_Type10,Soil_Type11,Soil_Type12,"
+        "Soil_Type13,Soil_Type14,Soil_Type15,Soil_Type16,Soil_Type17,Soil_"
+        "Type18,Soil_Type19,Soil_Type20,Soil_Type21,Soil_Type22,Soil_Type23,"
+        "Soil_Type24,Soil_Type25,Soil_Type26,Soil_Type27,Soil_Type28,Soil_"
+        "Type29,Soil_Type30,Soil_Type31,Soil_Type32,Soil_Type33,Soil_Type34,"
+        "Soil_Type35,Soil_Type36,Soil_Type37,Soil_Type38,Soil_Type39,Soil_"
+        "Type40";
+  std::string mem_data
+      = "0,2499,326,7,300,88,480,202,232,169,1676,0,0,0,1,0,0,0,0,0,1,0,0,0,0,"
+        "0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0";
+  std::string jpredictstr
+      = "{\"service\":\"" + sname
+        + "\",\"parameters\":{\"input\":{\"connector\":\"csv\",\"id\":\"Id\","
+          "\"scale\":true,\"min_vals\":"
+        + str_min_vals + ",\"max_vals\":" + str_max_vals
+        + "},\"output\":{\"best\":3}},\"data\":[\"" + mem_data_head + "\",\""
+        + mem_data + "\"]}";
   joutstr = japi.jrender(japi.service_predict(jpredictstr));
   std::cout << "joutstr=" << joutstr << std::endl;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_TRUE(jd.HasMember("status"));
-  ASSERT_EQ(200,jd["status"]["code"].GetInt());
-  std::string cat0 = jd["body"]["predictions"][0]["classes"][0]["cat"].GetString(); // XXX: true cat is 3, which is 2 here with the label offset
-  std::string cat1 = jd["body"]["predictions"][0]["classes"][1]["cat"].GetString();
-  ASSERT_TRUE("2"==cat0||"2"==cat1);
-  
+  ASSERT_EQ(200, jd["status"]["code"].GetInt());
+  std::string cat0 = jd["body"]["predictions"][0]["classes"][0]["cat"]
+                         .GetString(); // XXX: true cat is 3, which is 2 here
+                                       // with the label offset
+  std::string cat1
+      = jd["body"]["predictions"][0]["classes"][1]["cat"].GetString();
+  ASSERT_TRUE("2" == cat0 || "2" == cat1);
+
   // predict from data, omitting header and sample id
-  std::string mem_data2 = "2499,326,7,300,88,480,202,232,169,1676,0,0,0,1,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0";
-  std::string str_min_vals2="[1863.0,0.0,0.0,0.0,-146.0,0.0,0.0,99.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0]";
-  std::string str_max_vals2="[3849.0,360.0,52.0,1343.0,554.0,6890.0,254.0,254.0,248.0,6993.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,7.0]";
-  jpredictstr = "{\"service\":\""+ sname + "\",\"parameters\":{\"input\":{\"connector\":\"csv\",\"scale\":true,\"min_vals\":" + str_min_vals2 + ",\"max_vals\":" + str_max_vals2 + "},\"output\":{\"best\":3}},\"data\":[\"" + mem_data2 + "\"]}";
+  std::string mem_data2
+      = "2499,326,7,300,88,480,202,232,169,1676,0,0,0,1,0,0,0,0,0,1,0,0,0,0,0,"
+        "0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0";
+  std::string str_min_vals2
+      = "[1863.0,0.0,0.0,0.0,-146.0,0.0,0.0,99.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,"
+        "0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,"
+        "0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,"
+        "0.0,0.0,0.0,0.0,0.0,1.0]";
+  std::string str_max_vals2
+      = "[3849.0,360.0,52.0,1343.0,554.0,6890.0,254.0,254.0,248.0,6993.0,1.0,"
+        "1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,"
+        "0.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,"
+        "1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,7.0]";
+  jpredictstr = "{\"service\":\"" + sname
+                + "\",\"parameters\":{\"input\":{\"connector\":\"csv\","
+                  "\"scale\":true,\"min_vals\":"
+                + str_min_vals2 + ",\"max_vals\":" + str_max_vals2
+                + "},\"output\":{\"best\":3}},\"data\":[\"" + mem_data2
+                + "\"]}";
   joutstr = japi.jrender(japi.service_predict(jpredictstr));
   std::cout << "joutstr=" << joutstr << std::endl;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_TRUE(jd.HasMember("status"));
-  ASSERT_EQ(200,jd["status"]["code"].GetInt());
-  cat0 = jd["body"]["predictions"][0]["classes"][0]["cat"].GetString(); // XXX: true cat is 3, which is 2 here with the label offset
+  ASSERT_EQ(200, jd["status"]["code"].GetInt());
+  cat0 = jd["body"]["predictions"][0]["classes"][0]["cat"]
+             .GetString(); // XXX: true cat is 3, which is 2 here with the
+                           // label offset
   cat1 = jd["body"]["predictions"][0]["classes"][1]["cat"].GetString();
-  ASSERT_TRUE("2"==cat0||"2"==cat1);
+  ASSERT_TRUE("2" == cat0 || "2" == cat1);
 
   // remove service
   jstr = "{\"clear\":\"lib\"}";
-  joutstr = japi.jrender(japi.service_delete(sname,jstr));
-  ASSERT_EQ(ok_str,joutstr);
+  joutstr = japi.jrender(japi.service_delete(sname, jstr));
+  ASSERT_EQ(ok_str, joutstr);
 
   // assert json blob file is still there (or gone if clear=full)
-  ASSERT_TRUE(!fileops::file_exists(forest_repo + "/" + JsonAPI::_json_blob_fname));
-  ASSERT_TRUE(!fileops::remove_directory_files(forest_repo,{".prototxt"}));
+  ASSERT_TRUE(
+      !fileops::file_exists(forest_repo + "/" + JsonAPI::_json_blob_fname));
+  ASSERT_TRUE(!fileops::remove_directory_files(forest_repo, { ".prototxt" }));
 }
 
-TEST(caffeapi,service_train_csv_in_memory)
+TEST(caffeapi, service_train_csv_in_memory)
 {
   // create service
   JsonAPI japi;
   std::string sname = "my_service2";
-  std::string jstr = "{\"mllib\":\"caffe\",\"description\":\"my classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\"" +  forest_repo + "\",\"templates\":\"" + model_templates_repo  + "\"},\"parameters\":{\"input\":{\"connector\":\"csv\"},\"mllib\":{\"template\":\"mlp\",\"nclasses\":7}}}";
-  std::string joutstr = japi.jrender(japi.service_create(sname,jstr));
-  ASSERT_EQ(created_str,joutstr);
+  std::string jstr
+      = "{\"mllib\":\"caffe\",\"description\":\"my "
+        "classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\""
+        + forest_repo + "\",\"templates\":\"" + model_templates_repo
+        + "\"},\"parameters\":{\"input\":{\"connector\":\"csv\"},\"mllib\":{"
+          "\"template\":\"mlp\",\"nclasses\":7}}}";
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
 
   // assert json blob file
-  ASSERT_TRUE(fileops::file_exists(forest_repo + "/" + JsonAPI::_json_blob_fname));
+  ASSERT_TRUE(
+      fileops::file_exists(forest_repo + "/" + JsonAPI::_json_blob_fname));
 
   // read CSV file
   std::string mem_data_str;
   std::ifstream inf(forest_repo + "train.csv");
   std::string line;
   int nlines = 0;
-  while(std::getline(inf,line))
+  while (std::getline(inf, line))
     {
       if (nlines > 0)
-	mem_data_str += ",";
+        mem_data_str += ",";
       mem_data_str += "\"" + line + "\"";
       ++nlines;
     }
-  
+
   // train
-  std::string jtrainstr = "{\"service\":\"" + sname + "\",\"async\":false,\"parameters\":{\"input\":{\"label\":\"Cover_Type\",\"id\":\"Id\",\"scale\":true,\"test_split\":0.1,\"label_offset\":-1,\"shuffle\":true},\"mllib\":{\"gpu\":true,\"gpuid\":"+gpuid+",\"solver\":{\"iterations\":" + iterations_forest + ",\"base_lr\":0.05},\"net\":{\"batch_size\":512}},\"output\":{\"measure\":[\"acc\",\"mcll\",\"f1\",\"cmdiag\"]}},\"data\":[" + mem_data_str + "]}";
+  std::string jtrainstr
+      = "{\"service\":\"" + sname
+        + "\",\"async\":false,\"parameters\":{\"input\":{\"label\":\"Cover_"
+          "Type\",\"id\":\"Id\",\"scale\":true,\"test_split\":0.1,\"label_"
+          "offset\":-1,\"shuffle\":true},\"mllib\":{\"gpu\":true,\"gpuid\":"
+        + gpuid + ",\"solver\":{\"iterations\":" + iterations_forest
+        + ",\"base_lr\":0.05},\"net\":{\"batch_size\":512}},\"output\":{"
+          "\"measure\":[\"acc\",\"mcll\",\"f1\",\"cmdiag\"]}},\"data\":["
+        + mem_data_str + "]}";
   joutstr = japi.jrender(japi.service_train(jtrainstr));
   std::cout << "joutstr=" << joutstr << std::endl;
   JDoc jd;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_TRUE(jd.HasMember("status"));
-  ASSERT_EQ(201,jd["status"]["code"].GetInt());
-  ASSERT_EQ("Created",jd["status"]["msg"]);
+  ASSERT_EQ(201, jd["status"]["code"].GetInt());
+  ASSERT_EQ("Created", jd["status"]["msg"]);
   ASSERT_TRUE(jd.HasMember("head"));
-  ASSERT_EQ("/train",jd["head"]["method"]);
+  ASSERT_EQ("/train", jd["head"]["method"]);
   ASSERT_TRUE(jd["head"]["time"].GetDouble() >= 0);
   ASSERT_TRUE(jd.HasMember("body"));
   ASSERT_TRUE(jd["body"]["measure"].HasMember("train_loss"));
@@ -515,52 +672,70 @@ TEST(caffeapi,service_train_csv_in_memory)
 #else
   ASSERT_TRUE(jd["body"]["measure"]["f1"].GetDouble() > 0.5);
 #endif
-  ASSERT_EQ(jd["body"]["measure"]["accp"].GetDouble(),jd["body"]["measure"]["acc"].GetDouble());
+  ASSERT_EQ(jd["body"]["measure"]["accp"].GetDouble(),
+            jd["body"]["measure"]["acc"].GetDouble());
   ASSERT_TRUE(jd["body"].HasMember("parameters"));
   ASSERT_TRUE(jd["body"]["parameters"].HasMember("input"));
   ASSERT_TRUE(jd["body"]["parameters"]["input"].HasMember("min_vals"));
   ASSERT_TRUE(jd["body"]["parameters"]["input"].HasMember("max_vals"));
   ASSERT_TRUE(jd["body"]["measure"].HasMember("cmdiag"));
-  ASSERT_EQ(7,jd["body"]["measure"]["cmdiag"].Size());
+  ASSERT_EQ(7, jd["body"]["measure"]["cmdiag"].Size());
   ASSERT_TRUE(jd["body"]["measure"]["cmdiag"][0].GetDouble() >= 0);
-  ASSERT_EQ(56,jd["body"]["parameters"]["input"]["min_vals"].Size());
-  ASSERT_EQ(56,jd["body"]["parameters"]["input"]["max_vals"].Size());
-  ASSERT_EQ(504,jd["body"]["parameters"]["mllib"]["batch_size"].GetInt());
-  
+  ASSERT_EQ(56, jd["body"]["parameters"]["input"]["min_vals"].Size());
+  ASSERT_EQ(56, jd["body"]["parameters"]["input"]["max_vals"].Size());
+  ASSERT_EQ(504, jd["body"]["parameters"]["mllib"]["batch_size"].GetInt());
+
   // remove service
   jstr = "{\"clear\":\"lib\"}";
-  joutstr = japi.jrender(japi.service_delete(sname,jstr));
-  ASSERT_EQ(ok_str,joutstr);
+  joutstr = japi.jrender(japi.service_delete(sname, jstr));
+  ASSERT_EQ(ok_str, joutstr);
 
   // assert json blob file is still there (or gone if clear=full)
-  ASSERT_TRUE(!fileops::file_exists(forest_repo + "/" + JsonAPI::_json_blob_fname));
-  ASSERT_TRUE(!fileops::remove_directory_files(forest_repo,{".prototxt"}));
+  ASSERT_TRUE(
+      !fileops::file_exists(forest_repo + "/" + JsonAPI::_json_blob_fname));
+  ASSERT_TRUE(!fileops::remove_directory_files(forest_repo, { ".prototxt" }));
 }
 
-TEST(caffeapi,service_train_csv_resnet)
+TEST(caffeapi, service_train_csv_resnet)
 {
   // create service
   JsonAPI japi;
   std::string sname = "my_service";
-  std::string jstr = "{\"mllib\":\"caffe\",\"description\":\"my classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\"" +  forest_repo + "\",\"templates\":\"" + model_templates_repo  + "\"},\"parameters\":{\"input\":{\"connector\":\"csv\"},\"mllib\":{\"template\":\"resnet\",\"nclasses\":7,\"activation\":\"relu\",\"layers\":[300,100,50],\"bn\":true,\"gpu\":false}}}";
-  std::string joutstr = japi.jrender(japi.service_create(sname,jstr));
-  ASSERT_EQ(created_str,joutstr);
+  std::string jstr
+      = "{\"mllib\":\"caffe\",\"description\":\"my "
+        "classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\""
+        + forest_repo + "\",\"templates\":\"" + model_templates_repo
+        + "\"},\"parameters\":{\"input\":{\"connector\":\"csv\"},\"mllib\":{"
+          "\"template\":\"resnet\",\"nclasses\":7,\"activation\":\"relu\","
+          "\"layers\":[300,100,50],\"bn\":true,\"gpu\":false}}}";
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
 
   // assert json blob file
-  ASSERT_TRUE(fileops::file_exists(forest_repo + "/" + JsonAPI::_json_blob_fname));
-  
+  ASSERT_TRUE(
+      fileops::file_exists(forest_repo + "/" + JsonAPI::_json_blob_fname));
+
   // train
-  std::string jtrainstr = "{\"service\":\"" + sname + "\",\"async\":false,\"parameters\":{\"input\":{\"label\":\"Cover_Type\",\"id\":\"Id\",\"scale\":true,\"test_split\":0.1,\"label_offset\":-1,\"shuffle\":true},\"mllib\":{\"gpu\":true,\"gpuid\":"+gpuid+",\"solver\":{\"iterations\":" + iterations_forest + ",\"base_lr\":0.001},\"net\":{\"batch_size\":512}},\"output\":{\"measure\":[\"acc\",\"mcll\",\"f1\",\"cmdiag\",\"cmfull\"]}},\"data\":[\"" + forest_repo + "train.csv\"]}";
+  std::string jtrainstr
+      = "{\"service\":\"" + sname
+        + "\",\"async\":false,\"parameters\":{\"input\":{\"label\":\"Cover_"
+          "Type\",\"id\":\"Id\",\"scale\":true,\"test_split\":0.1,\"label_"
+          "offset\":-1,\"shuffle\":true},\"mllib\":{\"gpu\":true,\"gpuid\":"
+        + gpuid + ",\"solver\":{\"iterations\":" + iterations_forest
+        + ",\"base_lr\":0.001},\"net\":{\"batch_size\":512}},\"output\":{"
+          "\"measure\":[\"acc\",\"mcll\",\"f1\",\"cmdiag\",\"cmfull\"]}},"
+          "\"data\":[\""
+        + forest_repo + "train.csv\"]}";
   joutstr = japi.jrender(japi.service_train(jtrainstr));
   std::cout << "joutstr=" << joutstr << std::endl;
   JDoc jd;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_TRUE(jd.HasMember("status"));
-  ASSERT_EQ(201,jd["status"]["code"].GetInt());
-  ASSERT_EQ("Created",jd["status"]["msg"]);
+  ASSERT_EQ(201, jd["status"]["code"].GetInt());
+  ASSERT_EQ("Created", jd["status"]["msg"]);
   ASSERT_TRUE(jd.HasMember("head"));
-  ASSERT_EQ("/train",jd["head"]["method"]);
+  ASSERT_EQ("/train", jd["head"]["method"]);
   ASSERT_TRUE(jd["head"]["time"].GetDouble() >= 0);
   ASSERT_TRUE(jd.HasMember("body"));
   ASSERT_TRUE(jd["body"]["measure"].HasMember("train_loss"));
@@ -571,87 +746,145 @@ TEST(caffeapi,service_train_csv_resnet)
 #else
   ASSERT_TRUE(jd["body"]["measure"]["f1"].GetDouble() > 0.5);
 #endif
-  ASSERT_EQ(jd["body"]["measure"]["accp"].GetDouble(),jd["body"]["measure"]["acc"].GetDouble());
+  ASSERT_EQ(jd["body"]["measure"]["accp"].GetDouble(),
+            jd["body"]["measure"]["acc"].GetDouble());
   ASSERT_TRUE(jd["body"].HasMember("parameters"));
   ASSERT_TRUE(jd["body"]["parameters"].HasMember("input"));
   ASSERT_TRUE(jd["body"]["parameters"]["input"].HasMember("min_vals"));
   ASSERT_TRUE(jd["body"]["parameters"]["input"].HasMember("max_vals"));
   ASSERT_TRUE(jd["body"]["measure"].HasMember("cmdiag"));
-  ASSERT_EQ(7,jd["body"]["measure"]["cmdiag"].Size());
+  ASSERT_EQ(7, jd["body"]["measure"]["cmdiag"].Size());
   ASSERT_TRUE(jd["body"]["measure"]["cmdiag"][0].GetDouble() >= 0);
-  ASSERT_TRUE(jd["body"]["measure"]["cmfull"].Size()); //TODO: update
-  ASSERT_EQ(56,jd["body"]["parameters"]["input"]["min_vals"].Size());
-  ASSERT_EQ(56,jd["body"]["parameters"]["input"]["max_vals"].Size());
-  ASSERT_EQ(504,jd["body"]["parameters"]["mllib"]["batch_size"].GetInt());
+  ASSERT_TRUE(jd["body"]["measure"]["cmfull"].Size()); // TODO: update
+  ASSERT_EQ(56, jd["body"]["parameters"]["input"]["min_vals"].Size());
+  ASSERT_EQ(56, jd["body"]["parameters"]["input"]["max_vals"].Size());
+  ASSERT_EQ(504, jd["body"]["parameters"]["mllib"]["batch_size"].GetInt());
 
-  std::string str_min_vals = japi.jrender(jd["body"]["parameters"]["input"]["min_vals"]);
-  std::string str_max_vals = japi.jrender(jd["body"]["parameters"]["input"]["max_vals"]);
+  std::string str_min_vals
+      = japi.jrender(jd["body"]["parameters"]["input"]["min_vals"]);
+  std::string str_max_vals
+      = japi.jrender(jd["body"]["parameters"]["input"]["max_vals"]);
   std::cerr << "str_min_vals=" << str_min_vals << std::endl;
   std::cerr << "str_max_vals=" << str_max_vals << std::endl;
-  
+
   // predict from data, with header and id
-  std::string mem_data_head = "Id,Elevation,Aspect,Slope,Horizontal_Distance_To_Hydrology,Vertical_Distance_To_Hydrology,Horizontal_Distance_To_Roadways,Hillshade_9am,Hillshade_Noon,Hillshade_3pm,Horizontal_Distance_To_Fire_Points,Wilderness_Area1,Wilderness_Area2,Wilderness_Area3,Wilderness_Area4,Soil_Type1,Soil_Type2,Soil_Type3,Soil_Type4,Soil_Type5,Soil_Type6,Soil_Type7,Soil_Type8,Soil_Type9,Soil_Type10,Soil_Type11,Soil_Type12,Soil_Type13,Soil_Type14,Soil_Type15,Soil_Type16,Soil_Type17,Soil_Type18,Soil_Type19,Soil_Type20,Soil_Type21,Soil_Type22,Soil_Type23,Soil_Type24,Soil_Type25,Soil_Type26,Soil_Type27,Soil_Type28,Soil_Type29,Soil_Type30,Soil_Type31,Soil_Type32,Soil_Type33,Soil_Type34,Soil_Type35,Soil_Type36,Soil_Type37,Soil_Type38,Soil_Type39,Soil_Type40";
-  std::string mem_data = "0,2499,326,7,300,88,480,202,232,169,1676,0,0,0,1,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0";
-  std::string jpredictstr = "{\"service\":\""+ sname + "\",\"parameters\":{\"input\":{\"connector\":\"csv\",\"id\":\"Id\",\"scale\":true,\"min_vals\":" + str_min_vals + ",\"max_vals\":" + str_max_vals + "},\"output\":{\"best\":3}},\"data\":[\"" + mem_data_head + "\",\"" + mem_data + "\"]}";
+  std::string mem_data_head
+      = "Id,Elevation,Aspect,Slope,Horizontal_Distance_To_Hydrology,Vertical_"
+        "Distance_To_Hydrology,Horizontal_Distance_To_Roadways,Hillshade_9am,"
+        "Hillshade_Noon,Hillshade_3pm,Horizontal_Distance_To_Fire_Points,"
+        "Wilderness_Area1,Wilderness_Area2,Wilderness_Area3,Wilderness_Area4,"
+        "Soil_Type1,Soil_Type2,Soil_Type3,Soil_Type4,Soil_Type5,Soil_Type6,"
+        "Soil_Type7,Soil_Type8,Soil_Type9,Soil_Type10,Soil_Type11,Soil_Type12,"
+        "Soil_Type13,Soil_Type14,Soil_Type15,Soil_Type16,Soil_Type17,Soil_"
+        "Type18,Soil_Type19,Soil_Type20,Soil_Type21,Soil_Type22,Soil_Type23,"
+        "Soil_Type24,Soil_Type25,Soil_Type26,Soil_Type27,Soil_Type28,Soil_"
+        "Type29,Soil_Type30,Soil_Type31,Soil_Type32,Soil_Type33,Soil_Type34,"
+        "Soil_Type35,Soil_Type36,Soil_Type37,Soil_Type38,Soil_Type39,Soil_"
+        "Type40";
+  std::string mem_data
+      = "0,2499,326,7,300,88,480,202,232,169,1676,0,0,0,1,0,0,0,0,0,1,0,0,0,0,"
+        "0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0";
+  std::string jpredictstr
+      = "{\"service\":\"" + sname
+        + "\",\"parameters\":{\"input\":{\"connector\":\"csv\",\"id\":\"Id\","
+          "\"scale\":true,\"min_vals\":"
+        + str_min_vals + ",\"max_vals\":" + str_max_vals
+        + "},\"output\":{\"best\":3}},\"data\":[\"" + mem_data_head + "\",\""
+        + mem_data + "\"]}";
   joutstr = japi.jrender(japi.service_predict(jpredictstr));
   std::cout << "joutstr=" << joutstr << std::endl;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_TRUE(jd.HasMember("status"));
-  ASSERT_EQ(200,jd["status"]["code"].GetInt());
-  std::string cat0 = jd["body"]["predictions"][0]["classes"][0]["cat"].GetString(); // XXX: true cat is 3, which is 2 here with the label offset
-  std::string cat1 = jd["body"]["predictions"][0]["classes"][1]["cat"].GetString();
-  ASSERT_TRUE("2"==cat0||"2"==cat1);
-  
+  ASSERT_EQ(200, jd["status"]["code"].GetInt());
+  std::string cat0 = jd["body"]["predictions"][0]["classes"][0]["cat"]
+                         .GetString(); // XXX: true cat is 3, which is 2 here
+                                       // with the label offset
+  std::string cat1
+      = jd["body"]["predictions"][0]["classes"][1]["cat"].GetString();
+  ASSERT_TRUE("2" == cat0 || "2" == cat1);
+
   // predict from data, omitting header and sample id
-  std::string mem_data2 = "2499,326,7,300,88,480,202,232,169,1676,0,0,0,1,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0";
-  std::string str_min_vals2="[1863.0,0.0,0.0,0.0,-146.0,0.0,0.0,99.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0]";
-  std::string str_max_vals2="[3849.0,360.0,52.0,1343.0,554.0,6890.0,254.0,254.0,248.0,6993.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,7.0]";
-  jpredictstr = "{\"service\":\""+ sname + "\",\"parameters\":{\"input\":{\"connector\":\"csv\",\"scale\":true,\"min_vals\":" + str_min_vals2 + ",\"max_vals\":" + str_max_vals2 + "},\"output\":{\"best\":3}},\"data\":[\"" + mem_data2 + "\"]}";
+  std::string mem_data2
+      = "2499,326,7,300,88,480,202,232,169,1676,0,0,0,1,0,0,0,0,0,1,0,0,0,0,0,"
+        "0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0";
+  std::string str_min_vals2
+      = "[1863.0,0.0,0.0,0.0,-146.0,0.0,0.0,99.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,"
+        "0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,"
+        "0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,"
+        "0.0,0.0,0.0,0.0,0.0,1.0]";
+  std::string str_max_vals2
+      = "[3849.0,360.0,52.0,1343.0,554.0,6890.0,254.0,254.0,248.0,6993.0,1.0,"
+        "1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,"
+        "0.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,"
+        "1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,7.0]";
+  jpredictstr = "{\"service\":\"" + sname
+                + "\",\"parameters\":{\"input\":{\"connector\":\"csv\","
+                  "\"scale\":true,\"min_vals\":"
+                + str_min_vals2 + ",\"max_vals\":" + str_max_vals2
+                + "},\"output\":{\"best\":3}},\"data\":[\"" + mem_data2
+                + "\"]}";
   joutstr = japi.jrender(japi.service_predict(jpredictstr));
   std::cout << "joutstr=" << joutstr << std::endl;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_TRUE(jd.HasMember("status"));
-  ASSERT_EQ(200,jd["status"]["code"].GetInt());
-  cat0 = jd["body"]["predictions"][0]["classes"][0]["cat"].GetString(); // XXX: true cat is 3, which is 2 here with the label offset
+  ASSERT_EQ(200, jd["status"]["code"].GetInt());
+  cat0 = jd["body"]["predictions"][0]["classes"][0]["cat"]
+             .GetString(); // XXX: true cat is 3, which is 2 here with the
+                           // label offset
   cat1 = jd["body"]["predictions"][0]["classes"][1]["cat"].GetString();
-  ASSERT_TRUE("2"==cat0||"2"==cat1);
-  
+  ASSERT_TRUE("2" == cat0 || "2" == cat1);
+
   // remove service
   jstr = "{\"clear\":\"lib\"}";
-  joutstr = japi.jrender(japi.service_delete(sname,jstr));
-  ASSERT_EQ(ok_str,joutstr);
+  joutstr = japi.jrender(japi.service_delete(sname, jstr));
+  ASSERT_EQ(ok_str, joutstr);
 
   // assert json blob file is still there (or gone if clear=full)
-  ASSERT_TRUE(!fileops::file_exists(forest_repo + "/" + JsonAPI::_json_blob_fname));
-  ASSERT_TRUE(!fileops::remove_directory_files(forest_repo,{".prototxt"}));
+  ASSERT_TRUE(
+      !fileops::file_exists(forest_repo + "/" + JsonAPI::_json_blob_fname));
+  ASSERT_TRUE(!fileops::remove_directory_files(forest_repo, { ".prototxt" }));
 }
 
-TEST(caffeapi,service_train_svm)
+TEST(caffeapi, service_train_svm)
 {
   // create service
   JsonAPI japi;
   std::string sname = "my_service";
-  std::string jstr = "{\"mllib\":\"caffe\",\"description\":\"my classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\"" +  farm_repo + "\",\"templates\":\"" + model_templates_repo  + "\"},\"parameters\":{\"input\":{\"connector\":\"svm\"},\"mllib\":{\"template\":\"mlp\",\"nclasses\":2,\"activation\":\"prelu\"}}}";
-  std::string joutstr = japi.jrender(japi.service_create(sname,jstr));
-  ASSERT_EQ(created_str,joutstr);
+  std::string jstr
+      = "{\"mllib\":\"caffe\",\"description\":\"my "
+        "classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\""
+        + farm_repo + "\",\"templates\":\"" + model_templates_repo
+        + "\"},\"parameters\":{\"input\":{\"connector\":\"svm\"},\"mllib\":{"
+          "\"template\":\"mlp\",\"nclasses\":2,\"activation\":\"prelu\"}}}";
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
 
   // assert json blob file
-  ASSERT_TRUE(fileops::file_exists(farm_repo + "/" + JsonAPI::_json_blob_fname));
-  
+  ASSERT_TRUE(
+      fileops::file_exists(farm_repo + "/" + JsonAPI::_json_blob_fname));
+
   // train
-  std::string jtrainstr = "{\"service\":\"" + sname + "\",\"async\":false,\"parameters\":{\"input\":{\"test_split\":0.1,\"shuffle\":true},\"mllib\":{\"gpu\":true,\"gpuid\":"+gpuid+",\"solver\":{\"iterations\":" + iterations_farm + ",\"base_lr\":0.01},\"net\":{\"batch_size\":100}},\"output\":{\"measure\":[\"acc\",\"mcll\",\"f1\",\"cmdiag\",\"cmfull\"]}},\"data\":[\"" + farm_repo + "farm-ads.svm\"]}";
+  std::string jtrainstr
+      = "{\"service\":\"" + sname
+        + "\",\"async\":false,\"parameters\":{\"input\":{\"test_split\":0.1,"
+          "\"shuffle\":true},\"mllib\":{\"gpu\":true,\"gpuid\":"
+        + gpuid + ",\"solver\":{\"iterations\":" + iterations_farm
+        + ",\"base_lr\":0.01},\"net\":{\"batch_size\":100}},\"output\":{"
+          "\"measure\":[\"acc\",\"mcll\",\"f1\",\"cmdiag\",\"cmfull\"]}},"
+          "\"data\":[\""
+        + farm_repo + "farm-ads.svm\"]}";
   joutstr = japi.jrender(japi.service_train(jtrainstr));
   std::cout << "joutstr=" << joutstr << std::endl;
   JDoc jd;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_TRUE(jd.HasMember("status"));
-  ASSERT_EQ(201,jd["status"]["code"].GetInt());
-  ASSERT_EQ("Created",jd["status"]["msg"]);
+  ASSERT_EQ(201, jd["status"]["code"].GetInt());
+  ASSERT_EQ("Created", jd["status"]["msg"]);
   ASSERT_TRUE(jd.HasMember("head"));
-  ASSERT_EQ("/train",jd["head"]["method"]);
+  ASSERT_EQ("/train", jd["head"]["method"]);
   ASSERT_TRUE(jd["head"]["time"].GetDouble() >= 0);
   ASSERT_TRUE(jd.HasMember("body"));
   ASSERT_TRUE(jd["body"]["measure"].HasMember("train_loss"));
@@ -662,59 +895,166 @@ TEST(caffeapi,service_train_svm)
 #else
   ASSERT_TRUE(jd["body"]["measure"]["f1"].GetDouble() > 0.7);
 #endif
-  ASSERT_EQ(jd["body"]["measure"]["accp"].GetDouble(),jd["body"]["measure"]["acc"].GetDouble());
+  ASSERT_EQ(jd["body"]["measure"]["accp"].GetDouble(),
+            jd["body"]["measure"]["acc"].GetDouble());
   ASSERT_TRUE(jd["body"].HasMember("parameters"));
   ASSERT_TRUE(jd["body"]["measure"].HasMember("cmdiag"));
-  ASSERT_EQ(2,jd["body"]["measure"]["cmdiag"].Size());
+  ASSERT_EQ(2, jd["body"]["measure"]["cmdiag"].Size());
   ASSERT_TRUE(jd["body"]["measure"]["cmdiag"][0].GetDouble() >= 0);
   ASSERT_TRUE(jd["body"]["measure"]["cmfull"].Size());
-  ASSERT_EQ(16,jd["body"]["parameters"]["mllib"]["batch_size"].GetInt());
+  ASSERT_EQ(16, jd["body"]["parameters"]["mllib"]["batch_size"].GetInt());
 
-  std::string mem_data = "8:1 9:1 23:1 31:1 32:1 34:1 45:1 46:1 49:1 50:1 52:1 54:1 57:1 60:1 61:1 64:1 70:1 80:1 82:1 84:1 87:1 91:1 94:1 95:1 101:1 104:1 106:1 107:1 113:1 115:1 125:1 126:1 127:1 128:1 129:1 131:1 132:1 134:1 152:1 161:1 166:1 167:1 179:1 229:1 235:1 248:1 251:1 255:1 260:1 262:1 267:1 268:1 270:1 272:1 273:1 277:1 280:1 281:1 282:1 285:1 299:1 305:1 310:1 311:1 324:1 342:1 372:1 379:1 390:1 391:1 408:1 409:1 415:1 472:1 483:1 486:1 498:1 525:1 538:1 548:1 583:1 614:1 616:1 620:1 621:1 651:1 678:1 700:1 712:1 715:1 794:1 796:1 800:1 804:1 805:1 811:1 819:1 847:1 848:1 853:1 873:1 885:1 899:1 949:1 963:1 964:1 965:1 966:1 967:1 968:1 969:1 970:1 971:1 972:1 973:1 974:1 975:1 976:1 977:1 978:1 979:1 980:1 981:1 982:1 983:1 984:1 985:1 986:1 987:1 988:1 989:1 990:1 991:1 992:1 993:1 994:1 995:1 996:1 997:1 998:1 999:1 1000:1 1001:1 1002:1 1003:1 1004:1 1005:1 1006:1 1007:1 1008:1 1009:1 1010:1 1011:1 1012:1 1013:1 1014:1 1015:1 1016:1 1017:1 1018:1 1019:1 1020:1 1021:1 1022:1 1023:1 1024:1 1025:1 1026:1 1027:1 1028:1 1029:1 1030:1 1031:1 1032:1 1033:1 1034:1 1035:1 1036:1 1037:1 1038:1 1039:1 1040:1 1041:1 1042:1 1043:1 1044:1 1045:1 1046:1 1047:1 1048:1 1049:1 1051:1 1052:1 1053:1 1054:1 1055:1 1056:1 1057:1 1058:1 1059:1 1060:1 1061:1 1062:1 1063:1 1064:1 1065:1 1066:1 1067:1 1068:1 1069:1 1070:1 1071:1 1072:1 1073:1 1074:1 1075:1 1076:1 1077:1 1078:1 1079:1 1080:1 1081:1 1082:1 1083:1 1084:1 1085:1 1086:1 1087:1 1088:1 1089:1 1090:1 1091:1 1092:1 1093:1 1094:1 1095:1 1096:1 1097:1 1098:1 1099:1 1100:1 1101:1 1102:1 1103:1 1104:1 1105:1 1106:1 1107:1 1108:1 1109:1 1110:1 1111:1 1112:1 1113:1 1114:1 1115:1 1116:1 1117:1 1118:1 1119:1 1120:1 1121:1 1122:1 1123:1 1124:1 1125:1 1126:1 1127:1 1128:1 1129:1 1130:1 1131:1 1132:1 1133:1 1134:1 1135:1 1136:1 1137:1 1138:1 1139:1 1140:1 1141:1 1142:1 1143:1 1144:1 1145:1 1146:1 1147:1 1148:1 1149:1 1150:1 1151:1 1152:1 1153:1 1154:1 1155:1 1156:1 1157:1 1158:1 1159:1 1160:1 1161:1 1162:1 1163:1 1164:1 1165:1 1166:1 1167:1 1168:1 1169:1 1170:1 1171:1 1172:1 1173:1 1174:1 1175:1 1176:1 1177:1 1178:1 1179:1 1180:1 1181:1 1182:1 1183:1 1184:1 1185:1 1186:1 1187:1 1188:1 1189:1 1190:1 1191:1 1192:1 1193:1 1194:1 1195:1 1196:1 1197:1 1198:1 1199:1 1200:1 1201:1 1202:1 1203:1 1204:1 1205:1 1206:1 1207:1 1208:1 1209:1 1210:1 1211:1 1212:1 1213:1 1214:1 1215:1 1216:1 1217:1 1218:1 1219:1 1220:1 1221:1 1222:1 1223:1 1224:1 1225:1 1226:1 1227:1 1228:1 1229:1 1230:1 1231:1 1232:1 1233:1 1234:1 1235:1 1236:1 1237:1 1238:1 1239:1 1240:1 1241:1 1242:1 1243:1 1244:1 1245:1 1246:1 1247:1 1248:1 1249:1 1250:1 1251:1 1252:1 1253:1 1254:1 1255:1 1256:1 1257:1 1258:1 1262:1 1268:1 1269:1 1270:1 1271:1 2679:1 3031:1 3204:1 4065:1 4795:1 4960:1 4961:1 4962:1 4963:1 4964:1 4965:1 4966:1 4967:11 8:1 9:1 23:1 31:1 32:1 34:1 45:1 46:1 49:1 50:1 52:1 54:1 57:1 60:1 61:1 64:1 70:1 80:1 82:1 84:1 87:1 91:1 94:1 95:1 101:1 104:1 106:1 107:1 113:1 115:1 125:1 126:1 127:1 128:1 129:1 131:1 132:1 134:1 152:1 161:1 166:1 167:1 179:1 229:1 235:1 248:1 251:1 255:1 260:1 262:1 267:1 268:1 270:1 272:1 273:1 277:1 280:1 281:1 282:1 285:1 299:1 305:1 310:1 311:1 324:1 342:1 372:1 379:1 390:1 391:1 408:1 409:1 415:1 472:1 483:1 486:1 498:1 525:1 538:1 548:1 583:1 614:1 616:1 620:1 621:1 651:1 678:1 700:1 712:1 715:1 794:1 796:1 800:1 804:1 805:1 811:1 819:1 847:1 848:1 853:1 873:1 885:1 899:1 949:1 963:1 964:1 965:1 966:1 967:1 968:1 969:1 970:1 971:1 972:1 973:1 974:1 975:1 976:1 977:1 978:1 979:1 980:1 981:1 982:1 983:1 984:1 985:1 986:1 987:1 988:1 989:1 990:1 991:1 992:1 993:1 994:1 995:1 996:1 997:1 998:1 999:1 1000:1 1001:1 1002:1 1003:1 1004:1 1005:1 1006:1 1007:1 1008:1 1009:1 1010:1 1011:1 1012:1 1013:1 1014:1 1015:1 1016:1 1017:1 1018:1 1019:1 1020:1 1021:1 1022:1 1023:1 1024:1 1025:1 1026:1 1027:1 1028:1 1029:1 1030:1 1031:1 1032:1 1033:1 1034:1 1035:1 1036:1 1037:1 1038:1 1039:1 1040:1 1041:1 1042:1 1043:1 1044:1 1045:1 1046:1 1047:1 1048:1 1049:1 1051:1 1052:1 1053:1 1054:1 1055:1 1056:1 1057:1 1058:1 1059:1 1060:1 1061:1 1062:1 1063:1 1064:1 1065:1 1066:1 1067:1 1068:1 1069:1 1070:1 1071:1 1072:1 1073:1 1074:1 1075:1 1076:1 1077:1 1078:1 1079:1 1080:1 1081:1 1082:1 1083:1 1084:1 1085:1 1086:1 1087:1 1088:1 1089:1 1090:1 1091:1 1092:1 1093:1 1094:1 1095:1 1096:1 1097:1 1098:1 1099:1 1100:1 1101:1 1102:1 1103:1 1104:1 1105:1 1106:1 1107:1 1108:1 1109:1 1110:1 1111:1 1112:1 1113:1 1114:1 1115:1 1116:1 1117:1 1118:1 1119:1 1120:1 1121:1 1122:1 1123:1 1124:1 1125:1 1126:1 1127:1 1128:1 1129:1 1130:1 1131:1 1132:1 1133:1 1134:1 1135:1 1136:1 1137:1 1138:1 1139:1 1140:1 1141:1 1142:1 1143:1 1144:1 1145:1 1146:1 1147:1 1148:1 1149:1 1150:1 1151:1 1152:1 1153:1 1154:1 1155:1 1156:1 1157:1 1158:1 1159:1 1160:1 1161:1 1162:1 1163:1 1164:1 1165:1 1166:1 1167:1 1168:1 1169:1 1170:1 1171:1 1172:1 1173:1 1174:1 1175:1 1176:1 1177:1 1178:1 1179:1 1180:1 1181:1 1182:1 1183:1 1184:1 1185:1 1186:1 1187:1 1188:1 1189:1 1190:1 1191:1 1192:1 1193:1 1194:1 1195:1 1196:1 1197:1 1198:1 1199:1 1200:1 1201:1 1202:1 1203:1 1204:1 1205:1 1206:1 1207:1 1208:1 1209:1 1210:1 1211:1 1212:1 1213:1 1214:1 1215:1 1216:1 1217:1 1218:1 1219:1 1220:1 1221:1 1222:1 1223:1 1224:1 1225:1 1226:1 1227:1 1228:1 1229:1 1230:1 1231:1 1232:1 1233:1 1234:1 1235:1 1236:1 1237:1 1238:1 1239:1 1240:1 1241:1 1242:1 1243:1 1244:1 1245:1 1246:1 1247:1 1248:1 1249:1 1250:1 1251:1 1252:1 1253:1 1254:1 1255:1 1256:1 1257:1 1258:1 1262:1 1268:1 1269:1 1270:1 1271:1 2679:1 3031:1 3204:1 4065:1 4795:1 4960:1 4961:1 4962:1 4963:1 4964:1 4965:1 4966:1 4967:1";
-  std::string jpredictstr = "{\"service\":\""+ sname + "\",\"parameters\":{\"input\":{\"connector\":\"svm\"},\"output\":{\"best\":3}},\"data\":[\"" + mem_data + "\"]}";
+  std::string mem_data
+      = "8:1 9:1 23:1 31:1 32:1 34:1 45:1 46:1 49:1 50:1 52:1 54:1 57:1 60:1 "
+        "61:1 64:1 70:1 80:1 82:1 84:1 87:1 91:1 94:1 95:1 101:1 104:1 106:1 "
+        "107:1 113:1 115:1 125:1 126:1 127:1 128:1 129:1 131:1 132:1 134:1 "
+        "152:1 161:1 166:1 167:1 179:1 229:1 235:1 248:1 251:1 255:1 260:1 "
+        "262:1 267:1 268:1 270:1 272:1 273:1 277:1 280:1 281:1 282:1 285:1 "
+        "299:1 305:1 310:1 311:1 324:1 342:1 372:1 379:1 390:1 391:1 408:1 "
+        "409:1 415:1 472:1 483:1 486:1 498:1 525:1 538:1 548:1 583:1 614:1 "
+        "616:1 620:1 621:1 651:1 678:1 700:1 712:1 715:1 794:1 796:1 800:1 "
+        "804:1 805:1 811:1 819:1 847:1 848:1 853:1 873:1 885:1 899:1 949:1 "
+        "963:1 964:1 965:1 966:1 967:1 968:1 969:1 970:1 971:1 972:1 973:1 "
+        "974:1 975:1 976:1 977:1 978:1 979:1 980:1 981:1 982:1 983:1 984:1 "
+        "985:1 986:1 987:1 988:1 989:1 990:1 991:1 992:1 993:1 994:1 995:1 "
+        "996:1 997:1 998:1 999:1 1000:1 1001:1 1002:1 1003:1 1004:1 1005:1 "
+        "1006:1 1007:1 1008:1 1009:1 1010:1 1011:1 1012:1 1013:1 1014:1 "
+        "1015:1 1016:1 1017:1 1018:1 1019:1 1020:1 1021:1 1022:1 1023:1 "
+        "1024:1 1025:1 1026:1 1027:1 1028:1 1029:1 1030:1 1031:1 1032:1 "
+        "1033:1 1034:1 1035:1 1036:1 1037:1 1038:1 1039:1 1040:1 1041:1 "
+        "1042:1 1043:1 1044:1 1045:1 1046:1 1047:1 1048:1 1049:1 1051:1 "
+        "1052:1 1053:1 1054:1 1055:1 1056:1 1057:1 1058:1 1059:1 1060:1 "
+        "1061:1 1062:1 1063:1 1064:1 1065:1 1066:1 1067:1 1068:1 1069:1 "
+        "1070:1 1071:1 1072:1 1073:1 1074:1 1075:1 1076:1 1077:1 1078:1 "
+        "1079:1 1080:1 1081:1 1082:1 1083:1 1084:1 1085:1 1086:1 1087:1 "
+        "1088:1 1089:1 1090:1 1091:1 1092:1 1093:1 1094:1 1095:1 1096:1 "
+        "1097:1 1098:1 1099:1 1100:1 1101:1 1102:1 1103:1 1104:1 1105:1 "
+        "1106:1 1107:1 1108:1 1109:1 1110:1 1111:1 1112:1 1113:1 1114:1 "
+        "1115:1 1116:1 1117:1 1118:1 1119:1 1120:1 1121:1 1122:1 1123:1 "
+        "1124:1 1125:1 1126:1 1127:1 1128:1 1129:1 1130:1 1131:1 1132:1 "
+        "1133:1 1134:1 1135:1 1136:1 1137:1 1138:1 1139:1 1140:1 1141:1 "
+        "1142:1 1143:1 1144:1 1145:1 1146:1 1147:1 1148:1 1149:1 1150:1 "
+        "1151:1 1152:1 1153:1 1154:1 1155:1 1156:1 1157:1 1158:1 1159:1 "
+        "1160:1 1161:1 1162:1 1163:1 1164:1 1165:1 1166:1 1167:1 1168:1 "
+        "1169:1 1170:1 1171:1 1172:1 1173:1 1174:1 1175:1 1176:1 1177:1 "
+        "1178:1 1179:1 1180:1 1181:1 1182:1 1183:1 1184:1 1185:1 1186:1 "
+        "1187:1 1188:1 1189:1 1190:1 1191:1 1192:1 1193:1 1194:1 1195:1 "
+        "1196:1 1197:1 1198:1 1199:1 1200:1 1201:1 1202:1 1203:1 1204:1 "
+        "1205:1 1206:1 1207:1 1208:1 1209:1 1210:1 1211:1 1212:1 1213:1 "
+        "1214:1 1215:1 1216:1 1217:1 1218:1 1219:1 1220:1 1221:1 1222:1 "
+        "1223:1 1224:1 1225:1 1226:1 1227:1 1228:1 1229:1 1230:1 1231:1 "
+        "1232:1 1233:1 1234:1 1235:1 1236:1 1237:1 1238:1 1239:1 1240:1 "
+        "1241:1 1242:1 1243:1 1244:1 1245:1 1246:1 1247:1 1248:1 1249:1 "
+        "1250:1 1251:1 1252:1 1253:1 1254:1 1255:1 1256:1 1257:1 1258:1 "
+        "1262:1 1268:1 1269:1 1270:1 1271:1 2679:1 3031:1 3204:1 4065:1 "
+        "4795:1 4960:1 4961:1 4962:1 4963:1 4964:1 4965:1 4966:1 4967:11 8:1 "
+        "9:1 23:1 31:1 32:1 34:1 45:1 46:1 49:1 50:1 52:1 54:1 57:1 60:1 61:1 "
+        "64:1 70:1 80:1 82:1 84:1 87:1 91:1 94:1 95:1 101:1 104:1 106:1 107:1 "
+        "113:1 115:1 125:1 126:1 127:1 128:1 129:1 131:1 132:1 134:1 152:1 "
+        "161:1 166:1 167:1 179:1 229:1 235:1 248:1 251:1 255:1 260:1 262:1 "
+        "267:1 268:1 270:1 272:1 273:1 277:1 280:1 281:1 282:1 285:1 299:1 "
+        "305:1 310:1 311:1 324:1 342:1 372:1 379:1 390:1 391:1 408:1 409:1 "
+        "415:1 472:1 483:1 486:1 498:1 525:1 538:1 548:1 583:1 614:1 616:1 "
+        "620:1 621:1 651:1 678:1 700:1 712:1 715:1 794:1 796:1 800:1 804:1 "
+        "805:1 811:1 819:1 847:1 848:1 853:1 873:1 885:1 899:1 949:1 963:1 "
+        "964:1 965:1 966:1 967:1 968:1 969:1 970:1 971:1 972:1 973:1 974:1 "
+        "975:1 976:1 977:1 978:1 979:1 980:1 981:1 982:1 983:1 984:1 985:1 "
+        "986:1 987:1 988:1 989:1 990:1 991:1 992:1 993:1 994:1 995:1 996:1 "
+        "997:1 998:1 999:1 1000:1 1001:1 1002:1 1003:1 1004:1 1005:1 1006:1 "
+        "1007:1 1008:1 1009:1 1010:1 1011:1 1012:1 1013:1 1014:1 1015:1 "
+        "1016:1 1017:1 1018:1 1019:1 1020:1 1021:1 1022:1 1023:1 1024:1 "
+        "1025:1 1026:1 1027:1 1028:1 1029:1 1030:1 1031:1 1032:1 1033:1 "
+        "1034:1 1035:1 1036:1 1037:1 1038:1 1039:1 1040:1 1041:1 1042:1 "
+        "1043:1 1044:1 1045:1 1046:1 1047:1 1048:1 1049:1 1051:1 1052:1 "
+        "1053:1 1054:1 1055:1 1056:1 1057:1 1058:1 1059:1 1060:1 1061:1 "
+        "1062:1 1063:1 1064:1 1065:1 1066:1 1067:1 1068:1 1069:1 1070:1 "
+        "1071:1 1072:1 1073:1 1074:1 1075:1 1076:1 1077:1 1078:1 1079:1 "
+        "1080:1 1081:1 1082:1 1083:1 1084:1 1085:1 1086:1 1087:1 1088:1 "
+        "1089:1 1090:1 1091:1 1092:1 1093:1 1094:1 1095:1 1096:1 1097:1 "
+        "1098:1 1099:1 1100:1 1101:1 1102:1 1103:1 1104:1 1105:1 1106:1 "
+        "1107:1 1108:1 1109:1 1110:1 1111:1 1112:1 1113:1 1114:1 1115:1 "
+        "1116:1 1117:1 1118:1 1119:1 1120:1 1121:1 1122:1 1123:1 1124:1 "
+        "1125:1 1126:1 1127:1 1128:1 1129:1 1130:1 1131:1 1132:1 1133:1 "
+        "1134:1 1135:1 1136:1 1137:1 1138:1 1139:1 1140:1 1141:1 1142:1 "
+        "1143:1 1144:1 1145:1 1146:1 1147:1 1148:1 1149:1 1150:1 1151:1 "
+        "1152:1 1153:1 1154:1 1155:1 1156:1 1157:1 1158:1 1159:1 1160:1 "
+        "1161:1 1162:1 1163:1 1164:1 1165:1 1166:1 1167:1 1168:1 1169:1 "
+        "1170:1 1171:1 1172:1 1173:1 1174:1 1175:1 1176:1 1177:1 1178:1 "
+        "1179:1 1180:1 1181:1 1182:1 1183:1 1184:1 1185:1 1186:1 1187:1 "
+        "1188:1 1189:1 1190:1 1191:1 1192:1 1193:1 1194:1 1195:1 1196:1 "
+        "1197:1 1198:1 1199:1 1200:1 1201:1 1202:1 1203:1 1204:1 1205:1 "
+        "1206:1 1207:1 1208:1 1209:1 1210:1 1211:1 1212:1 1213:1 1214:1 "
+        "1215:1 1216:1 1217:1 1218:1 1219:1 1220:1 1221:1 1222:1 1223:1 "
+        "1224:1 1225:1 1226:1 1227:1 1228:1 1229:1 1230:1 1231:1 1232:1 "
+        "1233:1 1234:1 1235:1 1236:1 1237:1 1238:1 1239:1 1240:1 1241:1 "
+        "1242:1 1243:1 1244:1 1245:1 1246:1 1247:1 1248:1 1249:1 1250:1 "
+        "1251:1 1252:1 1253:1 1254:1 1255:1 1256:1 1257:1 1258:1 1262:1 "
+        "1268:1 1269:1 1270:1 1271:1 2679:1 3031:1 3204:1 4065:1 4795:1 "
+        "4960:1 4961:1 4962:1 4963:1 4964:1 4965:1 4966:1 4967:1";
+  std::string jpredictstr = "{\"service\":\"" + sname
+                            + "\",\"parameters\":{\"input\":{\"connector\":"
+                              "\"svm\"},\"output\":{\"best\":3}},\"data\":[\""
+                            + mem_data + "\"]}";
   joutstr = japi.jrender(japi.service_predict(jpredictstr));
   std::cout << "joutstr=" << joutstr << std::endl;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_TRUE(jd.HasMember("status"));
-  ASSERT_EQ(200,jd["status"]["code"].GetInt());
-  std::string cat0 = jd["body"]["predictions"][0]["classes"][0]["cat"].GetString();
-  ASSERT_TRUE("1"==cat0);
-  
+  ASSERT_EQ(200, jd["status"]["code"].GetInt());
+  std::string cat0
+      = jd["body"]["predictions"][0]["classes"][0]["cat"].GetString();
+  ASSERT_TRUE("1" == cat0);
+
   // remove service
   jstr = "{\"clear\":\"lib\"}";
-  joutstr = japi.jrender(japi.service_delete(sname,jstr));
-  ASSERT_EQ(ok_str,joutstr);
+  joutstr = japi.jrender(japi.service_delete(sname, jstr));
+  ASSERT_EQ(ok_str, joutstr);
 
   // assert json blob file is still there (or gone if clear=full)
-  ASSERT_TRUE(!fileops::file_exists(farm_repo + "/" + JsonAPI::_json_blob_fname));
-  ASSERT_TRUE(!fileops::remove_directory_files(farm_repo,{".prototxt"}));
+  ASSERT_TRUE(
+      !fileops::file_exists(farm_repo + "/" + JsonAPI::_json_blob_fname));
+  ASSERT_TRUE(!fileops::remove_directory_files(farm_repo, { ".prototxt" }));
 }
 
-TEST(caffeapi,service_train_svm_resnet)
+TEST(caffeapi, service_train_svm_resnet)
 {
   // create service
   JsonAPI japi;
   std::string sname = "my_service";
-  std::string jstr = "{\"mllib\":\"caffe\",\"description\":\"my classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\"" +  farm_repo + "\",\"templates\":\"" + model_templates_repo  + "\"},\"parameters\":{\"input\":{\"connector\":\"svm\"},\"mllib\":{\"template\":\"resnet\",\"nclasses\":2,\"activation\":\"prelu\",\"layers\":[30,25,15]}}}";
-  std::string joutstr = japi.jrender(japi.service_create(sname,jstr));
-  ASSERT_EQ(created_str,joutstr);
+  std::string jstr
+      = "{\"mllib\":\"caffe\",\"description\":\"my "
+        "classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\""
+        + farm_repo + "\",\"templates\":\"" + model_templates_repo
+        + "\"},\"parameters\":{\"input\":{\"connector\":\"svm\"},\"mllib\":{"
+          "\"template\":\"resnet\",\"nclasses\":2,\"activation\":\"prelu\","
+          "\"layers\":[30,25,15]}}}";
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
 
   // assert json blob file
-  ASSERT_TRUE(fileops::file_exists(farm_repo + "/" + JsonAPI::_json_blob_fname));
-  
+  ASSERT_TRUE(
+      fileops::file_exists(farm_repo + "/" + JsonAPI::_json_blob_fname));
+
   // train
-  std::string jtrainstr = "{\"service\":\"" + sname + "\",\"async\":false,\"parameters\":{\"input\":{\"test_split\":0.1,\"shuffle\":true},\"mllib\":{\"gpu\":true,\"gpuid\":"+gpuid+",\"solver\":{\"iterations\":" + iterations_farm + ",\"base_lr\":0.01},\"net\":{\"batch_size\":16}},\"output\":{\"measure\":[\"acc\",\"mcll\",\"f1\",\"cmdiag\",\"cmfull\"]}},\"data\":[\"" + farm_repo + "farm-ads.svm\"]}";
+  std::string jtrainstr
+      = "{\"service\":\"" + sname
+        + "\",\"async\":false,\"parameters\":{\"input\":{\"test_split\":0.1,"
+          "\"shuffle\":true},\"mllib\":{\"gpu\":true,\"gpuid\":"
+        + gpuid + ",\"solver\":{\"iterations\":" + iterations_farm
+        + ",\"base_lr\":0.01},\"net\":{\"batch_size\":16}},\"output\":{"
+          "\"measure\":[\"acc\",\"mcll\",\"f1\",\"cmdiag\",\"cmfull\"]}},"
+          "\"data\":[\""
+        + farm_repo + "farm-ads.svm\"]}";
   joutstr = japi.jrender(japi.service_train(jtrainstr));
   std::cout << "joutstr=" << joutstr << std::endl;
   JDoc jd;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_TRUE(jd.HasMember("status"));
-  ASSERT_EQ(201,jd["status"]["code"].GetInt());
-  ASSERT_EQ("Created",jd["status"]["msg"]);
+  ASSERT_EQ(201, jd["status"]["code"].GetInt());
+  ASSERT_EQ("Created", jd["status"]["msg"]);
   ASSERT_TRUE(jd.HasMember("head"));
-  ASSERT_EQ("/train",jd["head"]["method"]);
+  ASSERT_EQ("/train", jd["head"]["method"]);
   ASSERT_TRUE(jd["head"]["time"].GetDouble() >= 0);
   ASSERT_TRUE(jd.HasMember("body"));
   ASSERT_TRUE(jd["body"]["measure"].HasMember("train_loss"));
@@ -725,57 +1065,164 @@ TEST(caffeapi,service_train_svm_resnet)
 #else
   ASSERT_TRUE(jd["body"]["measure"]["f1"].GetDouble() > 0.7);
 #endif
-  ASSERT_EQ(jd["body"]["measure"]["accp"].GetDouble(),jd["body"]["measure"]["acc"].GetDouble());
-    ASSERT_TRUE(jd["body"]["measure"].HasMember("cmdiag"));
-  ASSERT_EQ(2,jd["body"]["measure"]["cmdiag"].Size());
+  ASSERT_EQ(jd["body"]["measure"]["accp"].GetDouble(),
+            jd["body"]["measure"]["acc"].GetDouble());
+  ASSERT_TRUE(jd["body"]["measure"].HasMember("cmdiag"));
+  ASSERT_EQ(2, jd["body"]["measure"]["cmdiag"].Size());
   ASSERT_TRUE(jd["body"]["measure"]["cmdiag"][0].GetDouble() >= 0);
   ASSERT_TRUE(jd["body"]["measure"]["cmfull"].Size());
-  
-  std::string mem_data = "8:1 9:1 23:1 31:1 32:1 34:1 45:1 46:1 49:1 50:1 52:1 54:1 57:1 60:1 61:1 64:1 70:1 80:1 82:1 84:1 87:1 91:1 94:1 95:1 101:1 104:1 106:1 107:1 113:1 115:1 125:1 126:1 127:1 128:1 129:1 131:1 132:1 134:1 152:1 161:1 166:1 167:1 179:1 229:1 235:1 248:1 251:1 255:1 260:1 262:1 267:1 268:1 270:1 272:1 273:1 277:1 280:1 281:1 282:1 285:1 299:1 305:1 310:1 311:1 324:1 342:1 372:1 379:1 390:1 391:1 408:1 409:1 415:1 472:1 483:1 486:1 498:1 525:1 538:1 548:1 583:1 614:1 616:1 620:1 621:1 651:1 678:1 700:1 712:1 715:1 794:1 796:1 800:1 804:1 805:1 811:1 819:1 847:1 848:1 853:1 873:1 885:1 899:1 949:1 963:1 964:1 965:1 966:1 967:1 968:1 969:1 970:1 971:1 972:1 973:1 974:1 975:1 976:1 977:1 978:1 979:1 980:1 981:1 982:1 983:1 984:1 985:1 986:1 987:1 988:1 989:1 990:1 991:1 992:1 993:1 994:1 995:1 996:1 997:1 998:1 999:1 1000:1 1001:1 1002:1 1003:1 1004:1 1005:1 1006:1 1007:1 1008:1 1009:1 1010:1 1011:1 1012:1 1013:1 1014:1 1015:1 1016:1 1017:1 1018:1 1019:1 1020:1 1021:1 1022:1 1023:1 1024:1 1025:1 1026:1 1027:1 1028:1 1029:1 1030:1 1031:1 1032:1 1033:1 1034:1 1035:1 1036:1 1037:1 1038:1 1039:1 1040:1 1041:1 1042:1 1043:1 1044:1 1045:1 1046:1 1047:1 1048:1 1049:1 1051:1 1052:1 1053:1 1054:1 1055:1 1056:1 1057:1 1058:1 1059:1 1060:1 1061:1 1062:1 1063:1 1064:1 1065:1 1066:1 1067:1 1068:1 1069:1 1070:1 1071:1 1072:1 1073:1 1074:1 1075:1 1076:1 1077:1 1078:1 1079:1 1080:1 1081:1 1082:1 1083:1 1084:1 1085:1 1086:1 1087:1 1088:1 1089:1 1090:1 1091:1 1092:1 1093:1 1094:1 1095:1 1096:1 1097:1 1098:1 1099:1 1100:1 1101:1 1102:1 1103:1 1104:1 1105:1 1106:1 1107:1 1108:1 1109:1 1110:1 1111:1 1112:1 1113:1 1114:1 1115:1 1116:1 1117:1 1118:1 1119:1 1120:1 1121:1 1122:1 1123:1 1124:1 1125:1 1126:1 1127:1 1128:1 1129:1 1130:1 1131:1 1132:1 1133:1 1134:1 1135:1 1136:1 1137:1 1138:1 1139:1 1140:1 1141:1 1142:1 1143:1 1144:1 1145:1 1146:1 1147:1 1148:1 1149:1 1150:1 1151:1 1152:1 1153:1 1154:1 1155:1 1156:1 1157:1 1158:1 1159:1 1160:1 1161:1 1162:1 1163:1 1164:1 1165:1 1166:1 1167:1 1168:1 1169:1 1170:1 1171:1 1172:1 1173:1 1174:1 1175:1 1176:1 1177:1 1178:1 1179:1 1180:1 1181:1 1182:1 1183:1 1184:1 1185:1 1186:1 1187:1 1188:1 1189:1 1190:1 1191:1 1192:1 1193:1 1194:1 1195:1 1196:1 1197:1 1198:1 1199:1 1200:1 1201:1 1202:1 1203:1 1204:1 1205:1 1206:1 1207:1 1208:1 1209:1 1210:1 1211:1 1212:1 1213:1 1214:1 1215:1 1216:1 1217:1 1218:1 1219:1 1220:1 1221:1 1222:1 1223:1 1224:1 1225:1 1226:1 1227:1 1228:1 1229:1 1230:1 1231:1 1232:1 1233:1 1234:1 1235:1 1236:1 1237:1 1238:1 1239:1 1240:1 1241:1 1242:1 1243:1 1244:1 1245:1 1246:1 1247:1 1248:1 1249:1 1250:1 1251:1 1252:1 1253:1 1254:1 1255:1 1256:1 1257:1 1258:1 1262:1 1268:1 1269:1 1270:1 1271:1 2679:1 3031:1 3204:1 4065:1 4795:1 4960:1 4961:1 4962:1 4963:1 4964:1 4965:1 4966:1 4967:11 8:1 9:1 23:1 31:1 32:1 34:1 45:1 46:1 49:1 50:1 52:1 54:1 57:1 60:1 61:1 64:1 70:1 80:1 82:1 84:1 87:1 91:1 94:1 95:1 101:1 104:1 106:1 107:1 113:1 115:1 125:1 126:1 127:1 128:1 129:1 131:1 132:1 134:1 152:1 161:1 166:1 167:1 179:1 229:1 235:1 248:1 251:1 255:1 260:1 262:1 267:1 268:1 270:1 272:1 273:1 277:1 280:1 281:1 282:1 285:1 299:1 305:1 310:1 311:1 324:1 342:1 372:1 379:1 390:1 391:1 408:1 409:1 415:1 472:1 483:1 486:1 498:1 525:1 538:1 548:1 583:1 614:1 616:1 620:1 621:1 651:1 678:1 700:1 712:1 715:1 794:1 796:1 800:1 804:1 805:1 811:1 819:1 847:1 848:1 853:1 873:1 885:1 899:1 949:1 963:1 964:1 965:1 966:1 967:1 968:1 969:1 970:1 971:1 972:1 973:1 974:1 975:1 976:1 977:1 978:1 979:1 980:1 981:1 982:1 983:1 984:1 985:1 986:1 987:1 988:1 989:1 990:1 991:1 992:1 993:1 994:1 995:1 996:1 997:1 998:1 999:1 1000:1 1001:1 1002:1 1003:1 1004:1 1005:1 1006:1 1007:1 1008:1 1009:1 1010:1 1011:1 1012:1 1013:1 1014:1 1015:1 1016:1 1017:1 1018:1 1019:1 1020:1 1021:1 1022:1 1023:1 1024:1 1025:1 1026:1 1027:1 1028:1 1029:1 1030:1 1031:1 1032:1 1033:1 1034:1 1035:1 1036:1 1037:1 1038:1 1039:1 1040:1 1041:1 1042:1 1043:1 1044:1 1045:1 1046:1 1047:1 1048:1 1049:1 1051:1 1052:1 1053:1 1054:1 1055:1 1056:1 1057:1 1058:1 1059:1 1060:1 1061:1 1062:1 1063:1 1064:1 1065:1 1066:1 1067:1 1068:1 1069:1 1070:1 1071:1 1072:1 1073:1 1074:1 1075:1 1076:1 1077:1 1078:1 1079:1 1080:1 1081:1 1082:1 1083:1 1084:1 1085:1 1086:1 1087:1 1088:1 1089:1 1090:1 1091:1 1092:1 1093:1 1094:1 1095:1 1096:1 1097:1 1098:1 1099:1 1100:1 1101:1 1102:1 1103:1 1104:1 1105:1 1106:1 1107:1 1108:1 1109:1 1110:1 1111:1 1112:1 1113:1 1114:1 1115:1 1116:1 1117:1 1118:1 1119:1 1120:1 1121:1 1122:1 1123:1 1124:1 1125:1 1126:1 1127:1 1128:1 1129:1 1130:1 1131:1 1132:1 1133:1 1134:1 1135:1 1136:1 1137:1 1138:1 1139:1 1140:1 1141:1 1142:1 1143:1 1144:1 1145:1 1146:1 1147:1 1148:1 1149:1 1150:1 1151:1 1152:1 1153:1 1154:1 1155:1 1156:1 1157:1 1158:1 1159:1 1160:1 1161:1 1162:1 1163:1 1164:1 1165:1 1166:1 1167:1 1168:1 1169:1 1170:1 1171:1 1172:1 1173:1 1174:1 1175:1 1176:1 1177:1 1178:1 1179:1 1180:1 1181:1 1182:1 1183:1 1184:1 1185:1 1186:1 1187:1 1188:1 1189:1 1190:1 1191:1 1192:1 1193:1 1194:1 1195:1 1196:1 1197:1 1198:1 1199:1 1200:1 1201:1 1202:1 1203:1 1204:1 1205:1 1206:1 1207:1 1208:1 1209:1 1210:1 1211:1 1212:1 1213:1 1214:1 1215:1 1216:1 1217:1 1218:1 1219:1 1220:1 1221:1 1222:1 1223:1 1224:1 1225:1 1226:1 1227:1 1228:1 1229:1 1230:1 1231:1 1232:1 1233:1 1234:1 1235:1 1236:1 1237:1 1238:1 1239:1 1240:1 1241:1 1242:1 1243:1 1244:1 1245:1 1246:1 1247:1 1248:1 1249:1 1250:1 1251:1 1252:1 1253:1 1254:1 1255:1 1256:1 1257:1 1258:1 1262:1 1268:1 1269:1 1270:1 1271:1 2679:1 3031:1 3204:1 4065:1 4795:1 4960:1 4961:1 4962:1 4963:1 4964:1 4965:1 4966:1 4967:1";
-  std::string jpredictstr = "{\"service\":\""+ sname + "\",\"parameters\":{\"input\":{\"connector\":\"svm\"},\"output\":{\"best\":3}},\"data\":[\"" + mem_data + "\"]}";
+
+  std::string mem_data
+      = "8:1 9:1 23:1 31:1 32:1 34:1 45:1 46:1 49:1 50:1 52:1 54:1 57:1 60:1 "
+        "61:1 64:1 70:1 80:1 82:1 84:1 87:1 91:1 94:1 95:1 101:1 104:1 106:1 "
+        "107:1 113:1 115:1 125:1 126:1 127:1 128:1 129:1 131:1 132:1 134:1 "
+        "152:1 161:1 166:1 167:1 179:1 229:1 235:1 248:1 251:1 255:1 260:1 "
+        "262:1 267:1 268:1 270:1 272:1 273:1 277:1 280:1 281:1 282:1 285:1 "
+        "299:1 305:1 310:1 311:1 324:1 342:1 372:1 379:1 390:1 391:1 408:1 "
+        "409:1 415:1 472:1 483:1 486:1 498:1 525:1 538:1 548:1 583:1 614:1 "
+        "616:1 620:1 621:1 651:1 678:1 700:1 712:1 715:1 794:1 796:1 800:1 "
+        "804:1 805:1 811:1 819:1 847:1 848:1 853:1 873:1 885:1 899:1 949:1 "
+        "963:1 964:1 965:1 966:1 967:1 968:1 969:1 970:1 971:1 972:1 973:1 "
+        "974:1 975:1 976:1 977:1 978:1 979:1 980:1 981:1 982:1 983:1 984:1 "
+        "985:1 986:1 987:1 988:1 989:1 990:1 991:1 992:1 993:1 994:1 995:1 "
+        "996:1 997:1 998:1 999:1 1000:1 1001:1 1002:1 1003:1 1004:1 1005:1 "
+        "1006:1 1007:1 1008:1 1009:1 1010:1 1011:1 1012:1 1013:1 1014:1 "
+        "1015:1 1016:1 1017:1 1018:1 1019:1 1020:1 1021:1 1022:1 1023:1 "
+        "1024:1 1025:1 1026:1 1027:1 1028:1 1029:1 1030:1 1031:1 1032:1 "
+        "1033:1 1034:1 1035:1 1036:1 1037:1 1038:1 1039:1 1040:1 1041:1 "
+        "1042:1 1043:1 1044:1 1045:1 1046:1 1047:1 1048:1 1049:1 1051:1 "
+        "1052:1 1053:1 1054:1 1055:1 1056:1 1057:1 1058:1 1059:1 1060:1 "
+        "1061:1 1062:1 1063:1 1064:1 1065:1 1066:1 1067:1 1068:1 1069:1 "
+        "1070:1 1071:1 1072:1 1073:1 1074:1 1075:1 1076:1 1077:1 1078:1 "
+        "1079:1 1080:1 1081:1 1082:1 1083:1 1084:1 1085:1 1086:1 1087:1 "
+        "1088:1 1089:1 1090:1 1091:1 1092:1 1093:1 1094:1 1095:1 1096:1 "
+        "1097:1 1098:1 1099:1 1100:1 1101:1 1102:1 1103:1 1104:1 1105:1 "
+        "1106:1 1107:1 1108:1 1109:1 1110:1 1111:1 1112:1 1113:1 1114:1 "
+        "1115:1 1116:1 1117:1 1118:1 1119:1 1120:1 1121:1 1122:1 1123:1 "
+        "1124:1 1125:1 1126:1 1127:1 1128:1 1129:1 1130:1 1131:1 1132:1 "
+        "1133:1 1134:1 1135:1 1136:1 1137:1 1138:1 1139:1 1140:1 1141:1 "
+        "1142:1 1143:1 1144:1 1145:1 1146:1 1147:1 1148:1 1149:1 1150:1 "
+        "1151:1 1152:1 1153:1 1154:1 1155:1 1156:1 1157:1 1158:1 1159:1 "
+        "1160:1 1161:1 1162:1 1163:1 1164:1 1165:1 1166:1 1167:1 1168:1 "
+        "1169:1 1170:1 1171:1 1172:1 1173:1 1174:1 1175:1 1176:1 1177:1 "
+        "1178:1 1179:1 1180:1 1181:1 1182:1 1183:1 1184:1 1185:1 1186:1 "
+        "1187:1 1188:1 1189:1 1190:1 1191:1 1192:1 1193:1 1194:1 1195:1 "
+        "1196:1 1197:1 1198:1 1199:1 1200:1 1201:1 1202:1 1203:1 1204:1 "
+        "1205:1 1206:1 1207:1 1208:1 1209:1 1210:1 1211:1 1212:1 1213:1 "
+        "1214:1 1215:1 1216:1 1217:1 1218:1 1219:1 1220:1 1221:1 1222:1 "
+        "1223:1 1224:1 1225:1 1226:1 1227:1 1228:1 1229:1 1230:1 1231:1 "
+        "1232:1 1233:1 1234:1 1235:1 1236:1 1237:1 1238:1 1239:1 1240:1 "
+        "1241:1 1242:1 1243:1 1244:1 1245:1 1246:1 1247:1 1248:1 1249:1 "
+        "1250:1 1251:1 1252:1 1253:1 1254:1 1255:1 1256:1 1257:1 1258:1 "
+        "1262:1 1268:1 1269:1 1270:1 1271:1 2679:1 3031:1 3204:1 4065:1 "
+        "4795:1 4960:1 4961:1 4962:1 4963:1 4964:1 4965:1 4966:1 4967:11 8:1 "
+        "9:1 23:1 31:1 32:1 34:1 45:1 46:1 49:1 50:1 52:1 54:1 57:1 60:1 61:1 "
+        "64:1 70:1 80:1 82:1 84:1 87:1 91:1 94:1 95:1 101:1 104:1 106:1 107:1 "
+        "113:1 115:1 125:1 126:1 127:1 128:1 129:1 131:1 132:1 134:1 152:1 "
+        "161:1 166:1 167:1 179:1 229:1 235:1 248:1 251:1 255:1 260:1 262:1 "
+        "267:1 268:1 270:1 272:1 273:1 277:1 280:1 281:1 282:1 285:1 299:1 "
+        "305:1 310:1 311:1 324:1 342:1 372:1 379:1 390:1 391:1 408:1 409:1 "
+        "415:1 472:1 483:1 486:1 498:1 525:1 538:1 548:1 583:1 614:1 616:1 "
+        "620:1 621:1 651:1 678:1 700:1 712:1 715:1 794:1 796:1 800:1 804:1 "
+        "805:1 811:1 819:1 847:1 848:1 853:1 873:1 885:1 899:1 949:1 963:1 "
+        "964:1 965:1 966:1 967:1 968:1 969:1 970:1 971:1 972:1 973:1 974:1 "
+        "975:1 976:1 977:1 978:1 979:1 980:1 981:1 982:1 983:1 984:1 985:1 "
+        "986:1 987:1 988:1 989:1 990:1 991:1 992:1 993:1 994:1 995:1 996:1 "
+        "997:1 998:1 999:1 1000:1 1001:1 1002:1 1003:1 1004:1 1005:1 1006:1 "
+        "1007:1 1008:1 1009:1 1010:1 1011:1 1012:1 1013:1 1014:1 1015:1 "
+        "1016:1 1017:1 1018:1 1019:1 1020:1 1021:1 1022:1 1023:1 1024:1 "
+        "1025:1 1026:1 1027:1 1028:1 1029:1 1030:1 1031:1 1032:1 1033:1 "
+        "1034:1 1035:1 1036:1 1037:1 1038:1 1039:1 1040:1 1041:1 1042:1 "
+        "1043:1 1044:1 1045:1 1046:1 1047:1 1048:1 1049:1 1051:1 1052:1 "
+        "1053:1 1054:1 1055:1 1056:1 1057:1 1058:1 1059:1 1060:1 1061:1 "
+        "1062:1 1063:1 1064:1 1065:1 1066:1 1067:1 1068:1 1069:1 1070:1 "
+        "1071:1 1072:1 1073:1 1074:1 1075:1 1076:1 1077:1 1078:1 1079:1 "
+        "1080:1 1081:1 1082:1 1083:1 1084:1 1085:1 1086:1 1087:1 1088:1 "
+        "1089:1 1090:1 1091:1 1092:1 1093:1 1094:1 1095:1 1096:1 1097:1 "
+        "1098:1 1099:1 1100:1 1101:1 1102:1 1103:1 1104:1 1105:1 1106:1 "
+        "1107:1 1108:1 1109:1 1110:1 1111:1 1112:1 1113:1 1114:1 1115:1 "
+        "1116:1 1117:1 1118:1 1119:1 1120:1 1121:1 1122:1 1123:1 1124:1 "
+        "1125:1 1126:1 1127:1 1128:1 1129:1 1130:1 1131:1 1132:1 1133:1 "
+        "1134:1 1135:1 1136:1 1137:1 1138:1 1139:1 1140:1 1141:1 1142:1 "
+        "1143:1 1144:1 1145:1 1146:1 1147:1 1148:1 1149:1 1150:1 1151:1 "
+        "1152:1 1153:1 1154:1 1155:1 1156:1 1157:1 1158:1 1159:1 1160:1 "
+        "1161:1 1162:1 1163:1 1164:1 1165:1 1166:1 1167:1 1168:1 1169:1 "
+        "1170:1 1171:1 1172:1 1173:1 1174:1 1175:1 1176:1 1177:1 1178:1 "
+        "1179:1 1180:1 1181:1 1182:1 1183:1 1184:1 1185:1 1186:1 1187:1 "
+        "1188:1 1189:1 1190:1 1191:1 1192:1 1193:1 1194:1 1195:1 1196:1 "
+        "1197:1 1198:1 1199:1 1200:1 1201:1 1202:1 1203:1 1204:1 1205:1 "
+        "1206:1 1207:1 1208:1 1209:1 1210:1 1211:1 1212:1 1213:1 1214:1 "
+        "1215:1 1216:1 1217:1 1218:1 1219:1 1220:1 1221:1 1222:1 1223:1 "
+        "1224:1 1225:1 1226:1 1227:1 1228:1 1229:1 1230:1 1231:1 1232:1 "
+        "1233:1 1234:1 1235:1 1236:1 1237:1 1238:1 1239:1 1240:1 1241:1 "
+        "1242:1 1243:1 1244:1 1245:1 1246:1 1247:1 1248:1 1249:1 1250:1 "
+        "1251:1 1252:1 1253:1 1254:1 1255:1 1256:1 1257:1 1258:1 1262:1 "
+        "1268:1 1269:1 1270:1 1271:1 2679:1 3031:1 3204:1 4065:1 4795:1 "
+        "4960:1 4961:1 4962:1 4963:1 4964:1 4965:1 4966:1 4967:1";
+  std::string jpredictstr = "{\"service\":\"" + sname
+                            + "\",\"parameters\":{\"input\":{\"connector\":"
+                              "\"svm\"},\"output\":{\"best\":3}},\"data\":[\""
+                            + mem_data + "\"]}";
   joutstr = japi.jrender(japi.service_predict(jpredictstr));
   std::cout << "joutstr=" << joutstr << std::endl;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_TRUE(jd.HasMember("status"));
-  ASSERT_EQ(200,jd["status"]["code"].GetInt());
-  std::string cat0 = jd["body"]["predictions"][0]["classes"][0]["cat"].GetString();
-  ASSERT_TRUE("1"==cat0);
-  
+  ASSERT_EQ(200, jd["status"]["code"].GetInt());
+  std::string cat0
+      = jd["body"]["predictions"][0]["classes"][0]["cat"].GetString();
+  ASSERT_TRUE("1" == cat0);
+
   // remove service
   jstr = "{\"clear\":\"lib\"}";
-  joutstr = japi.jrender(japi.service_delete(sname,jstr));
-  ASSERT_EQ(ok_str,joutstr);
+  joutstr = japi.jrender(japi.service_delete(sname, jstr));
+  ASSERT_EQ(ok_str, joutstr);
 
   // assert json blob file is still there (or gone if clear=full)
-  ASSERT_TRUE(!fileops::file_exists(farm_repo + "/" + JsonAPI::_json_blob_fname));
-  ASSERT_TRUE(!fileops::remove_directory_files(farm_repo,{".prototxt"}));
+  ASSERT_TRUE(
+      !fileops::file_exists(farm_repo + "/" + JsonAPI::_json_blob_fname));
+  ASSERT_TRUE(!fileops::remove_directory_files(farm_repo, { ".prototxt" }));
 }
 
-TEST(caffeapi,service_train_images)
+TEST(caffeapi, service_train_images)
 {
   // create service
   JsonAPI japi;
   std::string plank_repo_loc = "plank";
   std::string plank_repo_loc2 = "plank2";
-  mkdir(plank_repo_loc.c_str(),0777);
+  mkdir(plank_repo_loc.c_str(), 0777);
   std::string sname = "my_service";
-  std::string jstr = "{\"mllib\":\"caffe\",\"description\":\"my classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\"" +  plank_repo_loc + "\",\"templates\":\"" + model_templates_repo  + "\"},\"parameters\":{\"input\":{\"connector\":\"image\"},\"mllib\":{\"db\":true,\"template\":\"cifar\",\"nclasses\":121}}}";
-  std::string joutstr = japi.jrender(japi.service_create(sname,jstr));
-  ASSERT_EQ(created_str,joutstr);
+  std::string jstr
+      = "{\"mllib\":\"caffe\",\"description\":\"my "
+        "classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\""
+        + plank_repo_loc + "\",\"templates\":\"" + model_templates_repo
+        + "\"},\"parameters\":{\"input\":{\"connector\":\"image\"},\"mllib\":{"
+          "\"db\":true,\"template\":\"cifar\",\"nclasses\":121}}}";
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
 
   // train
-  std::string jtrainstr = "{\"service\":\"" + sname + "\",\"async\":false,\"parameters\":{\"input\":{\"db\":true,\"width\":32,\"height\":32,\"test_split\":0.001,\"shuffle\":true,\"bw\":false},\"mllib\":{\"gpu\":true,\"gpuid\":"+gpuid+",\"solver\":{\"iterations\":" + iterations_plank + ",\"test_interval\":500,\"base_lr\":0.0001,\"snapshot\":2000,\"test_initialization\":true},\"net\":{\"batch_size\":100}},\"output\":{\"measure\":[\"acc\",\"acc-5\",\"mcll\",\"f1\"],\"target_repository\":\"" + plank_repo_loc2 + "\"}},\"data\":[\"" + plank_repo + "train\"]}";
+  std::string jtrainstr
+      = "{\"service\":\"" + sname
+        + "\",\"async\":false,\"parameters\":{\"input\":{\"db\":true,"
+          "\"width\":32,\"height\":32,\"test_split\":0.001,\"shuffle\":true,"
+          "\"bw\":false},\"mllib\":{\"gpu\":true,\"gpuid\":"
+        + gpuid + ",\"solver\":{\"iterations\":" + iterations_plank
+        + ",\"test_interval\":500,\"base_lr\":0.0001,\"snapshot\":2000,\"test_"
+          "initialization\":true},\"net\":{\"batch_size\":100}},\"output\":{"
+          "\"measure\":[\"acc\",\"acc-5\",\"mcll\",\"f1\"],\"target_"
+          "repository\":\""
+        + plank_repo_loc2 + "\"}},\"data\":[\"" + plank_repo + "train\"]}";
   joutstr = japi.jrender(japi.service_train(jtrainstr));
   std::cout << "joutstr=" << joutstr << std::endl;
   JDoc jd;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_TRUE(jd.HasMember("status"));
-  ASSERT_EQ(201,jd["status"]["code"].GetInt());
-  ASSERT_EQ("Created",jd["status"]["msg"]);
+  ASSERT_EQ(201, jd["status"]["code"].GetInt());
+  ASSERT_EQ("Created", jd["status"]["msg"]);
   ASSERT_TRUE(jd.HasMember("head"));
-  ASSERT_EQ("/train",jd["head"]["method"]);
+  ASSERT_EQ("/train", jd["head"]["method"]);
   ASSERT_TRUE(jd["head"]["time"].GetDouble() >= 0);
   ASSERT_TRUE(jd.HasMember("body"));
   ASSERT_TRUE(jd["body"]["measure"].HasMember("train_loss"));
@@ -783,42 +1230,59 @@ TEST(caffeapi,service_train_images)
   ASSERT_TRUE(jd["body"]["measure"].HasMember("f1"));
   ASSERT_TRUE(jd["body"]["measure"]["acc"].GetDouble() >= 0.0);
   ASSERT_TRUE(jd["body"]["measure"]["acc-5"].GetDouble() >= 0.0);
-  ASSERT_EQ(jd["body"]["measure"]["accp"].GetDouble(),jd["body"]["measure"]["acc"].GetDouble());
+  ASSERT_EQ(jd["body"]["measure"]["accp"].GetDouble(),
+            jd["body"]["measure"]["acc"].GetDouble());
   ASSERT_TRUE(fileops::file_exists(plank_repo_loc + "/best_model.txt"));
   ASSERT_TRUE(fileops::file_exists(plank_repo_loc2 + "/deploy.prototxt"));
-  
+
   // remove service
   jstr = "{\"clear\":\"full\"}";
-  joutstr = japi.jrender(japi.service_delete(sname,jstr));
-  ASSERT_EQ(ok_str,joutstr);
+  joutstr = japi.jrender(japi.service_delete(sname, jstr));
+  ASSERT_EQ(ok_str, joutstr);
   rmdir(plank_repo_loc.c_str());
   rmdir(plank_repo_loc2.c_str()); // XXX: fails due to creation with 0755
 }
 
-
-TEST(caffeapi,service_train_images_imagedatalayer_1label)
+TEST(caffeapi, service_train_images_imagedatalayer_1label)
 {
   // create service
   JsonAPI japi;
   std::string plank_repo_loc = "plank";
-  mkdir(plank_repo_loc.c_str(),0777);
+  mkdir(plank_repo_loc.c_str(), 0777);
   std::string sname = "my_service";
-  std::string jstr = "{\"mllib\":\"caffe\",\"description\":\"my classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\"" +  plank_repo_loc + "\",\"templates\":\"" + model_templates_repo  + "\"},\"parameters\":{\"input\":{\"db\":false,\"connector\":\"image\"},\"mllib\":{\"template\":\"cifar\",\"nclasses\":121}}}";
-  std::string joutstr = japi.jrender(japi.service_create(sname,jstr));
-  ASSERT_EQ(created_str,joutstr);
+  std::string jstr
+      = "{\"mllib\":\"caffe\",\"description\":\"my "
+        "classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\""
+        + plank_repo_loc + "\",\"templates\":\"" + model_templates_repo
+        + "\"},\"parameters\":{\"input\":{\"db\":false,\"connector\":"
+          "\"image\"},\"mllib\":{\"template\":\"cifar\",\"nclasses\":121}}}";
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
 
   // train
-  std::string jtrainstr = "{\"service\":\"" + sname + "\",\"async\":false,\"parameters\":{\"input\":{\"db\":false,\"width\":32,\"height\":32,\"test_split\":0.001,\"shuffle\":true,\"bw\":false,\"root_folder\":\"" + plank_repo + "\"},\"mllib\":{\"gpu\":true,\"gpuid\":"+gpuid+",\"solver\":{\"iterations\":" + iterations_plank + ",\"test_interval\":3000,\"base_lr\":0.0001,\"snapshot\":2000,\"test_initialization\":false},\"net\":{\"batch_size\":2}},\"output\":{\"measure\":[\"acc\",\"acc-5\",\"mcll\",\"f1\"]}},\"data\":[\"" + plank_repo + "file-lst.txt\",\"" + plank_repo + "file-lst-test.txt\"]}";
+  std::string jtrainstr
+      = "{\"service\":\"" + sname
+        + "\",\"async\":false,\"parameters\":{\"input\":{\"db\":false,"
+          "\"width\":32,\"height\":32,\"test_split\":0.001,\"shuffle\":true,"
+          "\"bw\":false,\"root_folder\":\""
+        + plank_repo + "\"},\"mllib\":{\"gpu\":true,\"gpuid\":" + gpuid
+        + ",\"solver\":{\"iterations\":" + iterations_plank
+        + ",\"test_interval\":3000,\"base_lr\":0.0001,\"snapshot\":2000,"
+          "\"test_initialization\":false},\"net\":{\"batch_size\":2}},"
+          "\"output\":{\"measure\":[\"acc\",\"acc-5\",\"mcll\",\"f1\"]}},"
+          "\"data\":[\""
+        + plank_repo + "file-lst.txt\",\"" + plank_repo
+        + "file-lst-test.txt\"]}";
   joutstr = japi.jrender(japi.service_train(jtrainstr));
   std::cout << "joutstr=" << joutstr << std::endl;
   JDoc jd;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_TRUE(jd.HasMember("status"));
-  ASSERT_EQ(201,jd["status"]["code"].GetInt());
-  ASSERT_EQ("Created",jd["status"]["msg"]);
+  ASSERT_EQ(201, jd["status"]["code"].GetInt());
+  ASSERT_EQ("Created", jd["status"]["msg"]);
   ASSERT_TRUE(jd.HasMember("head"));
-  ASSERT_EQ("/train",jd["head"]["method"]);
+  ASSERT_EQ("/train", jd["head"]["method"]);
   ASSERT_TRUE(jd["head"]["time"].GetDouble() >= 0);
   ASSERT_TRUE(jd.HasMember("body"));
   ASSERT_TRUE(jd["body"]["measure"].HasMember("train_loss"));
@@ -826,38 +1290,56 @@ TEST(caffeapi,service_train_images_imagedatalayer_1label)
   ASSERT_TRUE(jd["body"]["measure"].HasMember("f1"));
   ASSERT_TRUE(jd["body"]["measure"]["acc"].GetDouble() >= 0.0);
   ASSERT_TRUE(jd["body"]["measure"]["acc-5"].GetDouble() >= 0.0);
-  ASSERT_EQ(jd["body"]["measure"]["accp"].GetDouble(),jd["body"]["measure"]["acc"].GetDouble());
+  ASSERT_EQ(jd["body"]["measure"]["accp"].GetDouble(),
+            jd["body"]["measure"]["acc"].GetDouble());
 
   // remove service
   jstr = "{\"clear\":\"full\"}";
-  joutstr = japi.jrender(japi.service_delete(sname,jstr));
-  ASSERT_EQ(ok_str,joutstr);
+  joutstr = japi.jrender(japi.service_delete(sname, jstr));
+  ASSERT_EQ(ok_str, joutstr);
   rmdir(plank_repo_loc.c_str());
 }
 
-TEST(caffeapi,service_train_images_imagedatalayer_multilabel)
+TEST(caffeapi, service_train_images_imagedatalayer_multilabel)
 {
   // create service
   JsonAPI japi;
   std::string plank_repo_loc = "plank";
-  mkdir(plank_repo_loc.c_str(),0777);
+  mkdir(plank_repo_loc.c_str(), 0777);
   std::string sname = "my_service";
-  std::string jstr = "{\"mllib\":\"caffe\",\"description\":\"my classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\"" +  plank_repo_loc + "\",\"templates\":\"" + model_templates_repo  + "\"},\"parameters\":{\"input\":{\"db\":false,\"connector\":\"image\",\"multi_label\":true},\"mllib\":{\"template\":\"cifar\",\"nclasses\":3}}}";
-  std::string joutstr = japi.jrender(japi.service_create(sname,jstr));
-  ASSERT_EQ(created_str,joutstr);
+  std::string jstr
+      = "{\"mllib\":\"caffe\",\"description\":\"my "
+        "classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\""
+        + plank_repo_loc + "\",\"templates\":\"" + model_templates_repo
+        + "\"},\"parameters\":{\"input\":{\"db\":false,\"connector\":"
+          "\"image\",\"multi_label\":true},\"mllib\":{\"template\":\"cifar\","
+          "\"nclasses\":3}}}";
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
 
   // train
-  std::string jtrainstr = "{\"service\":\"" + sname + "\",\"async\":false,\"parameters\":{\"input\":{\"db\":false,\"width\":32,\"height\":32,\"test_split\":0.001,\"shuffle\":true,\"bw\":false,\"root_folder\":\"" + plank_repo + "\"},\"mllib\":{\"gpu\":true,\"gpuid\":"+gpuid+",\"solver\":{\"iterations\":" + iterations_plank + ",\"test_interval\":3000,\"base_lr\":0.0001,\"snapshot\":2000,\"test_initialization\":false},\"net\":{\"batch_size\":2}},\"output\":{\"measure\":[\"acc\"]}},\"data\":[\"" + plank_repo + "file-lst-ml.txt\",\"" + plank_repo + "file-lst-test-ml.txt\"]}";
+  std::string jtrainstr
+      = "{\"service\":\"" + sname
+        + "\",\"async\":false,\"parameters\":{\"input\":{\"db\":false,"
+          "\"width\":32,\"height\":32,\"test_split\":0.001,\"shuffle\":true,"
+          "\"bw\":false,\"root_folder\":\""
+        + plank_repo + "\"},\"mllib\":{\"gpu\":true,\"gpuid\":" + gpuid
+        + ",\"solver\":{\"iterations\":" + iterations_plank
+        + ",\"test_interval\":3000,\"base_lr\":0.0001,\"snapshot\":2000,"
+          "\"test_initialization\":false},\"net\":{\"batch_size\":2}},"
+          "\"output\":{\"measure\":[\"acc\"]}},\"data\":[\""
+        + plank_repo + "file-lst-ml.txt\",\"" + plank_repo
+        + "file-lst-test-ml.txt\"]}";
   joutstr = japi.jrender(japi.service_train(jtrainstr));
   std::cout << "joutstr=" << joutstr << std::endl;
   JDoc jd;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_TRUE(jd.HasMember("status"));
-  ASSERT_EQ(201,jd["status"]["code"].GetInt());
-  ASSERT_EQ("Created",jd["status"]["msg"]);
+  ASSERT_EQ(201, jd["status"]["code"].GetInt());
+  ASSERT_EQ("Created", jd["status"]["msg"]);
   ASSERT_TRUE(jd.HasMember("head"));
-  ASSERT_EQ("/train",jd["head"]["method"]);
+  ASSERT_EQ("/train", jd["head"]["method"]);
   ASSERT_TRUE(jd["head"]["time"].GetDouble() >= 0);
   ASSERT_TRUE(jd.HasMember("body"));
   ASSERT_TRUE(jd["body"]["measure"].HasMember("train_loss"));
@@ -867,34 +1349,51 @@ TEST(caffeapi,service_train_images_imagedatalayer_multilabel)
 
   // remove service
   jstr = "{\"clear\":\"full\"}";
-  joutstr = japi.jrender(japi.service_delete(sname,jstr));
-  ASSERT_EQ(ok_str,joutstr);
+  joutstr = japi.jrender(japi.service_delete(sname, jstr));
+  ASSERT_EQ(ok_str, joutstr);
   rmdir(plank_repo_loc.c_str());
 }
 
-TEST(caffeapi,service_train_images_imagedatalayer_multilabel_softprob)
+TEST(caffeapi, service_train_images_imagedatalayer_multilabel_softprob)
 {
   // create service
   JsonAPI japi;
   std::string plank_repo_loc = "plank";
-  mkdir(plank_repo_loc.c_str(),0777);
+  mkdir(plank_repo_loc.c_str(), 0777);
   std::string sname = "my_service";
-  std::string jstr = "{\"mllib\":\"caffe\",\"description\":\"my classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\"" +  plank_repo_loc + "\",\"templates\":\"" + model_templates_repo  + "\"},\"parameters\":{\"input\":{\"db\":false,\"connector\":\"image\",\"multi_label\":true},\"mllib\":{\"template\":\"cifar\",\"nclasses\":3,\"regression\":true}}}";
-  std::string joutstr = japi.jrender(japi.service_create(sname,jstr));
-  ASSERT_EQ(created_str,joutstr);
+  std::string jstr
+      = "{\"mllib\":\"caffe\",\"description\":\"my "
+        "classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\""
+        + plank_repo_loc + "\",\"templates\":\"" + model_templates_repo
+        + "\"},\"parameters\":{\"input\":{\"db\":false,\"connector\":"
+          "\"image\",\"multi_label\":true},\"mllib\":{\"template\":\"cifar\","
+          "\"nclasses\":3,\"regression\":true}}}";
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
 
   // train
-  std::string jtrainstr = "{\"service\":\"" + sname + "\",\"async\":false,\"parameters\":{\"input\":{\"db\":false,\"width\":32,\"height\":32,\"test_split\":0.001,\"shuffle\":true,\"bw\":false,\"root_folder\":\"" + plank_repo + "\"},\"mllib\":{\"gpu\":true,\"gpuid\":"+gpuid+",\"solver\":{\"iterations\":" + iterations_plank + ",\"test_interval\":3000,\"base_lr\":0.0001,\"snapshot\":2000,\"test_initialization\":false},\"net\":{\"batch_size\":2}},\"output\":{\"measure\":[\"acc\"]}},\"data\":[\"" + plank_repo + "file-lst-ml.txt\",\"" + plank_repo + "file-lst-test-ml.txt\"]}";
+  std::string jtrainstr
+      = "{\"service\":\"" + sname
+        + "\",\"async\":false,\"parameters\":{\"input\":{\"db\":false,"
+          "\"width\":32,\"height\":32,\"test_split\":0.001,\"shuffle\":true,"
+          "\"bw\":false,\"root_folder\":\""
+        + plank_repo + "\"},\"mllib\":{\"gpu\":true,\"gpuid\":" + gpuid
+        + ",\"solver\":{\"iterations\":" + iterations_plank
+        + ",\"test_interval\":3000,\"base_lr\":0.0001,\"snapshot\":2000,"
+          "\"test_initialization\":false},\"net\":{\"batch_size\":2}},"
+          "\"output\":{\"measure\":[\"acc\"]}},\"data\":[\""
+        + plank_repo + "file-lst-ml.txt\",\"" + plank_repo
+        + "file-lst-test-ml.txt\"]}";
   joutstr = japi.jrender(japi.service_train(jtrainstr));
   std::cout << "joutstr=" << joutstr << std::endl;
   JDoc jd;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_TRUE(jd.HasMember("status"));
-  ASSERT_EQ(201,jd["status"]["code"].GetInt());
-  ASSERT_EQ("Created",jd["status"]["msg"]);
+  ASSERT_EQ(201, jd["status"]["code"].GetInt());
+  ASSERT_EQ("Created", jd["status"]["msg"]);
   ASSERT_TRUE(jd.HasMember("head"));
-  ASSERT_EQ("/train",jd["head"]["method"]);
+  ASSERT_EQ("/train", jd["head"]["method"]);
   ASSERT_TRUE(jd["head"]["time"].GetDouble() >= 0);
   ASSERT_TRUE(jd.HasMember("body"));
   ASSERT_TRUE(jd["body"]["measure"].HasMember("train_loss"));
@@ -904,7 +1403,8 @@ TEST(caffeapi,service_train_images_imagedatalayer_multilabel_softprob)
   ASSERT_TRUE(jd["body"]["measure"].HasMember("kolmogorov_smirnov"));
   ASSERT_TRUE(jd["body"]["measure"]["kolmogorov_smirnov"].GetDouble() >= 0.0);
   ASSERT_TRUE(jd["body"]["measure"].HasMember("distance_correlation"));
-  ASSERT_TRUE(jd["body"]["measure"]["distance_correlation"].GetDouble() >= 0.0);
+  ASSERT_TRUE(jd["body"]["measure"]["distance_correlation"].GetDouble()
+              >= 0.0);
   ASSERT_TRUE(jd["body"]["measure"].HasMember("r2"));
   ASSERT_TRUE(jd["body"]["measure"]["r2"].GetDouble() <= 1.0);
   ASSERT_TRUE(jd["body"]["measure"].HasMember("delta_score_0.05"));
@@ -918,34 +1418,49 @@ TEST(caffeapi,service_train_images_imagedatalayer_multilabel_softprob)
 
   // remove service
   jstr = "{\"clear\":\"full\"}";
-  joutstr = japi.jrender(japi.service_delete(sname,jstr));
-  ASSERT_EQ(ok_str,joutstr);
+  joutstr = japi.jrender(japi.service_delete(sname, jstr));
+  ASSERT_EQ(ok_str, joutstr);
   rmdir(plank_repo_loc.c_str());
 }
 
-TEST(caffeapi,service_train_images_convnet)
+TEST(caffeapi, service_train_images_convnet)
 {
   // create service
   JsonAPI japi;
   std::string plank_repo_loc = "plank";
-  mkdir(plank_repo_loc.c_str(),0777);
+  mkdir(plank_repo_loc.c_str(), 0777);
   std::string sname = "my_service";
-  std::string jstr = "{\"mllib\":\"caffe\",\"description\":\"my classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\"" +  plank_repo_loc + "\",\"templates\":\"" + model_templates_repo  + "\"},\"parameters\":{\"input\":{\"connector\":\"image\"},\"mllib\":{\"db\":true,\"template\":\"convnet\",\"layers\":[\"1CR32\",\"1CR64\",\"1CR128\",\"1024\"],\"nclasses\":121}}}";
-  std::string joutstr = japi.jrender(japi.service_create(sname,jstr));
-  ASSERT_EQ(created_str,joutstr);
+  std::string jstr
+      = "{\"mllib\":\"caffe\",\"description\":\"my "
+        "classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\""
+        + plank_repo_loc + "\",\"templates\":\"" + model_templates_repo
+        + "\"},\"parameters\":{\"input\":{\"connector\":\"image\"},\"mllib\":{"
+          "\"db\":true,\"template\":\"convnet\",\"layers\":[\"1CR32\","
+          "\"1CR64\",\"1CR128\",\"1024\"],\"nclasses\":121}}}";
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
 
   // train
-  std::string jtrainstr = "{\"service\":\"" + sname + "\",\"async\":false,\"parameters\":{\"input\":{\"db\":true,\"width\":32,\"height\":32,\"test_split\":0.001,\"shuffle\":true,\"bw\":false},\"mllib\":{\"gpu\":true,\"gpuid\":"+gpuid+",\"solver\":{\"iterations\":" + iterations_plank + ",\"test_interval\":500,\"base_lr\":0.0001,\"snapshot\":2000,\"test_initialization\":false},\"net\":{\"batch_size\":100}},\"output\":{\"measure\":[\"acc\",\"acc-5\",\"mcll\",\"f1\"]}},\"data\":[\"" + plank_repo + "train\"]}";
+  std::string jtrainstr
+      = "{\"service\":\"" + sname
+        + "\",\"async\":false,\"parameters\":{\"input\":{\"db\":true,"
+          "\"width\":32,\"height\":32,\"test_split\":0.001,\"shuffle\":true,"
+          "\"bw\":false},\"mllib\":{\"gpu\":true,\"gpuid\":"
+        + gpuid + ",\"solver\":{\"iterations\":" + iterations_plank
+        + ",\"test_interval\":500,\"base_lr\":0.0001,\"snapshot\":2000,\"test_"
+          "initialization\":false},\"net\":{\"batch_size\":100}},\"output\":{"
+          "\"measure\":[\"acc\",\"acc-5\",\"mcll\",\"f1\"]}},\"data\":[\""
+        + plank_repo + "train\"]}";
   joutstr = japi.jrender(japi.service_train(jtrainstr));
   std::cout << "joutstr=" << joutstr << std::endl;
   JDoc jd;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_TRUE(jd.HasMember("status"));
-  ASSERT_EQ(201,jd["status"]["code"].GetInt());
-  ASSERT_EQ("Created",jd["status"]["msg"]);
+  ASSERT_EQ(201, jd["status"]["code"].GetInt());
+  ASSERT_EQ("Created", jd["status"]["msg"]);
   ASSERT_TRUE(jd.HasMember("head"));
-  ASSERT_EQ("/train",jd["head"]["method"]);
+  ASSERT_EQ("/train", jd["head"]["method"]);
   ASSERT_TRUE(jd["head"]["time"].GetDouble() >= 0);
   ASSERT_TRUE(jd.HasMember("body"));
   ASSERT_TRUE(jd["body"]["measure"].HasMember("train_loss"));
@@ -953,38 +1468,54 @@ TEST(caffeapi,service_train_images_convnet)
   ASSERT_TRUE(jd["body"]["measure"].HasMember("f1"));
   ASSERT_TRUE(jd["body"]["measure"]["acc"].GetDouble() >= 0.0);
   ASSERT_TRUE(jd["body"]["measure"]["acc-5"].GetDouble() >= 0.0);
-  ASSERT_EQ(jd["body"]["measure"]["accp"].GetDouble(),jd["body"]["measure"]["acc"].GetDouble());
+  ASSERT_EQ(jd["body"]["measure"]["accp"].GetDouble(),
+            jd["body"]["measure"]["acc"].GetDouble());
 
   // remove service
   jstr = "{\"clear\":\"full\"}";
-  joutstr = japi.jrender(japi.service_delete(sname,jstr));
-  ASSERT_EQ(ok_str,joutstr);
+  joutstr = japi.jrender(japi.service_delete(sname, jstr));
+  ASSERT_EQ(ok_str, joutstr);
   rmdir(plank_repo_loc.c_str());
 }
 
-TEST(caffeapi,service_train_images_resnet)
+TEST(caffeapi, service_train_images_resnet)
 {
   // create service
   JsonAPI japi;
   std::string plank_repo_loc = "plank";
-  mkdir(plank_repo_loc.c_str(),0777);
+  mkdir(plank_repo_loc.c_str(), 0777);
   std::string sname = "my_service";
-  std::string jstr = "{\"mllib\":\"caffe\",\"description\":\"my classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\"" +  plank_repo_loc + "\",\"templates\":\"" + model_templates_repo  + "\"},\"parameters\":{\"input\":{\"connector\":\"image\",\"width\":32,\"height\":32},\"mllib\":{\"db\":true,\"template\":\"resnet\",\"layers\":[\"Res10\"],\"nclasses\":121}}}";
-  std::string joutstr = japi.jrender(japi.service_create(sname,jstr));
-  ASSERT_EQ(created_str,joutstr);
+  std::string jstr
+      = "{\"mllib\":\"caffe\",\"description\":\"my "
+        "classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\""
+        + plank_repo_loc + "\",\"templates\":\"" + model_templates_repo
+        + "\"},\"parameters\":{\"input\":{\"connector\":\"image\",\"width\":"
+          "32,\"height\":32},\"mllib\":{\"db\":true,\"template\":\"resnet\","
+          "\"layers\":[\"Res10\"],\"nclasses\":121}}}";
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
 
   // train
-  std::string jtrainstr = "{\"service\":\"" + sname + "\",\"async\":false,\"parameters\":{\"input\":{\"db\":true,\"width\":32,\"height\":32,\"test_split\":0.001,\"shuffle\":true,\"bw\":false},\"mllib\":{\"gpu\":true,\"gpuid\":"+gpuid+",\"solver\":{\"iterations\":" + iterations_plank + ",\"test_interval\":500,\"base_lr\":0.001,\"snapshot\":2000,\"test_initialization\":false},\"net\":{\"batch_size\":100}},\"output\":{\"measure\":[\"acc\",\"acc-5\",\"mcll\",\"f1\"]}},\"data\":[\"" + plank_repo + "train\"]}";
+  std::string jtrainstr
+      = "{\"service\":\"" + sname
+        + "\",\"async\":false,\"parameters\":{\"input\":{\"db\":true,"
+          "\"width\":32,\"height\":32,\"test_split\":0.001,\"shuffle\":true,"
+          "\"bw\":false},\"mllib\":{\"gpu\":true,\"gpuid\":"
+        + gpuid + ",\"solver\":{\"iterations\":" + iterations_plank
+        + ",\"test_interval\":500,\"base_lr\":0.001,\"snapshot\":2000,\"test_"
+          "initialization\":false},\"net\":{\"batch_size\":100}},\"output\":{"
+          "\"measure\":[\"acc\",\"acc-5\",\"mcll\",\"f1\"]}},\"data\":[\""
+        + plank_repo + "train\"]}";
   joutstr = japi.jrender(japi.service_train(jtrainstr));
   std::cout << "joutstr=" << joutstr << std::endl;
   JDoc jd;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_TRUE(jd.HasMember("status"));
-  ASSERT_EQ(201,jd["status"]["code"].GetInt());
-  ASSERT_EQ("Created",jd["status"]["msg"]);
+  ASSERT_EQ(201, jd["status"]["code"].GetInt());
+  ASSERT_EQ("Created", jd["status"]["msg"]);
   ASSERT_TRUE(jd.HasMember("head"));
-  ASSERT_EQ("/train",jd["head"]["method"]);
+  ASSERT_EQ("/train", jd["head"]["method"]);
   ASSERT_TRUE(jd["head"]["time"].GetDouble() >= 0);
   ASSERT_TRUE(jd.HasMember("body"));
   ASSERT_TRUE(jd["body"]["measure"].HasMember("train_loss"));
@@ -992,38 +1523,57 @@ TEST(caffeapi,service_train_images_resnet)
   ASSERT_TRUE(jd["body"]["measure"].HasMember("f1"));
   ASSERT_TRUE(jd["body"]["measure"]["acc"].GetDouble() >= 0.0);
   ASSERT_TRUE(jd["body"]["measure"]["acc-5"].GetDouble() >= 0.0);
-  ASSERT_EQ(jd["body"]["measure"]["accp"].GetDouble(),jd["body"]["measure"]["acc"].GetDouble());
+  ASSERT_EQ(jd["body"]["measure"]["accp"].GetDouble(),
+            jd["body"]["measure"]["acc"].GetDouble());
 
   // remove service
   jstr = "{\"clear\":\"full\"}";
-  joutstr = japi.jrender(japi.service_delete(sname,jstr));
-  ASSERT_EQ(ok_str,joutstr);
+  joutstr = japi.jrender(japi.service_delete(sname, jstr));
+  ASSERT_EQ(ok_str, joutstr);
   rmdir(plank_repo_loc.c_str());
 }
 
-TEST(caffeapi,service_train_images_autoenc)
+TEST(caffeapi, service_train_images_autoenc)
 {
- // create service
+  // create service
   JsonAPI japi;
   std::string plank_repo_loc = "plank";
-  mkdir(plank_repo_loc.c_str(),0777);
+  mkdir(plank_repo_loc.c_str(), 0777);
   std::string sname = "my_service";
-  std::string jstr = "{\"mllib\":\"caffe\",\"description\":\"my classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\"" +  plank_repo_loc + "\",\"templates\":\"" + model_templates_repo  + "\"},\"parameters\":{\"input\":{\"connector\":\"image\",\"width\":224,\"height\":224},\"mllib\":{\"db\":true,\"template\":\"convnet\",\"layers\":[\"1CR32\",\"1CR64\",\"1CR128\",\"DR128\",\"1CR128\",\"DR64\",\"1CR64\",\"DR32\",\"1CR32\"],\"activation\":\"relu\",\"autoencoder\":true,\"scale\":0.0039}}}";
-  std::string joutstr = japi.jrender(japi.service_create(sname,jstr));
-  ASSERT_EQ(created_str,joutstr);
-  
+  std::string jstr
+      = "{\"mllib\":\"caffe\",\"description\":\"my "
+        "classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\""
+        + plank_repo_loc + "\",\"templates\":\"" + model_templates_repo
+        + "\"},\"parameters\":{\"input\":{\"connector\":\"image\",\"width\":"
+          "224,\"height\":224},\"mllib\":{\"db\":true,\"template\":"
+          "\"convnet\",\"layers\":[\"1CR32\",\"1CR64\",\"1CR128\",\"DR128\","
+          "\"1CR128\",\"DR64\",\"1CR64\",\"DR32\",\"1CR32\"],\"activation\":"
+          "\"relu\",\"autoencoder\":true,\"scale\":0.0039}}}";
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
+
   // train
-  std::string jtrainstr = "{\"service\":\"" + sname + "\",\"async\":false,\"parameters\":{\"input\":{\"db\":true,\"test_split\":0.001,\"shuffle\":true,\"bw\":false},\"mllib\":{\"gpu\":true,\"gpuid\":"+gpuid+",\"resume\":false,\"solver\":{\"iterations\":" + iterations_plank + ",\"test_interval\":500,\"base_lr\":0.0001,\"snapshot\":2000,\"test_initialization\":false},\"net\":{\"batch_size\":10}},\"output\":{\"measure\":[\"eucll\"]}},\"data\":[\"" + plank_repo + "train\"]}";
+  std::string jtrainstr
+      = "{\"service\":\"" + sname
+        + "\",\"async\":false,\"parameters\":{\"input\":{\"db\":true,\"test_"
+          "split\":0.001,\"shuffle\":true,\"bw\":false},\"mllib\":{\"gpu\":"
+          "true,\"gpuid\":"
+        + gpuid
+        + ",\"resume\":false,\"solver\":{\"iterations\":" + iterations_plank
+        + ",\"test_interval\":500,\"base_lr\":0.0001,\"snapshot\":2000,\"test_"
+          "initialization\":false},\"net\":{\"batch_size\":10}},\"output\":{"
+          "\"measure\":[\"eucll\"]}},\"data\":[\""
+        + plank_repo + "train\"]}";
   joutstr = japi.jrender(japi.service_train(jtrainstr));
   std::cout << "joutstr=" << joutstr << std::endl;
   JDoc jd;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_TRUE(jd.HasMember("status"));
-  ASSERT_EQ(201,jd["status"]["code"].GetInt());
-  ASSERT_EQ("Created",jd["status"]["msg"]);
+  ASSERT_EQ(201, jd["status"]["code"].GetInt());
+  ASSERT_EQ("Created", jd["status"]["msg"]);
   ASSERT_TRUE(jd.HasMember("head"));
-  ASSERT_EQ("/train",jd["head"]["method"]);
+  ASSERT_EQ("/train", jd["head"]["method"]);
   ASSERT_TRUE(jd["head"]["time"].GetDouble() >= 0);
   ASSERT_TRUE(jd.HasMember("body"));
   ASSERT_TRUE(jd["body"]["measure"].HasMember("train_loss"));
@@ -1033,50 +1583,70 @@ TEST(caffeapi,service_train_images_autoenc)
 
   // remove service
   jstr = "{\"clear\":\"full\"}";
-  joutstr = japi.jrender(japi.service_delete(sname,jstr));
-  ASSERT_EQ(ok_str,joutstr);
+  joutstr = japi.jrender(japi.service_delete(sname, jstr));
+  ASSERT_EQ(ok_str, joutstr);
   rmdir(plank_repo_loc.c_str());
 }
 
-TEST(caffeapi,service_train_images_autoenc_geometry)
+TEST(caffeapi, service_train_images_autoenc_geometry)
 {
   // create service
   JsonAPI japi;
   std::string plank_repo_loc = "plank";
-  mkdir(plank_repo_loc.c_str(),0777);
+  mkdir(plank_repo_loc.c_str(), 0777);
   std::string sname = "my_service";
-  std::string jstr = "{\"mllib\":\"caffe\",\"description\":\"my classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\"" +  plank_repo_loc + "\",\"templates\":\"" + model_templates_repo  + "\"},\"parameters\":{\"input\":{\"connector\":\"image\",\"width\":224,\"height\":224},\"mllib\":{\"db\":true,\"template\":\"convnet\",\"layers\":[\"1CR32\",\"1CR64\",\"1CR128\",\"DR128\",\"1CR128\",\"DR64\",\"1CR64\",\"DR32\",\"1CR32\"],\"activation\":\"relu\",\"autoencoder\":true,\"scale\":0.0039,\"geometry\":{\"all_effects\":false,\"persp_horizontal\":true,\"persp_vertical\":false,\"zoom_in\":true,\"zoom_out\":true,\"pad_mode\":\"mirrored\",\"prob\":0.1}}}}";
-  std::string joutstr = japi.jrender(japi.service_create(sname,jstr));
-  ASSERT_EQ(created_str,joutstr);
-
+  std::string jstr
+      = "{\"mllib\":\"caffe\",\"description\":\"my "
+        "classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\""
+        + plank_repo_loc + "\",\"templates\":\"" + model_templates_repo
+        + "\"},\"parameters\":{\"input\":{\"connector\":\"image\",\"width\":"
+          "224,\"height\":224},\"mllib\":{\"db\":true,\"template\":"
+          "\"convnet\",\"layers\":[\"1CR32\",\"1CR64\",\"1CR128\",\"DR128\","
+          "\"1CR128\",\"DR64\",\"1CR64\",\"DR32\",\"1CR32\"],\"activation\":"
+          "\"relu\",\"autoencoder\":true,\"scale\":0.0039,\"geometry\":{\"all_"
+          "effects\":false,\"persp_horizontal\":true,\"persp_vertical\":false,"
+          "\"zoom_in\":true,\"zoom_out\":true,\"pad_mode\":\"mirrored\","
+          "\"prob\":0.1}}}}";
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
 
   caffe::NetParameter net_param;
-  std::string prototxt = plank_repo_loc + "/convnet.prototxt";;
-  bool succ = caffe::ReadProtoFromTextFile(prototxt,&net_param);
+  std::string prototxt = plank_repo_loc + "/convnet.prototxt";
+  ;
+  bool succ = caffe::ReadProtoFromTextFile(prototxt, &net_param);
   ASSERT_TRUE(succ);
-
 
   caffe::LayerParameter *lparam = net_param.mutable_layer(0);
   caffe::GeometryParameter gparam = lparam->transform_param().geometry_param();
   ASSERT_FLOAT_EQ(gparam.prob(), 0.1);
-  ASSERT_EQ(gparam.persp_horizontal(),true);
-  ASSERT_EQ(gparam.persp_vertical(),false);
-  ASSERT_EQ(gparam.zoom_out(),true);
-  ASSERT_EQ(gparam.zoom_in(),true);
-  ASSERT_EQ(gparam.pad_mode(),caffe::GeometryParameter_Pad_mode_MIRRORED);
+  ASSERT_EQ(gparam.persp_horizontal(), true);
+  ASSERT_EQ(gparam.persp_vertical(), false);
+  ASSERT_EQ(gparam.zoom_out(), true);
+  ASSERT_EQ(gparam.zoom_in(), true);
+  ASSERT_EQ(gparam.pad_mode(), caffe::GeometryParameter_Pad_mode_MIRRORED);
 
   // // train
-  std::string jtrainstr = "{\"service\":\"" + sname + "\",\"async\":false,\"parameters\":{\"input\":{\"db\":true,\"test_split\":0.001,\"shuffle\":true,\"bw\":false},\"mllib\":{\"gpu\":true,\"gpuid\":"+gpuid+",\"resume\":false,\"solver\":{\"iterations\":" + iterations_plank + ",\"test_interval\":500,\"base_lr\":0.0001,\"snapshot\":2000,\"test_initialization\":false},\"net\":{\"batch_size\":10}},\"output\":{\"measure\":[\"eucll\"]}},\"data\":[\"" + plank_repo + "train\"]}";
+  std::string jtrainstr
+      = "{\"service\":\"" + sname
+        + "\",\"async\":false,\"parameters\":{\"input\":{\"db\":true,\"test_"
+          "split\":0.001,\"shuffle\":true,\"bw\":false},\"mllib\":{\"gpu\":"
+          "true,\"gpuid\":"
+        + gpuid
+        + ",\"resume\":false,\"solver\":{\"iterations\":" + iterations_plank
+        + ",\"test_interval\":500,\"base_lr\":0.0001,\"snapshot\":2000,\"test_"
+          "initialization\":false},\"net\":{\"batch_size\":10}},\"output\":{"
+          "\"measure\":[\"eucll\"]}},\"data\":[\""
+        + plank_repo + "train\"]}";
   joutstr = japi.jrender(japi.service_train(jtrainstr));
   std::cout << "joutstr=" << joutstr << std::endl;
   JDoc jd;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_TRUE(jd.HasMember("status"));
-  ASSERT_EQ(201,jd["status"]["code"].GetInt());
-  ASSERT_EQ("Created",jd["status"]["msg"]);
+  ASSERT_EQ(201, jd["status"]["code"].GetInt());
+  ASSERT_EQ("Created", jd["status"]["msg"]);
   ASSERT_TRUE(jd.HasMember("head"));
-  ASSERT_EQ("/train",jd["head"]["method"]);
+  ASSERT_EQ("/train", jd["head"]["method"]);
   ASSERT_TRUE(jd["head"]["time"].GetDouble() >= 0);
   ASSERT_TRUE(jd.HasMember("body"));
   ASSERT_TRUE(jd["body"]["measure"].HasMember("train_loss"));
@@ -1086,230 +1656,257 @@ TEST(caffeapi,service_train_images_autoenc_geometry)
 
   // remove service
   jstr = "{\"clear\":\"full\"}";
-  joutstr = japi.jrender(japi.service_delete(sname,jstr));
-  ASSERT_EQ(ok_str,joutstr);
+  joutstr = japi.jrender(japi.service_delete(sname, jstr));
+  ASSERT_EQ(ok_str, joutstr);
   rmdir(plank_repo_loc.c_str());
 }
 
-TEST(caffeapi,service_train_images_seg)
+TEST(caffeapi, service_train_images_seg)
 {
   // create service
   JsonAPI japi;
   std::string camvid_repo_loc = "camvid";
-  mkdir(camvid_repo_loc.c_str(),0777);
+  mkdir(camvid_repo_loc.c_str(), 0777);
   std::string sname = "my_service";
-  std::string jstr = "{\"mllib\":\"caffe\",\"description\":\"my classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\"" +  camvid_repo_loc + "\",\"templates\":\"" + model_templates_repo  + "\"},\"parameters\":{\"input\":{\"connector\":\"image\",\"segmentation\":true,\"width\":480,\"height\":480},\"mllib\":{\"template\":\"unet\",\"nclasses\":12}}}";
-  std::string joutstr = japi.jrender(japi.service_create(sname,jstr));
-  ASSERT_EQ(created_str,joutstr);
+  std::string jstr
+      = "{\"mllib\":\"caffe\",\"description\":\"my "
+        "classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\""
+        + camvid_repo_loc + "\",\"templates\":\"" + model_templates_repo
+        + "\"},\"parameters\":{\"input\":{\"connector\":\"image\","
+          "\"segmentation\":true,\"width\":480,\"height\":480},\"mllib\":{"
+          "\"template\":\"unet\",\"nclasses\":12}}}";
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
 
   // train
-  std::string jtrainstr = "{\"service\":\"" + sname + "\",\"async\":false,\"parameters\":{\"input\":{\"segmentation\":true},\"mllib\":{\"gpu\":true,\"gpuid\":"+gpuid+",\"class_weights\":[0.2595,0.1826,4.5640,0.1417,0.9051,0.3826,9.6446,1.8418,0.6823,6.2478,7.3614,0.5],\"ignore_label\":11,\"solver\":{\"iterations\":" + iterations_camvid + ",\"test_interval\":200,\"base_lr\":0.0001,\"test_initialization\":false,\"mirror\":true,\"solver_type\":\"SGD\"},\"net\":{\"batch_size\":1,\"test_batch_size\":1}},\"output\":{\"measure\":[\"acc\"]}},\"data\":[\"" + camvid_repo + "train.txt\",\"" + camvid_repo + "test2.txt\"]}";
+  std::string jtrainstr
+      = "{\"service\":\"" + sname
+        + "\",\"async\":false,\"parameters\":{\"input\":{\"segmentation\":"
+          "true},\"mllib\":{\"gpu\":true,\"gpuid\":"
+        + gpuid
+        + ",\"class_weights\":[0.2595,0.1826,4.5640,0.1417,0.9051,0.3826,9."
+          "6446,1.8418,0.6823,6.2478,7.3614,0.5],\"ignore_label\":11,"
+          "\"solver\":{\"iterations\":"
+        + iterations_camvid
+        + ",\"test_interval\":200,\"base_lr\":0.0001,\"test_initialization\":"
+          "false,\"mirror\":true,\"solver_type\":\"SGD\"},\"net\":{\"batch_"
+          "size\":1,\"test_batch_size\":1}},\"output\":{\"measure\":[\"acc\"]}"
+          "},\"data\":[\""
+        + camvid_repo + "train.txt\",\"" + camvid_repo + "test2.txt\"]}";
   joutstr = japi.jrender(japi.service_train(jtrainstr));
   std::cout << "joutstr=" << joutstr << std::endl;
   JDoc jd;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_TRUE(jd.HasMember("status"));
-  ASSERT_EQ(201,jd["status"]["code"].GetInt());
-  ASSERT_EQ("Created",jd["status"]["msg"]);
+  ASSERT_EQ(201, jd["status"]["code"].GetInt());
+  ASSERT_EQ("Created", jd["status"]["msg"]);
   ASSERT_TRUE(jd.HasMember("head"));
-  ASSERT_EQ("/train",jd["head"]["method"]);
+  ASSERT_EQ("/train", jd["head"]["method"]);
   ASSERT_TRUE(jd["head"]["time"].GetDouble() >= 0);
   ASSERT_TRUE(jd.HasMember("body"));
   ASSERT_TRUE(jd["body"]["measure"].HasMember("train_loss"));
   ASSERT_TRUE(fabs(jd["body"]["measure"]["train_loss"].GetDouble()) > 0);
   ASSERT_TRUE(jd["body"]["measure"]["acc"].GetDouble() >= 0.0);
 
-  //predict + conf map
-  std::string jpredictstr = "{\"service\":\"" + sname + "\",\"async\":false,\"parameters\":{\"input\":{\"segmentation\":true},\"mllib\":{\"gpu\":true,\"gpuid\":"+gpuid+",\"net\":{\"batch_size\":1,\"test_batch_size\":1}},\"output\":{\"confidences\":[\"best\",\"2\"]}},\"data\":[\"" + camvid_repo + "test/0001TP_008550.png\"]}";
+  // predict + conf map
+  std::string jpredictstr
+      = "{\"service\":\"" + sname
+        + "\",\"async\":false,\"parameters\":{\"input\":{\"segmentation\":"
+          "true},\"mllib\":{\"gpu\":true,\"gpuid\":"
+        + gpuid
+        + ",\"net\":{\"batch_size\":1,\"test_batch_size\":1}},\"output\":{"
+          "\"confidences\":[\"best\",\"2\"]}},\"data\":[\""
+        + camvid_repo + "test/0001TP_008550.png\"]}";
   joutstr = japi.jrender(japi.service_predict(jpredictstr));
-  //std::cout << "joutstr predict=" << joutstr << std::endl;
+  // std::cout << "joutstr predict=" << joutstr << std::endl;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
-  ASSERT_EQ(200,jd["status"]["code"]);
+  ASSERT_EQ(200, jd["status"]["code"]);
   ASSERT_TRUE(jd["body"]["predictions"][0].HasMember("vals"));
   ASSERT_TRUE(jd["body"]["predictions"][0]["vals"].IsArray());
-  ASSERT_TRUE(jd["body"]["predictions"][0]["vals"].Size() == (480*480));
+  ASSERT_TRUE(jd["body"]["predictions"][0]["vals"].Size() == (480 * 480));
   ASSERT_TRUE(jd["body"]["predictions"][0].HasMember("confidences"));
   ASSERT_TRUE(jd["body"]["predictions"][0]["confidences"].HasMember("best"));
   ASSERT_TRUE(jd["body"]["predictions"][0]["confidences"]["best"].IsArray());
-  ASSERT_TRUE(jd["body"]["predictions"][0]["confidences"]["best"].Size() == 480*480);
+  ASSERT_TRUE(jd["body"]["predictions"][0]["confidences"]["best"].Size()
+              == 480 * 480);
   ASSERT_TRUE(jd["body"]["predictions"][0]["confidences"].HasMember("2"));
   ASSERT_TRUE(jd["body"]["predictions"][0]["confidences"]["2"].IsArray());
-  ASSERT_TRUE(jd["body"]["predictions"][0]["confidences"]["2"].Size() == 480*480);
-
+  ASSERT_TRUE(jd["body"]["predictions"][0]["confidences"]["2"].Size()
+              == 480 * 480);
 
   // remove service
   jstr = "{\"clear\":\"full\"}";
-  joutstr = japi.jrender(japi.service_delete(sname,jstr));
-  ASSERT_EQ(ok_str,joutstr);
+  joutstr = japi.jrender(japi.service_delete(sname, jstr));
+  ASSERT_EQ(ok_str, joutstr);
   rmdir(camvid_repo_loc.c_str());
 }
 
-TEST(caffeapi,service_test_bbox)
+TEST(caffeapi, service_test_bbox)
 {
-    // create service
+  // create service
   JsonAPI japi;
   std::string sname = "my_service";
-  std::string jstr = "{\"mllib\":\"caffe\",\"description\":\"my classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\"" +  voc_repo + "\"},\"parameters\":{\"input\":{\"connector\":\"image\",\"width\":300,\"height\":300},\"mllib\":{\"nclasses\":21}}}";
+  std::string jstr
+      = "{\"mllib\":\"caffe\",\"description\":\"my "
+        "classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\""
+        + voc_repo
+        + "\"},\"parameters\":{\"input\":{\"connector\":\"image\",\"width\":"
+          "300,\"height\":300},\"mllib\":{\"nclasses\":21}}}";
   std::cerr << "jstr=" << jstr << std::endl;
-  std::string joutstr = japi.jrender(japi.service_create(sname,jstr));
-  ASSERT_EQ(created_str,joutstr);
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
   JDoc jd;
 
   // predict
-  std::string jpredictstr = "{\"service\":\""+ sname + "\",\"parameters\":{\"input\":{},\"mllib\":{},\"output\":{\"bbox\":true,\"confidence_threshold\":0.1}},\"data\":[\"" + voc_repo + "/test_img.jpg\"]}";
+  std::string jpredictstr
+      = "{\"service\":\"" + sname
+        + "\",\"parameters\":{\"input\":{},\"mllib\":{},\"output\":{\"bbox\":"
+          "true,\"confidence_threshold\":0.1}},\"data\":[\""
+        + voc_repo + "/test_img.jpg\"]}";
   std::cerr << "jpredictstr=" << jpredictstr << std::endl;
   joutstr = japi.jrender(japi.service_predict(jpredictstr));
   std::cout << "joutstr predict=" << joutstr << std::endl;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
-  ASSERT_EQ(200,jd["status"]["code"]);
+  ASSERT_EQ(200, jd["status"]["code"]);
   ASSERT_TRUE(jd["body"]["predictions"][0].HasMember("classes"));
   ASSERT_TRUE(jd["body"]["predictions"][0]["classes"][0].HasMember("bbox"));
-  ASSERT_TRUE(jd["body"]["predictions"][0]["classes"][0]["bbox"].HasMember("xmin"));
+  ASSERT_TRUE(
+      jd["body"]["predictions"][0]["classes"][0]["bbox"].HasMember("xmin"));
 }
 
-TEST(caffeapi,service_train_txt)
+TEST(caffeapi, service_train_txt)
 {
   // create service
   JsonAPI japi;
   std::string n20_repo_loc = "n20";
-  mkdir(n20_repo_loc.c_str(),0777);
+  mkdir(n20_repo_loc.c_str(), 0777);
   std::string sname = "my_service";
-  std::string jstr = "{\"mllib\":\"caffe\",\"description\":\"my classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\"" +  n20_repo_loc + "\",\"templates\":\"" + model_templates_repo  + "\"},\"parameters\":{\"input\":{\"connector\":\"txt\"},\"mllib\":{\"template\":\"mlp\",\"nclasses\":20}}}";
-  std::string joutstr = japi.jrender(japi.service_create(sname,jstr));
-  ASSERT_EQ(created_str,joutstr);
+  std::string jstr
+      = "{\"mllib\":\"caffe\",\"description\":\"my "
+        "classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\""
+        + n20_repo_loc + "\",\"templates\":\"" + model_templates_repo
+        + "\"},\"parameters\":{\"input\":{\"connector\":\"txt\"},\"mllib\":{"
+          "\"template\":\"mlp\",\"nclasses\":20}}}";
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
 
   // train
-  std::string jtrainstr = "{\"service\":\"" + sname + "\",\"async\":false,\"parameters\":{\"input\":{\"test_split\":0.2,\"shuffle\":true,\"min_count\":10,\"min_word_length\":3,\"count\":false},\"mllib\":{\"gpu\":true,\"gpuid\":"+gpuid+",\"solver\":{\"iterations\":" + iterations_n20 + ",\"test_interval\":200,\"base_lr\":0.05,\"snapshot\":2000,\"test_initialization\":true},\"net\":{\"batch_size\":100}},\"output\":{\"measure\":[\"acc\",\"mcll\",\"f1\"]}},\"data\":[\"" + n20_repo + "news20\"]}";
+  std::string jtrainstr
+      = "{\"service\":\"" + sname
+        + "\",\"async\":false,\"parameters\":{\"input\":{\"test_split\":0.2,"
+          "\"shuffle\":true,\"min_count\":10,\"min_word_length\":3,\"count\":"
+          "false},\"mllib\":{\"gpu\":true,\"gpuid\":"
+        + gpuid + ",\"solver\":{\"iterations\":" + iterations_n20
+        + ",\"test_interval\":200,\"base_lr\":0.05,\"snapshot\":2000,\"test_"
+          "initialization\":true},\"net\":{\"batch_size\":100}},\"output\":{"
+          "\"measure\":[\"acc\",\"mcll\",\"f1\"]}},\"data\":[\""
+        + n20_repo + "news20\"]}";
   joutstr = japi.jrender(japi.service_train(jtrainstr));
   std::cout << "joutstr=" << joutstr << std::endl;
   JDoc jd;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_TRUE(jd.HasMember("status"));
-  ASSERT_EQ(201,jd["status"]["code"].GetInt());
-  ASSERT_EQ("Created",jd["status"]["msg"]);
+  ASSERT_EQ(201, jd["status"]["code"].GetInt());
+  ASSERT_EQ("Created", jd["status"]["msg"]);
   ASSERT_TRUE(jd.HasMember("head"));
-  ASSERT_EQ("/train",jd["head"]["method"]);
+  ASSERT_EQ("/train", jd["head"]["method"]);
   ASSERT_TRUE(jd["head"]["time"].GetDouble() >= 0);
   ASSERT_TRUE(jd.HasMember("body"));
   ASSERT_TRUE(jd["body"]["measure"].HasMember("train_loss"));
   ASSERT_TRUE(fabs(jd["body"]["measure"]["train_loss"].GetDouble()) > 0);
   ASSERT_TRUE(jd["body"]["measure"].HasMember("f1"));
   ASSERT_TRUE(jd["body"]["measure"]["acc"].GetDouble() >= 0.5);
-  ASSERT_EQ(jd["body"]["measure"]["accp"].GetDouble(),jd["body"]["measure"]["acc"].GetDouble());
+  ASSERT_EQ(jd["body"]["measure"]["accp"].GetDouble(),
+            jd["body"]["measure"]["acc"].GetDouble());
 
   // predict with measure
-  std::string jpredictstr = "{\"service\":\"" + sname + "\",\"parameters\":{\"mllib\":{\"gpu\":true,\"gpuid\":"+gpuid+",\"net\":{\"test_batch_size\":10}},\"output\":{\"measure\":[\"f1\"]}},\"data\":[\"" + n20_repo +"news20\"]}";
+  std::string jpredictstr
+      = "{\"service\":\"" + sname
+        + "\",\"parameters\":{\"mllib\":{\"gpu\":true,\"gpuid\":" + gpuid
+        + ",\"net\":{\"test_batch_size\":10}},\"output\":{\"measure\":[\"f1\"]"
+          "}},\"data\":[\""
+        + n20_repo + "news20\"]}";
   joutstr = japi.jrender(japi.service_predict(jpredictstr));
   std::cout << "joutstr=" << joutstr << std::endl;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_TRUE(jd.HasMember("status"));
-  ASSERT_EQ(200,jd["status"]["code"].GetInt());
+  ASSERT_EQ(200, jd["status"]["code"].GetInt());
   ASSERT_TRUE(jd.HasMember("body"));
   ASSERT_TRUE(jd["body"].HasMember("measure"));
   ASSERT_TRUE(jd["body"]["measure"]["f1"].GetDouble() >= 0.6);
-  
+
   // remove service
   jstr = "{\"clear\":\"full\"}";
-  joutstr = japi.jrender(japi.service_delete(sname,jstr));
-  ASSERT_EQ(ok_str,joutstr);
+  joutstr = japi.jrender(japi.service_delete(sname, jstr));
+  ASSERT_EQ(ok_str, joutstr);
   rmdir(n20_repo_loc.c_str());
 }
 
-TEST(caffeapi,service_train_txt_sparse)
+TEST(caffeapi, service_train_txt_sparse)
 {
   // create service
   JsonAPI japi;
   std::string n20_repo_loc = "n20";
-  mkdir(n20_repo_loc.c_str(),0777);
+  mkdir(n20_repo_loc.c_str(), 0777);
   std::string sname = "my_service";
-  std::string jstr = "{\"mllib\":\"caffe\",\"description\":\"my classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\"" +  n20_repo_loc + "\",\"templates\":\"" + model_templates_repo  + "\"},\"parameters\":{\"input\":{\"connector\":\"txt\",\"sparse\":true},\"mllib\":{\"gpu\":true,\"gpuid\":"+gpuid+",\"template\":\"mlp\",\"nclasses\":20,\"db\":false}}}";
-  std::string joutstr = japi.jrender(japi.service_create(sname,jstr));
-  ASSERT_EQ(created_str,joutstr);
+  std::string jstr
+      = "{\"mllib\":\"caffe\",\"description\":\"my "
+        "classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\""
+        + n20_repo_loc + "\",\"templates\":\"" + model_templates_repo
+        + "\"},\"parameters\":{\"input\":{\"connector\":\"txt\",\"sparse\":"
+          "true},\"mllib\":{\"gpu\":true,\"gpuid\":"
+        + gpuid + ",\"template\":\"mlp\",\"nclasses\":20,\"db\":false}}}";
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
 
   // train
-  std::string jtrainstr = "{\"service\":\"" + sname + "\",\"async\":false,\"parameters\":{\"input\":{\"test_split\":0.2,\"shuffle\":true,\"min_count\":10,\"min_word_length\":3,\"count\":false,\"db\":false},\"mllib\":{\"gpu\":true,\"gpuid\":"+gpuid+",\"solver\":{\"iterations\":" + iterations_n20 + ",\"test_interval\":200,\"base_lr\":0.01,\"snapshot\":2000,\"test_initialization\":true},\"net\":{\"batch_size\":100}},\"output\":{\"measure\":[\"acc\",\"mcll\",\"f1\",\"cmdiag\"]}},\"data\":[\"" + n20_repo + "news20\"]}";
+  std::string jtrainstr
+      = "{\"service\":\"" + sname
+        + "\",\"async\":false,\"parameters\":{\"input\":{\"test_split\":0.2,"
+          "\"shuffle\":true,\"min_count\":10,\"min_word_length\":3,\"count\":"
+          "false,\"db\":false},\"mllib\":{\"gpu\":true,\"gpuid\":"
+        + gpuid + ",\"solver\":{\"iterations\":" + iterations_n20
+        + ",\"test_interval\":200,\"base_lr\":0.01,\"snapshot\":2000,\"test_"
+          "initialization\":true},\"net\":{\"batch_size\":100}},\"output\":{"
+          "\"measure\":[\"acc\",\"mcll\",\"f1\",\"cmdiag\"]}},\"data\":[\""
+        + n20_repo + "news20\"]}";
   joutstr = japi.jrender(japi.service_train(jtrainstr));
   std::cout << "joutstr=" << joutstr << std::endl;
   JDoc jd;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_TRUE(jd.HasMember("status"));
-  ASSERT_EQ(201,jd["status"]["code"].GetInt());
-  ASSERT_EQ("Created",jd["status"]["msg"]);
+  ASSERT_EQ(201, jd["status"]["code"].GetInt());
+  ASSERT_EQ("Created", jd["status"]["msg"]);
   ASSERT_TRUE(jd.HasMember("head"));
-  ASSERT_EQ("/train",jd["head"]["method"]);
+  ASSERT_EQ("/train", jd["head"]["method"]);
   ASSERT_TRUE(jd["head"]["time"].GetDouble() >= 0);
   ASSERT_TRUE(jd.HasMember("body"));
   ASSERT_TRUE(jd["body"]["measure"].HasMember("train_loss"));
   ASSERT_TRUE(fabs(jd["body"]["measure"]["train_loss"].GetDouble()) > 0);
   ASSERT_TRUE(jd["body"]["measure"].HasMember("f1"));
   ASSERT_TRUE(jd["body"]["measure"]["acc"].GetDouble() >= 0.5);
-  ASSERT_EQ(jd["body"]["measure"]["accp"].GetDouble(),jd["body"]["measure"]["acc"].GetDouble());
+  ASSERT_EQ(jd["body"]["measure"]["accp"].GetDouble(),
+            jd["body"]["measure"]["acc"].GetDouble());
 
   // predict with measure
-  std::string jpredictstr = "{\"service\":\"" + sname + "\",\"parameters\":{\"mllib\":{\"gpu\":true,\"gpuid\":"+gpuid+",\"net\":{\"test_batch_size\":10}},\"output\":{\"measure\":[\"f1\"]}},\"data\":[\"" + n20_repo +"news20\"]}";
+  std::string jpredictstr
+      = "{\"service\":\"" + sname
+        + "\",\"parameters\":{\"mllib\":{\"gpu\":true,\"gpuid\":" + gpuid
+        + ",\"net\":{\"test_batch_size\":10}},\"output\":{\"measure\":[\"f1\"]"
+          "}},\"data\":[\""
+        + n20_repo + "news20\"]}";
   joutstr = japi.jrender(japi.service_predict(jpredictstr));
   std::cout << "joutstr=" << joutstr << std::endl;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_TRUE(jd.HasMember("status"));
-  ASSERT_EQ(200,jd["status"]["code"].GetInt());
-  ASSERT_TRUE(jd.HasMember("body"));
-  ASSERT_TRUE(jd["body"].HasMember("measure"));
-  ASSERT_TRUE(jd["body"]["measure"]["f1"].GetDouble() >= 0.6);
-  ASSERT_TRUE(jd["body"]["measure"]["f1"].GetDouble() <= 1.0);
-
-  // remove service
-  jstr = "{\"clear\":\"full\"}";
-  joutstr = japi.jrender(japi.service_delete(sname,jstr));
-  ASSERT_EQ(ok_str,joutstr);
-  rmdir(n20_repo_loc.c_str());
-}
-
-TEST(caffeapi,service_train_txt_sparse_lr)
-{
-  // create service
-  JsonAPI japi;
-  std::string n20_repo_loc = "n20";
-  mkdir(n20_repo_loc.c_str(),0777);
-  std::string sname = "my_service";
-  std::string jstr = "{\"mllib\":\"caffe\",\"description\":\"my classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\"" +  n20_repo_loc + "\",\"templates\":\"" + model_templates_repo  + "\"},\"parameters\":{\"input\":{\"connector\":\"txt\",\"sparse\":true},\"mllib\":{\"template\":\"lregression\",\"nclasses\":20,\"db\":true}}}";
-  std::string joutstr = japi.jrender(japi.service_create(sname,jstr));
-  ASSERT_EQ(created_str,joutstr);
-
-  // train
-  std::string jtrainstr = "{\"service\":\"" + sname + "\",\"async\":false,\"parameters\":{\"input\":{\"test_split\":0.2,\"shuffle\":true,\"min_count\":10,\"min_word_length\":3,\"count\":false,\"db\":true},\"mllib\":{\"gpu\":true,\"gpuid\":"+gpuid+",\"solver\":{\"iterations\":" + iterations_n20 + ",\"test_interval\":200,\"base_lr\":0.01,\"snapshot\":2000,\"test_initialization\":true},\"net\":{\"batch_size\":100}},\"output\":{\"measure\":[\"acc\",\"mcll\",\"f1\",\"cmdiag\"]}},\"data\":[\"" + n20_repo + "news20\"]}";
-  joutstr = japi.jrender(japi.service_train(jtrainstr));
-  std::cout << "joutstr=" << joutstr << std::endl;
-  JDoc jd;
-  jd.Parse(joutstr.c_str());
-  ASSERT_TRUE(!jd.HasParseError());
-  ASSERT_TRUE(jd.HasMember("status"));
-  ASSERT_EQ(201,jd["status"]["code"].GetInt());
-  ASSERT_EQ("Created",jd["status"]["msg"]);
-  ASSERT_TRUE(jd.HasMember("head"));
-  ASSERT_EQ("/train",jd["head"]["method"]);
-  ASSERT_TRUE(jd["head"]["time"].GetDouble() >= 0);
-  ASSERT_TRUE(jd.HasMember("body"));
-  ASSERT_TRUE(jd["body"]["measure"].HasMember("train_loss"));
-  ASSERT_TRUE(fabs(jd["body"]["measure"]["train_loss"].GetDouble()) > 0);
-  ASSERT_TRUE(jd["body"]["measure"].HasMember("f1"));
-  ASSERT_TRUE(jd["body"]["measure"]["acc"].GetDouble() >= 0.5);
-  ASSERT_EQ(jd["body"]["measure"]["accp"].GetDouble(),jd["body"]["measure"]["acc"].GetDouble());
-
-  // predict with measure
-  std::string jpredictstr = "{\"service\":\"" + sname + "\",\"parameters\":{\"mllib\":{\"gpu\":true,\"gpuid\":"+gpuid+",\"net\":{\"test_batch_size\":10}},\"output\":{\"measure\":[\"f1\"]}},\"data\":[\"" + n20_repo +"news20\"]}";
-  joutstr = japi.jrender(japi.service_predict(jpredictstr));
-  std::cout << "joutstr=" << joutstr << std::endl;
-  jd.Parse(joutstr.c_str());
-  ASSERT_TRUE(!jd.HasParseError());
-  ASSERT_TRUE(jd.HasMember("status"));
-  ASSERT_EQ(200,jd["status"]["code"].GetInt());
+  ASSERT_EQ(200, jd["status"]["code"].GetInt());
   ASSERT_TRUE(jd.HasMember("body"));
   ASSERT_TRUE(jd["body"].HasMember("measure"));
   ASSERT_TRUE(jd["body"]["measure"]["f1"].GetDouble() >= 0.6);
@@ -1317,100 +1914,223 @@ TEST(caffeapi,service_train_txt_sparse_lr)
 
   // remove service
   jstr = "{\"clear\":\"full\"}";
-  joutstr = japi.jrender(japi.service_delete(sname,jstr));
-  ASSERT_EQ(ok_str,joutstr);
+  joutstr = japi.jrender(japi.service_delete(sname, jstr));
+  ASSERT_EQ(ok_str, joutstr);
   rmdir(n20_repo_loc.c_str());
 }
 
-TEST(caffeapi,service_train_txt_char)
+TEST(caffeapi, service_train_txt_sparse_lr)
 {
   // create service
   JsonAPI japi;
   std::string n20_repo_loc = "n20";
-  mkdir(n20_repo_loc.c_str(),0777);
+  mkdir(n20_repo_loc.c_str(), 0777);
   std::string sname = "my_service";
-  std::string jstr = "{\"mllib\":\"caffe\",\"description\":\"my classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\"" +  n20_repo_loc + "\",\"templates\":\"" + model_templates_repo  + "\"},\"parameters\":{\"input\":{\"connector\":\"txt\",\"characters\":true,\"sequence\":50},\"mllib\":{\"template\":\"convnet\",\"layers\":[\"1CR16\",\"1CR16\",\"1CR16\",\"512\",\"512\"],\"nclasses\":20,\"db\":true}}}";
-  std::string joutstr = japi.jrender(japi.service_create(sname,jstr));
-  ASSERT_EQ(created_str,joutstr);
+  std::string jstr
+      = "{\"mllib\":\"caffe\",\"description\":\"my "
+        "classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\""
+        + n20_repo_loc + "\",\"templates\":\"" + model_templates_repo
+        + "\"},\"parameters\":{\"input\":{\"connector\":\"txt\",\"sparse\":"
+          "true},\"mllib\":{\"template\":\"lregression\",\"nclasses\":20,"
+          "\"db\":true}}}";
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
 
   // train
-  std::string jtrainstr = "{\"service\":\"" + sname + "\",\"async\":false,\"parameters\":{\"input\":{\"test_split\":0.2,\"shuffle\":true,\"characters\":true,\"sequence\":50,\"db\":true},\"mllib\":{\"gpu\":true,\"gpuid\":"+gpuid+",\"solver\":{\"iterations\":" + iterations_n20_char + ",\"test_interval\":30,\"base_lr\":0.01,\"snapshot\":2000,\"test_initialization\":true},\"net\":{\"batch_size\":100}},\"output\":{\"measure\":[\"acc\",\"mcll\",\"f1\"]}},\"data\":[\"" + n20_repo + "news20\"]}";
+  std::string jtrainstr
+      = "{\"service\":\"" + sname
+        + "\",\"async\":false,\"parameters\":{\"input\":{\"test_split\":0.2,"
+          "\"shuffle\":true,\"min_count\":10,\"min_word_length\":3,\"count\":"
+          "false,\"db\":true},\"mllib\":{\"gpu\":true,\"gpuid\":"
+        + gpuid + ",\"solver\":{\"iterations\":" + iterations_n20
+        + ",\"test_interval\":200,\"base_lr\":0.01,\"snapshot\":2000,\"test_"
+          "initialization\":true},\"net\":{\"batch_size\":100}},\"output\":{"
+          "\"measure\":[\"acc\",\"mcll\",\"f1\",\"cmdiag\"]}},\"data\":[\""
+        + n20_repo + "news20\"]}";
   joutstr = japi.jrender(japi.service_train(jtrainstr));
   std::cout << "joutstr=" << joutstr << std::endl;
   JDoc jd;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_TRUE(jd.HasMember("status"));
-  ASSERT_EQ(201,jd["status"]["code"].GetInt());
-  ASSERT_EQ("Created",jd["status"]["msg"]);
+  ASSERT_EQ(201, jd["status"]["code"].GetInt());
+  ASSERT_EQ("Created", jd["status"]["msg"]);
   ASSERT_TRUE(jd.HasMember("head"));
-  ASSERT_EQ("/train",jd["head"]["method"]);
+  ASSERT_EQ("/train", jd["head"]["method"]);
   ASSERT_TRUE(jd["head"]["time"].GetDouble() >= 0);
   ASSERT_TRUE(jd.HasMember("body"));
   ASSERT_TRUE(jd["body"]["measure"].HasMember("train_loss"));
   ASSERT_TRUE(fabs(jd["body"]["measure"]["train_loss"].GetDouble()) > 0);
   ASSERT_TRUE(jd["body"]["measure"].HasMember("f1"));
-  ASSERT_TRUE(jd["body"]["measure"]["acc"].GetDouble() > 0.0);
-  ASSERT_EQ(jd["body"]["measure"]["accp"].GetDouble(),jd["body"]["measure"]["acc"].GetDouble());
+  ASSERT_TRUE(jd["body"]["measure"]["acc"].GetDouble() >= 0.5);
+  ASSERT_EQ(jd["body"]["measure"]["accp"].GetDouble(),
+            jd["body"]["measure"]["acc"].GetDouble());
+
+  // predict with measure
+  std::string jpredictstr
+      = "{\"service\":\"" + sname
+        + "\",\"parameters\":{\"mllib\":{\"gpu\":true,\"gpuid\":" + gpuid
+        + ",\"net\":{\"test_batch_size\":10}},\"output\":{\"measure\":[\"f1\"]"
+          "}},\"data\":[\""
+        + n20_repo + "news20\"]}";
+  joutstr = japi.jrender(japi.service_predict(jpredictstr));
+  std::cout << "joutstr=" << joutstr << std::endl;
+  jd.Parse(joutstr.c_str());
+  ASSERT_TRUE(!jd.HasParseError());
+  ASSERT_TRUE(jd.HasMember("status"));
+  ASSERT_EQ(200, jd["status"]["code"].GetInt());
+  ASSERT_TRUE(jd.HasMember("body"));
+  ASSERT_TRUE(jd["body"].HasMember("measure"));
+  ASSERT_TRUE(jd["body"]["measure"]["f1"].GetDouble() >= 0.6);
+  ASSERT_TRUE(jd["body"]["measure"]["f1"].GetDouble() <= 1.0);
 
   // remove service
   jstr = "{\"clear\":\"full\"}";
-  joutstr = japi.jrender(japi.service_delete(sname,jstr));
-  ASSERT_EQ(ok_str,joutstr);
+  joutstr = japi.jrender(japi.service_delete(sname, jstr));
+  ASSERT_EQ(ok_str, joutstr);
   rmdir(n20_repo_loc.c_str());
 }
 
-TEST(caffeapi,service_train_txt_char_resnet)
+TEST(caffeapi, service_train_txt_char)
 {
   // create service
   JsonAPI japi;
   std::string n20_repo_loc = "n20";
-  mkdir(n20_repo_loc.c_str(),0777);
+  mkdir(n20_repo_loc.c_str(), 0777);
   std::string sname = "my_service";
-  std::string jstr = "{\"mllib\":\"caffe\",\"description\":\"my classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\"" +  n20_repo_loc + "\",\"templates\":\"" + model_templates_repo  + "\"},\"parameters\":{\"input\":{\"connector\":\"txt\",\"characters\":true,\"sequence\":50},\"mllib\":{\"template\":\"resnet\",\"layers\":[\"1CR16\",\"1CR16\",\"1CR16\",\"512\",\"512\"],\"nclasses\":20,\"db\":true}}}";
-  std::string joutstr = japi.jrender(japi.service_create(sname,jstr));
-  ASSERT_EQ(created_str,joutstr);
+  std::string jstr
+      = "{\"mllib\":\"caffe\",\"description\":\"my "
+        "classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\""
+        + n20_repo_loc + "\",\"templates\":\"" + model_templates_repo
+        + "\"},\"parameters\":{\"input\":{\"connector\":\"txt\","
+          "\"characters\":true,\"sequence\":50},\"mllib\":{\"template\":"
+          "\"convnet\",\"layers\":[\"1CR16\",\"1CR16\",\"1CR16\",\"512\","
+          "\"512\"],\"nclasses\":20,\"db\":true}}}";
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
 
   // train
-  std::string jtrainstr = "{\"service\":\"" + sname + "\",\"async\":false,\"parameters\":{\"input\":{\"test_split\":0.2,\"shuffle\":true,\"characters\":true,\"sequence\":50,\"db\":true},\"mllib\":{\"gpu\":true,\"gpuid\":"+gpuid+",\"solver\":{\"iterations\":" + iterations_n20_char + ",\"test_interval\":30,\"base_lr\":0.001,\"snapshot\":2000,\"test_initialization\":true},\"net\":{\"batch_size\":100}},\"output\":{\"measure\":[\"acc\",\"mcll\",\"f1\"]}},\"data\":[\"" + n20_repo + "news20\"]}";
+  std::string jtrainstr
+      = "{\"service\":\"" + sname
+        + "\",\"async\":false,\"parameters\":{\"input\":{\"test_split\":0.2,"
+          "\"shuffle\":true,\"characters\":true,\"sequence\":50,\"db\":true},"
+          "\"mllib\":{\"gpu\":true,\"gpuid\":"
+        + gpuid + ",\"solver\":{\"iterations\":" + iterations_n20_char
+        + ",\"test_interval\":30,\"base_lr\":0.01,\"snapshot\":2000,\"test_"
+          "initialization\":true},\"net\":{\"batch_size\":100}},\"output\":{"
+          "\"measure\":[\"acc\",\"mcll\",\"f1\"]}},\"data\":[\""
+        + n20_repo + "news20\"]}";
   joutstr = japi.jrender(japi.service_train(jtrainstr));
   std::cout << "joutstr=" << joutstr << std::endl;
   JDoc jd;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_TRUE(jd.HasMember("status"));
-  ASSERT_EQ(201,jd["status"]["code"].GetInt());
-  ASSERT_EQ("Created",jd["status"]["msg"]);
+  ASSERT_EQ(201, jd["status"]["code"].GetInt());
+  ASSERT_EQ("Created", jd["status"]["msg"]);
   ASSERT_TRUE(jd.HasMember("head"));
-  ASSERT_EQ("/train",jd["head"]["method"]);
+  ASSERT_EQ("/train", jd["head"]["method"]);
   ASSERT_TRUE(jd["head"]["time"].GetDouble() >= 0);
   ASSERT_TRUE(jd.HasMember("body"));
   ASSERT_TRUE(jd["body"]["measure"].HasMember("train_loss"));
   ASSERT_TRUE(fabs(jd["body"]["measure"]["train_loss"].GetDouble()) > 0);
   ASSERT_TRUE(jd["body"]["measure"].HasMember("f1"));
   ASSERT_TRUE(jd["body"]["measure"]["acc"].GetDouble() > 0.0);
-  ASSERT_EQ(jd["body"]["measure"]["accp"].GetDouble(),jd["body"]["measure"]["acc"].GetDouble());
+  ASSERT_EQ(jd["body"]["measure"]["accp"].GetDouble(),
+            jd["body"]["measure"]["acc"].GetDouble());
 
   // remove service
   jstr = "{\"clear\":\"full\"}";
-  joutstr = japi.jrender(japi.service_delete(sname,jstr));
-  ASSERT_EQ(ok_str,joutstr);
+  joutstr = japi.jrender(japi.service_delete(sname, jstr));
+  ASSERT_EQ(ok_str, joutstr);
   rmdir(n20_repo_loc.c_str());
 }
 
-TEST(caffeapi,service_train_csv_mt_regression)
+TEST(caffeapi, service_train_txt_char_resnet)
+{
+  // create service
+  JsonAPI japi;
+  std::string n20_repo_loc = "n20";
+  mkdir(n20_repo_loc.c_str(), 0777);
+  std::string sname = "my_service";
+  std::string jstr
+      = "{\"mllib\":\"caffe\",\"description\":\"my "
+        "classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\""
+        + n20_repo_loc + "\",\"templates\":\"" + model_templates_repo
+        + "\"},\"parameters\":{\"input\":{\"connector\":\"txt\","
+          "\"characters\":true,\"sequence\":50},\"mllib\":{\"template\":"
+          "\"resnet\",\"layers\":[\"1CR16\",\"1CR16\",\"1CR16\",\"512\","
+          "\"512\"],\"nclasses\":20,\"db\":true}}}";
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
+
+  // train
+  std::string jtrainstr
+      = "{\"service\":\"" + sname
+        + "\",\"async\":false,\"parameters\":{\"input\":{\"test_split\":0.2,"
+          "\"shuffle\":true,\"characters\":true,\"sequence\":50,\"db\":true},"
+          "\"mllib\":{\"gpu\":true,\"gpuid\":"
+        + gpuid + ",\"solver\":{\"iterations\":" + iterations_n20_char
+        + ",\"test_interval\":30,\"base_lr\":0.001,\"snapshot\":2000,\"test_"
+          "initialization\":true},\"net\":{\"batch_size\":100}},\"output\":{"
+          "\"measure\":[\"acc\",\"mcll\",\"f1\"]}},\"data\":[\""
+        + n20_repo + "news20\"]}";
+  joutstr = japi.jrender(japi.service_train(jtrainstr));
+  std::cout << "joutstr=" << joutstr << std::endl;
+  JDoc jd;
+  jd.Parse(joutstr.c_str());
+  ASSERT_TRUE(!jd.HasParseError());
+  ASSERT_TRUE(jd.HasMember("status"));
+  ASSERT_EQ(201, jd["status"]["code"].GetInt());
+  ASSERT_EQ("Created", jd["status"]["msg"]);
+  ASSERT_TRUE(jd.HasMember("head"));
+  ASSERT_EQ("/train", jd["head"]["method"]);
+  ASSERT_TRUE(jd["head"]["time"].GetDouble() >= 0);
+  ASSERT_TRUE(jd.HasMember("body"));
+  ASSERT_TRUE(jd["body"]["measure"].HasMember("train_loss"));
+  ASSERT_TRUE(fabs(jd["body"]["measure"]["train_loss"].GetDouble()) > 0);
+  ASSERT_TRUE(jd["body"]["measure"].HasMember("f1"));
+  ASSERT_TRUE(jd["body"]["measure"]["acc"].GetDouble() > 0.0);
+  ASSERT_EQ(jd["body"]["measure"]["accp"].GetDouble(),
+            jd["body"]["measure"]["acc"].GetDouble());
+
+  // remove service
+  jstr = "{\"clear\":\"full\"}";
+  joutstr = japi.jrender(japi.service_delete(sname, jstr));
+  ASSERT_EQ(ok_str, joutstr);
+  rmdir(n20_repo_loc.c_str());
+}
+
+TEST(caffeapi, service_train_csv_mt_regression)
 {
   // create service
   JsonAPI japi;
   std::string sflare_repo_loc = "sflare";
-  mkdir(sflare_repo_loc.c_str(),0777);
+  mkdir(sflare_repo_loc.c_str(), 0777);
   std::string sname = "my_service";
-  std::string jstr = "{\"mllib\":\"caffe\",\"description\":\"my classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\"" +  sflare_repo_loc + "\",\"templates\":\"" + model_templates_repo  + "\"},\"parameters\":{\"input\":{\"connector\":\"csv\"},\"mllib\":{\"template\":\"mlp\",\"regression\":true,\"ntargets\":3,\"layers\":[150,150]}}}";
-  std::string joutstr = japi.jrender(japi.service_create(sname,jstr));
-  ASSERT_EQ(created_str,joutstr);
+  std::string jstr
+      = "{\"mllib\":\"caffe\",\"description\":\"my "
+        "classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\""
+        + sflare_repo_loc + "\",\"templates\":\"" + model_templates_repo
+        + "\"},\"parameters\":{\"input\":{\"connector\":\"csv\"},\"mllib\":{"
+          "\"template\":\"mlp\",\"regression\":true,\"ntargets\":3,\"layers\":"
+          "[150,150]}}}";
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
 
   // train
-  std::string jtrainstr = "{\"service\":\"" + sname + "\",\"async\":false,\"parameters\":{\"input\":{\"test_split\":0.1,\"shuffle\":true,\"label\":[\"c_class\",\"m_class\",\"x_class\"],\"separator\":\",\",\"scale\":true,\"categoricals\":[\"class_code\",\"code_spot\",\"code_spot_distr\"]},\"mllib\":{\"gpu\":true,\"gpuid\":"+gpuid+",\"solver\":{\"iterations\":" + iterations_sflare + ",\"test_interval\":200,\"base_lr\":0.001,\"snapshot\":2000,\"test_initialization\":true},\"net\":{\"batch_size\":100}},\"output\":{\"measure\":[\"eucll\"]}},\"data\":[\"" + sflare_repo + "flare.csv\"]}";
+  std::string jtrainstr
+      = "{\"service\":\"" + sname
+        + "\",\"async\":false,\"parameters\":{\"input\":{\"test_split\":0.1,"
+          "\"shuffle\":true,\"label\":[\"c_class\",\"m_class\",\"x_class\"],"
+          "\"separator\":\",\",\"scale\":true,\"categoricals\":[\"class_"
+          "code\",\"code_spot\",\"code_spot_distr\"]},\"mllib\":{\"gpu\":true,"
+          "\"gpuid\":"
+        + gpuid + ",\"solver\":{\"iterations\":" + iterations_sflare
+        + ",\"test_interval\":200,\"base_lr\":0.001,\"snapshot\":2000,\"test_"
+          "initialization\":true},\"net\":{\"batch_size\":100}},\"output\":{"
+          "\"measure\":[\"eucll\"]}},\"data\":[\""
+        + sflare_repo + "flare.csv\"]}";
   std::cerr << "jtrainstr=" << jtrainstr << std::endl;
   joutstr = japi.jrender(japi.service_train(jtrainstr));
   std::cout << "joutstr=" << joutstr << std::endl;
@@ -1418,10 +2138,10 @@ TEST(caffeapi,service_train_csv_mt_regression)
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_TRUE(jd.HasMember("status"));
-  ASSERT_EQ(201,jd["status"]["code"].GetInt());
-  ASSERT_EQ("Created",jd["status"]["msg"]);
+  ASSERT_EQ(201, jd["status"]["code"].GetInt());
+  ASSERT_EQ("Created", jd["status"]["msg"]);
   ASSERT_TRUE(jd.HasMember("head"));
-  ASSERT_EQ("/train",jd["head"]["method"]);
+  ASSERT_EQ("/train", jd["head"]["method"]);
   ASSERT_TRUE(jd["head"]["time"].GetDouble() >= 0);
   ASSERT_TRUE(jd.HasMember("body"));
   ASSERT_TRUE(jd["body"]["measure"].HasMember("train_loss"));
@@ -1431,49 +2151,77 @@ TEST(caffeapi,service_train_csv_mt_regression)
   ASSERT_TRUE(jd["body"]["parameters"]["input"].HasMember("max_vals"));
   ASSERT_TRUE(jd["body"]["parameters"]["input"].HasMember("min_vals"));
 
-  std::string str_min_vals = japi.jrender(jd["body"]["parameters"]["input"]["min_vals"]);
-  std::string str_max_vals = japi.jrender(jd["body"]["parameters"]["input"]["max_vals"]);
-  std::string str_categoricals = japi.jrender(jd["body"]["parameters"]["input"]["categoricals_mapping"]);
+  std::string str_min_vals
+      = japi.jrender(jd["body"]["parameters"]["input"]["min_vals"]);
+  std::string str_max_vals
+      = japi.jrender(jd["body"]["parameters"]["input"]["max_vals"]);
+  std::string str_categoricals = japi.jrender(
+      jd["body"]["parameters"]["input"]["categoricals_mapping"]);
   std::cerr << "categoricals=" << str_categoricals << std::endl;
-  
+
   // predict
-  std::string sflare_data_head = "class_code,code_spot,code_spot_distr,act,evo,prev_act,hist,reg,area,larg_area,x,y,z";
+  std::string sflare_data_head = "class_code,code_spot,code_spot_distr,act,"
+                                 "evo,prev_act,hist,reg,area,larg_area,x,y,z";
   std::string sflare_data = "B,X,O,1,2,1,1,2,1,1,0,0,0";
-  std::string jpredictstr = "{\"service\":\""+ sname + "\",\"parameters\":{\"input\":{\"connector\":\"csv\",\"scale\":true,\"min_vals\":" + str_min_vals + ",\"max_vals\":" + str_max_vals + ",\"categoricals_mapping\":" + str_categoricals + "},\"output\":{}},\"data\":[\"" + sflare_data_head + "\",\"" + sflare_data + "\"]}";
+  std::string jpredictstr = "{\"service\":\"" + sname
+                            + "\",\"parameters\":{\"input\":{\"connector\":"
+                              "\"csv\",\"scale\":true,\"min_vals\":"
+                            + str_min_vals + ",\"max_vals\":" + str_max_vals
+                            + ",\"categoricals_mapping\":" + str_categoricals
+                            + "},\"output\":{}},\"data\":[\""
+                            + sflare_data_head + "\",\"" + sflare_data
+                            + "\"]}";
   joutstr = japi.jrender(japi.service_predict(jpredictstr));
   std::cout << "joutstr=" << joutstr << std::endl;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
-  ASSERT_EQ(200,jd["status"]["code"]);
+  ASSERT_EQ(200, jd["status"]["code"]);
   std::string uri = jd["body"]["predictions"][0]["uri"].GetString();
-  ASSERT_EQ("1",uri);
+  ASSERT_EQ("1", uri);
   ASSERT_TRUE(jd["body"]["predictions"][0]["vector"].IsArray());
-  ASSERT_TRUE(jd["body"]["predictions"][0]["vector"][0]["val"].GetDouble() > 0.0);
-  
+  ASSERT_TRUE(jd["body"]["predictions"][0]["vector"][0]["val"].GetDouble()
+              > 0.0);
+
   // remove service
   jstr = "{\"clear\":\"full\"}";
-  joutstr = japi.jrender(japi.service_delete(sname,jstr));
-  ASSERT_EQ(ok_str,joutstr);
+  joutstr = japi.jrender(japi.service_delete(sname, jstr));
+  ASSERT_EQ(ok_str, joutstr);
   rmdir(sflare_repo_loc.c_str());
 }
 
-
-TEST(caffeapi,service_train_csvts_lstm)
+TEST(caffeapi, service_train_csvts_lstm)
 {
   // create service
   JsonAPI japi;
   std::string csvts_data = sinus + "train";
-  std::string csvts_test = sinus +"test";
-  std::string csvts_predict = sinus +"predict";
+  std::string csvts_test = sinus + "test";
+  std::string csvts_predict = sinus + "predict";
   std::string csvts_repo = "csvts";
-  mkdir(csvts_repo.c_str(),0777);
+  mkdir(csvts_repo.c_str(), 0777);
   std::string sname = "my_service_csvts";
-  std::string jstr = "{\"mllib\":\"caffe\",\"description\":\"my ts regressor\",\"type\":\"supervised\",\"model\":{\"repository\":\"" +  csvts_repo+"\",\"templates\":\"" + model_templates_repo + "\"},\"parameters\":{\"input\":{\"connector\":\"csvts\",\"label\":[\"output\"]},\"mllib\":{\"template\":\"recurrent\",\"layers\":[\"L10\",\"L10\"],\"dropout\":[0.0,0.0,0.0],\"regression\":true,\"sl1sigma\":100.0,\"loss\":\"L1\"}}}";
-  std::string joutstr = japi.jrender(japi.service_create(sname,jstr));
-  ASSERT_EQ(created_str,joutstr);
+  std::string jstr
+      = "{\"mllib\":\"caffe\",\"description\":\"my ts "
+        "regressor\",\"type\":\"supervised\",\"model\":{\"repository\":\""
+        + csvts_repo + "\",\"templates\":\"" + model_templates_repo
+        + "\"},\"parameters\":{\"input\":{\"connector\":\"csvts\",\"label\":["
+          "\"output\"]},\"mllib\":{\"template\":\"recurrent\",\"layers\":["
+          "\"L10\",\"L10\"],\"dropout\":[0.0,0.0,0.0],\"regression\":true,"
+          "\"sl1sigma\":100.0,\"loss\":\"L1\"}}}";
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
 
   // train
-  std::string jtrainstr = "{\"service\":\"" + sname + "\",\"async\":false,\"parameters\":{\"input\":{\"shuffle\":true,\"separator\":\",\",\"scale\":true},\"mllib\":{\"gpu\":true,\"gpuid\":"+gpuid+",\"timesteps\":20,\"solver\":{\"iterations\":" + iterations_lstm + ",\"test_interval\":500,\"base_lr\":0.001,\"snapshot\":500,\"test_initialization\":false},\"net\":{\"batch_size\":100}},\"output\":{\"measure\":[\"L1\",\"L2\"]}},\"data\":[\"" + csvts_data+"\",\""+csvts_test+"\"]}";
+  std::string jtrainstr
+      = "{\"service\":\"" + sname
+        + "\",\"async\":false,\"parameters\":{\"input\":{\"shuffle\":true,"
+          "\"separator\":\",\",\"scale\":true},\"mllib\":{\"gpu\":true,"
+          "\"gpuid\":"
+        + gpuid
+        + ",\"timesteps\":20,\"solver\":{\"iterations\":" + iterations_lstm
+        + ",\"test_interval\":500,\"base_lr\":0.001,\"snapshot\":500,\"test_"
+          "initialization\":false},\"net\":{\"batch_size\":100}},\"output\":{"
+          "\"measure\":[\"L1\",\"L2\"]}},\"data\":[\""
+        + csvts_data + "\",\"" + csvts_test + "\"]}";
   std::cerr << "jtrainstr=" << jtrainstr << std::endl;
   joutstr = japi.jrender(japi.service_train(jtrainstr));
   std::cout << "joutstr=" << joutstr << std::endl;
@@ -1481,10 +2229,10 @@ TEST(caffeapi,service_train_csvts_lstm)
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_TRUE(jd.HasMember("status"));
-  ASSERT_EQ(201,jd["status"]["code"].GetInt());
-  ASSERT_EQ("Created",jd["status"]["msg"]);
+  ASSERT_EQ(201, jd["status"]["code"].GetInt());
+  ASSERT_EQ("Created", jd["status"]["msg"]);
   ASSERT_TRUE(jd.HasMember("head"));
-  ASSERT_EQ("/train",jd["head"]["method"]);
+  ASSERT_EQ("/train", jd["head"]["method"]);
   ASSERT_TRUE(jd["head"]["time"].GetDouble() >= 0);
   ASSERT_TRUE(jd.HasMember("body"));
   ASSERT_TRUE(jd["body"]["measure"].HasMember("train_loss"));
@@ -1494,45 +2242,69 @@ TEST(caffeapi,service_train_csvts_lstm)
   ASSERT_TRUE(jd["body"]["parameters"]["input"].HasMember("max_vals"));
   ASSERT_TRUE(jd["body"]["parameters"]["input"].HasMember("min_vals"));
 
-  std::string str_min_vals = japi.jrender(jd["body"]["parameters"]["input"]["min_vals"]);
-  std::string str_max_vals = japi.jrender(jd["body"]["parameters"]["input"]["max_vals"]);
+  std::string str_min_vals
+      = japi.jrender(jd["body"]["parameters"]["input"]["min_vals"]);
+  std::string str_max_vals
+      = japi.jrender(jd["body"]["parameters"]["input"]["max_vals"]);
 
   //  predict
-  std::string jpredictstr = "{\"service\":\""+ sname + "\",\"parameters\":{\"input\":{\"timesteps\":20,\"connector\":\"csvts\",\"scale\":true,\"min_vals\":" + str_min_vals + ",\"max_vals\":" + str_max_vals + "},\"output\":{}},\"data\":[\"" + csvts_predict + "\"]}";
+  std::string jpredictstr
+      = "{\"service\":\"" + sname
+        + "\",\"parameters\":{\"input\":{\"timesteps\":20,\"connector\":"
+          "\"csvts\",\"scale\":true,\"min_vals\":"
+        + str_min_vals + ",\"max_vals\":" + str_max_vals
+        + "},\"output\":{}},\"data\":[\"" + csvts_predict + "\"]}";
   joutstr = japi.jrender(japi.service_predict(jpredictstr));
   std::cout << "joutstr=" << joutstr << std::endl;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
-  ASSERT_EQ(200,jd["status"]["code"]);
+  ASSERT_EQ(200, jd["status"]["code"]);
   std::string uri = jd["body"]["predictions"][0]["uri"].GetString();
-  ASSERT_EQ("../examples/all/sinus/predict/seq_2.csv",uri);
+  ASSERT_EQ("../examples/all/sinus/predict/seq_2.csv", uri);
   ASSERT_TRUE(jd["body"]["predictions"][0]["series"].IsArray());
-  ASSERT_TRUE(jd["body"]["predictions"][0]["series"][0]["out"][0].GetDouble() >= -1.0);
+  ASSERT_TRUE(jd["body"]["predictions"][0]["series"][0]["out"][0].GetDouble()
+              >= -1.0);
 
   //  remove service
   jstr = "{\"clear\":\"full\"}";
-  joutstr = japi.jrender(japi.service_delete(sname,jstr));
-  ASSERT_EQ(ok_str,joutstr);
+  joutstr = japi.jrender(japi.service_delete(sname, jstr));
+  ASSERT_EQ(ok_str, joutstr);
   rmdir(csvts_repo.c_str());
 }
 
-
-TEST(caffeapi,service_train_csvts_db_lstm)
+TEST(caffeapi, service_train_csvts_db_lstm)
 {
   // create service
   JsonAPI japi;
   std::string csvts_data = sinus + "train";
-  std::string csvts_test = sinus +"test";
-  std::string csvts_predict = sinus +"predict";
+  std::string csvts_test = sinus + "test";
+  std::string csvts_predict = sinus + "predict";
   std::string csvts_repo = "csvts_db";
-  mkdir(csvts_repo.c_str(),0777);
+  mkdir(csvts_repo.c_str(), 0777);
   std::string sname = "my_service_csvts";
-  std::string jstr = "{\"mllib\":\"caffe\",\"description\":\"my ts regressor\",\"type\":\"supervised\",\"model\":{\"repository\":\"" +  csvts_repo+"\",\"templates\":\"" + model_templates_repo+  "\"},\"parameters\":{\"input\":{\"connector\":\"csvts\",\"db\":true,\"label\":[\"output\"]},\"mllib\":{\"template\":\"recurrent\",\"layers\":[\"L10\",\"L10\"],\"dropout\":[0.0,0.0],\"regression\":true,\"loss\":\"L1\",\"db\":true}}}";
-  std::string joutstr = japi.jrender(japi.service_create(sname,jstr));
-  ASSERT_EQ(created_str,joutstr);
+  std::string jstr
+      = "{\"mllib\":\"caffe\",\"description\":\"my ts "
+        "regressor\",\"type\":\"supervised\",\"model\":{\"repository\":\""
+        + csvts_repo + "\",\"templates\":\"" + model_templates_repo
+        + "\"},\"parameters\":{\"input\":{\"connector\":\"csvts\",\"db\":true,"
+          "\"label\":[\"output\"]},\"mllib\":{\"template\":\"recurrent\","
+          "\"layers\":[\"L10\",\"L10\"],\"dropout\":[0.0,0.0],\"regression\":"
+          "true,\"loss\":\"L1\",\"db\":true}}}";
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
 
   // train
-  std::string jtrainstr = "{\"service\":\"" + sname + "\",\"async\":false,\"parameters\":{\"input\":{\"shuffle\":true,\"separator\":\",\",\"scale\":false,\"db\":true},\"mllib\":{\"db\":true,\"gpu\":true,\"gpuid\":"+gpuid+",\"timesteps\":20,\"solver\":{\"iterations\":" + iterations_lstm + ",\"test_interval\":500,\"base_lr\":0.001,\"snapshot\":500,\"test_initialization\":false},\"net\":{\"batch_size\":10}},\"output\":{\"measure\":[\"L1\",\"L2\"]}},\"data\":[\"" + csvts_data+"\",\""+csvts_test+"\"]}";
+  std::string jtrainstr
+      = "{\"service\":\"" + sname
+        + "\",\"async\":false,\"parameters\":{\"input\":{\"shuffle\":true,"
+          "\"separator\":\",\",\"scale\":false,\"db\":true},\"mllib\":{\"db\":"
+          "true,\"gpu\":true,\"gpuid\":"
+        + gpuid
+        + ",\"timesteps\":20,\"solver\":{\"iterations\":" + iterations_lstm
+        + ",\"test_interval\":500,\"base_lr\":0.001,\"snapshot\":500,\"test_"
+          "initialization\":false},\"net\":{\"batch_size\":10}},\"output\":{"
+          "\"measure\":[\"L1\",\"L2\"]}},\"data\":[\""
+        + csvts_data + "\",\"" + csvts_test + "\"]}";
   std::cerr << "jtrainstr=" << jtrainstr << std::endl;
   joutstr = japi.jrender(japi.service_train(jtrainstr));
   std::cout << "joutstr=" << joutstr << std::endl;
@@ -1540,10 +2312,10 @@ TEST(caffeapi,service_train_csvts_db_lstm)
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_TRUE(jd.HasMember("status"));
-  ASSERT_EQ(201,jd["status"]["code"].GetInt());
-  ASSERT_EQ("Created",jd["status"]["msg"]);
+  ASSERT_EQ(201, jd["status"]["code"].GetInt());
+  ASSERT_EQ("Created", jd["status"]["msg"]);
   ASSERT_TRUE(jd.HasMember("head"));
-  ASSERT_EQ("/train",jd["head"]["method"]);
+  ASSERT_EQ("/train", jd["head"]["method"]);
   ASSERT_TRUE(jd["head"]["time"].GetDouble() >= 0);
   ASSERT_TRUE(jd.HasMember("body"));
   ASSERT_TRUE(jd["body"]["measure"].HasMember("train_loss"));
@@ -1551,22 +2323,26 @@ TEST(caffeapi,service_train_csvts_db_lstm)
   ASSERT_TRUE(jd["body"]["measure"].HasMember("L1_max_error"));
   ASSERT_TRUE(jd["body"]["measure"]["L1_mean_error"].GetDouble() > 0.0);
 
-
   // predict
-  std::string jpredictstr = "{\"service\":\""+ sname + "\",\"parameters\":{\"input\":{\"connector\":\"csvts\",\"scale\":false,\"timesteps\":20},\"output\":{}},\"data\":[\"" + csvts_predict + "\"]}";
+  std::string jpredictstr
+      = "{\"service\":\"" + sname
+        + "\",\"parameters\":{\"input\":{\"connector\":\"csvts\",\"scale\":"
+          "false,\"timesteps\":20},\"output\":{}},\"data\":[\""
+        + csvts_predict + "\"]}";
   joutstr = japi.jrender(japi.service_predict(jpredictstr));
   std::cout << "joutstr=" << joutstr << std::endl;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
-  ASSERT_EQ(200,jd["status"]["code"]);
+  ASSERT_EQ(200, jd["status"]["code"]);
   std::string uri = jd["body"]["predictions"][0]["uri"].GetString();
-  ASSERT_EQ("../examples/all/sinus/predict/seq_2.csv",uri);
+  ASSERT_EQ("../examples/all/sinus/predict/seq_2.csv", uri);
   ASSERT_TRUE(jd["body"]["predictions"][0]["series"].IsArray());
-  ASSERT_TRUE(jd["body"]["predictions"][0]["series"][0]["out"][0].GetDouble() >= -1.0);
+  ASSERT_TRUE(jd["body"]["predictions"][0]["series"][0]["out"][0].GetDouble()
+              >= -1.0);
 
   //  remove service
   jstr = "{\"clear\":\"full\"}";
-  joutstr = japi.jrender(japi.service_delete(sname,jstr));
-  ASSERT_EQ(ok_str,joutstr);
+  joutstr = japi.jrender(japi.service_delete(sname, jstr));
+  ASSERT_EQ(ok_str, joutstr);
   rmdir(csvts_repo.c_str());
 }

--- a/tests/ut-conn.cc
+++ b/tests/ut-conn.cc
@@ -31,48 +31,49 @@
 
 using namespace dd;
 
-TEST(outputconn,mlsoft)
+TEST(outputconn, mlsoft)
 {
-  std::vector<double> targets = {0.1, 0.6, 0.0, 0.9};
-  std::vector<double> preds = {0.0, 0.5, 0.1, 0.9};
+  std::vector<double> targets = { 0.1, 0.6, 0.0, 0.9 };
+  std::vector<double> preds = { 0.0, 0.5, 0.1, 0.9 };
   APIData res_ad;
-  res_ad.add("batch_size",2);
-  for (size_t i=0;i<2;i++)
+  res_ad.add("batch_size", 2);
+  for (size_t i = 0; i < 2; i++)
     {
       APIData bad;
-      bad.add("pred",preds);
-      bad.add("target",targets);
-      std::vector<APIData> vad = {bad};
-      res_ad.add(std::to_string(i),vad);
+      bad.add("pred", preds);
+      bad.add("target", targets);
+      std::vector<APIData> vad = { bad };
+      res_ad.add(std::to_string(i), vad);
     }
   SupervisedOutput so;
-  std::vector<std::string> measures = {"acc"};
-  double kl = so.multilabel_soft_kl(res_ad,-1);
-  double js = so.multilabel_soft_js(res_ad,-1);
-  double was = so.multilabel_soft_was(res_ad,-1);
-  double ks = so.multilabel_soft_ks(res_ad,-1);
-  double dc = so.multilabel_soft_dc(res_ad,-1);
-  double r2 = so.multilabel_soft_r2(res_ad,-1);;
-  std::vector<double> delta_scores {0,0,0,0};
-  std::vector<double> deltas {0.05, 0.1, 0.2, 0.5};
-  so.multilabel_soft_deltas(res_ad,delta_scores, deltas,-1);
-  ASSERT_NEAR(0.257584,kl, 0.0001); // val checked with def
-  ASSERT_NEAR(0.0178739,js, 0.0001);
-  ASSERT_NEAR(0.0866025,was, 0.0001);
-  ASSERT_EQ(0.1,ks);
-  ASSERT_NEAR(0.987,dc,0.001);
-  ASSERT_NEAR(0.94444,r2,0.0001);
-  ASSERT_EQ(0.25,delta_scores[0]);
-  ASSERT_EQ(0.5,delta_scores[1]);
-  ASSERT_EQ(1,delta_scores[2]);
-  ASSERT_EQ(1,delta_scores[3]);
-  measures = {"kl-0.1","dc"};
+  std::vector<std::string> measures = { "acc" };
+  double kl = so.multilabel_soft_kl(res_ad, -1);
+  double js = so.multilabel_soft_js(res_ad, -1);
+  double was = so.multilabel_soft_was(res_ad, -1);
+  double ks = so.multilabel_soft_ks(res_ad, -1);
+  double dc = so.multilabel_soft_dc(res_ad, -1);
+  double r2 = so.multilabel_soft_r2(res_ad, -1);
+  ;
+  std::vector<double> delta_scores{ 0, 0, 0, 0 };
+  std::vector<double> deltas{ 0.05, 0.1, 0.2, 0.5 };
+  so.multilabel_soft_deltas(res_ad, delta_scores, deltas, -1);
+  ASSERT_NEAR(0.257584, kl, 0.0001); // val checked with def
+  ASSERT_NEAR(0.0178739, js, 0.0001);
+  ASSERT_NEAR(0.0866025, was, 0.0001);
+  ASSERT_EQ(0.1, ks);
+  ASSERT_NEAR(0.987, dc, 0.001);
+  ASSERT_NEAR(0.94444, r2, 0.0001);
+  ASSERT_EQ(0.25, delta_scores[0]);
+  ASSERT_EQ(0.5, delta_scores[1]);
+  ASSERT_EQ(1, delta_scores[2]);
+  ASSERT_EQ(1, delta_scores[3]);
+  measures = { "kl-0.1", "dc" };
   bool do_kl = false;
   bool do_js = true;
   bool do_dc = false;
-  float kl_thres = -2 ;
-  float js_thres = -2 ;
-  float dc_thres = -1 ;
+  float kl_thres = -2;
+  float js_thres = -2;
+  float dc_thres = -1;
   so.find_presence_and_thres("kl", measures, do_kl, kl_thres);
   so.find_presence_and_thres("js", measures, do_js, js_thres);
   so.find_presence_and_thres("dc", measures, do_dc, dc_thres);
@@ -82,215 +83,216 @@ TEST(outputconn,mlsoft)
   ASSERT_NEAR(kl_thres, 0.1, 0.001);
   ASSERT_NEAR(js_thres, -2, 0.001);
   ASSERT_NEAR(dc_thres, 0, 0.001);
-
-
 }
 
-TEST(outputconn,acc)
+TEST(outputconn, acc)
 {
-  std::vector<double> targets = {0, 0, 1, 1};
-  std::vector<double> pred1 = {0.7, 0.3};
-  std::vector<double> pred2 = {0.4, 0.5};
-  std::vector<double> pred3 = {0.1, 0.9};
-  std::vector<double> pred4 = {0.2, 0.8};
+  std::vector<double> targets = { 0, 0, 1, 1 };
+  std::vector<double> pred1 = { 0.7, 0.3 };
+  std::vector<double> pred2 = { 0.4, 0.5 };
+  std::vector<double> pred3 = { 0.1, 0.9 };
+  std::vector<double> pred4 = { 0.2, 0.8 };
   std::vector<std::vector<double>> preds = { pred1, pred2, pred3, pred4 };
   APIData res_ad;
-  res_ad.add("batch_size",static_cast<int>(targets.size()));
-  for (size_t i=0;i<targets.size();i++)
+  res_ad.add("batch_size", static_cast<int>(targets.size()));
+  for (size_t i = 0; i < targets.size(); i++)
     {
       APIData bad;
-      bad.add("pred",preds.at(i));
-      bad.add("target",targets.at(i));
-      std::vector<APIData> vad = {bad};
-      res_ad.add(std::to_string(i),vad);
+      bad.add("pred", preds.at(i));
+      bad.add("target", targets.at(i));
+      std::vector<APIData> vad = { bad };
+      res_ad.add(std::to_string(i), vad);
     }
   SupervisedOutput so;
-  std::vector<std::string> measures = {"acc"};
-  std::map<std::string,double> accs = so.acc(res_ad,measures);
-  ASSERT_EQ(0.75,accs["acc"]);
+  std::vector<std::string> measures = { "acc" };
+  std::map<std::string, double> accs = so.acc(res_ad, measures);
+  ASSERT_EQ(0.75, accs["acc"]);
 }
 
-TEST(outputconn,acc_v)
+TEST(outputconn, acc_v)
 {
   APIData res_ad;
-  res_ad.add("batch_size",static_cast<int>(2));
-  res_ad.add("nclasses",static_cast<int>(2));
+  res_ad.add("batch_size", static_cast<int>(2));
+  res_ad.add("nclasses", static_cast<int>(2));
 
   APIData bad;
-  std::vector<double> targets = {0.0, 1.0 };
-  std::vector<double> pred1 = {0.0, 1.0};
-  bad.add("pred",pred1);
-  bad.add("target",targets);
-  std::vector<APIData> vad = {bad};
-  res_ad.add(std::to_string(0),vad);
-
+  std::vector<double> targets = { 0.0, 1.0 };
+  std::vector<double> pred1 = { 0.0, 1.0 };
+  bad.add("pred", pred1);
+  bad.add("target", targets);
+  std::vector<APIData> vad = { bad };
+  res_ad.add(std::to_string(0), vad);
 
   APIData bad2;
-  std::vector<double> targets2 = {0.0, 0.0};
-  std::vector<double> pred2 = {0.0, 1.0};
-  bad2.add("pred",pred2);
-  bad2.add("target",targets2);
-  std::vector<APIData> vad2 = {bad2};
-  res_ad.add(std::to_string(1),vad2);
-
-
+  std::vector<double> targets2 = { 0.0, 0.0 };
+  std::vector<double> pred2 = { 0.0, 1.0 };
+  bad2.add("pred", pred2);
+  bad2.add("target", targets2);
+  std::vector<APIData> vad2 = { bad2 };
+  res_ad.add(std::to_string(1), vad2);
 
   SupervisedOutput so;
   double meanacc = 0.0, meaniou = 0.0;
   std::vector<double> clacc;
   std::vector<double> cliou;
-  double acc = so.acc_v(res_ad,meanacc,meaniou,clacc,cliou);
-  ASSERT_EQ(0.75,acc);
-  ASSERT_EQ(0.875,meaniou);
+  double acc = so.acc_v(res_ad, meanacc, meaniou, clacc, cliou);
+  ASSERT_EQ(0.75, acc);
+  ASSERT_EQ(0.875, meaniou);
 }
 
-TEST(outputconn,acck)
+TEST(outputconn, acck)
 {
-  std::vector<double> targets = {0, 0, 1, 2};
-  std::vector<double> pred1 = {0.7, 0.1, 0.1, 0.1};
-  std::vector<double> pred2 = {0.3, 0.5, 0.1, 0.2};
-  std::vector<double> pred3 = {0.1, 0.9, 0.0, 0.0};
-  std::vector<double> pred4 = {0.1, 0.7, 0.05, 0.15};
+  std::vector<double> targets = { 0, 0, 1, 2 };
+  std::vector<double> pred1 = { 0.7, 0.1, 0.1, 0.1 };
+  std::vector<double> pred2 = { 0.3, 0.5, 0.1, 0.2 };
+  std::vector<double> pred3 = { 0.1, 0.9, 0.0, 0.0 };
+  std::vector<double> pred4 = { 0.1, 0.7, 0.05, 0.15 };
   std::vector<std::vector<double>> preds = { pred1, pred2, pred3, pred4 };
   APIData res_ad;
-  res_ad.add("batch_size",static_cast<int>(targets.size()));
-  for (size_t i=0;i<targets.size();i++)
+  res_ad.add("batch_size", static_cast<int>(targets.size()));
+  for (size_t i = 0; i < targets.size(); i++)
     {
       APIData bad;
-      bad.add("pred",preds.at(i));
-      bad.add("target",targets.at(i));
-      std::vector<APIData> vad = {bad};
-      res_ad.add(std::to_string(i),vad);
+      bad.add("pred", preds.at(i));
+      bad.add("target", targets.at(i));
+      std::vector<APIData> vad = { bad };
+      res_ad.add(std::to_string(i), vad);
     }
   SupervisedOutput so;
-  std::vector<std::string> measures = {"acc","acc-2","acc-3"};
-  std::map<std::string,double> accs = so.acc(res_ad,measures);
-  ASSERT_EQ(0.5,accs["acc"]);
-  ASSERT_EQ(0.75,accs["acc-2"]);
-  ASSERT_EQ(1.0,accs["acc-3"]);
+  std::vector<std::string> measures = { "acc", "acc-2", "acc-3" };
+  std::map<std::string, double> accs = so.acc(res_ad, measures);
+  ASSERT_EQ(0.5, accs["acc"]);
+  ASSERT_EQ(0.75, accs["acc-2"]);
+  ASSERT_EQ(1.0, accs["acc-3"]);
 }
 
-TEST(outputconn,auc)
+TEST(outputconn, auc)
 {
-  std::vector<double> targets = {0, 0, 1, 1};
-  std::vector<double> pred1 = {0.9, 0.1};
-  std::vector<double> pred2 = {0.6, 0.4};
-  std::vector<double> pred3 = {0.65, 0.35};
-  std::vector<double> pred4 = {0.2, 0.8};
+  std::vector<double> targets = { 0, 0, 1, 1 };
+  std::vector<double> pred1 = { 0.9, 0.1 };
+  std::vector<double> pred2 = { 0.6, 0.4 };
+  std::vector<double> pred3 = { 0.65, 0.35 };
+  std::vector<double> pred4 = { 0.2, 0.8 };
   std::vector<std::vector<double>> preds = { pred1, pred2, pred3, pred4 };
   APIData res_ad;
-  res_ad.add("batch_size",static_cast<int>(targets.size()));
-  for (size_t i=0;i<targets.size();i++)
+  res_ad.add("batch_size", static_cast<int>(targets.size()));
+  for (size_t i = 0; i < targets.size(); i++)
     {
       APIData bad;
-      bad.add("pred",preds.at(i));
-      bad.add("target",targets.at(i));
-      std::vector<APIData> vad = {bad};
-      res_ad.add(std::to_string(i),vad);
+      bad.add("pred", preds.at(i));
+      bad.add("target", targets.at(i));
+      std::vector<APIData> vad = { bad };
+      res_ad.add(std::to_string(i), vad);
     }
   SupervisedOutput so;
   double auc = so.auc(res_ad);
-  ASSERT_EQ(0.75,auc);
+  ASSERT_EQ(0.75, auc);
 }
 
-TEST(outputconn,mcc)
+TEST(outputconn, mcc)
 {
-  std::vector<double> targets = {0, 0, 1, 1};
-  std::vector<double> pred1 = {0.9, 0.1};
-  std::vector<double> pred2 = {0.6, 0.4};
-  std::vector<double> pred3 = {0.65, 0.35};
-  std::vector<double> pred4 = {0.2, 0.8};
+  std::vector<double> targets = { 0, 0, 1, 1 };
+  std::vector<double> pred1 = { 0.9, 0.1 };
+  std::vector<double> pred2 = { 0.6, 0.4 };
+  std::vector<double> pred3 = { 0.65, 0.35 };
+  std::vector<double> pred4 = { 0.2, 0.8 };
   std::vector<std::vector<double>> preds = { pred1, pred2, pred3, pred4 };
   APIData res_ad;
-  res_ad.add("nclasses",2);
-  res_ad.add("batch_size",static_cast<int>(targets.size()));
-  for (size_t i=0;i<targets.size();i++)
+  res_ad.add("nclasses", 2);
+  res_ad.add("batch_size", static_cast<int>(targets.size()));
+  for (size_t i = 0; i < targets.size(); i++)
     {
       APIData bad;
-      bad.add("pred",preds.at(i));
-      bad.add("target",targets.at(i));
-      std::vector<APIData> vad = {bad};
-      res_ad.add(std::to_string(i),vad);
+      bad.add("pred", preds.at(i));
+      bad.add("target", targets.at(i));
+      std::vector<APIData> vad = { bad };
+      res_ad.add(std::to_string(i), vad);
     }
   SupervisedOutput so;
   double mcc = so.mcc(res_ad);
-  ASSERT_NEAR(0.57735,mcc,1e-3);
+  ASSERT_NEAR(0.57735, mcc, 1e-3);
 }
 
-TEST(outputconn,gini)
+TEST(outputconn, gini)
 {
-  std::vector<double> targets = {1,1,0,1};
-  std::vector<double> pred1 = {0.86};
-  std::vector<double> pred2 = {0.26};
-  std::vector<double> pred3 = {0.52};
-  std::vector<double> pred4 = {0.32};
+  std::vector<double> targets = { 1, 1, 0, 1 };
+  std::vector<double> pred1 = { 0.86 };
+  std::vector<double> pred2 = { 0.26 };
+  std::vector<double> pred3 = { 0.52 };
+  std::vector<double> pred4 = { 0.32 };
   std::vector<std::vector<double>> preds = { pred1, pred2, pred3, pred4 };
   APIData res_ad;
-  res_ad.add("batch_size",static_cast<int>(targets.size()));
-  for (size_t i=0;i<targets.size();i++)
+  res_ad.add("batch_size", static_cast<int>(targets.size()));
+  for (size_t i = 0; i < targets.size(); i++)
     {
       APIData bad;
-      bad.add("pred",preds.at(i));
-      bad.add("target",targets.at(i));
-      std::vector<APIData> vad = {bad};
-      res_ad.add(std::to_string(i),vad);
+      bad.add("pred", preds.at(i));
+      bad.add("target", targets.at(i));
+      std::vector<APIData> vad = { bad };
+      res_ad.add(std::to_string(i), vad);
     }
-  double gini = SupervisedOutput::gini(res_ad,true);
+  double gini = SupervisedOutput::gini(res_ad, true);
   std::cout << "gini=" << gini << std::endl;
-  ASSERT_NEAR(-0.333,gini,1e-3);
+  ASSERT_NEAR(-0.333, gini, 1e-3);
 }
 
-TEST(outputconn,cmfull)
+TEST(outputconn, cmfull)
 {
-  std::vector<double> targets = {0, 0, 1, 2};
-  std::vector<double> pred1 = {0.7, 0.1, 0.1, 0.1};
-  std::vector<double> pred2 = {0.3, 0.5, 0.1, 0.2};
-  std::vector<double> pred3 = {0.1, 0.9, 0.0, 0.0};
-  std::vector<double> pred4 = {0.1, 0.7, 0.05, 0.15};
+  std::vector<double> targets = { 0, 0, 1, 2 };
+  std::vector<double> pred1 = { 0.7, 0.1, 0.1, 0.1 };
+  std::vector<double> pred2 = { 0.3, 0.5, 0.1, 0.2 };
+  std::vector<double> pred3 = { 0.1, 0.9, 0.0, 0.0 };
+  std::vector<double> pred4 = { 0.1, 0.7, 0.05, 0.15 };
   std::vector<std::vector<double>> preds = { pred1, pred2, pred3, pred4 };
   APIData res_ad;
-  res_ad.add("nclasses",4);
-  res_ad.add("batch_size",static_cast<int>(targets.size()));
-  for (size_t i=0;i<targets.size();i++)
+  res_ad.add("nclasses", 4);
+  res_ad.add("batch_size", static_cast<int>(targets.size()));
+  for (size_t i = 0; i < targets.size(); i++)
     {
       APIData bad;
-      bad.add("pred",preds.at(i));
-      bad.add("target",targets.at(i));
-      std::vector<APIData> vad = {bad};
-      res_ad.add(std::to_string(i),vad);
+      bad.add("pred", preds.at(i));
+      bad.add("target", targets.at(i));
+      std::vector<APIData> vad = { bad };
+      res_ad.add(std::to_string(i), vad);
     }
   SupervisedOutput so;
-  std::vector<std::string> measures = {"f1","cmdiag","cmfull"};
-  std::vector<std::string> clnames = {"zero","one","two","three"};
-  res_ad.add("clnames",clnames);
+  std::vector<std::string> measures = { "f1", "cmdiag", "cmfull" };
+  std::vector<std::string> clnames = { "zero", "one", "two", "three" };
+  res_ad.add("clnames", clnames);
   APIData ad_out;
-  ad_out.add("measure",measures);
-  
+  ad_out.add("measure", measures);
+
   APIData out;
-  SupervisedOutput::measure(res_ad,ad_out,out);
+  SupervisedOutput::measure(res_ad, ad_out, out);
   APIData meas_out = out.getobj("measure");
   auto lkeys = meas_out.list_keys();
-  ///std::cerr << "lkeys size=" << lkeys.size() << std::endl;
-  //for (auto k: lkeys)
-  //std::cerr << k << std::endl;
-  ASSERT_EQ(0.5,meas_out.get("accp").get<double>());
-  
+  /// std::cerr << "lkeys size=" << lkeys.size() << std::endl;
+  // for (auto k: lkeys)
+  // std::cerr << k << std::endl;
+  ASSERT_EQ(0.5, meas_out.get("accp").get<double>());
+
   // cmfull
   JsonAPI japi;
   JDoc jpred = japi.dd_ok_200();
   JVal jout(rapidjson::kObjectType);
-  out.toJVal(jpred,jout);
+  out.toJVal(jpred, jout);
   std::string jstr = japi.jrender(jout);
   std::cerr << "jstr=" << jstr << std::endl;
-  ASSERT_TRUE(jstr.find("\"cmfull\":[{\"zero\":[0.5,0.5,0.0,0.0]},{\"one\":[0.0,1.0,0.0,0.0]},{\"two\":[0.0,1.0,0.0,0.0]},{\"three\":[2.696539702293474e308,2.696539702293474e308,2.696539702293474e308,2.696539702293474e308]}]"));
+  ASSERT_TRUE(jstr.find(
+      "\"cmfull\":[{\"zero\":[0.5,0.5,0.0,0.0]},{\"one\":[0.0,1.0,0.0,0.0]},{"
+      "\"two\":[0.0,1.0,0.0,0.0]},{\"three\":[2.696539702293474e308,2."
+      "696539702293474e308,2.696539702293474e308,2.696539702293474e308]}]"));
 }
 
-TEST(inputconn,img)
+TEST(inputconn, img)
 {
   std::string mnist_repo = "../examples/caffe/mnist/";
   APIData ad;
-  std::vector<std::string> uris = {mnist_repo + "/sample_digit.png","https://www.deepdetect.com/dd/examples/caffe/mnist/sample_digit.png"};
-  ad.add("data",uris);
+  std::vector<std::string> uris = {
+    mnist_repo + "/sample_digit.png",
+    "https://www.deepdetect.com/dd/examples/caffe/mnist/sample_digit.png"
+  };
+  ad.add("data", uris);
   ImgInputFileConn iifc;
   try
     {
@@ -301,25 +303,26 @@ TEST(inputconn,img)
       std::cerr << e.what() << std::endl;
       ASSERT_FALSE(true); // trigger
     }
-  for (auto u: iifc._uris)
+  for (auto u : iifc._uris)
     std::cerr << u << std::endl;
-  ASSERT_EQ(2,iifc._uris.size());
-  ASSERT_EQ(2,iifc._images.size());
+  ASSERT_EQ(2, iifc._uris.size());
+  ASSERT_EQ(2, iifc._images.size());
   cv::Mat diff;
-  cv::compare(iifc._images.at(0),iifc._images.at(1),diff,cv::CMP_NE);
+  cv::compare(iifc._images.at(0), iifc._images.at(1), diff, cv::CMP_NE);
   std::vector<cv::Mat> channels(3);
-  cv::split(diff,channels);
-  for (int i=0;i<3;i++)
-    ASSERT_TRUE(cv::countNonZero(channels.at(i))==0); // the two images must be identical
+  cv::split(diff, channels);
+  for (int i = 0; i < 3; i++)
+    ASSERT_TRUE(cv::countNonZero(channels.at(i))
+                == 0); // the two images must be identical
 }
 
-//TODO: test csv scale, separator, categorical, ...
-TEST(inputconn,csv_mem1)
+// TODO: test csv scale, separator, categorical, ...
+TEST(inputconn, csv_mem1)
 {
   std::string no_header = "2590,56,2,212,5";
   std::vector<std::string> vdata = { no_header };
   APIData ad;
-  ad.add("data",vdata);
+  ad.add("data", vdata);
   CSVInputFileConn cifc;
   cifc._logger = spdlog::stdout_logger_mt("test");
   cifc._train = false; // prediction mode
@@ -332,25 +335,25 @@ TEST(inputconn,csv_mem1)
       std::cerr << "exception=" << e.what() << std::endl;
       ASSERT_FALSE(true);
     }
-  ASSERT_EQ(1,cifc._uris.size());
-  ASSERT_EQ(1,cifc._csvdata.size());
-  ASSERT_EQ(5,cifc._csvdata.at(0)._v.size());
-  ASSERT_EQ(2590,cifc._csvdata.at(0)._v.at(0));
+  ASSERT_EQ(1, cifc._uris.size());
+  ASSERT_EQ(1, cifc._csvdata.size());
+  ASSERT_EQ(5, cifc._csvdata.at(0)._v.size());
+  ASSERT_EQ(2590, cifc._csvdata.at(0)._v.at(0));
 }
 
-TEST(inputconn,csv_mem2)
+TEST(inputconn, csv_mem2)
 {
   std::string header = "id,val1,val2,val3,val4,val5";
   std::string d1 = "2,2590,56,2,212,5";
   std::vector<std::string> vdata = { header, d1 };
   APIData ad;
-  ad.add("data",vdata);
-  APIData pad,pinp;
-  pinp.add("id",std::string("id"));
+  ad.add("data", vdata);
+  APIData pad, pinp;
+  pinp.add("id", std::string("id"));
   std::vector<APIData> vpinp = { pinp };
-  pad.add("input",vpinp);
+  pad.add("input", vpinp);
   std::vector<APIData> vpad = { pad };
-  ad.add("parameters",vpad);
+  ad.add("parameters", vpad);
   CSVInputFileConn cifc;
   cifc._logger = spdlog::stdout_logger_mt("test1");
   cifc._train = false;
@@ -363,37 +366,37 @@ TEST(inputconn,csv_mem2)
       std::cerr << "exception=" << e.what() << std::endl;
       ASSERT_FALSE(true);
     }
-  ASSERT_EQ(2,cifc._uris.size());
-  ASSERT_EQ(1,cifc._csvdata.size());
+  ASSERT_EQ(2, cifc._uris.size());
+  ASSERT_EQ(1, cifc._csvdata.size());
   ASSERT_TRUE(!cifc._columns.empty());
-  ASSERT_EQ(6,cifc._csvdata.at(0)._v.size());
-  ASSERT_EQ(2,cifc._csvdata.at(0)._v.at(0));
-  ASSERT_EQ(2590,cifc._csvdata.at(0)._v.at(1));
+  ASSERT_EQ(6, cifc._csvdata.at(0)._v.size());
+  ASSERT_EQ(2, cifc._csvdata.at(0)._v.at(0));
+  ASSERT_EQ(2590, cifc._csvdata.at(0)._v.at(1));
 }
 
-TEST(inputconn,csv_copy)
+TEST(inputconn, csv_copy)
 {
   std::string header = "id,val1,val2,val3,val4,val5";
   std::string d1 = "2,2590,56,2,212,5";
   std::vector<std::string> vdata = { header, d1 };
   APIData ad;
-  ad.add("data",vdata);
-  APIData pad,pinp;
-  pinp.add("id",std::string("id"));
-  pinp.add("label",std::string("val5"));
+  ad.add("data", vdata);
+  APIData pad, pinp;
+  pinp.add("id", std::string("id"));
+  pinp.add("label", std::string("val5"));
   std::vector<APIData> vpinp = { pinp };
-  pad.add("input",vpinp);
+  pad.add("input", vpinp);
   std::vector<APIData> vpad = { pad };
-  ad.add("parameters",vpad);
+  ad.add("parameters", vpad);
   CSVInputFileConn cifc;
   cifc._logger = spdlog::stdout_logger_mt("test2");
   cifc.init(ad.getobj("parameters").getobj("input"));
   CSVInputFileConn cifc2 = cifc;
-  ASSERT_EQ("val5",cifc2._label[0]);
-  ASSERT_EQ("id",cifc2._id);
+  ASSERT_EQ("val5", cifc2._label[0]);
+  ASSERT_EQ("id", cifc2._id);
 }
 
-TEST(inputconn,csv_categoricals1)
+TEST(inputconn, csv_categoricals1)
 {
   std::string header = "target,cap-shape,cap-surface,cap-color,bruises";
   std::string d1 = "p,x,s,n,t";
@@ -402,15 +405,16 @@ TEST(inputconn,csv_categoricals1)
   of << d1 << std::endl;
   std::vector<std::string> vdata = { "test.csv" };
   APIData ad;
-  ad.add("data",vdata);
-  APIData pad,pinp;
-  pinp.add("label",std::string("target"));
-  std::vector<std::string> vcats = {"target","cap-shape","cap-surface","cap-color","bruises"};
-  pinp.add("categoricals",vcats);
+  ad.add("data", vdata);
+  APIData pad, pinp;
+  pinp.add("label", std::string("target"));
+  std::vector<std::string> vcats
+      = { "target", "cap-shape", "cap-surface", "cap-color", "bruises" };
+  pinp.add("categoricals", vcats);
   std::vector<APIData> vpinp = { pinp };
-  pad.add("input",vpinp);
+  pad.add("input", vpinp);
   std::vector<APIData> vpad = { pad };
-  ad.add("parameters",vpad);
+  ad.add("parameters", vpad);
   CSVInputFileConn cifc;
   cifc._logger = spdlog::stdout_logger_mt("test3");
   cifc._train = true;
@@ -419,21 +423,21 @@ TEST(inputconn,csv_categoricals1)
       std::cout << "trying to transform\n";
       cifc.transform(ad);
     }
-  catch(InputConnectorBadParamException &e)
+  catch (InputConnectorBadParamException &e)
     {
       std::cerr << "exception=" << e.what() << std::endl;
       ASSERT_FALSE(true);
     }
-  ASSERT_EQ(1,cifc._csvdata.size());
-  ASSERT_EQ(5,cifc._csvdata.at(0)._v.size());
-  for (double e: cifc._csvdata.at(0)._v)
-    ASSERT_EQ(1.0,e);
-  ASSERT_EQ(5,cifc._columns.size());
-  ASSERT_EQ("target_p",(*cifc._columns.begin()));
+  ASSERT_EQ(1, cifc._csvdata.size());
+  ASSERT_EQ(5, cifc._csvdata.at(0)._v.size());
+  for (double e : cifc._csvdata.at(0)._v)
+    ASSERT_EQ(1.0, e);
+  ASSERT_EQ(5, cifc._columns.size());
+  ASSERT_EQ("target_p", (*cifc._columns.begin()));
   remove("test.csv");
 }
 
-TEST(inputconn,csv_categoricals2)
+TEST(inputconn, csv_categoricals2)
 {
   std::string header = "target,cap-shape,cap-surface,cap-color,bruises";
   std::string d1 = "p,x,s,n,t\ne,x,s,y,t\ne,b,s,w,t";
@@ -442,52 +446,75 @@ TEST(inputconn,csv_categoricals2)
   of << d1 << std::endl;
   std::vector<std::string> vdata = { "test.csv" };
   APIData ad;
-  ad.add("data",vdata);
-  APIData pad,pinp;
-  pinp.add("label",std::string("target"));
-  std::vector<std::string> vcats = {"target","cap-shape","cap-surface","cap-color","bruises"};
-  pinp.add("categoricals",vcats);
+  ad.add("data", vdata);
+  APIData pad, pinp;
+  pinp.add("label", std::string("target"));
+  std::vector<std::string> vcats
+      = { "target", "cap-shape", "cap-surface", "cap-color", "bruises" };
+  pinp.add("categoricals", vcats);
   std::vector<APIData> vpinp = { pinp };
-  pad.add("input",vpinp);
+  pad.add("input", vpinp);
   std::vector<APIData> vpad = { pad };
-  ad.add("parameters",vpad);
+  ad.add("parameters", vpad);
   CSVInputFileConn cifc;
   cifc._logger = spdlog::stdout_logger_mt("test4");
   cifc._train = true;
   cifc.transform(ad);
-  ASSERT_EQ(3,cifc._csvdata.size());
-  ASSERT_EQ(9,cifc._csvdata.at(0)._v.size());
-  std::vector<double> v1 = {1,0,1,0,1,1,0,0,1};
-  std::vector<double> v2 = {0,1,1,0,1,0,1,0,1};
-  std::vector<double> v3 = {0,1,0,1,1,0,0,1,1};
-  ASSERT_EQ(v1,cifc._csvdata.at(0)._v);
-  ASSERT_EQ(v2,cifc._csvdata.at(1)._v);
-  ASSERT_EQ(v3,cifc._csvdata.at(2)._v);
-  ASSERT_EQ(9,cifc._columns.size());
-  ASSERT_EQ("target_p",(*cifc._columns.begin()));
+  ASSERT_EQ(3, cifc._csvdata.size());
+  ASSERT_EQ(9, cifc._csvdata.at(0)._v.size());
+  std::vector<double> v1 = { 1, 0, 1, 0, 1, 1, 0, 0, 1 };
+  std::vector<double> v2 = { 0, 1, 1, 0, 1, 0, 1, 0, 1 };
+  std::vector<double> v3 = { 0, 1, 0, 1, 1, 0, 0, 1, 1 };
+  ASSERT_EQ(v1, cifc._csvdata.at(0)._v);
+  ASSERT_EQ(v2, cifc._csvdata.at(1)._v);
+  ASSERT_EQ(v3, cifc._csvdata.at(2)._v);
+  ASSERT_EQ(9, cifc._columns.size());
+  ASSERT_EQ("target_p", (*cifc._columns.begin()));
   remove("test.csv");
 }
 
-TEST(inputconn,csv_read_categoricals)
+TEST(inputconn, csv_read_categoricals)
 {
-  std::string json_categorical_mapping = "{\"categoricals_mapping\":{\"bruises\":{\"t\":0,\"f\":1},\"cap-color\":{\"n\":0,\"y\":1,\"p\":5,\"c\":8,\"r\":9,\"w\":2,\"g\":3,\"e\":4,\"b\":6,\"u\":7},\"ring-number\":{\"o\":0,\"t\":1,\"n\":2},\"odor\":{\"p\":0,\"c\":5,\"y\":6,\"s\":7,\"a\":1,\"l\":2,\"n\":3,\"f\":4,\"m\":8},\"stalk-shape\":{\"e\":0,\"t\":1},\"stalk-surface-above-ring\":{\"s\":0,\"y\":3,\"f\":1,\"k\":2},\"gill-size\":{\"n\":0,\"b\":1},\"veil-type\":{\"p\":0},\"ring-type\":{\"p\":0,\"e\":1,\"l\":2,\"f\":3,\"n\":4},\"spore-print-color\":{\"k\":0,\"n\":1,\"u\":2,\"h\":3,\"w\":4,\"r\":5,\"y\":7,\"o\":6,\"b\":8},\"gill-color\":{\"b\":8,\"e\":7,\"o\":11,\"k\":0,\"n\":1,\"y\":10,\"g\":2,\"r\":9,\"w\":4,\"p\":3,\"h\":5,\"u\":6},\"gill-spacing\":{\"c\":0,\"w\":1},\"habitat\":{\"u\":0,\"d\":3,\"l\":6,\"g\":1,\"m\":2,\"p\":4,\"w\":5},\"cap-surface\":{\"s\":0,\"y\":1,\"f\":2,\"g\":3},\"gill-attachment\":{\"f\":0,\"a\":1},\"cap-shape\":{\"x\":0,\"s\":2,\"c\":5,\"b\":1,\"f\":3,\"k\":4},\"target\":{\"p\":0,\"e\":1},\"stalk-root\":{\"e\":0,\"b\":2,\"c\":1,\"r\":3,\"?\":4},\"stalk-surface-below-ring\":{\"s\":0,\"y\":2,\"f\":1,\"k\":3},\"veil-color\":{\"w\":0,\"n\":1,\"o\":2,\"y\":3},\"population\":{\"s\":0,\"y\":4,\"c\":5,\"n\":1,\"a\":2,\"v\":3},\"stalk-color-above-ring\":{\"w\":0,\"g\":1,\"p\":2,\"c\":7,\"y\":8,\"n\":3,\"b\":4,\"e\":5,\"o\":6},\"stalk-color-below-ring\":{\"w\":0,\"p\":1,\"y\":6,\"c\":8,\"g\":2,\"b\":3,\"e\":5,\"n\":4,\"o\":7}}}";
+  std::string json_categorical_mapping
+      = "{\"categoricals_mapping\":{\"bruises\":{\"t\":0,\"f\":1},\"cap-"
+        "color\":{\"n\":0,\"y\":1,\"p\":5,\"c\":8,\"r\":9,\"w\":2,\"g\":3,"
+        "\"e\":4,\"b\":6,\"u\":7},\"ring-number\":{\"o\":0,\"t\":1,\"n\":2},"
+        "\"odor\":{\"p\":0,\"c\":5,\"y\":6,\"s\":7,\"a\":1,\"l\":2,\"n\":3,"
+        "\"f\":4,\"m\":8},\"stalk-shape\":{\"e\":0,\"t\":1},\"stalk-surface-"
+        "above-ring\":{\"s\":0,\"y\":3,\"f\":1,\"k\":2},\"gill-size\":{\"n\":"
+        "0,\"b\":1},\"veil-type\":{\"p\":0},\"ring-type\":{\"p\":0,\"e\":1,"
+        "\"l\":2,\"f\":3,\"n\":4},\"spore-print-color\":{\"k\":0,\"n\":1,"
+        "\"u\":2,\"h\":3,\"w\":4,\"r\":5,\"y\":7,\"o\":6,\"b\":8},\"gill-"
+        "color\":{\"b\":8,\"e\":7,\"o\":11,\"k\":0,\"n\":1,\"y\":10,\"g\":2,"
+        "\"r\":9,\"w\":4,\"p\":3,\"h\":5,\"u\":6},\"gill-spacing\":{\"c\":0,"
+        "\"w\":1},\"habitat\":{\"u\":0,\"d\":3,\"l\":6,\"g\":1,\"m\":2,\"p\":"
+        "4,\"w\":5},\"cap-surface\":{\"s\":0,\"y\":1,\"f\":2,\"g\":3},\"gill-"
+        "attachment\":{\"f\":0,\"a\":1},\"cap-shape\":{\"x\":0,\"s\":2,\"c\":"
+        "5,\"b\":1,\"f\":3,\"k\":4},\"target\":{\"p\":0,\"e\":1},\"stalk-"
+        "root\":{\"e\":0,\"b\":2,\"c\":1,\"r\":3,\"?\":4},\"stalk-surface-"
+        "below-ring\":{\"s\":0,\"y\":2,\"f\":1,\"k\":3},\"veil-color\":{\"w\":"
+        "0,\"n\":1,\"o\":2,\"y\":3},\"population\":{\"s\":0,\"y\":4,\"c\":5,"
+        "\"n\":1,\"a\":2,\"v\":3},\"stalk-color-above-ring\":{\"w\":0,\"g\":1,"
+        "\"p\":2,\"c\":7,\"y\":8,\"n\":3,\"b\":4,\"e\":5,\"o\":6},\"stalk-"
+        "color-below-ring\":{\"w\":0,\"p\":1,\"y\":6,\"c\":8,\"g\":2,\"b\":3,"
+        "\"e\":5,\"n\":4,\"o\":7}}}";
   JDoc d;
   d.Parse(json_categorical_mapping.c_str());
   ASSERT_FALSE(d.HasParseError());
   APIData ap(d);
-  ASSERT_EQ(1,ap.size());
+  ASSERT_EQ(1, ap.size());
   ASSERT_TRUE(ap.has("categoricals_mapping"));
   APIData ap_cm = ap.getobj("categoricals_mapping");
   CSVInputFileConn cifc;
   cifc._logger = spdlog::stdout_logger_mt("test5");
   cifc._train = true;
   cifc.read_categoricals(ap);
-  ASSERT_EQ(23,cifc._categoricals.size());
+  ASSERT_EQ(23, cifc._categoricals.size());
   CCategorical cc = cifc._categoricals["odor"];
-  ASSERT_EQ(9,cc._vals.size());
+  ASSERT_EQ(9, cc._vals.size());
 }
 
-TEST(inputconn,csv_ignore)
+TEST(inputconn, csv_ignore)
 {
   std::string header = "target,cap-shape,cap-surface,cap-color,bruises";
   std::string d1 = "1,2,3,4,5";
@@ -496,15 +523,15 @@ TEST(inputconn,csv_ignore)
   of << d1 << std::endl;
   std::vector<std::string> vdata = { "test.csv" };
   APIData ad;
-  ad.add("data",vdata);
-  APIData pad,pinp;
-  pinp.add("label",std::string("target"));
-  std::vector<std::string> vign = {"cap-shape"};
-  pinp.add("ignore",vign);
+  ad.add("data", vdata);
+  APIData pad, pinp;
+  pinp.add("label", std::string("target"));
+  std::vector<std::string> vign = { "cap-shape" };
+  pinp.add("ignore", vign);
   std::vector<APIData> vpinp = { pinp };
-  pad.add("input",vpinp);
+  pad.add("input", vpinp);
   std::vector<APIData> vpad = { pad };
-  ad.add("parameters",vpad);
+  ad.add("parameters", vpad);
   CSVInputFileConn cifc;
   cifc._logger = spdlog::stdout_logger_mt("test6");
   cifc._train = true;
@@ -512,15 +539,15 @@ TEST(inputconn,csv_ignore)
     {
       cifc.transform(ad);
     }
-  catch(InputConnectorBadParamException &e)
+  catch (InputConnectorBadParamException &e)
     {
       std::cerr << "exception=" << e.what() << std::endl;
       ASSERT_FALSE(true);
     }
-  ASSERT_EQ(1,cifc._csvdata.size());
-  ASSERT_EQ(4,cifc._csvdata.at(0)._v.size());
-  ASSERT_EQ(4,cifc._columns.size());
-  ASSERT_EQ("target",(*cifc._columns.begin()));
+  ASSERT_EQ(1, cifc._csvdata.size());
+  ASSERT_EQ(4, cifc._csvdata.at(0)._v.size());
+  ASSERT_EQ(4, cifc._columns.size());
+  ASSERT_EQ("target", (*cifc._columns.begin()));
   remove("test.csv");
 }
 
@@ -548,12 +575,12 @@ TEST(inputconn, csvts_basic)
   of3 << d6 << std::endl;
   std::vector<std::string> vdata = { "csvts" };
   APIData ad;
-  ad.add("data",vdata);
-  APIData pad,pinp;
+  ad.add("data", vdata);
+  APIData pad, pinp;
   std::vector<APIData> vpinp = { pinp };
-  pad.add("input",vpinp);
+  pad.add("input", vpinp);
   std::vector<APIData> vpad = { pad };
-  ad.add("parameters",vpad);
+  ad.add("parameters", vpad);
   CSVTSInputFileConn cifc;
   cifc._logger = spdlog::stdout_logger_mt("test_csvts");
   cifc._train = true;
@@ -561,20 +588,20 @@ TEST(inputconn, csvts_basic)
     {
       cifc.transform(ad);
     }
-  catch(InputConnectorBadParamException &e)
+  catch (InputConnectorBadParamException &e)
     {
       std::cerr << "exception=" << e.what() << std::endl;
       ASSERT_FALSE(true);
     }
-  ASSERT_EQ(3,cifc._csvtsdata.size());
-  ASSERT_EQ(5,cifc._csvtsdata.at(0).at(0)._v.size());
-  ASSERT_EQ(2,cifc._csvtsdata.at(0).size());
-  ASSERT_EQ(2,cifc._csvtsdata.at(1).size());
-  ASSERT_EQ(2,cifc._csvtsdata.at(2).size());
+  ASSERT_EQ(3, cifc._csvtsdata.size());
+  ASSERT_EQ(5, cifc._csvtsdata.at(0).at(0)._v.size());
+  ASSERT_EQ(2, cifc._csvtsdata.at(0).size());
+  ASSERT_EQ(2, cifc._csvtsdata.at(1).size());
+  ASSERT_EQ(2, cifc._csvtsdata.at(2).size());
 
-  ASSERT_EQ(5,cifc._columns.size());
+  ASSERT_EQ(5, cifc._columns.size());
 
-  ASSERT_EQ("target",(*cifc._columns.begin()));
+  ASSERT_EQ("target", (*cifc._columns.begin()));
   // fileops::clear_directory("test");
   // fileops::remove_dir("test");
 }

--- a/tests/ut-dlibapi.cc
+++ b/tests/ut-dlibapi.cc
@@ -31,110 +31,160 @@
 using namespace dd;
 
 static std::string ok_str = "{\"status\":{\"code\":200,\"msg\":\"OK\"}}";
-static std::string created_str = "{\"status\":{\"code\":201,\"msg\":\"Created\"}}";
-static std::string bad_param_str = "{\"status\":{\"code\":400,\"msg\":\"BadRequest\"}}";
-static std::string not_found_str = "{\"status\":{\"code\":404,\"msg\":\"NotFound\"}}";
+static std::string created_str
+    = "{\"status\":{\"code\":201,\"msg\":\"Created\"}}";
+static std::string bad_param_str
+    = "{\"status\":{\"code\":400,\"msg\":\"BadRequest\"}}";
+static std::string not_found_str
+    = "{\"status\":{\"code\":404,\"msg\":\"NotFound\"}}";
 
 static std::string face_repo = "../examples/dlib/face/";
 static std::string obj_repo = "../examples/dlib/obj/";
 
-TEST(dlibapi,service_predict_face)
+TEST(dlibapi, service_predict_face)
 {
-    // create service
-    JsonAPI japi;
-    std::string sname = "imgserv";
-    std::string jstr = "{\"mllib\":\"dlib\",\"description\":\"my face classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\"" +  face_repo + "\"},\"parameters\":{\"input\":{\"connector\":\"image\", \"width\": 512, \"height\": 600},\"mllib\":{\"model_type\":\"face_detector\"}}}";
-    std::string joutstr = japi.jrender(japi.service_create(sname,jstr));
-    ASSERT_EQ(created_str,joutstr);
+  // create service
+  JsonAPI japi;
+  std::string sname = "imgserv";
+  std::string jstr
+      = "{\"mllib\":\"dlib\",\"description\":\"my face "
+        "classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\""
+        + face_repo
+        + "\"},\"parameters\":{\"input\":{\"connector\":\"image\", \"width\": "
+          "512, \"height\": "
+          "600},\"mllib\":{\"model_type\":\"face_detector\"}}}";
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
 
-    // predict
-    std::string jpredictstr = "{\"service\":\"imgserv\",\"parameters\":{\"output\":{\"bbox\":true}},\"data\":[\"" + face_repo + "grace_hopper.jpg\"]}";
-    joutstr = japi.jrender(japi.service_predict(jpredictstr));
-    JDoc jd;
-    std::cout << "joutstr=" << joutstr << std::endl;
-    jd.Parse(joutstr.c_str());
-    ASSERT_TRUE(!jd.HasParseError());
-    ASSERT_EQ(200,jd["status"]["code"]);
-    ASSERT_TRUE(jd["body"]["predictions"].IsArray());
-    std::string cl1 = jd["body"]["predictions"][0]["classes"][0]["cat"].GetString();
-    ASSERT_EQ("1", cl1); // default label is "1" when no label is provided
-    ASSERT_TRUE(jd["body"]["predictions"][0]["classes"][0]["prob"].GetDouble() > 0.4);
-    ASSERT_TRUE(jd["body"]["predictions"][0]["classes"][0].HasMember("bbox"));
-    ASSERT_TRUE(jd["body"]["predictions"][0]["classes"][0]["bbox"].HasMember("xmin"));
+  // predict
+  std::string jpredictstr = "{\"service\":\"imgserv\",\"parameters\":{"
+                            "\"output\":{\"bbox\":true}},\"data\":[\""
+                            + face_repo + "grace_hopper.jpg\"]}";
+  joutstr = japi.jrender(japi.service_predict(jpredictstr));
+  JDoc jd;
+  std::cout << "joutstr=" << joutstr << std::endl;
+  jd.Parse(joutstr.c_str());
+  ASSERT_TRUE(!jd.HasParseError());
+  ASSERT_EQ(200, jd["status"]["code"]);
+  ASSERT_TRUE(jd["body"]["predictions"].IsArray());
+  std::string cl1
+      = jd["body"]["predictions"][0]["classes"][0]["cat"].GetString();
+  ASSERT_EQ("1", cl1); // default label is "1" when no label is provided
+  ASSERT_TRUE(jd["body"]["predictions"][0]["classes"][0]["prob"].GetDouble()
+              > 0.4);
+  ASSERT_TRUE(jd["body"]["predictions"][0]["classes"][0].HasMember("bbox"));
+  ASSERT_TRUE(
+      jd["body"]["predictions"][0]["classes"][0]["bbox"].HasMember("xmin"));
 
-    // predict batch
-    jpredictstr = "{\"service\":\"imgserv\",\"parameters\":{\"output\":{\"bbox\":true}},\"data\":[\"" + face_repo + "grace_hopper.jpg\",\"" + face_repo + "cat.jpg\"]}";
-    joutstr = japi.jrender(japi.service_predict(jpredictstr));
-    std::cout << "joutstr=" << joutstr << std::endl;
-    jd.Parse(joutstr.c_str());
-    ASSERT_TRUE(!jd.HasParseError());
-    ASSERT_EQ(200,jd["status"]["code"]);
-    ASSERT_TRUE(jd["body"]["predictions"].IsArray());
-    ASSERT_EQ(2,jd["body"]["predictions"].Size()); // Ensure we got a predictions obj back for each file
+  // predict batch
+  jpredictstr = "{\"service\":\"imgserv\",\"parameters\":{\"output\":{"
+                "\"bbox\":true}},\"data\":[\""
+                + face_repo + "grace_hopper.jpg\",\"" + face_repo
+                + "cat.jpg\"]}";
+  joutstr = japi.jrender(japi.service_predict(jpredictstr));
+  std::cout << "joutstr=" << joutstr << std::endl;
+  jd.Parse(joutstr.c_str());
+  ASSERT_TRUE(!jd.HasParseError());
+  ASSERT_EQ(200, jd["status"]["code"]);
+  ASSERT_TRUE(jd["body"]["predictions"].IsArray());
+  ASSERT_EQ(2,
+            jd["body"]["predictions"]
+                .Size()); // Ensure we got a predictions obj back for each file
 
-    int grace_hopper_idx = 0, cat_idx = 1;
-    if (jd["body"]["predictions"][0]["classes"].Size() == 0) { // If the first result happens to be cat.jpg, check the other one
-        grace_hopper_idx = 1;
-        cat_idx = 0;
+  int grace_hopper_idx = 0, cat_idx = 1;
+  if (jd["body"]["predictions"][0]["classes"].Size() == 0)
+    { // If the first result happens to be cat.jpg, check the other one
+      grace_hopper_idx = 1;
+      cat_idx = 0;
     }
-    ASSERT_TRUE(jd["body"]["predictions"][grace_hopper_idx]["classes"].Size() > 0);
-    cl1 = jd["body"]["predictions"][grace_hopper_idx]["classes"][0]["cat"].GetString();
-    ASSERT_EQ("1", cl1); // default label is "1" when no label is provided
-    ASSERT_TRUE(jd["body"]["predictions"][grace_hopper_idx]["classes"][0]["prob"].GetDouble() > 0.4);
-    ASSERT_TRUE(jd["body"]["predictions"][grace_hopper_idx]["classes"][0].HasMember("bbox"));
-    ASSERT_TRUE(jd["body"]["predictions"][grace_hopper_idx]["classes"][0]["bbox"].HasMember("xmin"));
-    // There's no face in cat.jpg, so no result for it
-    ASSERT_TRUE(jd["body"]["predictions"][cat_idx]["classes"].IsArray());
-    ASSERT_EQ(0, jd["body"]["predictions"][cat_idx]["classes"].Size());
+  ASSERT_TRUE(jd["body"]["predictions"][grace_hopper_idx]["classes"].Size()
+              > 0);
+  cl1 = jd["body"]["predictions"][grace_hopper_idx]["classes"][0]["cat"]
+            .GetString();
+  ASSERT_EQ("1", cl1); // default label is "1" when no label is provided
+  ASSERT_TRUE(jd["body"]["predictions"][grace_hopper_idx]["classes"][0]["prob"]
+                  .GetDouble()
+              > 0.4);
+  ASSERT_TRUE(
+      jd["body"]["predictions"][grace_hopper_idx]["classes"][0].HasMember(
+          "bbox"));
+  ASSERT_TRUE(jd["body"]["predictions"][grace_hopper_idx]["classes"][0]["bbox"]
+                  .HasMember("xmin"));
+  // There's no face in cat.jpg, so no result for it
+  ASSERT_TRUE(jd["body"]["predictions"][cat_idx]["classes"].IsArray());
+  ASSERT_EQ(0, jd["body"]["predictions"][cat_idx]["classes"].Size());
 }
 
-TEST(dlibapi,service_predict_obj)
+TEST(dlibapi, service_predict_obj)
 {
-    // create service
-    JsonAPI japi;
-    std::string sname = "imgserv";
-    std::string jstr = "{\"mllib\":\"dlib\",\"description\":\"my obj classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\"" +  obj_repo + "\"},\"parameters\":{\"input\":{\"connector\":\"image\", \"width\": 1024, \"height\": 254},\"mllib\":{\"model_type\":\"obj_detector\"}}}";
-    std::string joutstr = japi.jrender(japi.service_create(sname,jstr));
-    ASSERT_EQ(created_str,joutstr);
+  // create service
+  JsonAPI japi;
+  std::string sname = "imgserv";
+  std::string jstr
+      = "{\"mllib\":\"dlib\",\"description\":\"my obj "
+        "classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\""
+        + obj_repo
+        + "\"},\"parameters\":{\"input\":{\"connector\":\"image\", \"width\": "
+          "1024, \"height\": "
+          "254},\"mllib\":{\"model_type\":\"obj_detector\"}}}";
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
 
-    // predict
-    std::string jpredictstr = "{\"service\":\"imgserv\",\"parameters\":{\"output\":{\"bbox\":true}},\"data\":[\"" + obj_repo + "mmod_cars_test_image2.jpg\"]}";
-    joutstr = japi.jrender(japi.service_predict(jpredictstr));
-    JDoc jd;
-    std::cout << "joutstr=" << joutstr << std::endl;
-    jd.Parse(joutstr.c_str());
-    ASSERT_TRUE(!jd.HasParseError());
-    ASSERT_EQ(200,jd["status"]["code"]);
-    ASSERT_TRUE(jd["body"]["predictions"].IsArray());
-    std::string cl1 = jd["body"]["predictions"][0]["classes"][0]["cat"].GetString();
-    ASSERT_TRUE(cl1 == "rear");
-    ASSERT_TRUE(jd["body"]["predictions"][0]["classes"][0]["prob"].GetDouble() > 0.4);
-    ASSERT_TRUE(jd["body"]["predictions"][0]["classes"][0].HasMember("bbox"));
-    ASSERT_TRUE(jd["body"]["predictions"][0]["classes"][0]["bbox"].HasMember("xmin"));
-    ASSERT_EQ(5, jd["body"]["predictions"][0]["classes"].Size());
+  // predict
+  std::string jpredictstr = "{\"service\":\"imgserv\",\"parameters\":{"
+                            "\"output\":{\"bbox\":true}},\"data\":[\""
+                            + obj_repo + "mmod_cars_test_image2.jpg\"]}";
+  joutstr = japi.jrender(japi.service_predict(jpredictstr));
+  JDoc jd;
+  std::cout << "joutstr=" << joutstr << std::endl;
+  jd.Parse(joutstr.c_str());
+  ASSERT_TRUE(!jd.HasParseError());
+  ASSERT_EQ(200, jd["status"]["code"]);
+  ASSERT_TRUE(jd["body"]["predictions"].IsArray());
+  std::string cl1
+      = jd["body"]["predictions"][0]["classes"][0]["cat"].GetString();
+  ASSERT_TRUE(cl1 == "rear");
+  ASSERT_TRUE(jd["body"]["predictions"][0]["classes"][0]["prob"].GetDouble()
+              > 0.4);
+  ASSERT_TRUE(jd["body"]["predictions"][0]["classes"][0].HasMember("bbox"));
+  ASSERT_TRUE(
+      jd["body"]["predictions"][0]["classes"][0]["bbox"].HasMember("xmin"));
+  ASSERT_EQ(5, jd["body"]["predictions"][0]["classes"].Size());
 
-    // predict batch
-    jpredictstr = "{\"service\":\"imgserv\",\"parameters\":{\"output\":{\"bbox\":true}},\"data\":[\"" + obj_repo + "mmod_cars_test_image2.jpg\",\"" + face_repo + "cat.jpg\"]}";
-    joutstr = japi.jrender(japi.service_predict(jpredictstr));
-    std::cout << "joutstr=" << joutstr << std::endl;
-    jd.Parse(joutstr.c_str());
-    ASSERT_TRUE(!jd.HasParseError());
-    ASSERT_EQ(200,jd["status"]["code"]);
-    ASSERT_TRUE(jd["body"]["predictions"].IsArray());
-    ASSERT_EQ(2,jd["body"]["predictions"].Size()); // Ensure we got a predictions obj back for each file
-    int vehicle_idx = 0, cat_idx = 1;
-    if (jd["body"]["predictions"][0]["classes"].Size() == 0) { // If the first result happens to be cat.jpg, check the other one
-        vehicle_idx = 1;
-        cat_idx = 0;
+  // predict batch
+  jpredictstr = "{\"service\":\"imgserv\",\"parameters\":{\"output\":{"
+                "\"bbox\":true}},\"data\":[\""
+                + obj_repo + "mmod_cars_test_image2.jpg\",\"" + face_repo
+                + "cat.jpg\"]}";
+  joutstr = japi.jrender(japi.service_predict(jpredictstr));
+  std::cout << "joutstr=" << joutstr << std::endl;
+  jd.Parse(joutstr.c_str());
+  ASSERT_TRUE(!jd.HasParseError());
+  ASSERT_EQ(200, jd["status"]["code"]);
+  ASSERT_TRUE(jd["body"]["predictions"].IsArray());
+  ASSERT_EQ(2,
+            jd["body"]["predictions"]
+                .Size()); // Ensure we got a predictions obj back for each file
+  int vehicle_idx = 0, cat_idx = 1;
+  if (jd["body"]["predictions"][0]["classes"].Size() == 0)
+    { // If the first result happens to be cat.jpg, check the other one
+      vehicle_idx = 1;
+      cat_idx = 0;
     }
-    // There's no front or rear vehicle in cat.jpg, so no result for it
-    ASSERT_TRUE(jd["body"]["predictions"][cat_idx]["classes"].IsArray());
-    ASSERT_EQ(0, jd["body"]["predictions"][cat_idx]["classes"].Size());
+  // There's no front or rear vehicle in cat.jpg, so no result for it
+  ASSERT_TRUE(jd["body"]["predictions"][cat_idx]["classes"].IsArray());
+  ASSERT_EQ(0, jd["body"]["predictions"][cat_idx]["classes"].Size());
 
-    ASSERT_TRUE(jd["body"]["predictions"][vehicle_idx]["classes"].Size() > 0);
-    cl1 = jd["body"]["predictions"][vehicle_idx]["classes"][0]["cat"].GetString();
-    ASSERT_TRUE(cl1 == "rear");
-    ASSERT_TRUE(jd["body"]["predictions"][vehicle_idx]["classes"][0]["prob"].GetDouble() > 0.4);
-    ASSERT_TRUE(jd["body"]["predictions"][vehicle_idx]["classes"][0].HasMember("bbox"));
-    ASSERT_TRUE(jd["body"]["predictions"][vehicle_idx]["classes"][0]["bbox"].HasMember("xmin"));
+  ASSERT_TRUE(jd["body"]["predictions"][vehicle_idx]["classes"].Size() > 0);
+  cl1 = jd["body"]["predictions"][vehicle_idx]["classes"][0]["cat"]
+            .GetString();
+  ASSERT_TRUE(cl1 == "rear");
+  ASSERT_TRUE(
+      jd["body"]["predictions"][vehicle_idx]["classes"][0]["prob"].GetDouble()
+      > 0.4);
+  ASSERT_TRUE(
+      jd["body"]["predictions"][vehicle_idx]["classes"][0].HasMember("bbox"));
+  ASSERT_TRUE(
+      jd["body"]["predictions"][vehicle_idx]["classes"][0]["bbox"].HasMember(
+          "xmin"));
 }

--- a/tests/ut-graph.cc
+++ b/tests/ut-graph.cc
@@ -11,28 +11,28 @@
 
 using namespace dd;
 
-
 static std::string ok_str = "{\"status\":{\"code\":200,\"msg\":\"OK\"}}";
-static std::string created_str = "{\"status\":{\"code\":201,\"msg\":\"Created\"}}";
-static std::string bad_param_str = "{\"status\":{\"code\":400,\"msg\":\"BadRequest\"}}";
-static std::string not_found_str = "{\"status\":{\"code\":404,\"msg\":\"NotFound\"}}";
+static std::string created_str
+    = "{\"status\":{\"code\":201,\"msg\":\"Created\"}}";
+static std::string bad_param_str
+    = "{\"status\":{\"code\":400,\"msg\":\"BadRequest\"}}";
+static std::string not_found_str
+    = "{\"status\":{\"code\":404,\"msg\":\"NotFound\"}}";
 
 static std::string gpuid = "0"; // change as needed
-
 
 static std::string sinus = "../examples/all/sinus/";
 
 static std::string iterations_lstm_gpu = "1000";
 static std::string iterations_lstm_cpu = "20";
 
-
 TEST(graphapi, proto_read)
 {
-	CaffeToTorch ctt("../../examples/graph/recurrent.prototxt");
-	std::stringstream ss;
-	ctt.finalize();
-	ctt.todot(ss);
-	int cmp = ss.str().compare(R"DOT(digraph G {
+  CaffeToTorch ctt("../../examples/graph/recurrent.prototxt");
+  std::stringstream ss;
+  ctt.finalize();
+  ctt.todot(ss);
+  int cmp = ss.str().compare(R"DOT(digraph G {
 0[label="data { 1 , 50 , 9 }", shape=ellipse];
 1[label="LSTM0", shape=box];
 2[label="LSTM_0 { 1 , 50 , 50 }", shape=ellipse];
@@ -48,230 +48,274 @@ TEST(graphapi, proto_read)
 5->6 ;
 }
 )DOT");
-	ASSERT_EQ(cmp,0);
+  ASSERT_EQ(cmp, 0);
 }
-
 
 TEST(graphapi, compute_lstm)
 {
-	CaffeToTorch ctt("../../examples/graph/recurrent.prototxt");
-	torch::Tensor input = torch::randn({2,10,9});
-	torch::Tensor output = ctt.forward(input);
-	ASSERT_EQ(output.size(0),2);
-	ASSERT_EQ(output.size(1),10);
-	ASSERT_EQ(output.size(2),3);
+  CaffeToTorch ctt("../../examples/graph/recurrent.prototxt");
+  torch::Tensor input = torch::randn({ 2, 10, 9 });
+  torch::Tensor output = ctt.forward(input);
+  ASSERT_EQ(output.size(0), 2);
+  ASSERT_EQ(output.size(1), 10);
+  ASSERT_EQ(output.size(2), 3);
 }
 
 TEST(graphapi, simple_cuda)
 {
-	CaffeToTorch ctt("../../examples/graph/recurrent.prototxt");
-	ctt.to(torch::Device(c10::DeviceType::CUDA, 0));
-	torch::Tensor input = torch::randn({2,50,9}).to(torch::Device(c10::DeviceType::CUDA, 0));
-	torch::Tensor output = ctt.forward(input);
-	ASSERT_EQ(output.size(0),2);
-	ASSERT_EQ(output.size(1),50);
-	ASSERT_EQ(output.size(2),3);
+  CaffeToTorch ctt("../../examples/graph/recurrent.prototxt");
+  ctt.to(torch::Device(c10::DeviceType::CUDA, 0));
+  torch::Tensor input
+      = torch::randn({ 2, 50, 9 }).to(torch::Device(c10::DeviceType::CUDA, 0));
+  torch::Tensor output = ctt.forward(input);
+  ASSERT_EQ(output.size(0), 2);
+  ASSERT_EQ(output.size(1), 50);
+  ASSERT_EQ(output.size(2), 3);
 }
 
 TEST(graphapi, simple_lstm_train)
 {
-	CaffeToTorch ctt("../../examples/graph/recurrent.prototxt");
-	torch::Tensor input = torch::randn({2,50,9});
-	torch::Tensor target = torch::randn({2,50,3});
-	torch::Tensor output = ctt.forward(input);
-	ASSERT_EQ(output.size(0),2);
-	ASSERT_EQ(output.size(1),50);
-	ASSERT_EQ(output.size(2),3);
+  CaffeToTorch ctt("../../examples/graph/recurrent.prototxt");
+  torch::Tensor input = torch::randn({ 2, 50, 9 });
+  torch::Tensor target = torch::randn({ 2, 50, 3 });
+  torch::Tensor output = ctt.forward(input);
+  ASSERT_EQ(output.size(0), 2);
+  ASSERT_EQ(output.size(1), 50);
+  ASSERT_EQ(output.size(2), 3);
 
-	std::unique_ptr<torch::optim::Optimizer> optimizer;
-	double base_lr = 0.0001;
-	optimizer = std::unique_ptr<torch::optim::Optimizer>
-	  (new torch::optim::RMSprop(ctt.parameters(), torch::optim::RMSpropOptions(base_lr)));
+  std::unique_ptr<torch::optim::Optimizer> optimizer;
+  double base_lr = 0.0001;
+  optimizer
+      = std::unique_ptr<torch::optim::Optimizer>(new torch::optim::RMSprop(
+          ctt.parameters(), torch::optim::RMSpropOptions(base_lr)));
 
-	optimizer->zero_grad();
-	ctt.train();
+  optimizer->zero_grad();
+  ctt.train();
 
-	torch::Tensor loss;
-	double l0;
-	double l9;
+  torch::Tensor loss;
+  double l0;
+  double l9;
 
-	auto tstart = std::chrono::system_clock::now();
-	for (int i = 0; i< std::stoi(iterations_lstm_cpu); ++i)
-		{
-		  output = ctt.forward(input);
-			loss = torch::l1_loss(output,target);
-			if (i==0)
-				l0 = loss.item<double>();
-			else if (i==9)
-				l9 = loss.item<double>();
-			std::cout << "loss: " << loss.item<double>() << std::endl;
-			loss.backward();
-			optimizer->step();
-			optimizer->zero_grad();
-		}
-	auto tstop = std::chrono::system_clock::now();
-	std::cout << "optimization duration: " << std::chrono::duration_cast<std::chrono::milliseconds>(tstop - tstart).count() << std::endl;;
-	ASSERT_TRUE(l9<l0);
+  auto tstart = std::chrono::system_clock::now();
+  for (int i = 0; i < std::stoi(iterations_lstm_cpu); ++i)
+    {
+      output = ctt.forward(input);
+      loss = torch::l1_loss(output, target);
+      if (i == 0)
+        l0 = loss.item<double>();
+      else if (i == 9)
+        l9 = loss.item<double>();
+      std::cout << "loss: " << loss.item<double>() << std::endl;
+      loss.backward();
+      optimizer->step();
+      optimizer->zero_grad();
+    }
+  auto tstop = std::chrono::system_clock::now();
+  std::cout << "optimization duration: "
+            << std::chrono::duration_cast<std::chrono::milliseconds>(tstop
+                                                                     - tstart)
+                   .count()
+            << std::endl;
+  ;
+  ASSERT_TRUE(l9 < l0);
 }
 
 #ifndef CPU_ONLY
 TEST(graphapi, simple_lstm_train_gpu)
 {
-	// torch model allocated to cpu with size of 1,50,9 as in prototxt
-	CaffeToTorch ctt("../../examples/graph/recurrent.prototxt");
-	// moving previous torch model to gpu
-	ctt.to(torch::Device(c10::DeviceType::CUDA, 0));
+  // torch model allocated to cpu with size of 1,50,9 as in prototxt
+  CaffeToTorch ctt("../../examples/graph/recurrent.prototxt");
+  // moving previous torch model to gpu
+  ctt.to(torch::Device(c10::DeviceType::CUDA, 0));
 
-	auto tstart = std::chrono::system_clock::now();
-	torch::Tensor input = torch::randn({2,10,9}).to(torch::Device(c10::DeviceType::CUDA, 0));
-	torch::Tensor target = torch::randn({2,10,3}).to(torch::Device(c10::DeviceType::CUDA, 0));
-	auto tstop = std::chrono::system_clock::now();
-	std::cout << "data transfer duration: " << std::chrono::duration_cast<std::chrono::milliseconds>(tstop - tstart).count() << std::endl;
-	//below forward is forced to reallocate all model as datasize has changed from 50 to 10
-	tstart = std::chrono::system_clock::now();
-	torch::Tensor output = ctt.forward(input);
-	tstop = std::chrono::system_clock::now();
-	std::cout << "realloc + push model on GPU + 1 forward  duration: " << std::chrono::duration_cast<std::chrono::milliseconds>(tstop - tstart).count() << std::endl;
-	// it is reallocated and moved to gpu automatically :)
-	ASSERT_EQ(output.size(0),2);
-	ASSERT_EQ(output.size(1),10);
-	ASSERT_EQ(output.size(2),3);
+  auto tstart = std::chrono::system_clock::now();
+  torch::Tensor input
+      = torch::randn({ 2, 10, 9 }).to(torch::Device(c10::DeviceType::CUDA, 0));
+  torch::Tensor target
+      = torch::randn({ 2, 10, 3 }).to(torch::Device(c10::DeviceType::CUDA, 0));
+  auto tstop = std::chrono::system_clock::now();
+  std::cout << "data transfer duration: "
+            << std::chrono::duration_cast<std::chrono::milliseconds>(tstop
+                                                                     - tstart)
+                   .count()
+            << std::endl;
+  // below forward is forced to reallocate all model as datasize has changed
+  // from 50 to 10
+  tstart = std::chrono::system_clock::now();
+  torch::Tensor output = ctt.forward(input);
+  tstop = std::chrono::system_clock::now();
+  std::cout << "realloc + push model on GPU + 1 forward  duration: "
+            << std::chrono::duration_cast<std::chrono::milliseconds>(tstop
+                                                                     - tstart)
+                   .count()
+            << std::endl;
+  // it is reallocated and moved to gpu automatically :)
+  ASSERT_EQ(output.size(0), 2);
+  ASSERT_EQ(output.size(1), 10);
+  ASSERT_EQ(output.size(2), 3);
 
-	std::unique_ptr<torch::optim::Optimizer> optimizer;
-	double base_lr = 0.0001;
-	optimizer = std::unique_ptr<torch::optim::Optimizer>
-		(new torch::optim::RMSprop(ctt.parameters(), torch::optim::RMSpropOptions(base_lr)));
-	optimizer->zero_grad();
-	ctt.train();
+  std::unique_ptr<torch::optim::Optimizer> optimizer;
+  double base_lr = 0.0001;
+  optimizer
+      = std::unique_ptr<torch::optim::Optimizer>(new torch::optim::RMSprop(
+          ctt.parameters(), torch::optim::RMSpropOptions(base_lr)));
+  optimizer->zero_grad();
+  ctt.train();
 
-	torch::Tensor loss;
-	//	loss.to(torch::Device(c10::DeviceType::CUDA, 0));
-	double l0;
-	double l9;
+  torch::Tensor loss;
+  //	loss.to(torch::Device(c10::DeviceType::CUDA, 0));
+  double l0;
+  double l9;
 
-	tstart = std::chrono::system_clock::now();
-	for (int i = 0; i< std::stoi(iterations_lstm_gpu); ++i)
-		{
-			output = ctt.forward(input);
-			loss = torch::l1_loss(output,target);
-			if (i==0)
-				l0 = loss.item<double>();
-			else if (i==9)
-				l9 = loss.item<double>();
-			std::cout << "loss: " << loss.item<double>() << std::endl;
-			loss.backward();
-			optimizer->step();
-			optimizer->zero_grad();
-		}
-	tstop = std::chrono::system_clock::now();
-	std::cout << "optimizaton duration: " << std::chrono::duration_cast<std::chrono::milliseconds>(tstop - tstart).count() << std::endl;
-	ASSERT_TRUE(l9<l0);
+  tstart = std::chrono::system_clock::now();
+  for (int i = 0; i < std::stoi(iterations_lstm_gpu); ++i)
+    {
+      output = ctt.forward(input);
+      loss = torch::l1_loss(output, target);
+      if (i == 0)
+        l0 = loss.item<double>();
+      else if (i == 9)
+        l9 = loss.item<double>();
+      std::cout << "loss: " << loss.item<double>() << std::endl;
+      loss.backward();
+      optimizer->step();
+      optimizer->zero_grad();
+    }
+  tstop = std::chrono::system_clock::now();
+  std::cout << "optimizaton duration: "
+            << std::chrono::duration_cast<std::chrono::milliseconds>(tstop
+                                                                     - tstart)
+                   .count()
+            << std::endl;
+  ASSERT_TRUE(l9 < l0);
 }
 #endif
 
 TEST(graphapi, intermediate_lstm_train)
 {
-	CaffeToTorch ctt("../../examples/graph/recurrent.prototxt");
-	CSVTSTorchInputFileConn inputc;
-	inputc._train = true;
-	inputc._logger = spdlog::stdout_logger_mt("ut-graphapi");
+  CaffeToTorch ctt("../../examples/graph/recurrent.prototxt");
+  CSVTSTorchInputFileConn inputc;
+  inputc._train = true;
+  inputc._logger = spdlog::stdout_logger_mt("ut-graphapi");
 
-	APIData ad;
-	APIData ad_param;
-	APIData ad_input;
-	std::vector<std::string> data;
-	data.push_back("../examples/all/sinus/train");
-	data.push_back("../examples/all/sinus/test");
-	ad.add("data",data);
-	ad_input.add("connector",std::string("csvts"));
-	std::vector<std::string> outputs;
-	outputs.push_back("output");
-	ad_input.add("label",outputs);
-	ad_input.add("separator",std::string(","));
-	ad_input.add("timesteps",200);
-	ad_param.add("input", ad_input);
-	ad.add("parameters",ad_param);
+  APIData ad;
+  APIData ad_param;
+  APIData ad_input;
+  std::vector<std::string> data;
+  data.push_back("../examples/all/sinus/train");
+  data.push_back("../examples/all/sinus/test");
+  ad.add("data", data);
+  ad_input.add("connector", std::string("csvts"));
+  std::vector<std::string> outputs;
+  outputs.push_back("output");
+  ad_input.add("label", outputs);
+  ad_input.add("separator", std::string(","));
+  ad_input.add("timesteps", 200);
+  ad_param.add("input", ad_input);
+  ad.add("parameters", ad_param);
 
-	inputc.transform(ad);
+  inputc.transform(ad);
 
-	ASSERT_EQ(inputc._dataset.cache_size(), 485);
-	ASSERT_EQ(inputc._test_dataset.cache_size(), 10);
+  ASSERT_EQ(inputc._dataset.cache_size(), 485);
+  ASSERT_EQ(inputc._test_dataset.cache_size(), 10);
 
-	auto batchoptional = inputc._dataset.get_batch({inputc._dataset.cache_size()});
-	TorchBatch batch = batchoptional.value();
-	torch::Tensor td = batch.data[0];
-	torch::Tensor tt = batch.target[0];
+  auto batchoptional
+      = inputc._dataset.get_batch({ inputc._dataset.cache_size() });
+  TorchBatch batch = batchoptional.value();
+  torch::Tensor td = batch.data[0];
+  torch::Tensor tt = batch.target[0];
 
-	ctt.finalize(td.sizes());
+  ctt.finalize(td.sizes());
 
-	ASSERT_TRUE(td.sizes() ==  std::vector<int64_t>({485,200,1}));
-	ASSERT_TRUE(tt.sizes() == std::vector<int64_t>({485,200,1}));
+  ASSERT_TRUE(td.sizes() == std::vector<int64_t>({ 485, 200, 1 }));
+  ASSERT_TRUE(tt.sizes() == std::vector<int64_t>({ 485, 200, 1 }));
 
-	std::unique_ptr<torch::optim::Optimizer> optimizer;
-	double base_lr = 0.1;
-	optimizer = std::unique_ptr<torch::optim::Optimizer>
-	  (new torch::optim::RMSprop(ctt.parameters(), torch::optim::RMSpropOptions(base_lr)));
-	optimizer->zero_grad();
-	ctt.train();
+  std::unique_ptr<torch::optim::Optimizer> optimizer;
+  double base_lr = 0.1;
+  optimizer
+      = std::unique_ptr<torch::optim::Optimizer>(new torch::optim::RMSprop(
+          ctt.parameters(), torch::optim::RMSpropOptions(base_lr)));
+  optimizer->zero_grad();
+  ctt.train();
 
-	torch::Tensor loss;
-	double l0;
-	double l9;
+  torch::Tensor loss;
+  double l0;
+  double l9;
 
-	inputc._dataset.reset();
-	auto dataloader =
-	  torch::data::make_data_loader(std::move(inputc._dataset),
-									torch::data::DataLoaderOptions(100));
+  inputc._dataset.reset();
+  auto dataloader = torch::data::make_data_loader(
+      std::move(inputc._dataset), torch::data::DataLoaderOptions(100));
 
-	auto tstart = std::chrono::system_clock::now();
-	for (int i = 0; i< std::stoi(iterations_lstm_cpu); ++i)
-	  {
-		int nbatches = 0;
-		double train_loss = 0;
-		for (TorchBatch batch : *dataloader)
-		  {
-			torch::Tensor input = batch.data[0]; //input is only one tensor, hence [0]
-			ASSERT_TRUE(input.size(0) <= 100);
-			ASSERT_EQ(input.size(1), 200);
-			ASSERT_EQ(input.size(2), 1);
-			torch::Tensor target = batch.target[0];
-			torch::Tensor output = ctt.forward(input);
-			loss = torch::l1_loss(output,target);
-			train_loss += loss.item<double>();
-			nbatches++;
-			loss.backward();
-			std::cout << "minibatch loss : " << loss.item<double>() << std::endl;
-			optimizer->step();
-			optimizer->zero_grad();
-		  }
-		std::cout << "epoch loss: " << train_loss/nbatches << std::endl;
-		if (i == 0)
-		  l0 = train_loss/nbatches;
-		else if (i==9)
-		  l9 = train_loss/nbatches;
-	 	}
-	 auto tstop = std::chrono::system_clock::now();
-	 std::cout << "optimization duration: " << std::chrono::duration_cast<std::chrono::milliseconds>(tstop - tstart).count() << std::endl;;
-	 ASSERT_TRUE(l9<l0);
+  auto tstart = std::chrono::system_clock::now();
+  for (int i = 0; i < std::stoi(iterations_lstm_cpu); ++i)
+    {
+      int nbatches = 0;
+      double train_loss = 0;
+      for (TorchBatch batch : *dataloader)
+        {
+          torch::Tensor input
+              = batch.data[0]; // input is only one tensor, hence [0]
+          ASSERT_TRUE(input.size(0) <= 100);
+          ASSERT_EQ(input.size(1), 200);
+          ASSERT_EQ(input.size(2), 1);
+          torch::Tensor target = batch.target[0];
+          torch::Tensor output = ctt.forward(input);
+          loss = torch::l1_loss(output, target);
+          train_loss += loss.item<double>();
+          nbatches++;
+          loss.backward();
+          std::cout << "minibatch loss : " << loss.item<double>() << std::endl;
+          optimizer->step();
+          optimizer->zero_grad();
+        }
+      std::cout << "epoch loss: " << train_loss / nbatches << std::endl;
+      if (i == 0)
+        l0 = train_loss / nbatches;
+      else if (i == 9)
+        l9 = train_loss / nbatches;
+    }
+  auto tstop = std::chrono::system_clock::now();
+  std::cout << "optimization duration: "
+            << std::chrono::duration_cast<std::chrono::milliseconds>(tstop
+                                                                     - tstart)
+                   .count()
+            << std::endl;
+  ;
+  ASSERT_TRUE(l9 < l0);
 }
-
 
 TEST(graphapi, complete_lstm_train)
 {
   // create service
   JsonAPI japi;
   std::string csvts_data = sinus + "train";
-  std::string csvts_test = sinus +"test";
-  std::string csvts_predict = sinus +"predict";
+  std::string csvts_test = sinus + "test";
+  std::string csvts_predict = sinus + "predict";
   std::string csvts_repo = "csvts";
-  mkdir(csvts_repo.c_str(),0777);
+  mkdir(csvts_repo.c_str(), 0777);
   std::string sname = "my_service_csvts";
-  std::string jstr = "{\"mllib\":\"torch\",\"description\":\"my ts regressor\",\"type\":\"supervised\",\"model\":{\"repository\":\"" +  csvts_repo+"\"},\"parameters\":{\"input\":{\"connector\":\"csvts\",\"label\":[\"output\"]},\"mllib\":{\"template\":\"recurrent\",\"layers\":[\"L10\",\"L10\"],\"dropout\":[0.0,0.0,0.0],\"regression\":true,\"sl1sigma\":100.0,\"loss\":\"L1\"}}}";
-  std::string joutstr = japi.jrender(japi.service_create(sname,jstr));
-  ASSERT_EQ(created_str,joutstr);
+  std::string jstr
+      = "{\"mllib\":\"torch\",\"description\":\"my ts "
+        "regressor\",\"type\":\"supervised\",\"model\":{\"repository\":\""
+        + csvts_repo
+        + "\"},\"parameters\":{\"input\":{\"connector\":\"csvts\",\"label\":["
+          "\"output\"]},\"mllib\":{\"template\":\"recurrent\",\"layers\":["
+          "\"L10\",\"L10\"],\"dropout\":[0.0,0.0,0.0],\"regression\":true,"
+          "\"sl1sigma\":100.0,\"loss\":\"L1\"}}}";
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
 
   // train
-  std::string jtrainstr = "{\"service\":\"" + sname + "\",\"async\":false,\"parameters\":{\"input\":{\"shuffle\":true,\"separator\":\",\",\"scale\":true,\"timesteps\":200,\"label\":[\"output\"]},\"mllib\":{\"gpu\":false,\"solver\":{\"iterations\":" + iterations_lstm_cpu + ",\"test_interval\":10,\"base_lr\":0.1,\"snapshot\":500,\"test_initialization\":false},\"net\":{\"batch_size\":100,\"test_batch_size\":10}},\"output\":{\"measure\":[\"L1\",\"L2\"]}},\"data\":[\"" + csvts_data+"\",\""+csvts_test+"\"]}";
+  std::string jtrainstr
+      = "{\"service\":\"" + sname
+        + "\",\"async\":false,\"parameters\":{\"input\":{\"shuffle\":true,"
+          "\"separator\":\",\",\"scale\":true,\"timesteps\":200,\"label\":["
+          "\"output\"]},\"mllib\":{\"gpu\":false,\"solver\":{\"iterations\":"
+        + iterations_lstm_cpu
+        + ",\"test_interval\":10,\"base_lr\":0.1,\"snapshot\":500,\"test_"
+          "initialization\":false},\"net\":{\"batch_size\":100,\"test_batch_"
+          "size\":10}},\"output\":{\"measure\":[\"L1\",\"L2\"]}},\"data\":[\""
+        + csvts_data + "\",\"" + csvts_test + "\"]}";
   std::cerr << "jtrainstr=" << jtrainstr << std::endl;
   joutstr = japi.jrender(japi.service_train(jtrainstr));
   std::cout << "joutstr=" << joutstr << std::endl;
@@ -279,10 +323,10 @@ TEST(graphapi, complete_lstm_train)
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_TRUE(jd.HasMember("status"));
-  ASSERT_EQ(201,jd["status"]["code"].GetInt());
-  ASSERT_EQ("Created",jd["status"]["msg"]);
+  ASSERT_EQ(201, jd["status"]["code"].GetInt());
+  ASSERT_EQ("Created", jd["status"]["msg"]);
   ASSERT_TRUE(jd.HasMember("head"));
-  ASSERT_EQ("/train",jd["head"]["method"]);
+  ASSERT_EQ("/train", jd["head"]["method"]);
   ASSERT_TRUE(jd["head"]["time"].GetDouble() >= 0);
   ASSERT_TRUE(jd.HasMember("body"));
   ASSERT_TRUE(jd["body"]["measure"].HasMember("train_loss"));
@@ -292,27 +336,35 @@ TEST(graphapi, complete_lstm_train)
   ASSERT_TRUE(jd["body"]["parameters"]["input"].HasMember("max_vals"));
   ASSERT_TRUE(jd["body"]["parameters"]["input"].HasMember("min_vals"));
 
-  std::string str_min_vals = japi.jrender(jd["body"]["parameters"]["input"]["min_vals"]);
-  std::string str_max_vals = japi.jrender(jd["body"]["parameters"]["input"]["max_vals"]);
+  std::string str_min_vals
+      = japi.jrender(jd["body"]["parameters"]["input"]["min_vals"]);
+  std::string str_max_vals
+      = japi.jrender(jd["body"]["parameters"]["input"]["max_vals"]);
 
   //  predict
-  std::string jpredictstr = "{\"service\":\""+ sname + "\",\"parameters\":{\"input\":{\"timesteps\":20,\"connector\":\"csvts\",\"scale\":true,\"continuation\":true,\"label\":[\"output\"],\"min_vals\":" + str_min_vals + ",\"max_vals\":" + str_max_vals + "},\"output\":{}},\"data\":[\"" + csvts_predict + "\"]}";
+  std::string jpredictstr
+      = "{\"service\":\"" + sname
+        + "\",\"parameters\":{\"input\":{\"timesteps\":20,\"connector\":"
+          "\"csvts\",\"scale\":true,\"continuation\":true,\"label\":["
+          "\"output\"],\"min_vals\":"
+        + str_min_vals + ",\"max_vals\":" + str_max_vals
+        + "},\"output\":{}},\"data\":[\"" + csvts_predict + "\"]}";
   joutstr = japi.jrender(japi.service_predict(jpredictstr));
   std::cout << "joutstr=" << joutstr << std::endl;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
-  ASSERT_EQ(200,jd["status"]["code"]);
+  ASSERT_EQ(200, jd["status"]["code"]);
   std::string uri = jd["body"]["predictions"][0]["uri"].GetString();
-  ASSERT_EQ("../examples/all/sinus/predict/seq_2.csv #0_998",uri);
+  ASSERT_EQ("../examples/all/sinus/predict/seq_2.csv #0_998", uri);
   ASSERT_TRUE(jd["body"]["predictions"][0]["series"].IsArray());
-  ASSERT_TRUE(jd["body"]["predictions"][0]["series"][0]["out"][0].GetDouble() >= -1.0);
+  ASSERT_TRUE(jd["body"]["predictions"][0]["series"][0]["out"][0].GetDouble()
+              >= -1.0);
 
   //  remove service
   jstr = "{\"clear\":\"full\"}";
-  joutstr = japi.jrender(japi.service_delete(sname,jstr));
-  ASSERT_EQ(ok_str,joutstr);
+  joutstr = japi.jrender(japi.service_delete(sname, jstr));
+  ASSERT_EQ(ok_str, joutstr);
   rmdir(csvts_repo.c_str());
-
 }
 
 #ifndef CPU_ONLY
@@ -321,17 +373,34 @@ TEST(graphapi, complete_lstm_train_gpu)
   // create service
   JsonAPI japi;
   std::string csvts_data = sinus + "train";
-  std::string csvts_test = sinus +"test";
-  std::string csvts_predict = sinus +"predict";
+  std::string csvts_test = sinus + "test";
+  std::string csvts_predict = sinus + "predict";
   std::string csvts_repo = "csvts";
-  mkdir(csvts_repo.c_str(),0777);
+  mkdir(csvts_repo.c_str(), 0777);
   std::string sname = "my_service_csvts";
-  std::string jstr = "{\"mllib\":\"torch\",\"description\":\"my ts regressor\",\"type\":\"supervised\",\"model\":{\"repository\":\"" +  csvts_repo+"\"},\"parameters\":{\"input\":{\"connector\":\"csvts\",\"label\":[\"output\"]},\"mllib\":{\"template\":\"recurrent\",\"layers\":[\"L10\",\"L10\"],\"dropout\":[0.0,0.0,0.0],\"regression\":true,\"sl1sigma\":100.0,\"loss\":\"L1\",\"gpu\":true,\"gpuid\":"+gpuid+"}}}";
-  std::string joutstr = japi.jrender(japi.service_create(sname,jstr));
-  ASSERT_EQ(created_str,joutstr);
+  std::string jstr
+      = "{\"mllib\":\"torch\",\"description\":\"my ts "
+        "regressor\",\"type\":\"supervised\",\"model\":{\"repository\":\""
+        + csvts_repo
+        + "\"},\"parameters\":{\"input\":{\"connector\":\"csvts\",\"label\":["
+          "\"output\"]},\"mllib\":{\"template\":\"recurrent\",\"layers\":["
+          "\"L10\",\"L10\"],\"dropout\":[0.0,0.0,0.0],\"regression\":true,"
+          "\"sl1sigma\":100.0,\"loss\":\"L1\",\"gpu\":true,\"gpuid\":"
+        + gpuid + "}}}";
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
 
   // train
-  std::string jtrainstr = "{\"service\":\"" + sname + "\",\"async\":false,\"parameters\":{\"input\":{\"shuffle\":true,\"separator\":\",\",\"scale\":true,\"timesteps\":200,\"label\":[\"output\"]},\"mllib\":{\"gpu\":false,\"solver\":{\"iterations\":" + iterations_lstm_gpu + ",\"test_interval\":500,\"base_lr\":0.1,\"snapshot\":500,\"test_initialization\":false},\"net\":{\"batch_size\":100,\"test_batch_size\":10}},\"output\":{\"measure\":[\"L1\",\"L2\"]}},\"data\":[\"" + csvts_data+"\",\""+csvts_test+"\"]}";
+  std::string jtrainstr
+      = "{\"service\":\"" + sname
+        + "\",\"async\":false,\"parameters\":{\"input\":{\"shuffle\":true,"
+          "\"separator\":\",\",\"scale\":true,\"timesteps\":200,\"label\":["
+          "\"output\"]},\"mllib\":{\"gpu\":false,\"solver\":{\"iterations\":"
+        + iterations_lstm_gpu
+        + ",\"test_interval\":500,\"base_lr\":0.1,\"snapshot\":500,\"test_"
+          "initialization\":false},\"net\":{\"batch_size\":100,\"test_batch_"
+          "size\":10}},\"output\":{\"measure\":[\"L1\",\"L2\"]}},\"data\":[\""
+        + csvts_data + "\",\"" + csvts_test + "\"]}";
   std::cerr << "jtrainstr=" << jtrainstr << std::endl;
   joutstr = japi.jrender(japi.service_train(jtrainstr));
   std::cout << "joutstr=" << joutstr << std::endl;
@@ -339,10 +408,10 @@ TEST(graphapi, complete_lstm_train_gpu)
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_TRUE(jd.HasMember("status"));
-  ASSERT_EQ(201,jd["status"]["code"].GetInt());
-  ASSERT_EQ("Created",jd["status"]["msg"]);
+  ASSERT_EQ(201, jd["status"]["code"].GetInt());
+  ASSERT_EQ("Created", jd["status"]["msg"]);
   ASSERT_TRUE(jd.HasMember("head"));
-  ASSERT_EQ("/train",jd["head"]["method"]);
+  ASSERT_EQ("/train", jd["head"]["method"]);
   ASSERT_TRUE(jd["head"]["time"].GetDouble() >= 0);
   ASSERT_TRUE(jd.HasMember("body"));
   ASSERT_TRUE(jd["body"]["measure"].HasMember("train_loss"));
@@ -352,26 +421,34 @@ TEST(graphapi, complete_lstm_train_gpu)
   ASSERT_TRUE(jd["body"]["parameters"]["input"].HasMember("max_vals"));
   ASSERT_TRUE(jd["body"]["parameters"]["input"].HasMember("min_vals"));
 
-  std::string str_min_vals = japi.jrender(jd["body"]["parameters"]["input"]["min_vals"]);
-  std::string str_max_vals = japi.jrender(jd["body"]["parameters"]["input"]["max_vals"]);
+  std::string str_min_vals
+      = japi.jrender(jd["body"]["parameters"]["input"]["min_vals"]);
+  std::string str_max_vals
+      = japi.jrender(jd["body"]["parameters"]["input"]["max_vals"]);
 
   //  predict
-  std::string jpredictstr = "{\"service\":\""+ sname + "\",\"parameters\":{\"input\":{\"timesteps\":20,\"connector\":\"csvts\",\"scale\":true,\"label\":[\"output\"],\"continuation\":true,\"min_vals\":" + str_min_vals + ",\"max_vals\":" + str_max_vals + "},\"output\":{}},\"data\":[\"" + csvts_predict + "\"]}";
+  std::string jpredictstr
+      = "{\"service\":\"" + sname
+        + "\",\"parameters\":{\"input\":{\"timesteps\":20,\"connector\":"
+          "\"csvts\",\"scale\":true,\"label\":[\"output\"],\"continuation\":"
+          "true,\"min_vals\":"
+        + str_min_vals + ",\"max_vals\":" + str_max_vals
+        + "},\"output\":{}},\"data\":[\"" + csvts_predict + "\"]}";
   joutstr = japi.jrender(japi.service_predict(jpredictstr));
   std::cout << "joutstr=" << joutstr << std::endl;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
-  ASSERT_EQ(200,jd["status"]["code"]);
+  ASSERT_EQ(200, jd["status"]["code"]);
   std::string uri = jd["body"]["predictions"][0]["uri"].GetString();
-  ASSERT_EQ("../examples/all/sinus/predict/seq_2.csv #0_998",uri);
+  ASSERT_EQ("../examples/all/sinus/predict/seq_2.csv #0_998", uri);
   ASSERT_TRUE(jd["body"]["predictions"][0]["series"].IsArray());
-  ASSERT_TRUE(jd["body"]["predictions"][0]["series"][0]["out"][0].GetDouble() >= -1.0);
+  ASSERT_TRUE(jd["body"]["predictions"][0]["series"][0]["out"][0].GetDouble()
+              >= -1.0);
 
   //  remove service
   jstr = "{\"clear\":\"full\"}";
-  joutstr = japi.jrender(japi.service_delete(sname,jstr));
-  ASSERT_EQ(ok_str,joutstr);
+  joutstr = japi.jrender(japi.service_delete(sname, jstr));
+  ASSERT_EQ(ok_str, joutstr);
   rmdir(csvts_repo.c_str());
-
 }
 #endif

--- a/tests/ut-httpapi.cc
+++ b/tests/ut-httpapi.cc
@@ -31,7 +31,12 @@ std::string host = "127.0.0.1";
 int port = 8080;
 int nthreads = 10;
 std::string serv = "myserv";
-std::string serv_put = "{\"mllib\":\"caffe\",\"description\":\"example classification service\",\"type\":\"supervised\",\"parameters\":{\"input\":{\"connector\":\"csv\"},\"mllib\":{\"template\":\"mlp\",\"nclasses\":2,\"layers\":[50,50,50],\"activation\":\"PReLU\"}},\"model\":{\"templates\":\"../templates/caffe/\",\"repository\":\".\"}}";
+std::string serv_put
+    = "{\"mllib\":\"caffe\",\"description\":\"example classification "
+      "service\",\"type\":\"supervised\",\"parameters\":{\"input\":{"
+      "\"connector\":\"csv\"},\"mllib\":{\"template\":\"mlp\",\"nclasses\":2,"
+      "\"layers\":[50,50,50],\"activation\":\"PReLU\"}},\"model\":{"
+      "\"templates\":\"../templates/caffe/\",\"repository\":\".\"}}";
 
 #ifndef CPU_ONLY
 static std::string iterations_mnist = "10000";
@@ -39,440 +44,501 @@ static std::string iterations_mnist = "10000";
 static std::string iterations_mnist = "10";
 #endif
 
-
-
-
-TEST(httpjsonapi,uri_query_to_json)
+TEST(httpjsonapi, uri_query_to_json)
 {
   std::string q = "service=myserv&job=1";
   std::string q1 = q + "&test=true";
   std::string p = uri_query_to_json(q1);
-  ASSERT_EQ("{\"service\":\"myserv\",\"job\":1,\"test\":true}",p);
+  ASSERT_EQ("{\"service\":\"myserv\",\"job\":1,\"test\":true}", p);
   std::string q1b = q + "&test=false";
   p = uri_query_to_json(q1b);
-  ASSERT_EQ("{\"service\":\"myserv\",\"job\":1,\"test\":false}",p);
+  ASSERT_EQ("{\"service\":\"myserv\",\"job\":1,\"test\":false}", p);
   std::string q2 = q + "&parameters.output.measure_hist=true";
   p = uri_query_to_json(q2);
-  ASSERT_EQ("{\"service\":\"myserv\",\"job\":1,\"parameters\":{\"output\":{\"measure_hist\":true}}}",p);
+  ASSERT_EQ("{\"service\":\"myserv\",\"job\":1,\"parameters\":{\"output\":{"
+            "\"measure_hist\":true}}}",
+            p);
   std::string q3 = q + "&parameters.output.measure_hist=false";
   p = uri_query_to_json(q3);
-  ASSERT_EQ("{\"service\":\"myserv\",\"job\":1,\"parameters\":{\"output\":{\"measure_hist\":false}}}",p);
-  std::string q4 = q + "&parameters.output.measure_hist=true&parameters.output.max_hist_points=100";
+  ASSERT_EQ("{\"service\":\"myserv\",\"job\":1,\"parameters\":{\"output\":{"
+            "\"measure_hist\":false}}}",
+            p);
+  std::string q4 = q
+                   + "&parameters.output.measure_hist=true&parameters.output."
+                     "max_hist_points=100";
   p = uri_query_to_json(q4);
-  ASSERT_EQ("{\"service\":\"myserv\",\"job\":1,\"parameters\":{\"output\":{\"measure_hist\":true,\"max_hist_points\":100}}}",p);
+  ASSERT_EQ("{\"service\":\"myserv\",\"job\":1,\"parameters\":{\"output\":{"
+            "\"measure_hist\":true,\"max_hist_points\":100}}}",
+            p);
 }
 
-TEST(httpjsonapi,info)
+TEST(httpjsonapi, info)
 {
   HttpJsonAPI hja;
-  hja.start_server_daemon(host,std::to_string(port),nthreads);
+  hja.start_server_daemon(host, std::to_string(port), nthreads);
   std::string luri = "http://" + host + ":" + std::to_string(port);
   sleep(2);
-  
+
   int code = -1;
   std::string jstr;
-  httpclient::get_call(luri+"/info","GET",code,jstr);
-  
-  ASSERT_EQ(200,code);
+  httpclient::get_call(luri + "/info", "GET", code, jstr);
+
+  ASSERT_EQ(200, code);
   rapidjson::Document d;
   d.Parse(jstr.c_str());
   ASSERT_FALSE(d.HasParseError());
   ASSERT_TRUE(d.HasMember("status"));
   ASSERT_TRUE(d.HasMember("head"));
   ASSERT_TRUE(d["head"].HasMember("services"));
-  ASSERT_EQ(0,d["head"]["services"].Size());
-  
+  ASSERT_EQ(0, d["head"]["services"].Size());
+
   hja.stop_server();
 }
 
-TEST(httpjsonapi,services)
+TEST(httpjsonapi, services)
 {
-  
+
   HttpJsonAPI hja;
-  hja.start_server_daemon(host,std::to_string(++port),nthreads);
+  hja.start_server_daemon(host, std::to_string(++port), nthreads);
   std::string luri = "http://" + host + ":" + std::to_string(port);
   sleep(2);
 
   // service creation
   int code = 1;
   std::string jstr;
-  httpclient::post_call(luri+"/services/"+serv,serv_put,"PUT",
-	    code,jstr);  
-  ASSERT_EQ(201,code);
+  httpclient::post_call(luri + "/services/" + serv, serv_put, "PUT", code,
+                        jstr);
+  ASSERT_EQ(201, code);
   rapidjson::Document d;
   d.Parse(jstr.c_str());
   ASSERT_FALSE(d.HasParseError());
   ASSERT_TRUE(d.HasMember("status"));
-  ASSERT_EQ(201,d["status"]["code"].GetInt());
+  ASSERT_EQ(201, d["status"]["code"].GetInt());
 
   // service info
-  httpclient::get_call(luri+"/services/"+serv,"GET",code,jstr);
+  httpclient::get_call(luri + "/services/" + serv, "GET", code, jstr);
   d = rapidjson::Document();
   d.Parse(jstr.c_str());
-  ASSERT_EQ(200,code);
+  ASSERT_EQ(200, code);
   ASSERT_TRUE(d.HasMember("status"));
   ASSERT_TRUE(d.HasMember("body"));
-  ASSERT_EQ("caffe",d["body"]["mllib"]);
-  ASSERT_EQ("myserv",d["body"]["name"]);
+  ASSERT_EQ("caffe", d["body"]["mllib"]);
+  ASSERT_EQ("myserv", d["body"]["name"]);
   ASSERT_TRUE(d["body"].HasMember("jobs"));
-  
+
   // info call
-  httpclient::get_call(luri+"/info","GET",code,jstr);
+  httpclient::get_call(luri + "/info", "GET", code, jstr);
   d = rapidjson::Document();
   d.Parse(jstr.c_str());
-  ASSERT_EQ(200,code);
+  ASSERT_EQ(200, code);
   ASSERT_TRUE(d["head"].HasMember("services"));
-  ASSERT_EQ(1,d["head"]["services"].Size());
+  ASSERT_EQ(1, d["head"]["services"].Size());
 
   // delete call
-  httpclient::get_call(luri+"/services/"+serv,"DELETE",code,jstr);
-  ASSERT_EQ(200,code);
+  httpclient::get_call(luri + "/services/" + serv, "DELETE", code, jstr);
+  ASSERT_EQ(200, code);
 
   // info call
-  httpclient::get_call(luri+"/info","GET",code,jstr);
+  httpclient::get_call(luri + "/info", "GET", code, jstr);
   d = rapidjson::Document();
   d.Parse(jstr.c_str());
-  ASSERT_EQ(200,code);
+  ASSERT_EQ(200, code);
   ASSERT_TRUE(d["head"].HasMember("services"));
-  ASSERT_EQ(0,d["head"]["services"].Size());
+  ASSERT_EQ(0, d["head"]["services"].Size());
 
   // service info
-  httpclient::get_call(luri+"/services/"+serv,"GET",code,jstr);
+  httpclient::get_call(luri + "/services/" + serv, "GET", code, jstr);
   d = rapidjson::Document();
   d.Parse(jstr.c_str());
-  ASSERT_EQ(404,code);
-  
+  ASSERT_EQ(404, code);
+
   hja.stop_server();
 }
 
-TEST(httpjsonapi,train)
+TEST(httpjsonapi, train)
 {
   HttpJsonAPI hja;
-  hja.start_server_daemon(host,std::to_string(++port),nthreads);
+  hja.start_server_daemon(host, std::to_string(++port), nthreads);
   std::string luri = "http://" + host + ":" + std::to_string(port);
   sleep(2);
 
   // service definition
   std::string mnist_repo = "../examples/caffe/mnist/";
-  std::string serv_put2 = "{\"mllib\":\"caffe\",\"description\":\"my classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\"" +  mnist_repo + "\"},\"parameters\":{\"input\":{\"connector\":\"image\"},\"mllib\":{\"nclasses\":10}}}";
-  
+  std::string serv_put2
+      = "{\"mllib\":\"caffe\",\"description\":\"my "
+        "classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\""
+        + mnist_repo
+        + "\"},\"parameters\":{\"input\":{\"connector\":\"image\"},\"mllib\":{"
+          "\"nclasses\":10}}}";
+
   // service creation
   int code = 1;
   std::string jstr;
-  httpclient::post_call(luri+"/services/"+serv,serv_put2,"PUT",
-			 code,jstr);  
-  ASSERT_EQ(201,code);
+  httpclient::post_call(luri + "/services/" + serv, serv_put2, "PUT", code,
+                        jstr);
+  ASSERT_EQ(201, code);
   rapidjson::Document d;
   d.Parse(jstr.c_str());
   ASSERT_FALSE(d.HasParseError());
   ASSERT_TRUE(d.HasMember("status"));
-  ASSERT_EQ(201,d["status"]["code"].GetInt());
+  ASSERT_EQ(201, d["status"]["code"].GetInt());
 
-  //train blocking
-  std::string train_post = "{\"service\":\"" + serv + "\",\"async\":false,\"parameters\":{\"mllib\":{\"gpu\":true,\"solver\":{\"iterations\":" + iterations_mnist + "}}}}";
-  httpclient::post_call(luri+"/train",train_post,"POST",code,jstr);
-  ASSERT_EQ(201,code);
+  // train blocking
+  std::string train_post = "{\"service\":\"" + serv
+                           + "\",\"async\":false,\"parameters\":{\"mllib\":{"
+                             "\"gpu\":true,\"solver\":{\"iterations\":"
+                           + iterations_mnist + "}}}}";
+  httpclient::post_call(luri + "/train", train_post, "POST", code, jstr);
+  ASSERT_EQ(201, code);
   d.Parse(jstr.c_str());
   ASSERT_TRUE(d.HasMember("body"));
   ASSERT_TRUE(d["body"].HasMember("measure"));
 #ifndef CPU_ONLY
-  ASSERT_EQ(9999,d["body"]["measure"]["iteration"].GetDouble());
+  ASSERT_EQ(9999, d["body"]["measure"]["iteration"].GetDouble());
 #else
-  ASSERT_EQ(9,d["body"]["measure"]["iteration"].GetDouble());
+  ASSERT_EQ(9, d["body"]["measure"]["iteration"].GetDouble());
 #endif
   ASSERT_TRUE(fabs(d["body"]["measure"]["train_loss"].GetDouble()) > 0.0);
-  
+
   // remove service and trained model files
-  httpclient::get_call(luri+"/services/"+serv+"?clear=lib","DELETE",code,jstr);
-  ASSERT_EQ(200,code);
+  httpclient::get_call(luri + "/services/" + serv + "?clear=lib", "DELETE",
+                       code, jstr);
+  ASSERT_EQ(200, code);
 
   // service creation
-  httpclient::post_call(luri+"/services/"+serv,serv_put2,"PUT",
-			 code,jstr);  
-  ASSERT_EQ(201,code);
+  httpclient::post_call(luri + "/services/" + serv, serv_put2, "PUT", code,
+                        jstr);
+  ASSERT_EQ(201, code);
   d.Parse(jstr.c_str());
   ASSERT_FALSE(d.HasParseError());
   ASSERT_TRUE(d.HasMember("status"));
-  ASSERT_EQ(201,d["status"]["code"].GetInt());
-  
-  //train async
-  train_post = "{\"service\":\"" + serv + "\",\"async\":true,\"parameters\":{\"mllib\":{\"gpu\":true,\"solver\":{\"iterations\":" + iterations_mnist + "}}}}";
-  httpclient::post_call(luri+"/train",train_post,"POST",code,jstr);
-  ASSERT_EQ(201,code);
+  ASSERT_EQ(201, d["status"]["code"].GetInt());
+
+  // train async
+  train_post = "{\"service\":\"" + serv
+               + "\",\"async\":true,\"parameters\":{\"mllib\":{\"gpu\":true,"
+                 "\"solver\":{\"iterations\":"
+               + iterations_mnist + "}}}}";
+  httpclient::post_call(luri + "/train", train_post, "POST", code, jstr);
+  ASSERT_EQ(201, code);
   d.Parse(jstr.c_str());
   ASSERT_FALSE(d.HasMember("body"));
 
   sleep(1);
 
   // service info
-  httpclient::get_call(luri+"/services/"+serv,"GET",code,jstr);
+  httpclient::get_call(luri + "/services/" + serv, "GET", code, jstr);
   d = rapidjson::Document();
   d.Parse(jstr.c_str());
-  ASSERT_EQ(200,code);
+  ASSERT_EQ(200, code);
   ASSERT_TRUE(d.HasMember("status"));
   ASSERT_TRUE(d.HasMember("body"));
-  ASSERT_EQ("caffe",d["body"]["mllib"]);
-  ASSERT_EQ("myserv",d["body"]["name"]);
+  ASSERT_EQ("caffe", d["body"]["mllib"]);
+  ASSERT_EQ("myserv", d["body"]["name"]);
   ASSERT_TRUE(d["body"].HasMember("jobs"));
-  ASSERT_EQ("running",d["body"]["jobs"][0]["status"]);
-  
+  ASSERT_EQ("running", d["body"]["jobs"][0]["status"]);
+
   // get info on training job
   bool running = true;
-  while(running)
+  while (running)
     {
-      httpclient::get_call(luri+"/train?service="+serv+"&job=1&timeout=1&parameters.output.max_hist_points=100","GET",code,jstr);
+      httpclient::get_call(
+          luri + "/train?service=" + serv
+              + "&job=1&timeout=1&parameters.output.max_hist_points=100",
+          "GET", code, jstr);
       running = jstr.find("running") != std::string::npos;
       if (running)
-	{
-	  std::cerr << "jstr=" << jstr << std::endl;
-	  JDoc jd2;
-	  jd2.Parse(jstr.c_str());
-	  ASSERT_TRUE(!jd2.HasParseError());
-	  ASSERT_TRUE(jd2.HasMember("status"));
-	  ASSERT_EQ(200,jd2["status"]["code"]);
-	  ASSERT_EQ("OK",jd2["status"]["msg"]);
-	  ASSERT_TRUE(jd2.HasMember("head"));
-	  ASSERT_EQ("/train",jd2["head"]["method"]);
-	  ASSERT_TRUE(jd2["head"]["time"].GetDouble() >= 0);
-	  ASSERT_EQ("running",jd2["head"]["status"]);
-	  ASSERT_EQ(1,jd2["head"]["job"]);
-	  ASSERT_TRUE(jd2.HasMember("body"));
-	  ASSERT_TRUE(jd2["body"]["measure"].HasMember("train_loss"));
-	  ASSERT_TRUE(fabs(jd2["body"]["measure"]["train_loss"].GetDouble()) > 0);
-	  ASSERT_TRUE(jd2["body"]["measure"].HasMember("iteration"));
-	  ASSERT_TRUE(jd2["body"]["measure"]["iteration"].GetDouble() >= 0);
-	  ASSERT_TRUE(jd2["body"].HasMember("measure_hist"));
-	  ASSERT_TRUE(100 >= jd2["body"]["measure_hist"]["train_loss_hist"].Size());
-	}
-      else ASSERT_TRUE(jstr.find("finished")!=std::string::npos);
+        {
+          std::cerr << "jstr=" << jstr << std::endl;
+          JDoc jd2;
+          jd2.Parse(jstr.c_str());
+          ASSERT_TRUE(!jd2.HasParseError());
+          ASSERT_TRUE(jd2.HasMember("status"));
+          ASSERT_EQ(200, jd2["status"]["code"]);
+          ASSERT_EQ("OK", jd2["status"]["msg"]);
+          ASSERT_TRUE(jd2.HasMember("head"));
+          ASSERT_EQ("/train", jd2["head"]["method"]);
+          ASSERT_TRUE(jd2["head"]["time"].GetDouble() >= 0);
+          ASSERT_EQ("running", jd2["head"]["status"]);
+          ASSERT_EQ(1, jd2["head"]["job"]);
+          ASSERT_TRUE(jd2.HasMember("body"));
+          ASSERT_TRUE(jd2["body"]["measure"].HasMember("train_loss"));
+          ASSERT_TRUE(fabs(jd2["body"]["measure"]["train_loss"].GetDouble())
+                      > 0);
+          ASSERT_TRUE(jd2["body"]["measure"].HasMember("iteration"));
+          ASSERT_TRUE(jd2["body"]["measure"]["iteration"].GetDouble() >= 0);
+          ASSERT_TRUE(jd2["body"].HasMember("measure_hist"));
+          ASSERT_TRUE(
+              100 >= jd2["body"]["measure_hist"]["train_loss_hist"].Size());
+        }
+      else
+        ASSERT_TRUE(jstr.find("finished") != std::string::npos);
     }
-  
+
   // remove service and trained model files
-  httpclient::get_call(luri+"/services/"+serv+"?clear=lib","DELETE",code,jstr);
-  ASSERT_EQ(200,code);
-  
+  httpclient::get_call(luri + "/services/" + serv + "?clear=lib", "DELETE",
+                       code, jstr);
+  ASSERT_EQ(200, code);
+
   hja.stop_server();
 }
 
-TEST(httpjsonapi,multiservices)
+TEST(httpjsonapi, multiservices)
 {
   HttpJsonAPI hja;
-  hja.start_server_daemon(host,std::to_string(++port),nthreads);
+  hja.start_server_daemon(host, std::to_string(++port), nthreads);
   std::string luri = "http://" + host + ":" + std::to_string(port);
   sleep(2);
 
   // service definition
   std::string mnist_repo = "../examples/caffe/mnist/";
-  std::string serv_put2 = "{\"mllib\":\"caffe\",\"description\":\"my classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\"" +  mnist_repo + "\"},\"parameters\":{\"input\":{\"connector\":\"image\"},\"mllib\":{\"nclasses\":10}}}";
-  
+  std::string serv_put2
+      = "{\"mllib\":\"caffe\",\"description\":\"my "
+        "classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\""
+        + mnist_repo
+        + "\"},\"parameters\":{\"input\":{\"connector\":\"image\"},\"mllib\":{"
+          "\"nclasses\":10}}}";
+
   // service creation
   int code = 1;
   std::string jstr;
-  httpclient::post_call(luri+"/services/"+serv,serv_put2,"PUT",
-			 code,jstr);  
-  ASSERT_EQ(201,code);
+  httpclient::post_call(luri + "/services/" + serv, serv_put2, "PUT", code,
+                        jstr);
+  ASSERT_EQ(201, code);
   rapidjson::Document d;
   d.Parse(jstr.c_str());
   ASSERT_FALSE(d.HasParseError());
   ASSERT_TRUE(d.HasMember("status"));
-  ASSERT_EQ(201,d["status"]["code"].GetInt());
+  ASSERT_EQ(201, d["status"]["code"].GetInt());
 
   // service creation
   std::string serv2 = "myserv2";
-  httpclient::post_call(luri+"/services/"+serv2,serv_put2,"PUT",
-			 code,jstr);  
-  ASSERT_EQ(201,code);
+  httpclient::post_call(luri + "/services/" + serv2, serv_put2, "PUT", code,
+                        jstr);
+  ASSERT_EQ(201, code);
   d.Parse(jstr.c_str());
   ASSERT_FALSE(d.HasParseError());
   ASSERT_TRUE(d.HasMember("status"));
-  ASSERT_EQ(201,d["status"]["code"].GetInt());
+  ASSERT_EQ(201, d["status"]["code"].GetInt());
 
   // info call
-  httpclient::get_call(luri+"/info","GET",code,jstr);
+  httpclient::get_call(luri + "/info", "GET", code, jstr);
   d = rapidjson::Document();
   d.Parse(jstr.c_str());
-  ASSERT_EQ(200,code);
+  ASSERT_EQ(200, code);
   ASSERT_TRUE(d["head"].HasMember("services"));
-  ASSERT_EQ(2,d["head"]["services"].Size());
-  ASSERT_TRUE(jstr.find("\"name\":\"myserv\"")!=std::string::npos);
-  ASSERT_TRUE(jstr.find("\"name\":\"myserv2\"")!=std::string::npos);
-  
+  ASSERT_EQ(2, d["head"]["services"].Size());
+  ASSERT_TRUE(jstr.find("\"name\":\"myserv\"") != std::string::npos);
+  ASSERT_TRUE(jstr.find("\"name\":\"myserv2\"") != std::string::npos);
+
   // remove services and trained model files
-  httpclient::get_call(luri+"/services/"+serv+"?clear=lib","DELETE",code,jstr);
-  ASSERT_EQ(200,code);
-  httpclient::get_call(luri+"/services/"+serv2+"?clear=lib","DELETE",code,jstr);
-  ASSERT_EQ(200,code);
-  
+  httpclient::get_call(luri + "/services/" + serv + "?clear=lib", "DELETE",
+                       code, jstr);
+  ASSERT_EQ(200, code);
+  httpclient::get_call(luri + "/services/" + serv2 + "?clear=lib", "DELETE",
+                       code, jstr);
+  ASSERT_EQ(200, code);
+
   hja.stop_server();
 }
 
-TEST(httpjsonapi,concurrency)
+TEST(httpjsonapi, concurrency)
 {
   HttpJsonAPI hja;
-  hja.start_server_daemon(host,std::to_string(++port),nthreads);
+  hja.start_server_daemon(host, std::to_string(++port), nthreads);
   std::string luri = "http://" + host + ":" + std::to_string(port);
   sleep(2);
 
   // service definition
   std::string mnist_repo = "../examples/caffe/mnist/";
-  std::string serv_put2 = "{\"mllib\":\"caffe\",\"description\":\"my classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\"" +  mnist_repo + "\"},\"parameters\":{\"input\":{\"connector\":\"image\"},\"mllib\":{\"nclasses\":10}}}";
-  
+  std::string serv_put2
+      = "{\"mllib\":\"caffe\",\"description\":\"my "
+        "classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\""
+        + mnist_repo
+        + "\"},\"parameters\":{\"input\":{\"connector\":\"image\"},\"mllib\":{"
+          "\"nclasses\":10}}}";
+
   // service creation
   int code = 1;
   std::string jstr;
-  httpclient::post_call(luri+"/services/"+serv,serv_put2,"PUT",
-			 code,jstr);  
-  ASSERT_EQ(201,code);
+  httpclient::post_call(luri + "/services/" + serv, serv_put2, "PUT", code,
+                        jstr);
+  ASSERT_EQ(201, code);
   rapidjson::Document d;
   d.Parse(jstr.c_str());
   ASSERT_FALSE(d.HasParseError());
   ASSERT_TRUE(d.HasMember("status"));
-  ASSERT_EQ(201,d["status"]["code"].GetInt());
+  ASSERT_EQ(201, d["status"]["code"].GetInt());
 
-  //train async
-  std::string train_post = "{\"service\":\"" + serv + "\",\"async\":true,\"parameters\":{\"mllib\":{\"gpu\":true,\"solver\":{\"iterations\":10000}}}}";
-  httpclient::post_call(luri+"/train",train_post,"POST",code,jstr);
-  ASSERT_EQ(201,code);
+  // train async
+  std::string train_post
+      = "{\"service\":\"" + serv
+        + "\",\"async\":true,\"parameters\":{\"mllib\":{\"gpu\":true,"
+          "\"solver\":{\"iterations\":10000}}}}";
+  httpclient::post_call(luri + "/train", train_post, "POST", code, jstr);
+  ASSERT_EQ(201, code);
   d.Parse(jstr.c_str());
   ASSERT_FALSE(d.HasMember("body"));
-  
+
   // service creation
   std::string serv2 = "myserv2";
-  httpclient::post_call(luri+"/services/"+serv2,serv_put2,"PUT",
-			 code,jstr);  
-  ASSERT_EQ(201,code);
+  httpclient::post_call(luri + "/services/" + serv2, serv_put2, "PUT", code,
+                        jstr);
+  ASSERT_EQ(201, code);
   d.Parse(jstr.c_str());
   ASSERT_FALSE(d.HasParseError());
   ASSERT_TRUE(d.HasMember("status"));
-  ASSERT_EQ(201,d["status"]["code"].GetInt());
+  ASSERT_EQ(201, d["status"]["code"].GetInt());
 
   // info call
-  httpclient::get_call(luri+"/info","GET",code,jstr);
+  httpclient::get_call(luri + "/info", "GET", code, jstr);
   d = rapidjson::Document();
   d.Parse(jstr.c_str());
-  ASSERT_EQ(200,code);
+  ASSERT_EQ(200, code);
   ASSERT_TRUE(d["head"].HasMember("services"));
-  ASSERT_EQ(2,d["head"]["services"].Size());
-  ASSERT_TRUE(jstr.find("\"name\":\"myserv\"")!=std::string::npos);
-  ASSERT_TRUE(jstr.find("\"name\":\"myserv2\"")!=std::string::npos);
+  ASSERT_EQ(2, d["head"]["services"].Size());
+  ASSERT_TRUE(jstr.find("\"name\":\"myserv\"") != std::string::npos);
+  ASSERT_TRUE(jstr.find("\"name\":\"myserv2\"") != std::string::npos);
 
-  //train async second job
-  train_post = "{\"service\":\"" + serv2 + "\",\"async\":true,\"parameters\":{\"mllib\":{\"gpu\":true,\"solver\":{\"iterations\":10000}}}}";
-  httpclient::post_call(luri+"/train",train_post,"POST",code,jstr);
-  ASSERT_EQ(201,code);
+  // train async second job
+  train_post = "{\"service\":\"" + serv2
+               + "\",\"async\":true,\"parameters\":{\"mllib\":{\"gpu\":true,"
+                 "\"solver\":{\"iterations\":10000}}}}";
+  httpclient::post_call(luri + "/train", train_post, "POST", code, jstr);
+  ASSERT_EQ(201, code);
   d.Parse(jstr.c_str());
   ASSERT_FALSE(d.HasMember("body"));
 
   sleep(1);
 
   // get info on job2
-  httpclient::get_call(luri+"/train?service="+serv2+"&job=1","GET",code,jstr);
-  ASSERT_EQ(200,code);
-  
+  httpclient::get_call(luri + "/train?service=" + serv2 + "&job=1", "GET",
+                       code, jstr);
+  ASSERT_EQ(200, code);
+
   // get info on first training job
   int tmax = 10, t = 0;
   bool running = true;
-  while(running)
+  while (running)
     {
-      httpclient::get_call(luri+"/train?service="+serv+"&job=1&timeout=1","GET",code,jstr);
+      httpclient::get_call(luri + "/train?service=" + serv
+                               + "&job=1&timeout=1",
+                           "GET", code, jstr);
       running = jstr.find("running") != std::string::npos;
       if (!running)
-	{
-	  std::cerr << "jstr=" << jstr << std::endl;
-	  JDoc jd2;
-	  jd2.Parse(jstr.c_str());
-	  ASSERT_TRUE(!jd2.HasParseError());
-	  ASSERT_TRUE(jd2.HasMember("status"));
-	  ASSERT_EQ(200,jd2["status"]["code"]);
-	  ASSERT_EQ("OK",jd2["status"]["msg"]);
-	  ASSERT_TRUE(jd2.HasMember("head"));
-	  ASSERT_EQ("/train",jd2["head"]["method"]);
-	  ASSERT_TRUE(jd2["head"]["time"].GetDouble() >= 0);
-	  ASSERT_EQ("finished",jd2["head"]["status"]);
-	  ASSERT_EQ(1,jd2["head"]["job"]);
-	  ASSERT_TRUE(jd2.HasMember("body"));
-	  ASSERT_TRUE(jd2["body"]["measure"].HasMember("train_loss"));
-	  ASSERT_TRUE(fabs(jd2["body"]["measure"]["train_loss"].GetDouble()) > 0);
-	  ASSERT_TRUE(jd2["body"]["measure"].HasMember("iteration"));
-	  ASSERT_TRUE(jd2["body"]["measure"]["iteration"].GetDouble() > 0);
-	}
+        {
+          std::cerr << "jstr=" << jstr << std::endl;
+          JDoc jd2;
+          jd2.Parse(jstr.c_str());
+          ASSERT_TRUE(!jd2.HasParseError());
+          ASSERT_TRUE(jd2.HasMember("status"));
+          ASSERT_EQ(200, jd2["status"]["code"]);
+          ASSERT_EQ("OK", jd2["status"]["msg"]);
+          ASSERT_TRUE(jd2.HasMember("head"));
+          ASSERT_EQ("/train", jd2["head"]["method"]);
+          ASSERT_TRUE(jd2["head"]["time"].GetDouble() >= 0);
+          ASSERT_EQ("finished", jd2["head"]["status"]);
+          ASSERT_EQ(1, jd2["head"]["job"]);
+          ASSERT_TRUE(jd2.HasMember("body"));
+          ASSERT_TRUE(jd2["body"]["measure"].HasMember("train_loss"));
+          ASSERT_TRUE(fabs(jd2["body"]["measure"]["train_loss"].GetDouble())
+                      > 0);
+          ASSERT_TRUE(jd2["body"]["measure"].HasMember("iteration"));
+          ASSERT_TRUE(jd2["body"]["measure"]["iteration"].GetDouble() > 0);
+        }
       ++t;
       if (t > tmax)
-	break;
+        break;
     }
 
   // delete job1
-  httpclient::get_call(luri+"/train?service="+serv+"&job=1","DELETE",code,jstr);
-  ASSERT_EQ(200,code);
+  httpclient::get_call(luri + "/train?service=" + serv + "&job=1", "DELETE",
+                       code, jstr);
+  ASSERT_EQ(200, code);
   d.Parse(jstr.c_str());
   ASSERT_TRUE(d.HasMember("head"));
   ASSERT_TRUE(d["head"].HasMember("status"));
-  ASSERT_EQ("terminated",d["head"]["status"]);
+  ASSERT_EQ("terminated", d["head"]["status"]);
 
   sleep(1);
-  
+
   // get info on job1
-  httpclient::get_call(luri+"/train?service="+serv+"&job=1","GET",code,jstr);
-  ASSERT_EQ(404,code);
+  httpclient::get_call(luri + "/train?service=" + serv + "&job=1", "GET", code,
+                       jstr);
+  ASSERT_EQ(404, code);
 
   // delete job2
-  httpclient::get_call(luri+"/train?service="+serv2+"&job=1","DELETE",code,jstr);
-  ASSERT_EQ(200,code);
+  httpclient::get_call(luri + "/train?service=" + serv2 + "&job=1", "DELETE",
+                       code, jstr);
+  ASSERT_EQ(200, code);
   d.Parse(jstr.c_str());
   ASSERT_TRUE(d.HasMember("head"));
   ASSERT_TRUE(d["head"].HasMember("status"));
-  ASSERT_EQ("terminated",d["head"]["status"]);
+  ASSERT_EQ("terminated", d["head"]["status"]);
 
   sleep(1);
-  
+
   // get info on job2
-  httpclient::get_call(luri+"/train?service="+serv2+"&job=1","GET",code,jstr);
-  ASSERT_EQ(404,code);
-  
+  httpclient::get_call(luri + "/train?service=" + serv2 + "&job=1", "GET",
+                       code, jstr);
+  ASSERT_EQ(404, code);
+
   // remove services and trained model files
-  httpclient::get_call(luri+"/services/"+serv+"?clear=lib","DELETE",code,jstr);
-  ASSERT_EQ(200,code);
-  httpclient::get_call(luri+"/services/"+serv2+"?clear=lib","DELETE",code,jstr);
-  ASSERT_EQ(200,code);
-  
+  httpclient::get_call(luri + "/services/" + serv + "?clear=lib", "DELETE",
+                       code, jstr);
+  ASSERT_EQ(200, code);
+  httpclient::get_call(luri + "/services/" + serv2 + "?clear=lib", "DELETE",
+                       code, jstr);
+  ASSERT_EQ(200, code);
+
   hja.stop_server();
 }
 
-TEST(httpjsonapi,predict)
+TEST(httpjsonapi, predict)
 {
   HttpJsonAPI hja;
-  hja.start_server_daemon(host,std::to_string(++port),nthreads);
+  hja.start_server_daemon(host, std::to_string(++port), nthreads);
   std::string luri = "http://" + host + ":" + std::to_string(port);
   sleep(2);
 
   std::string mnist_repo = "../examples/caffe/mnist/";
-  std::string serv_put2 = "{\"mllib\":\"caffe\",\"description\":\"my classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\"" +  mnist_repo + "\"},\"parameters\":{\"input\":{\"connector\":\"image\"},\"mllib\":{\"nclasses\":10}}}";
-  
+  std::string serv_put2
+      = "{\"mllib\":\"caffe\",\"description\":\"my "
+        "classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\""
+        + mnist_repo
+        + "\"},\"parameters\":{\"input\":{\"connector\":\"image\"},\"mllib\":{"
+          "\"nclasses\":10}}}";
+
   // service creation
   int code = 1;
   std::string jstr;
-  httpclient::post_call(luri+"/services/"+serv,serv_put2,"PUT",
-			 code,jstr);  
-  ASSERT_EQ(201,code);
+  httpclient::post_call(luri + "/services/" + serv, serv_put2, "PUT", code,
+                        jstr);
+  ASSERT_EQ(201, code);
   rapidjson::Document d;
   d.Parse(jstr.c_str());
   ASSERT_FALSE(d.HasParseError());
   ASSERT_TRUE(d.HasMember("status"));
-  ASSERT_EQ(201,d["status"]["code"].GetInt());
+  ASSERT_EQ(201, d["status"]["code"].GetInt());
 
   // train sync
-  std::string train_post = "{\"service\":\"" + serv + "\",\"async\":false,\"parameters\":{\"mllib\":{\"gpu\":true,\"solver\":{\"iterations\":" + iterations_mnist + ",\"snapshot_prefix\":\""+mnist_repo+"/mylenet\"}},\"output\":{\"measure_hist\":true}}}";
-  httpclient::post_call(luri+"/train",train_post,"POST",code,jstr);
+  std::string train_post
+      = "{\"service\":\"" + serv
+        + "\",\"async\":false,\"parameters\":{\"mllib\":{\"gpu\":true,"
+          "\"solver\":{\"iterations\":"
+        + iterations_mnist + ",\"snapshot_prefix\":\"" + mnist_repo
+        + "/mylenet\"}},\"output\":{\"measure_hist\":true}}}";
+  httpclient::post_call(luri + "/train", train_post, "POST", code, jstr);
   std::cerr << "jstr=" << jstr << std::endl;
-  ASSERT_EQ(201,code);
+  ASSERT_EQ(201, code);
   JDoc jd;
   jd.Parse(jstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_TRUE(jd.HasMember("status"));
-  ASSERT_EQ(201,jd["status"]["code"].GetInt());
-  ASSERT_EQ("Created",jd["status"]["msg"]);
+  ASSERT_EQ(201, jd["status"]["code"].GetInt());
+  ASSERT_EQ("Created", jd["status"]["msg"]);
   ASSERT_TRUE(jd.HasMember("head"));
-  ASSERT_EQ("/train",jd["head"]["method"]);
+  ASSERT_EQ("/train", jd["head"]["method"]);
   ASSERT_TRUE(jd["head"]["time"].GetDouble() >= 0);
   ASSERT_TRUE(jd.HasMember("body"));
   ASSERT_TRUE(jd["body"].HasMember("measure"));
@@ -480,28 +546,44 @@ TEST(httpjsonapi,predict)
   ASSERT_TRUE(jd["body"]["measure_hist"]["train_loss_hist"].Size() > 0);
 
   // predict
-  std::string predict_post = "{\"service\":\""+ serv + "\",\"parameters\":{\"mllib\":{\"gpu\":true},\"input\":{\"bw\":true,\"width\":28,\"height\":28},\"output\":{\"best\":3}},\"data\":[\"" + mnist_repo + "/sample_digit.png\",\"" + mnist_repo + "/sample_digit2.png\"]}";
-  httpclient::post_call(luri+"/predict",predict_post,"POST",code,jstr);
+  std::string predict_post
+      = "{\"service\":\"" + serv
+        + "\",\"parameters\":{\"mllib\":{\"gpu\":true},\"input\":{\"bw\":true,"
+          "\"width\":28,\"height\":28},\"output\":{\"best\":3}},\"data\":[\""
+        + mnist_repo + "/sample_digit.png\",\"" + mnist_repo
+        + "/sample_digit2.png\"]}";
+  httpclient::post_call(luri + "/predict", predict_post, "POST", code, jstr);
   std::cerr << "code=" << code << std::endl;
-  ASSERT_EQ(200,code);
+  ASSERT_EQ(200, code);
   std::cerr << "jstr=" << jstr << std::endl;
   jd.Parse(jstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
-  ASSERT_EQ(200,jd["status"]["code"]);
-  ASSERT_TRUE(jd["body"]["predictions"][0]["classes"][0]["prob"].GetDouble() > 0);
-  ASSERT_TRUE(jd["body"]["predictions"][1]["classes"][0]["prob"].GetDouble() > 0);
+  ASSERT_EQ(200, jd["status"]["code"]);
+  ASSERT_TRUE(jd["body"]["predictions"][0]["classes"][0]["prob"].GetDouble()
+              > 0);
+  ASSERT_TRUE(jd["body"]["predictions"][1]["classes"][0]["prob"].GetDouble()
+              > 0);
 
   // predict with output template
-  std::string ot = "{{#status}}{{code}}{{/status}}\\n{{#body}}{{#predictions}}*{{uri}}:\\n{{#classes}}{{cat}}->{{prob}}\\n{{/classes}}{{/predictions}}{{/body}}";
-  predict_post = "{\"service\":\""+ serv + "\",\"parameters\":{\"mllib\":{\"gpu\":true},\"input\":{\"bw\":true,\"width\":28,\"height\":28},\"output\":{\"best\":3,\"template\":\"" + ot + "\"}},\"data\":[\"" + mnist_repo + "/sample_digit.png\",\"" + mnist_repo + "/sample_digit2.png\"]}";
-  httpclient::post_call(luri+"/predict",predict_post,"POST",code,jstr);
+  std::string ot
+      = "{{#status}}{{code}}{{/"
+        "status}}\\n{{#body}}{{#predictions}}*{{uri}}:\\n{{#classes}}{{cat}}->"
+        "{{prob}}\\n{{/classes}}{{/predictions}}{{/body}}";
+  predict_post
+      = "{\"service\":\"" + serv
+        + "\",\"parameters\":{\"mllib\":{\"gpu\":true},\"input\":{\"bw\":true,"
+          "\"width\":28,\"height\":28},\"output\":{\"best\":3,\"template\":\""
+        + ot + "\"}},\"data\":[\"" + mnist_repo + "/sample_digit.png\",\""
+        + mnist_repo + "/sample_digit2.png\"]}";
+  httpclient::post_call(luri + "/predict", predict_post, "POST", code, jstr);
   std::cerr << "code=" << code << std::endl;
-  ASSERT_EQ(200,code);
+  ASSERT_EQ(200, code);
   std::cerr << "jstr=" << jstr << std::endl;
-  
+
   // remove services and trained model files
-  httpclient::get_call(luri+"/services/"+serv+"?clear=lib","DELETE",code,jstr);
-  ASSERT_EQ(200,code);
-  
+  httpclient::get_call(luri + "/services/" + serv + "?clear=lib", "DELETE",
+                       code, jstr);
+  ASSERT_EQ(200, code);
+
   hja.stop_server();
 }

--- a/tests/ut-jsonapi.cc
+++ b/tests/ut-jsonapi.cc
@@ -29,137 +29,158 @@
 using namespace dd;
 
 static std::string ok_str = "{\"status\":{\"code\":200,\"msg\":\"OK\"}}";
-static std::string created_str = "{\"status\":{\"code\":201,\"msg\":\"Created\"}}";
-static std::string bad_param_str = "{\"status\":{\"code\":400,\"msg\":\"BadRequest\"}}";
-static std::string bad_param_str_false = "{\"status\":{\"code\":400,\"msg\":\"BadRequest\",\"dd_code\":400,\"dd_msg\":\"false\"}}";
-static std::string bad_request_str = "{\"status\":{\"code\":400,\"msg\":\"BadRequest\",\"dd_code\":1006,\"dd_msg\":\"Service Bad Request Error\"}}";
-static std::string not_found_str = "{\"status\":{\"code\":404,\"msg\":\"NotFound\"}}";
+static std::string created_str
+    = "{\"status\":{\"code\":201,\"msg\":\"Created\"}}";
+static std::string bad_param_str
+    = "{\"status\":{\"code\":400,\"msg\":\"BadRequest\"}}";
+static std::string bad_param_str_false
+    = "{\"status\":{\"code\":400,\"msg\":\"BadRequest\",\"dd_code\":400,\"dd_"
+      "msg\":\"false\"}}";
+static std::string bad_request_str
+    = "{\"status\":{\"code\":400,\"msg\":\"BadRequest\",\"dd_code\":1006,\"dd_"
+      "msg\":\"Service Bad Request Error\"}}";
+static std::string not_found_str
+    = "{\"status\":{\"code\":404,\"msg\":\"NotFound\"}}";
 
-TEST(jsonapi,service_delete)
+TEST(jsonapi, service_delete)
 {
   // fake model repository
   //  std::string here = "here";
   //  mkdir(here.c_str(),0777);
-  
+
   // create service.
   JsonAPI japi;
   std::string sname = "my_service";
-  std::string jstr = "{\"mllib\":\"caffe\",\"description\":\"my classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\"here/\",\"create_repository\":true},\"parameters\":{\"input\":{\"connector\":\"image\"},\"mllib\":{\"nclasses\":2}}}";
-  std::string joutstr = japi.jrender(japi.service_create(sname,jstr));
-  ASSERT_EQ(created_str,joutstr);
+  std::string jstr
+      = "{\"mllib\":\"caffe\",\"description\":\"my "
+        "classifier\",\"type\":\"supervised\",\"model\":{\"repository\":"
+        "\"here/"
+        "\",\"create_repository\":true},\"parameters\":{\"input\":{"
+        "\"connector\":\"image\"},\"mllib\":{\"nclasses\":2}}}";
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
   bool isdir = false;
   bool exists = fileops::file_exists("here", isdir);
 
   ASSERT_EQ(isdir, true);
   ASSERT_EQ(exists, true);
-  //delete service.
+  // delete service.
   jstr = "{\"clear\":\"mem\"}";
-  std::string jdelstr = japi.jrender(japi.service_delete(sname,jstr));
-  ASSERT_EQ(ok_str,jdelstr);
+  std::string jdelstr = japi.jrender(japi.service_delete(sname, jstr));
+  ASSERT_EQ(ok_str, jdelstr);
   std::string jinfostr = japi.jrender(japi.info(""));
   JDoc jd;
   jd.Parse(jinfostr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_TRUE(jd.HasMember("status"));
-  ASSERT_EQ(200,jd["status"]["code"]);
-  ASSERT_EQ("OK",jd["status"]["msg"]);
-  ASSERT_EQ(0,jd["head"]["services"].Size());
+  ASSERT_EQ(200, jd["status"]["code"]);
+  ASSERT_EQ("OK", jd["status"]["msg"]);
+  ASSERT_EQ(0, jd["head"]["services"].Size());
 }
 
-TEST(jsonapi,service_create)
+TEST(jsonapi, service_create)
 {
   JsonAPI japi;
   std::string sname = "my_service";
-  std::string jstr = "{\"mllib\":\"caffe\",\"description\":\"my classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\"here\"},\"parameters\":{\"input\":{\"connector\":\"image\"},\"mllib\":{\"nclasses\":2}}}";
-  std::string joutstr = japi.jrender(japi.service_create(sname,jstr));
-  ASSERT_EQ(created_str,joutstr);
+  std::string jstr = "{\"mllib\":\"caffe\",\"description\":\"my "
+                     "classifier\",\"type\":\"supervised\",\"model\":{"
+                     "\"repository\":\"here\"},\"parameters\":{\"input\":{"
+                     "\"connector\":\"image\"},\"mllib\":{\"nclasses\":2}}}";
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
   std::string deljstr = "{\"clear\":\"mem\"}";
-  std::string jdelstr = japi.jrender(japi.service_delete(sname,deljstr));
-  ASSERT_EQ(ok_str,jdelstr);
+  std::string jdelstr = japi.jrender(japi.service_delete(sname, deljstr));
+  ASSERT_EQ(ok_str, jdelstr);
 
   JDoc jd;
   jd.Parse(jstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
-  
+
   // service
-  joutstr = japi.jrender(japi.service_create("",jstr));
-  ASSERT_EQ(not_found_str,joutstr);
+  joutstr = japi.jrender(japi.service_create("", jstr));
+  ASSERT_EQ(not_found_str, joutstr);
   jd.Parse(jstr.c_str());
   std::string jstrt = japi.jrender(jd);
 
   // mllib
   jd.RemoveMember("mllib");
   jstrt = japi.jrender(jd);
-  joutstr = japi.jrender(japi.service_create(sname,jstrt));
-  ASSERT_EQ(bad_param_str_false,joutstr);
+  joutstr = japi.jrender(japi.service_create(sname, jstrt));
+  ASSERT_EQ(bad_param_str_false, joutstr);
   jd.Parse(jstr.c_str());
 
   // description
   jd.RemoveMember("description");
   jstrt = japi.jrender(jd);
-  joutstr = japi.jrender(japi.service_create(sname,jstrt));
-  ASSERT_EQ(created_str,joutstr);
+  joutstr = japi.jrender(japi.service_create(sname, jstrt));
+  ASSERT_EQ(created_str, joutstr);
   jd.Parse(jstr.c_str());
   deljstr = "{\"clear\":\"mem\"}";
-  jdelstr = japi.jrender(japi.service_delete(sname,deljstr));
-  ASSERT_EQ(ok_str,jdelstr);
+  jdelstr = japi.jrender(japi.service_delete(sname, deljstr));
+  ASSERT_EQ(ok_str, jdelstr);
 
   // for Caffe
   // model
-  
+
   // input
   jd["parameters"].RemoveMember("input");
   jstrt = japi.jrender(jd);
-  joutstr = japi.jrender(japi.service_create(sname,jstrt));
-  ASSERT_EQ(bad_param_str_false,joutstr);
+  joutstr = japi.jrender(japi.service_create(sname, jstrt));
+  ASSERT_EQ(bad_param_str_false, joutstr);
 }
 
-TEST(jsonapi,info)
+TEST(jsonapi, info)
 {
   // create service
   JsonAPI japi;
   std::string sname = "my_service";
-  std::string jstr = "{\"mllib\":\"caffe\",\"description\":\"my classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\"here\"},\"parameters\":{\"input\":{\"connector\":\"image\"},\"mllib\":{\"nclasses\":2}}}";
-  std::string joutstr = japi.jrender(japi.service_create(sname,jstr));
-  ASSERT_EQ(created_str,joutstr);
+  std::string jstr = "{\"mllib\":\"caffe\",\"description\":\"my "
+                     "classifier\",\"type\":\"supervised\",\"model\":{"
+                     "\"repository\":\"here\"},\"parameters\":{\"input\":{"
+                     "\"connector\":\"image\"},\"mllib\":{\"nclasses\":2}}}";
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
 
   // info
   std::string jinfostr = japi.jrender(japi.info(""));
-  //std::cout << "jinfostr=" << jinfostr << std::endl;
+  // std::cout << "jinfostr=" << jinfostr << std::endl;
   JDoc jd;
   jd.Parse(jinfostr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_TRUE(jd.HasMember("status"));
-  ASSERT_EQ(200,jd["status"]["code"]);
-  ASSERT_EQ("OK",jd["status"]["msg"]);
-  ASSERT_TRUE(jd.HasMember("head"));  
+  ASSERT_EQ(200, jd["status"]["code"]);
+  ASSERT_EQ("OK", jd["status"]["msg"]);
+  ASSERT_TRUE(jd.HasMember("head"));
   ASSERT_TRUE(jd["head"].HasMember("version"));
   ASSERT_TRUE(jd["head"].HasMember("commit"));
   ASSERT_TRUE(jd["head"].HasMember("services"));
-  ASSERT_EQ(1,jd["head"]["services"].Size());
-  ASSERT_EQ("caffe",jd["head"]["services"][0]["mllib"]);
-  ASSERT_EQ("my classifier",jd["head"]["services"][0]["description"]);
-  ASSERT_EQ("my_service",jd["head"]["services"][0]["name"]);
+  ASSERT_EQ(1, jd["head"]["services"].Size());
+  ASSERT_EQ("caffe", jd["head"]["services"][0]["mllib"]);
+  ASSERT_EQ("my classifier", jd["head"]["services"][0]["description"]);
+  ASSERT_EQ("my_service", jd["head"]["services"][0]["name"]);
 }
 
-TEST(jsonapi,service_status)
+TEST(jsonapi, service_status)
 {
   // create service.
   JsonAPI japi;
   std::string sname = "my_service";
-  std::string jstr = "{\"mllib\":\"caffe\",\"description\":\"my classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\"here\"},\"parameters\":{\"input\":{\"connector\":\"image\"},\"mllib\":{\"nclasses\":2}}}";
-  std::string joutstr = japi.jrender(japi.service_create(sname,jstr));
-  ASSERT_EQ(created_str,joutstr);
+  std::string jstr = "{\"mllib\":\"caffe\",\"description\":\"my "
+                     "classifier\",\"type\":\"supervised\",\"model\":{"
+                     "\"repository\":\"here\"},\"parameters\":{\"input\":{"
+                     "\"connector\":\"image\"},\"mllib\":{\"nclasses\":2}}}";
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
 
   // service status.
   std::string jstatstr = japi.jrender(japi.service_status(sname));
-  //std::cout << "jstatstr=" << jstatstr << std::endl;
+  // std::cout << "jstatstr=" << jstatstr << std::endl;
   JDoc jd;
   jd.Parse(jstatstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_TRUE(jd.HasMember("status"));
-  ASSERT_EQ(200,jd["status"]["code"]);
-  ASSERT_EQ("OK",jd["status"]["msg"]);
+  ASSERT_EQ(200, jd["status"]["code"]);
+  ASSERT_EQ("OK", jd["status"]["msg"]);
   ASSERT_TRUE(jd.HasMember("body"));
   ASSERT_TRUE(jd["body"].HasMember("description"));
 }
@@ -168,22 +189,24 @@ TEST(jsonapi, service_purge)
 {
   JsonAPI japi;
   std::string sname = "my_service";
-  std::string jstr = "{\"mllib\":\"caffe\",\"description\":\"my classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\"here\"},\"parameters\":{\"input\":{\"connector\":\"image\"},\"mllib\":{\"nclasses\":2}}}";
-  std::string joutstr = japi.jrender(japi.service_create(sname,jstr));
-  ASSERT_EQ(created_str,joutstr);
-
+  std::string jstr = "{\"mllib\":\"caffe\",\"description\":\"my "
+                     "classifier\",\"type\":\"supervised\",\"model\":{"
+                     "\"repository\":\"here\"},\"parameters\":{\"input\":{"
+                     "\"connector\":\"image\"},\"mllib\":{\"nclasses\":2}}}";
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
 
   jstr = "{\"clear\":\"dir\"}";
-  std::string jdelstr = japi.jrender(japi.service_delete(sname,jstr));
-  ASSERT_EQ(ok_str,jdelstr);
+  std::string jdelstr = japi.jrender(japi.service_delete(sname, jstr));
+  ASSERT_EQ(ok_str, jdelstr);
   std::string jinfostr = japi.jrender(japi.info(""));
   JDoc jd;
   jd.Parse(jinfostr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_TRUE(jd.HasMember("status"));
-  ASSERT_EQ(200,jd["status"]["code"]);
-  ASSERT_EQ("OK",jd["status"]["msg"]);
-  ASSERT_EQ(0,jd["head"]["services"].Size());
+  ASSERT_EQ(200, jd["status"]["code"]);
+  ASSERT_EQ("OK", jd["status"]["msg"]);
+  ASSERT_EQ(0, jd["head"]["services"].Size());
   bool isdir;
   bool exists = fileops::file_exists("here", isdir);
   ASSERT_EQ(exists, false);

--- a/tests/ut-ncnnapi.cc
+++ b/tests/ut-ncnnapi.cc
@@ -28,31 +28,44 @@
 using namespace dd;
 
 static std::string ok_str = "{\"status\":{\"code\":200,\"msg\":\"OK\"}}";
-static std::string created_str = "{\"status\":{\"code\":201,\"msg\":\"Created\"}}";
-static std::string bad_param_str = "{\"status\":{\"code\":400,\"msg\":\"BadRequest\"}}";
-static std::string not_found_str = "{\"status\":{\"code\":404,\"msg\":\"NotFound\"}}";
+static std::string created_str
+    = "{\"status\":{\"code\":201,\"msg\":\"Created\"}}";
+static std::string bad_param_str
+    = "{\"status\":{\"code\":400,\"msg\":\"BadRequest\"}}";
+static std::string not_found_str
+    = "{\"status\":{\"code\":404,\"msg\":\"NotFound\"}}";
 
 static std::string incept_repo = "../examples/ncnn/squeezenet_ssd_ncnn/";
 
-TEST(ncnnapi,service_predict)
+TEST(ncnnapi, service_predict)
 {
   // create service
   JsonAPI japi;
   std::string sname = "imgserv";
-  std::string jstr = "{\"mllib\":\"ncnn\",\"description\":\"squeezenet-ssd\",\"type\":\"supervised\",\"model\":{\"repository\":\"" +  incept_repo + "\"},\"parameters\":{\"input\":{\"connector\":\"image\",\"height\":300,\"width\":300},\"mllib\":{\"nclasses\":21}}}";
-  std::string joutstr = japi.jrender(japi.service_create(sname,jstr));
-  ASSERT_EQ(created_str,joutstr);
+  std::string jstr
+      = "{\"mllib\":\"ncnn\",\"description\":\"squeezenet-ssd\",\"type\":"
+        "\"supervised\",\"model\":{\"repository\":\""
+        + incept_repo
+        + "\"},\"parameters\":{\"input\":{\"connector\":\"image\",\"height\":"
+          "300,\"width\":300},\"mllib\":{\"nclasses\":21}}}";
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
 
   // predict
-  std::string jpredictstr = "{\"service\":\"imgserv\",\"parameters\":{\"input\":{\"height\":300,\"width\":300},\"output\":{\"bbox\":true}},\"data\":[\"" + incept_repo + "face.jpg\"]}";
+  std::string jpredictstr
+      = "{\"service\":\"imgserv\",\"parameters\":{\"input\":{\"height\":300,"
+        "\"width\":300},\"output\":{\"bbox\":true}},\"data\":[\""
+        + incept_repo + "face.jpg\"]}";
   joutstr = japi.jrender(japi.service_predict(jpredictstr));
   JDoc jd;
   std::cout << "joutstr=" << joutstr << std::endl;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
-  ASSERT_EQ(200,jd["status"]["code"]);
+  ASSERT_EQ(200, jd["status"]["code"]);
   ASSERT_TRUE(jd["body"]["predictions"].IsArray());
-  std::string cl1 = jd["body"]["predictions"][0]["classes"][0]["cat"].GetString();
+  std::string cl1
+      = jd["body"]["predictions"][0]["classes"][0]["cat"].GetString();
   ASSERT_TRUE(cl1 == "15");
-  ASSERT_TRUE(jd["body"]["predictions"][0]["classes"][0]["prob"].GetDouble() > 0.4);
+  ASSERT_TRUE(jd["body"]["predictions"][0]["classes"][0]["prob"].GetDouble()
+              > 0.4);
 }

--- a/tests/ut-simsearch-faiss.cc
+++ b/tests/ut-simsearch-faiss.cc
@@ -27,268 +27,348 @@
 using namespace dd;
 
 static std::string ok_str = "{\"status\":{\"code\":200,\"msg\":\"OK\"}}";
-static std::string created_str = "{\"status\":{\"code\":201,\"msg\":\"Created\"}}";
-static std::string bad_param_str = "{\"status\":{\"code\":400,\"msg\":\"BadRequest\"}}";
-static std::string not_found_str = "{\"status\":{\"code\":404,\"msg\":\"NotFound\"}}";
+static std::string created_str
+    = "{\"status\":{\"code\":201,\"msg\":\"Created\"}}";
+static std::string bad_param_str
+    = "{\"status\":{\"code\":400,\"msg\":\"BadRequest\"}}";
+static std::string not_found_str
+    = "{\"status\":{\"code\":404,\"msg\":\"NotFound\"}}";
 
 static std::string mnist_repo = "../examples/caffe/mnist/";
 static std::string iterations_mnist = "2";
 static std::string voc_repo = "../examples/caffe/voc_roi/voc_roi/";
 
-TEST(faissse,index_search)
+TEST(faissse, index_search)
 {
-  std::vector<double> vec1 = {1.0,0.0,0.0,0.0};
-  std::vector<double> vec2 = {0.0,1.0,0.0,0.0};
-  std::vector<double> vec3 = {1.0,0.0,1.0,0.0};
-  
+  std::vector<double> vec1 = { 1.0, 0.0, 0.0, 0.0 };
+  std::vector<double> vec2 = { 0.0, 1.0, 0.0, 0.0 };
+  std::vector<double> vec3 = { 1.0, 0.0, 1.0, 0.0 };
+
   int t = 4;
   std::string model_repo = "simsearch";
-  mkdir(model_repo.c_str(),0770);
-  FaissSE fse(t,model_repo);
-  fse.create_index(); // index creation
-  fse.index(URIData("test1"),vec1); // indexing data
-  fse.index(URIData("test2"),vec2);
-  fse.index(URIData("test3"),vec3);
+  mkdir(model_repo.c_str(), 0770);
+  FaissSE fse(t, model_repo);
+  fse.create_index();                // index creation
+  fse.index(URIData("test1"), vec1); // indexing data
+  fse.index(URIData("test2"), vec2);
+  fse.index(URIData("test3"), vec3);
   std::vector<URIData> uris;
   std::vector<double> distances;
   fse.update_index();
-  fse.search(vec1,3,uris,distances); // searching nearest neighbors
+  fse.search(vec1, 3, uris, distances); // searching nearest neighbors
   std::cerr << "search uris size=" << uris.size() << std::endl;
-  for (size_t i=0;i<uris.size();i++)
-    std::cout << uris.at(i)._uri << " / distances=" << distances.at(i) << std::endl;
+  for (size_t i = 0; i < uris.size(); i++)
+    std::cout << uris.at(i)._uri << " / distances=" << distances.at(i)
+              << std::endl;
   fse.remove_index();
   rmdir(model_repo.c_str());
 }
 
-TEST(faissse,index_search_incr)
+TEST(faissse, index_search_incr)
 {
-  std::vector<double> vec1 = {1.0,0.0,0.0,0.0};
-  std::vector<double> vec2 = {0.0,1.0,0.0,0.0};
-  std::vector<double> vec3 = {1.0,0.0,1.0,0.0};
-  std::vector<double> vec4 = {0.0,0.0,5.0,5.0};
-  
+  std::vector<double> vec1 = { 1.0, 0.0, 0.0, 0.0 };
+  std::vector<double> vec2 = { 0.0, 1.0, 0.0, 0.0 };
+  std::vector<double> vec3 = { 1.0, 0.0, 1.0, 0.0 };
+  std::vector<double> vec4 = { 0.0, 0.0, 5.0, 5.0 };
+
   int t = 4;
   std::string model_repo = "simsearch";
-  mkdir(model_repo.c_str(),0770);
-  FaissSE fse(t,model_repo);
+  mkdir(model_repo.c_str(), 0770);
+  FaissSE fse(t, model_repo);
   fse.create_index();
-  fse.index(URIData("test1"),vec1);
-  fse.index(URIData("test2"),vec2);
-  fse.index(URIData("test3"),vec3);
+  fse.index(URIData("test1"), vec1);
+  fse.index(URIData("test2"), vec2);
+  fse.index(URIData("test3"), vec3);
   std::vector<URIData> uris;
   std::vector<double> distances;
   fse.update_index();
-  fse.search(vec1,3,uris,distances);
+  fse.search(vec1, 3, uris, distances);
   std::cerr << "search uris size=" << uris.size() << std::endl;
-  for (size_t i=0;i<uris.size();i++)
-    std::cout << uris.at(i)._uri << " / distances=" << distances.at(i) << std::endl;
+  for (size_t i = 0; i < uris.size(); i++)
+    std::cout << uris.at(i)._uri << " / distances=" << distances.at(i)
+              << std::endl;
   uris.clear();
   distances.clear();
-  fse.index(URIData("test4"),vec4);
+  fse.index(URIData("test4"), vec4);
   fse.update_index();
-  fse.search(vec4,3,uris,distances);
+  fse.search(vec4, 3, uris, distances);
   std::cerr << "search uris size=" << uris.size() << std::endl;
-  for (size_t i=0;i<uris.size();i++)
-    std::cout << uris.at(i)._uri << " / distances=" << distances.at(i) << std::endl;
+  for (size_t i = 0; i < uris.size(); i++)
+    std::cout << uris.at(i)._uri << " / distances=" << distances.at(i)
+              << std::endl;
   fse.remove_index();
   rmdir(model_repo.c_str());
 }
 
-TEST(simsearch,predict_simsearch_unsup)
+TEST(simsearch, predict_simsearch_unsup)
 {
   // create service
   JsonAPI japi;
   std::string sname = "my_service";
-  std::string jstr = "{\"mllib\":\"caffe\",\"description\":\"my classifier\",\"type\":\"unsupervised\",\"model\":{\"repository\":\"" +  mnist_repo + "\"},\"parameters\":{\"input\":{\"connector\":\"image\"},\"mllib\":{\"nclasses\":10}}}";
-  std::string joutstr = japi.jrender(japi.service_create(sname,jstr));
-  ASSERT_EQ(created_str,joutstr);
+  std::string jstr
+      = "{\"mllib\":\"caffe\",\"description\":\"my "
+        "classifier\",\"type\":\"unsupervised\",\"model\":{\"repository\":\""
+        + mnist_repo
+        + "\"},\"parameters\":{\"input\":{\"connector\":\"image\"},\"mllib\":{"
+          "\"nclasses\":10}}}";
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
   JDoc jd;
-  
+
   // train
   std::string gpuid = "0";
-  std::string jtrainstr = "{\"service\":\"" + sname + "\",\"async\":false,\"parameters\":{\"mllib\":{\"gpu\":true,\"gpuid\":"+gpuid+",\"solver\":{\"iterations\":" + iterations_mnist + ",\"snapshot\":200,\"snapshot_prefix\":\"" + mnist_repo + "/mylenet\",\"test_interval\":2}},\"output\":{\"measure_hist\":true,\"measure\":[\"f1\"]}}}";
+  std::string jtrainstr
+      = "{\"service\":\"" + sname
+        + "\",\"async\":false,\"parameters\":{\"mllib\":{\"gpu\":true,"
+          "\"gpuid\":"
+        + gpuid + ",\"solver\":{\"iterations\":" + iterations_mnist
+        + ",\"snapshot\":200,\"snapshot_prefix\":\"" + mnist_repo
+        + "/mylenet\",\"test_interval\":2}},\"output\":{\"measure_hist\":true,"
+          "\"measure\":[\"f1\"]}}}";
   joutstr = japi.jrender(japi.service_train(jtrainstr));
   std::cout << "joutstr=" << joutstr << std::endl;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_TRUE(jd.HasMember("status"));
-  ASSERT_EQ(201,jd["status"]["code"].GetInt());
-  ASSERT_EQ("Created",jd["status"]["msg"]);
+  ASSERT_EQ(201, jd["status"]["code"].GetInt());
+  ASSERT_EQ("Created", jd["status"]["msg"]);
   ASSERT_TRUE(jd.HasMember("head"));
-  ASSERT_EQ("/train",jd["head"]["method"]);
+  ASSERT_EQ("/train", jd["head"]["method"]);
   ASSERT_TRUE(jd["head"]["time"].GetDouble() >= 0);
   ASSERT_TRUE(jd.HasMember("body"));
   ASSERT_TRUE(jd["body"].HasMember("measure"));
   ASSERT_TRUE(fabs(jd["body"]["measure"]["train_loss"].GetDouble()) > 0);
-  ASSERT_EQ(jd["body"]["measure_hist"]["iteration_hist"].Size(),jd["body"]["measure_hist"]["f1_hist"].Size());
-  
+  ASSERT_EQ(jd["body"]["measure_hist"]["iteration_hist"].Size(),
+            jd["body"]["measure_hist"]["f1_hist"].Size());
+
   // predict
-  std::string jpredictstr = "{\"service\":\""+ sname + "\",\"parameters\":{\"input\":{\"bw\":true,\"width\":28,\"height\":28},\"mllib\":{\"extract_layer\":\"ip2\"},\"output\":{\"index\":true,\"index_type\":\"Flat\",\"index_gpu\":false}},\"data\":[\"" + mnist_repo + "/sample_digit.png\"]}";
+  std::string jpredictstr
+      = "{\"service\":\"" + sname
+        + "\",\"parameters\":{\"input\":{\"bw\":true,\"width\":28,\"height\":"
+          "28},\"mllib\":{\"extract_layer\":\"ip2\"},\"output\":{\"index\":"
+          "true,\"index_type\":\"Flat\",\"index_gpu\":false}},\"data\":[\""
+        + mnist_repo + "/sample_digit.png\"]}";
   joutstr = japi.jrender(japi.service_predict(jpredictstr));
   std::cout << "joutstr predict index=" << joutstr << std::endl;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
-  ASSERT_EQ(200,jd["status"]["code"]);
+  ASSERT_EQ(200, jd["status"]["code"]);
   ASSERT_TRUE(jd["body"]["predictions"][0].HasMember("indexed"));
   ASSERT_TRUE(jd["body"]["predictions"][0]["indexed"].GetBool());
-  
+
   // build & save index
-  jpredictstr = "{\"service\":\""+ sname + "\",\"parameters\":{\"input\":{\"bw\":true,\"width\":28,\"height\":28},\"mllib\":{\"extract_layer\":\"ip2\"},\"output\":{\"build_index\":true}},\"data\":[\"" + mnist_repo + "/sample_digit.png\"]}";
+  jpredictstr = "{\"service\":\"" + sname
+                + "\",\"parameters\":{\"input\":{\"bw\":true,\"width\":28,"
+                  "\"height\":28},\"mllib\":{\"extract_layer\":\"ip2\"},"
+                  "\"output\":{\"build_index\":true}},\"data\":[\""
+                + mnist_repo + "/sample_digit.png\"]}";
   joutstr = japi.jrender(japi.service_predict(jpredictstr));
   std::cout << "joutstr predict build index=" << joutstr << std::endl;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
-  ASSERT_EQ(200,jd["status"]["code"]);
+  ASSERT_EQ(200, jd["status"]["code"]);
 
   // assert existence of index
   ASSERT_TRUE(fileops::file_exists(mnist_repo + "index.faiss"));
   ASSERT_TRUE(fileops::file_exists(mnist_repo + "names.bin/data.mdb"));
 
   // search index
-  jpredictstr = "{\"service\":\""+ sname + "\",\"parameters\":{\"input\":{\"bw\":true,\"width\":28,\"height\":28},\"mllib\":{\"extract_layer\":\"ip2\"},\"output\":{\"search\":true}},\"data\":[\"" + mnist_repo + "/sample_digit.png\"]}";
+  jpredictstr = "{\"service\":\"" + sname
+                + "\",\"parameters\":{\"input\":{\"bw\":true,\"width\":28,"
+                  "\"height\":28},\"mllib\":{\"extract_layer\":\"ip2\"},"
+                  "\"output\":{\"search\":true}},\"data\":[\""
+                + mnist_repo + "/sample_digit.png\"]}";
   joutstr = japi.jrender(japi.service_predict(jpredictstr));
   std::cout << "joutstr predict search=" << joutstr << std::endl;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
-  ASSERT_EQ(200,jd["status"]["code"]);
+  ASSERT_EQ(200, jd["status"]["code"]);
   // assert result is itself
   ASSERT_TRUE(jd["body"]["predictions"][0].HasMember("nns"));
-  ASSERT_TRUE(jd["body"]["predictions"][0]["nns"][0]["dist"].GetDouble()<1.0);
-  ASSERT_TRUE(jd["body"]["predictions"][0]["nns"][0]["uri"]=="../examples/caffe/mnist//sample_digit.png");
-  
+  ASSERT_TRUE(jd["body"]["predictions"][0]["nns"][0]["dist"].GetDouble()
+              < 1.0);
+  ASSERT_TRUE(jd["body"]["predictions"][0]["nns"][0]["uri"]
+              == "../examples/caffe/mnist//sample_digit.png");
+
   // remove service
   jstr = "{\"clear\":\"lib\"}";
-  joutstr = japi.jrender(japi.service_delete(sname,jstr));
-  ASSERT_EQ(ok_str,joutstr);
+  joutstr = japi.jrender(japi.service_delete(sname, jstr));
+  ASSERT_EQ(ok_str, joutstr);
 
   // assert non-existence of index
   ASSERT_TRUE(!fileops::file_exists(mnist_repo + "index.faiss"));
   ASSERT_TRUE(!fileops::file_exists(mnist_repo + "names.bin/data.mdb"));
 }
 
-TEST(simsearch,predict_simsearch_sup)
+TEST(simsearch, predict_simsearch_sup)
 {
   // create service
   JsonAPI japi;
   std::string sname = "my_service";
-  std::string jstr = "{\"mllib\":\"caffe\",\"description\":\"my classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\"" +  mnist_repo + "\"},\"parameters\":{\"input\":{\"connector\":\"image\"},\"mllib\":{\"nclasses\":10}}}";
-  std::string joutstr = japi.jrender(japi.service_create(sname,jstr));
-  ASSERT_EQ(created_str,joutstr);
+  std::string jstr
+      = "{\"mllib\":\"caffe\",\"description\":\"my "
+        "classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\""
+        + mnist_repo
+        + "\"},\"parameters\":{\"input\":{\"connector\":\"image\"},\"mllib\":{"
+          "\"nclasses\":10}}}";
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
   JDoc jd;
-  
+
   // train
   std::string gpuid = "0";
-  std::string jtrainstr = "{\"service\":\"" + sname + "\",\"async\":false,\"parameters\":{\"mllib\":{\"gpu\":true,\"gpuid\":"+gpuid+",\"solver\":{\"iterations\":" + iterations_mnist + ",\"snapshot\":200,\"snapshot_prefix\":\"" + mnist_repo + "/mylenet\",\"test_interval\":2}},\"output\":{\"measure_hist\":true,\"measure\":[\"f1\"]}}}";
+  std::string jtrainstr
+      = "{\"service\":\"" + sname
+        + "\",\"async\":false,\"parameters\":{\"mllib\":{\"gpu\":true,"
+          "\"gpuid\":"
+        + gpuid + ",\"solver\":{\"iterations\":" + iterations_mnist
+        + ",\"snapshot\":200,\"snapshot_prefix\":\"" + mnist_repo
+        + "/mylenet\",\"test_interval\":2}},\"output\":{\"measure_hist\":true,"
+          "\"measure\":[\"f1\"]}}}";
   joutstr = japi.jrender(japi.service_train(jtrainstr));
   std::cout << "joutstr=" << joutstr << std::endl;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_TRUE(jd.HasMember("status"));
-  ASSERT_EQ(201,jd["status"]["code"].GetInt());
-  ASSERT_EQ("Created",jd["status"]["msg"]);
+  ASSERT_EQ(201, jd["status"]["code"].GetInt());
+  ASSERT_EQ("Created", jd["status"]["msg"]);
   ASSERT_TRUE(jd.HasMember("head"));
-  ASSERT_EQ("/train",jd["head"]["method"]);
+  ASSERT_EQ("/train", jd["head"]["method"]);
   ASSERT_TRUE(jd["head"]["time"].GetDouble() >= 0);
   ASSERT_TRUE(jd.HasMember("body"));
   ASSERT_TRUE(jd["body"].HasMember("measure"));
   ASSERT_TRUE(fabs(jd["body"]["measure"]["train_loss"].GetDouble()) > 0);
-  ASSERT_EQ(jd["body"]["measure_hist"]["iteration_hist"].Size(),jd["body"]["measure_hist"]["f1_hist"].Size());
-  
+  ASSERT_EQ(jd["body"]["measure_hist"]["iteration_hist"].Size(),
+            jd["body"]["measure_hist"]["f1_hist"].Size());
+
   // predict
-  std::string jpredictstr = "{\"service\":\""+ sname + "\",\"parameters\":{\"input\":{\"bw\":true,\"width\":28,\"height\":28},\"mllib\":{},\"output\":{\"index\":true,\"best\":2,\"index_type\":\"Flat\",\"index_gpu\":false}},\"data\":[\"" + mnist_repo + "/sample_digit.png\"]}";
+  std::string jpredictstr
+      = "{\"service\":\"" + sname
+        + "\",\"parameters\":{\"input\":{\"bw\":true,\"width\":28,\"height\":"
+          "28},\"mllib\":{},\"output\":{\"index\":true,\"best\":2,\"index_"
+          "type\":\"Flat\",\"index_gpu\":false}},\"data\":[\""
+        + mnist_repo + "/sample_digit.png\"]}";
   joutstr = japi.jrender(japi.service_predict(jpredictstr));
   std::cout << "joutstr predict index=" << joutstr << std::endl;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
-  ASSERT_EQ(200,jd["status"]["code"]);
+  ASSERT_EQ(200, jd["status"]["code"]);
   ASSERT_TRUE(jd["body"]["predictions"][0].HasMember("indexed"));
   ASSERT_TRUE(jd["body"]["predictions"][0]["indexed"].GetBool());
-  
+
   // build & save index
-  jpredictstr = "{\"service\":\""+ sname + "\",\"parameters\":{\"input\":{\"bw\":true,\"width\":28,\"height\":28},\"mllib\":{},\"output\":{\"build_index\":true,\"best\":2}},\"data\":[\"" + mnist_repo + "/sample_digit.png\"]}";
+  jpredictstr = "{\"service\":\"" + sname
+                + "\",\"parameters\":{\"input\":{\"bw\":true,\"width\":28,"
+                  "\"height\":28},\"mllib\":{},\"output\":{\"build_index\":"
+                  "true,\"best\":2}},\"data\":[\""
+                + mnist_repo + "/sample_digit.png\"]}";
   joutstr = japi.jrender(japi.service_predict(jpredictstr));
   std::cout << "joutstr predict build index=" << joutstr << std::endl;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
-  ASSERT_EQ(200,jd["status"]["code"]);
+  ASSERT_EQ(200, jd["status"]["code"]);
 
   // assert existence of index
   ASSERT_TRUE(fileops::file_exists(mnist_repo + "index.faiss"));
   ASSERT_TRUE(fileops::file_exists(mnist_repo + "names.bin/data.mdb"));
 
-
   // search index
-  jpredictstr = "{\"service\":\""+ sname + "\",\"parameters\":{\"input\":{\"bw\":true,\"width\":28,\"height\":28},\"mllib\":{},\"output\":{\"search\":true,\"best\":2}},\"data\":[\"" + mnist_repo + "/sample_digit.png\"]}";
+  jpredictstr = "{\"service\":\"" + sname
+                + "\",\"parameters\":{\"input\":{\"bw\":true,\"width\":28,"
+                  "\"height\":28},\"mllib\":{},\"output\":{\"search\":true,"
+                  "\"best\":2}},\"data\":[\""
+                + mnist_repo + "/sample_digit.png\"]}";
   joutstr = japi.jrender(japi.service_predict(jpredictstr));
   std::cout << "joutstr predict search=" << joutstr << std::endl;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
-  ASSERT_EQ(200,jd["status"]["code"]);
+  ASSERT_EQ(200, jd["status"]["code"]);
   // assert result is itself
   ASSERT_TRUE(jd["body"]["predictions"][0].HasMember("nns"));
-  ASSERT_TRUE(jd["body"]["predictions"][0]["nns"][0]["dist"]==0.0);
-  ASSERT_TRUE(jd["body"]["predictions"][0]["nns"][0]["uri"]=="../examples/caffe/mnist//sample_digit.png");
-  
+  ASSERT_TRUE(jd["body"]["predictions"][0]["nns"][0]["dist"] == 0.0);
+  ASSERT_TRUE(jd["body"]["predictions"][0]["nns"][0]["uri"]
+              == "../examples/caffe/mnist//sample_digit.png");
+
   // remove service
   jstr = "{\"clear\":\"lib\"}";
-  joutstr = japi.jrender(japi.service_delete(sname,jstr));
-  ASSERT_EQ(ok_str,joutstr);
+  joutstr = japi.jrender(japi.service_delete(sname, jstr));
+  ASSERT_EQ(ok_str, joutstr);
 
   // assert non-existence of index
   ASSERT_TRUE(!fileops::file_exists(mnist_repo + "index.faiss"));
   ASSERT_TRUE(!fileops::file_exists(mnist_repo + "names.bin/data.mdb"));
 }
 
-TEST(simsearch,predict_roi_simsearch)
+TEST(simsearch, predict_roi_simsearch)
 {
   // create service
   JsonAPI japi;
   std::string sname = "my_service";
-  std::string jstr = "{\"mllib\":\"caffe\",\"description\":\"my classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\"" +  voc_repo + "\"},\"parameters\":{\"input\":{\"connector\":\"image\",\"width\":300,\"height\":300},\"mllib\":{\"nclasses\":21}}}";
+  std::string jstr
+      = "{\"mllib\":\"caffe\",\"description\":\"my "
+        "classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\""
+        + voc_repo
+        + "\"},\"parameters\":{\"input\":{\"connector\":\"image\",\"width\":"
+          "300,\"height\":300},\"mllib\":{\"nclasses\":21}}}";
   std::cerr << "jstr=" << jstr << std::endl;
-  std::string joutstr = japi.jrender(japi.service_create(sname,jstr));
-  ASSERT_EQ(created_str,joutstr);
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
   JDoc jd;
 
   // predict
-  std::string jpredictstr = "{\"service\":\""+ sname + "\",\"parameters\":{\"input\":{},\"mllib\":{},\"output\":{\"rois\":\"rois\",\"confidence_threshold\":0.1,\"index\":true,\"index_type\":\"Flat\",\"index_gpu\":false}},\"data\":[\"" + voc_repo + "/test_img.jpg\"]}";
+  std::string jpredictstr
+      = "{\"service\":\"" + sname
+        + "\",\"parameters\":{\"input\":{},\"mllib\":{},\"output\":{\"rois\":"
+          "\"rois\",\"confidence_threshold\":0.1,\"index\":true,\"index_"
+          "type\":\"Flat\",\"index_gpu\":false}},\"data\":[\""
+        + voc_repo + "/test_img.jpg\"]}";
   std::cerr << "jpredictstr=" << jpredictstr << std::endl;
   joutstr = japi.jrender(japi.service_predict(jpredictstr));
   std::cout << "joutstr predict index=" << joutstr << std::endl;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
-  ASSERT_EQ(200,jd["status"]["code"]);
+  ASSERT_EQ(200, jd["status"]["code"]);
   ASSERT_TRUE(jd["body"]["predictions"][0].HasMember("indexed"));
   ASSERT_TRUE(jd["body"]["predictions"][0]["indexed"].GetBool());
-  
+
   // build & save index
-  jpredictstr = "{\"service\":\""+ sname + "\",\"parameters\":{\"input\":{},\"mllib\":{},\"output\":{\"build_index\":true,\"rois\":\"rois\",\"confidence_threshold\":0.1}},\"data\":[\"" + voc_repo + "/test_img.jpg\"]}";
+  jpredictstr = "{\"service\":\"" + sname
+                + "\",\"parameters\":{\"input\":{},\"mllib\":{},\"output\":{"
+                  "\"build_index\":true,\"rois\":\"rois\",\"confidence_"
+                  "threshold\":0.1}},\"data\":[\""
+                + voc_repo + "/test_img.jpg\"]}";
   joutstr = japi.jrender(japi.service_predict(jpredictstr));
   std::cout << "joutstr predict build index=" << joutstr << std::endl;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
-  ASSERT_EQ(200,jd["status"]["code"]);
+  ASSERT_EQ(200, jd["status"]["code"]);
 
   // assert existence of index
   ASSERT_TRUE(fileops::file_exists(voc_repo + "index.faiss"));
   ASSERT_TRUE(fileops::file_exists(voc_repo + "names.bin/data.mdb"));
 
   // search index
-  jpredictstr = "{\"service\":\""+ sname + "\",\"parameters\":{\"input\":{},\"mllib\":{},\"output\":{\"search\":true,\"rois\":\"rois\",\"confidence_threshold\":0.1}},\"data\":[\"" + voc_repo + "/test_img.jpg\"]}";
+  jpredictstr = "{\"service\":\"" + sname
+                + "\",\"parameters\":{\"input\":{},\"mllib\":{},\"output\":{"
+                  "\"search\":true,\"rois\":\"rois\",\"confidence_threshold\":"
+                  "0.1}},\"data\":[\""
+                + voc_repo + "/test_img.jpg\"]}";
   joutstr = japi.jrender(japi.service_predict(jpredictstr));
   std::cout << "joutstr predict search=" << joutstr << std::endl;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
-  ASSERT_EQ(200,jd["status"]["code"]);
+  ASSERT_EQ(200, jd["status"]["code"]);
   // assert result is itself
   ASSERT_TRUE(jd["body"]["predictions"][0]["rois"][0].HasMember("nns"));
-  ASSERT_TRUE(jd["body"]["predictions"][0]["rois"][0]["nns"][0]["dist"]==0.0);
-  ASSERT_TRUE(jd["body"]["predictions"][0]["rois"][0]["nns"][0]["uri"]=="../examples/caffe/voc_roi/voc_roi//test_img.jpg");
-  
+  ASSERT_TRUE(jd["body"]["predictions"][0]["rois"][0]["nns"][0]["dist"]
+              == 0.0);
+  ASSERT_TRUE(jd["body"]["predictions"][0]["rois"][0]["nns"][0]["uri"]
+              == "../examples/caffe/voc_roi/voc_roi//test_img.jpg");
+
   // remove service
   jstr = "{\"clear\":\"index\"}";
-  joutstr = japi.jrender(japi.service_delete(sname,jstr));
-  ASSERT_EQ(ok_str,joutstr);
+  joutstr = japi.jrender(japi.service_delete(sname, jstr));
+  ASSERT_EQ(ok_str, joutstr);
 
   // assert non-existence of index
   ASSERT_TRUE(!fileops::file_exists(voc_repo + "index.faiss"));

--- a/tests/ut-simsearch.cc
+++ b/tests/ut-simsearch.cc
@@ -27,285 +27,372 @@
 using namespace dd;
 
 static std::string ok_str = "{\"status\":{\"code\":200,\"msg\":\"OK\"}}";
-static std::string created_str = "{\"status\":{\"code\":201,\"msg\":\"Created\"}}";
-static std::string bad_param_str = "{\"status\":{\"code\":400,\"msg\":\"BadRequest\"}}";
-static std::string not_found_str = "{\"status\":{\"code\":404,\"msg\":\"NotFound\"}}";
+static std::string created_str
+    = "{\"status\":{\"code\":201,\"msg\":\"Created\"}}";
+static std::string bad_param_str
+    = "{\"status\":{\"code\":400,\"msg\":\"BadRequest\"}}";
+static std::string not_found_str
+    = "{\"status\":{\"code\":404,\"msg\":\"NotFound\"}}";
 
 static std::string mnist_repo = "../examples/caffe/mnist/";
 static std::string iterations_mnist = "2";
 static std::string voc_repo = "../examples/caffe/voc_roi/voc_roi/";
 
-TEST(annoyse,index_search)
+TEST(annoyse, index_search)
 {
-  std::vector<double> vec1 = {1.0,0.0,0.0,0.0};
-  std::vector<double> vec2 = {0.0,1.0,0.0,0.0};
-  std::vector<double> vec3 = {1.0,0.0,1.0,0.0};
-  
+  std::vector<double> vec1 = { 1.0, 0.0, 0.0, 0.0 };
+  std::vector<double> vec2 = { 0.0, 1.0, 0.0, 0.0 };
+  std::vector<double> vec3 = { 1.0, 0.0, 1.0, 0.0 };
+
   int t = 4;
   std::string model_repo = "simsearch";
-  mkdir(model_repo.c_str(),0770);
-  AnnoySE ase(t,model_repo);
-  ase.create_index(); // index creation
-  ase.index(URIData("test1"),vec1); // indexing data
-  ase.index(URIData("test2"),vec2);
-  ase.index(URIData("test3"),vec3);
+  mkdir(model_repo.c_str(), 0770);
+  AnnoySE ase(t, model_repo);
+  ase.create_index();                // index creation
+  ase.index(URIData("test1"), vec1); // indexing data
+  ase.index(URIData("test2"), vec2);
+  ase.index(URIData("test3"), vec3);
   std::vector<URIData> uris;
   std::vector<double> distances;
-  ase.build_tree(); // tree building
-  ase.save_tree(); // tree saving
-  ase.search(vec1,3,uris,distances); // searching nearest neighbors
+  ase.build_tree();                     // tree building
+  ase.save_tree();                      // tree saving
+  ase.search(vec1, 3, uris, distances); // searching nearest neighbors
   std::cerr << "search uris size=" << uris.size() << std::endl;
-  for (size_t i=0;i<uris.size();i++)
-    std::cout << uris.at(i)._uri << " / distances=" << distances.at(i) << std::endl;
+  for (size_t i = 0; i < uris.size(); i++)
+    std::cout << uris.at(i)._uri << " / distances=" << distances.at(i)
+              << std::endl;
   ase.remove_index();
   rmdir(model_repo.c_str());
 }
 
-TEST(annoyse,index_search_incr)
+TEST(annoyse, index_search_incr)
 {
-  std::vector<double> vec1 = {1.0,0.0,0.0,0.0};
-  std::vector<double> vec2 = {0.0,1.0,0.0,0.0};
-  std::vector<double> vec3 = {1.0,0.0,1.0,0.0};
-  std::vector<double> vec4 = {0.0,0.0,5.0,5.0};
-  
+  std::vector<double> vec1 = { 1.0, 0.0, 0.0, 0.0 };
+  std::vector<double> vec2 = { 0.0, 1.0, 0.0, 0.0 };
+  std::vector<double> vec3 = { 1.0, 0.0, 1.0, 0.0 };
+  std::vector<double> vec4 = { 0.0, 0.0, 5.0, 5.0 };
+
   int t = 4;
   std::string model_repo = "simsearch";
-  mkdir(model_repo.c_str(),0770);
-  AnnoySE ase(t,model_repo);
+  mkdir(model_repo.c_str(), 0770);
+  AnnoySE ase(t, model_repo);
   ase.create_index();
-  ase.index(URIData("test1"),vec1);
-  ase.index(URIData("test2"),vec2);
-  ase.index(URIData("test3"),vec3);
+  ase.index(URIData("test1"), vec1);
+  ase.index(URIData("test2"), vec2);
+  ase.index(URIData("test3"), vec3);
   std::vector<URIData> uris;
   std::vector<double> distances;
   ase.build_tree();
-  ase.search(vec1,3,uris,distances);
+  ase.search(vec1, 3, uris, distances);
   std::cerr << "search uris size=" << uris.size() << std::endl;
-  for (size_t i=0;i<uris.size();i++)
-    std::cout << uris.at(i)._uri << " / distances=" << distances.at(i) << std::endl;
+  for (size_t i = 0; i < uris.size(); i++)
+    std::cout << uris.at(i)._uri << " / distances=" << distances.at(i)
+              << std::endl;
   uris.clear();
   distances.clear();
   ase.unbuild_tree();
-  ase.index(URIData("test4"),vec4);
+  ase.index(URIData("test4"), vec4);
   ase.build_tree();
-  ase.search(vec4,3,uris,distances);
+  ase.search(vec4, 3, uris, distances);
   std::cerr << "search uris size=" << uris.size() << std::endl;
-  for (size_t i=0;i<uris.size();i++)
-    std::cout << uris.at(i)._uri << " / distances=" << distances.at(i) << std::endl;
+  for (size_t i = 0; i < uris.size(); i++)
+    std::cout << uris.at(i)._uri << " / distances=" << distances.at(i)
+              << std::endl;
   ase.remove_index();
   rmdir(model_repo.c_str());
 }
 
-TEST(simsearch,predict_simsearch_unsup)
+TEST(simsearch, predict_simsearch_unsup)
 {
   // create service
   JsonAPI japi;
   std::string sname = "my_service";
-  std::string jstr = "{\"mllib\":\"caffe\",\"description\":\"my classifier\",\"type\":\"unsupervised\",\"model\":{\"repository\":\"" +  mnist_repo + "\"},\"parameters\":{\"input\":{\"connector\":\"image\"},\"mllib\":{\"nclasses\":10}}}";
-  std::string joutstr = japi.jrender(japi.service_create(sname,jstr));
-  ASSERT_EQ(created_str,joutstr);
+  std::string jstr
+      = "{\"mllib\":\"caffe\",\"description\":\"my "
+        "classifier\",\"type\":\"unsupervised\",\"model\":{\"repository\":\""
+        + mnist_repo
+        + "\"},\"parameters\":{\"input\":{\"connector\":\"image\"},\"mllib\":{"
+          "\"nclasses\":10}}}";
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
   JDoc jd;
-  
+
   // train
   std::string gpuid = "0";
-  std::string jtrainstr = "{\"service\":\"" + sname + "\",\"async\":false,\"parameters\":{\"mllib\":{\"gpu\":true,\"gpuid\":"+gpuid+",\"solver\":{\"iterations\":" + iterations_mnist + ",\"snapshot\":200,\"snapshot_prefix\":\"" + mnist_repo + "/mylenet\",\"test_interval\":2}},\"output\":{\"measure_hist\":true,\"measure\":[\"f1\"]}}}";
+  std::string jtrainstr
+      = "{\"service\":\"" + sname
+        + "\",\"async\":false,\"parameters\":{\"mllib\":{\"gpu\":true,"
+          "\"gpuid\":"
+        + gpuid + ",\"solver\":{\"iterations\":" + iterations_mnist
+        + ",\"snapshot\":200,\"snapshot_prefix\":\"" + mnist_repo
+        + "/mylenet\",\"test_interval\":2}},\"output\":{\"measure_hist\":true,"
+          "\"measure\":[\"f1\"]}}}";
   joutstr = japi.jrender(japi.service_train(jtrainstr));
   std::cout << "joutstr=" << joutstr << std::endl;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_TRUE(jd.HasMember("status"));
-  ASSERT_EQ(201,jd["status"]["code"].GetInt());
-  ASSERT_EQ("Created",jd["status"]["msg"]);
+  ASSERT_EQ(201, jd["status"]["code"].GetInt());
+  ASSERT_EQ("Created", jd["status"]["msg"]);
   ASSERT_TRUE(jd.HasMember("head"));
-  ASSERT_EQ("/train",jd["head"]["method"]);
+  ASSERT_EQ("/train", jd["head"]["method"]);
   ASSERT_TRUE(jd["head"]["time"].GetDouble() >= 0);
   ASSERT_TRUE(jd.HasMember("body"));
   ASSERT_TRUE(jd["body"].HasMember("measure"));
   ASSERT_TRUE(fabs(jd["body"]["measure"]["train_loss"].GetDouble()) > 0);
-  ASSERT_EQ(jd["body"]["measure_hist"]["iteration_hist"].Size(),jd["body"]["measure_hist"]["f1_hist"].Size());
-  
+  ASSERT_EQ(jd["body"]["measure_hist"]["iteration_hist"].Size(),
+            jd["body"]["measure_hist"]["f1_hist"].Size());
+
   // predict
-  std::string jpredictstr = "{\"service\":\""+ sname + "\",\"parameters\":{\"input\":{\"bw\":true,\"width\":28,\"height\":28},\"mllib\":{\"extract_layer\":\"ip2\"},\"output\":{\"index\":true}},\"data\":[\"" + mnist_repo + "/sample_digit.png\"]}";
+  std::string jpredictstr
+      = "{\"service\":\"" + sname
+        + "\",\"parameters\":{\"input\":{\"bw\":true,\"width\":28,\"height\":"
+          "28},\"mllib\":{\"extract_layer\":\"ip2\"},\"output\":{\"index\":"
+          "true}},\"data\":[\""
+        + mnist_repo + "/sample_digit.png\"]}";
   joutstr = japi.jrender(japi.service_predict(jpredictstr));
   std::cout << "joutstr predict index=" << joutstr << std::endl;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
-  ASSERT_EQ(200,jd["status"]["code"]);
+  ASSERT_EQ(200, jd["status"]["code"]);
   ASSERT_TRUE(jd["body"]["predictions"][0].HasMember("indexed"));
   ASSERT_TRUE(jd["body"]["predictions"][0]["indexed"].GetBool());
-  
+
   // build & save index
-  jpredictstr = "{\"service\":\""+ sname + "\",\"parameters\":{\"input\":{\"bw\":true,\"width\":28,\"height\":28},\"mllib\":{\"extract_layer\":\"ip2\"},\"output\":{\"build_index\":true}},\"data\":[\"" + mnist_repo + "/sample_digit.png\"]}";
+  jpredictstr = "{\"service\":\"" + sname
+                + "\",\"parameters\":{\"input\":{\"bw\":true,\"width\":28,"
+                  "\"height\":28},\"mllib\":{\"extract_layer\":\"ip2\"},"
+                  "\"output\":{\"build_index\":true}},\"data\":[\""
+                + mnist_repo + "/sample_digit.png\"]}";
   joutstr = japi.jrender(japi.service_predict(jpredictstr));
   std::cout << "joutstr predict build index=" << joutstr << std::endl;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
-  ASSERT_EQ(200,jd["status"]["code"]);
+  ASSERT_EQ(200, jd["status"]["code"]);
 
   // assert existence of index
   ASSERT_TRUE(fileops::file_exists(mnist_repo + "index.ann"));
   ASSERT_TRUE(fileops::file_exists(mnist_repo + "names.bin/data.mdb"));
 
   // assert error on indexing over a built index
-  jpredictstr = "{\"service\":\""+ sname + "\",\"parameters\":{\"input\":{\"bw\":true,\"width\":28,\"height\":28},\"mllib\":{\"extract_layer\":\"ip2\"},\"output\":{\"index\":true}},\"data\":[\"" + mnist_repo + "/sample_digit.png\"]}";
+  jpredictstr = "{\"service\":\"" + sname
+                + "\",\"parameters\":{\"input\":{\"bw\":true,\"width\":28,"
+                  "\"height\":28},\"mllib\":{\"extract_layer\":\"ip2\"},"
+                  "\"output\":{\"index\":true}},\"data\":[\""
+                + mnist_repo + "/sample_digit.png\"]}";
   joutstr = japi.jrender(japi.service_predict(jpredictstr));
   std::cout << "joutstr predict index=" << joutstr << std::endl;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
-  ASSERT_EQ(403,jd["status"]["code"]);
-  
+  ASSERT_EQ(403, jd["status"]["code"]);
+
   // search index
-  jpredictstr = "{\"service\":\""+ sname + "\",\"parameters\":{\"input\":{\"bw\":true,\"width\":28,\"height\":28},\"mllib\":{\"extract_layer\":\"ip2\"},\"output\":{\"search\":true}},\"data\":[\"" + mnist_repo + "/sample_digit.png\"]}";
+  jpredictstr = "{\"service\":\"" + sname
+                + "\",\"parameters\":{\"input\":{\"bw\":true,\"width\":28,"
+                  "\"height\":28},\"mllib\":{\"extract_layer\":\"ip2\"},"
+                  "\"output\":{\"search\":true}},\"data\":[\""
+                + mnist_repo + "/sample_digit.png\"]}";
   joutstr = japi.jrender(japi.service_predict(jpredictstr));
   std::cout << "joutstr predict search=" << joutstr << std::endl;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
-  ASSERT_EQ(200,jd["status"]["code"]);
+  ASSERT_EQ(200, jd["status"]["code"]);
   // assert result is itself
   ASSERT_TRUE(jd["body"]["predictions"][0].HasMember("nns"));
-  ASSERT_TRUE(jd["body"]["predictions"][0]["nns"][0]["dist"]==0.0);
-  ASSERT_TRUE(jd["body"]["predictions"][0]["nns"][0]["uri"]=="../examples/caffe/mnist//sample_digit.png");
-  
+  ASSERT_TRUE(jd["body"]["predictions"][0]["nns"][0]["dist"] == 0.0);
+  ASSERT_TRUE(jd["body"]["predictions"][0]["nns"][0]["uri"]
+              == "../examples/caffe/mnist//sample_digit.png");
+
   // remove service
   jstr = "{\"clear\":\"lib\"}";
-  joutstr = japi.jrender(japi.service_delete(sname,jstr));
-  ASSERT_EQ(ok_str,joutstr);
+  joutstr = japi.jrender(japi.service_delete(sname, jstr));
+  ASSERT_EQ(ok_str, joutstr);
 
   // assert non-existence of index
   ASSERT_TRUE(!fileops::file_exists(mnist_repo + "index.ann"));
   ASSERT_TRUE(!fileops::file_exists(mnist_repo + "names.bin/data.mdb"));
 }
 
-TEST(simsearch,predict_simsearch_sup)
+TEST(simsearch, predict_simsearch_sup)
 {
   // create service
   JsonAPI japi;
   std::string sname = "my_service";
-  std::string jstr = "{\"mllib\":\"caffe\",\"description\":\"my classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\"" +  mnist_repo + "\"},\"parameters\":{\"input\":{\"connector\":\"image\"},\"mllib\":{\"nclasses\":10}}}";
-  std::string joutstr = japi.jrender(japi.service_create(sname,jstr));
-  ASSERT_EQ(created_str,joutstr);
+  std::string jstr
+      = "{\"mllib\":\"caffe\",\"description\":\"my "
+        "classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\""
+        + mnist_repo
+        + "\"},\"parameters\":{\"input\":{\"connector\":\"image\"},\"mllib\":{"
+          "\"nclasses\":10}}}";
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
   JDoc jd;
-  
+
   // train
   std::string gpuid = "0";
-  std::string jtrainstr = "{\"service\":\"" + sname + "\",\"async\":false,\"parameters\":{\"mllib\":{\"gpu\":true,\"gpuid\":"+gpuid+",\"solver\":{\"iterations\":" + iterations_mnist + ",\"snapshot\":200,\"snapshot_prefix\":\"" + mnist_repo + "/mylenet\",\"test_interval\":2}},\"output\":{\"measure_hist\":true,\"measure\":[\"f1\"]}}}";
+  std::string jtrainstr
+      = "{\"service\":\"" + sname
+        + "\",\"async\":false,\"parameters\":{\"mllib\":{\"gpu\":true,"
+          "\"gpuid\":"
+        + gpuid + ",\"solver\":{\"iterations\":" + iterations_mnist
+        + ",\"snapshot\":200,\"snapshot_prefix\":\"" + mnist_repo
+        + "/mylenet\",\"test_interval\":2}},\"output\":{\"measure_hist\":true,"
+          "\"measure\":[\"f1\"]}}}";
   joutstr = japi.jrender(japi.service_train(jtrainstr));
   std::cout << "joutstr=" << joutstr << std::endl;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_TRUE(jd.HasMember("status"));
-  ASSERT_EQ(201,jd["status"]["code"].GetInt());
-  ASSERT_EQ("Created",jd["status"]["msg"]);
+  ASSERT_EQ(201, jd["status"]["code"].GetInt());
+  ASSERT_EQ("Created", jd["status"]["msg"]);
   ASSERT_TRUE(jd.HasMember("head"));
-  ASSERT_EQ("/train",jd["head"]["method"]);
+  ASSERT_EQ("/train", jd["head"]["method"]);
   ASSERT_TRUE(jd["head"]["time"].GetDouble() >= 0);
   ASSERT_TRUE(jd.HasMember("body"));
   ASSERT_TRUE(jd["body"].HasMember("measure"));
   ASSERT_TRUE(fabs(jd["body"]["measure"]["train_loss"].GetDouble()) > 0);
-  ASSERT_EQ(jd["body"]["measure_hist"]["iteration_hist"].Size(),jd["body"]["measure_hist"]["f1_hist"].Size());
-  
+  ASSERT_EQ(jd["body"]["measure_hist"]["iteration_hist"].Size(),
+            jd["body"]["measure_hist"]["f1_hist"].Size());
+
   // predict
-  std::string jpredictstr = "{\"service\":\""+ sname + "\",\"parameters\":{\"input\":{\"bw\":true,\"width\":28,\"height\":28},\"mllib\":{},\"output\":{\"index\":true,\"best\":2}},\"data\":[\"" + mnist_repo + "/sample_digit.png\"]}";
+  std::string jpredictstr
+      = "{\"service\":\"" + sname
+        + "\",\"parameters\":{\"input\":{\"bw\":true,\"width\":28,\"height\":"
+          "28},\"mllib\":{},\"output\":{\"index\":true,\"best\":2}},\"data\":["
+          "\""
+        + mnist_repo + "/sample_digit.png\"]}";
   joutstr = japi.jrender(japi.service_predict(jpredictstr));
   std::cout << "joutstr predict index=" << joutstr << std::endl;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
-  ASSERT_EQ(200,jd["status"]["code"]);
+  ASSERT_EQ(200, jd["status"]["code"]);
   ASSERT_TRUE(jd["body"]["predictions"][0].HasMember("indexed"));
   ASSERT_TRUE(jd["body"]["predictions"][0]["indexed"].GetBool());
-  
+
   // build & save index
-  jpredictstr = "{\"service\":\""+ sname + "\",\"parameters\":{\"input\":{\"bw\":true,\"width\":28,\"height\":28},\"mllib\":{},\"output\":{\"build_index\":true,\"best\":2}},\"data\":[\"" + mnist_repo + "/sample_digit.png\"]}";
+  jpredictstr = "{\"service\":\"" + sname
+                + "\",\"parameters\":{\"input\":{\"bw\":true,\"width\":28,"
+                  "\"height\":28},\"mllib\":{},\"output\":{\"build_index\":"
+                  "true,\"best\":2}},\"data\":[\""
+                + mnist_repo + "/sample_digit.png\"]}";
   joutstr = japi.jrender(japi.service_predict(jpredictstr));
   std::cout << "joutstr predict build index=" << joutstr << std::endl;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
-  ASSERT_EQ(200,jd["status"]["code"]);
+  ASSERT_EQ(200, jd["status"]["code"]);
 
   // assert existence of index
   ASSERT_TRUE(fileops::file_exists(mnist_repo + "index.ann"));
   ASSERT_TRUE(fileops::file_exists(mnist_repo + "names.bin/data.mdb"));
 
   // assert error on indexing over a built index
-  jpredictstr = "{\"service\":\""+ sname + "\",\"parameters\":{\"input\":{\"bw\":true,\"width\":28,\"height\":28},\"mllib\":{},\"output\":{\"index\":true,\"best\":2}},\"data\":[\"" + mnist_repo + "/sample_digit.png\"]}";
+  jpredictstr = "{\"service\":\"" + sname
+                + "\",\"parameters\":{\"input\":{\"bw\":true,\"width\":28,"
+                  "\"height\":28},\"mllib\":{},\"output\":{\"index\":true,"
+                  "\"best\":2}},\"data\":[\""
+                + mnist_repo + "/sample_digit.png\"]}";
   joutstr = japi.jrender(japi.service_predict(jpredictstr));
   std::cout << "joutstr predict index=" << joutstr << std::endl;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
-  ASSERT_EQ(403,jd["status"]["code"]);
-  
+  ASSERT_EQ(403, jd["status"]["code"]);
+
   // search index
-  jpredictstr = "{\"service\":\""+ sname + "\",\"parameters\":{\"input\":{\"bw\":true,\"width\":28,\"height\":28},\"mllib\":{},\"output\":{\"search\":true,\"best\":2}},\"data\":[\"" + mnist_repo + "/sample_digit.png\"]}";
+  jpredictstr = "{\"service\":\"" + sname
+                + "\",\"parameters\":{\"input\":{\"bw\":true,\"width\":28,"
+                  "\"height\":28},\"mllib\":{},\"output\":{\"search\":true,"
+                  "\"best\":2}},\"data\":[\""
+                + mnist_repo + "/sample_digit.png\"]}";
   joutstr = japi.jrender(japi.service_predict(jpredictstr));
   std::cout << "joutstr predict search=" << joutstr << std::endl;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
-  ASSERT_EQ(200,jd["status"]["code"]);
+  ASSERT_EQ(200, jd["status"]["code"]);
   // assert result is itself
   ASSERT_TRUE(jd["body"]["predictions"][0].HasMember("nns"));
-  ASSERT_TRUE(jd["body"]["predictions"][0]["nns"][0]["dist"]==0.0);
-  ASSERT_TRUE(jd["body"]["predictions"][0]["nns"][0]["uri"]=="../examples/caffe/mnist//sample_digit.png");
-  
+  ASSERT_TRUE(jd["body"]["predictions"][0]["nns"][0]["dist"] == 0.0);
+  ASSERT_TRUE(jd["body"]["predictions"][0]["nns"][0]["uri"]
+              == "../examples/caffe/mnist//sample_digit.png");
+
   // remove service
   jstr = "{\"clear\":\"lib\"}";
-  joutstr = japi.jrender(japi.service_delete(sname,jstr));
-  ASSERT_EQ(ok_str,joutstr);
+  joutstr = japi.jrender(japi.service_delete(sname, jstr));
+  ASSERT_EQ(ok_str, joutstr);
 
   // assert non-existence of index
   ASSERT_TRUE(!fileops::file_exists(mnist_repo + "index.ann"));
   ASSERT_TRUE(!fileops::file_exists(mnist_repo + "names.bin/data.mdb"));
 }
 
-TEST(simsearch,predict_roi_simsearch)
+TEST(simsearch, predict_roi_simsearch)
 {
   // create service
   JsonAPI japi;
   std::string sname = "my_service";
-  std::string jstr = "{\"mllib\":\"caffe\",\"description\":\"my classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\"" +  voc_repo + "\"},\"parameters\":{\"input\":{\"connector\":\"image\",\"width\":300,\"height\":300},\"mllib\":{\"nclasses\":21}}}";
+  std::string jstr
+      = "{\"mllib\":\"caffe\",\"description\":\"my "
+        "classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\""
+        + voc_repo
+        + "\"},\"parameters\":{\"input\":{\"connector\":\"image\",\"width\":"
+          "300,\"height\":300},\"mllib\":{\"nclasses\":21}}}";
   std::cerr << "jstr=" << jstr << std::endl;
-  std::string joutstr = japi.jrender(japi.service_create(sname,jstr));
-  ASSERT_EQ(created_str,joutstr);
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
   JDoc jd;
 
   // predict
-  std::string jpredictstr = "{\"service\":\""+ sname + "\",\"parameters\":{\"input\":{},\"mllib\":{},\"output\":{\"rois\":\"rois\",\"confidence_threshold\":0.1,\"index\":true}},\"data\":[\"" + voc_repo + "/test_img.jpg\"]}";
+  std::string jpredictstr
+      = "{\"service\":\"" + sname
+        + "\",\"parameters\":{\"input\":{},\"mllib\":{},\"output\":{\"rois\":"
+          "\"rois\",\"confidence_threshold\":0.1,\"index\":true}},\"data\":[\""
+        + voc_repo + "/test_img.jpg\"]}";
   std::cerr << "jpredictstr=" << jpredictstr << std::endl;
   joutstr = japi.jrender(japi.service_predict(jpredictstr));
   std::cout << "joutstr predict index=" << joutstr << std::endl;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
-  ASSERT_EQ(200,jd["status"]["code"]);
+  ASSERT_EQ(200, jd["status"]["code"]);
   ASSERT_TRUE(jd["body"]["predictions"][0].HasMember("indexed"));
   ASSERT_TRUE(jd["body"]["predictions"][0]["indexed"].GetBool());
-  
+
   // build & save index
-  jpredictstr = "{\"service\":\""+ sname + "\",\"parameters\":{\"input\":{},\"mllib\":{},\"output\":{\"build_index\":true,\"rois\":\"rois\",\"confidence_threshold\":0.1}},\"data\":[\"" + voc_repo + "/test_img.jpg\"]}";
+  jpredictstr = "{\"service\":\"" + sname
+                + "\",\"parameters\":{\"input\":{},\"mllib\":{},\"output\":{"
+                  "\"build_index\":true,\"rois\":\"rois\",\"confidence_"
+                  "threshold\":0.1}},\"data\":[\""
+                + voc_repo + "/test_img.jpg\"]}";
   joutstr = japi.jrender(japi.service_predict(jpredictstr));
   std::cout << "joutstr predict build index=" << joutstr << std::endl;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
-  ASSERT_EQ(200,jd["status"]["code"]);
+  ASSERT_EQ(200, jd["status"]["code"]);
 
   // assert existence of index
   ASSERT_TRUE(fileops::file_exists(voc_repo + "index.ann"));
   ASSERT_TRUE(fileops::file_exists(voc_repo + "names.bin/data.mdb"));
 
   // search index
-  jpredictstr = "{\"service\":\""+ sname + "\",\"parameters\":{\"input\":{},\"mllib\":{},\"output\":{\"search\":true,\"rois\":\"rois\",\"confidence_threshold\":0.1}},\"data\":[\"" + voc_repo + "/test_img.jpg\"]}";
+  jpredictstr = "{\"service\":\"" + sname
+                + "\",\"parameters\":{\"input\":{},\"mllib\":{},\"output\":{"
+                  "\"search\":true,\"rois\":\"rois\",\"confidence_threshold\":"
+                  "0.1}},\"data\":[\""
+                + voc_repo + "/test_img.jpg\"]}";
   joutstr = japi.jrender(japi.service_predict(jpredictstr));
   std::cout << "joutstr predict search=" << joutstr << std::endl;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
-  ASSERT_EQ(200,jd["status"]["code"]);
+  ASSERT_EQ(200, jd["status"]["code"]);
   // assert result is itself
   ASSERT_TRUE(jd["body"]["predictions"][0]["rois"][0].HasMember("nns"));
-  ASSERT_TRUE(jd["body"]["predictions"][0]["rois"][0]["nns"][0]["dist"]==0.0);
-  ASSERT_TRUE(jd["body"]["predictions"][0]["rois"][0]["nns"][0]["uri"]=="../examples/caffe/voc_roi/voc_roi//test_img.jpg");
-  
+  ASSERT_TRUE(jd["body"]["predictions"][0]["rois"][0]["nns"][0]["dist"]
+              == 0.0);
+  ASSERT_TRUE(jd["body"]["predictions"][0]["rois"][0]["nns"][0]["uri"]
+              == "../examples/caffe/voc_roi/voc_roi//test_img.jpg");
+
   // remove service
   jstr = "{\"clear\":\"index\"}";
-  joutstr = japi.jrender(japi.service_delete(sname,jstr));
-  ASSERT_EQ(ok_str,joutstr);
+  joutstr = japi.jrender(japi.service_delete(sname, jstr));
+  ASSERT_EQ(ok_str, joutstr);
 
   // assert non-existence of index
   ASSERT_TRUE(!fileops::file_exists(voc_repo + "index.ann"));

--- a/tests/ut-tensorrtapi.cc
+++ b/tests/ut-tensorrtapi.cc
@@ -28,55 +28,79 @@
 using namespace dd;
 
 static std::string ok_str = "{\"status\":{\"code\":200,\"msg\":\"OK\"}}";
-static std::string created_str = "{\"status\":{\"code\":201,\"msg\":\"Created\"}}";
-static std::string bad_param_str = "{\"status\":{\"code\":400,\"msg\":\"BadRequest\"}}";
-static std::string not_found_str = "{\"status\":{\"code\":404,\"msg\":\"NotFound\"}}";
+static std::string created_str
+    = "{\"status\":{\"code\":201,\"msg\":\"Created\"}}";
+static std::string bad_param_str
+    = "{\"status\":{\"code\":400,\"msg\":\"BadRequest\"}}";
+static std::string not_found_str
+    = "{\"status\":{\"code\":404,\"msg\":\"NotFound\"}}";
 
 static std::string incept_repo = "../examples/trt/squeezenet_ssd_trt/";
 static std::string age_repo = "../examples/trt/age_real/";
 
-TEST(tensorrtapi,service_predict)
+TEST(tensorrtapi, service_predict)
 {
   // create service
   JsonAPI japi;
   std::string sname = "imgserv";
-  std::string jstr = "{\"mllib\":\"tensorrt\",\"description\":\"squeezenet-ssd\",\"type\":\"supervised\",\"model\":{\"repository\":\"" +  incept_repo + "\"},\"parameters\":{\"input\":{\"connector\":\"image\",\"height\":300,\"width\":300},\"mllib\":{\"nclasses\":21}}}";
-  std::string joutstr = japi.jrender(japi.service_create(sname,jstr));
-  ASSERT_EQ(created_str,joutstr);
+  std::string jstr
+      = "{\"mllib\":\"tensorrt\",\"description\":\"squeezenet-ssd\",\"type\":"
+        "\"supervised\",\"model\":{\"repository\":\""
+        + incept_repo
+        + "\"},\"parameters\":{\"input\":{\"connector\":\"image\",\"height\":"
+          "300,\"width\":300},\"mllib\":{\"nclasses\":21}}}";
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
 
   // predict
-  std::string jpredictstr = "{\"service\":\"imgserv\",\"parameters\":{\"input\":{\"height\":300,\"width\":300},\"output\":{\"bbox\":true}},\"data\":[\"" + incept_repo + "face.jpg\"]}";
+  std::string jpredictstr
+      = "{\"service\":\"imgserv\",\"parameters\":{\"input\":{\"height\":300,"
+        "\"width\":300},\"output\":{\"bbox\":true}},\"data\":[\""
+        + incept_repo + "face.jpg\"]}";
   joutstr = japi.jrender(japi.service_predict(jpredictstr));
   JDoc jd;
   std::cout << "joutstr=" << joutstr << std::endl;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
-  ASSERT_EQ(200,jd["status"]["code"]);
+  ASSERT_EQ(200, jd["status"]["code"]);
   ASSERT_TRUE(jd["body"]["predictions"].IsArray());
-  std::string cl1 = jd["body"]["predictions"][0]["classes"][0]["cat"].GetString();
+  std::string cl1
+      = jd["body"]["predictions"][0]["classes"][0]["cat"].GetString();
   ASSERT_TRUE(cl1 == "15");
-  ASSERT_TRUE(jd["body"]["predictions"][0]["classes"][0]["prob"].GetDouble() > 0.4);
+  ASSERT_TRUE(jd["body"]["predictions"][0]["classes"][0]["prob"].GetDouble()
+              > 0.4);
 }
 
-TEST(tensorrtapi,service_predict_best)
+TEST(tensorrtapi, service_predict_best)
 {
   // create service
   JsonAPI japi;
   std::string sname = "age";
-  std::string jstr = "{\"mllib\":\"tensorrt\",\"description\":\"age_classif\",\"type\":\"supervised\",\"model\":{\"repository\":\"" +  age_repo + "\"},\"parameters\":{\"input\":{\"connector\":\"image\",\"height\":224,\"width\":224},\"mllib\":{\"datatype\":\"fp32\",\"maxBatchSize\":1,\"maxWorkspaceSize\":6096,\"tensorRTEngineFile\":\"TRTengine_bs\",\"gpuid\":0}}}";
-  std::string joutstr = japi.jrender(japi.service_create(sname,jstr));
-  ASSERT_EQ(created_str,joutstr);
+  std::string jstr
+      = "{\"mllib\":\"tensorrt\",\"description\":\"age_classif\",\"type\":"
+        "\"supervised\",\"model\":{\"repository\":\""
+        + age_repo
+        + "\"},\"parameters\":{\"input\":{\"connector\":\"image\",\"height\":"
+          "224,\"width\":224},\"mllib\":{\"datatype\":\"fp32\","
+          "\"maxBatchSize\":1,\"maxWorkspaceSize\":6096,"
+          "\"tensorRTEngineFile\":\"TRTengine_bs\",\"gpuid\":0}}}";
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
 
   // predict
-  std::string jpredictstr = "{\"service\":\"age\",\"parameters\":{\"input\":{\"height\":224,\"width\":224},\"output\":{\"best\":2}},\"data\":[\"" + incept_repo + "face.jpg\"]}";
+  std::string jpredictstr
+      = "{\"service\":\"age\",\"parameters\":{\"input\":{\"height\":224,"
+        "\"width\":224},\"output\":{\"best\":2}},\"data\":[\""
+        + incept_repo + "face.jpg\"]}";
   joutstr = japi.jrender(japi.service_predict(jpredictstr));
   JDoc jd;
   std::cout << "joutstr=" << joutstr << std::endl;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
-  ASSERT_EQ(200,jd["status"]["code"]);
+  ASSERT_EQ(200, jd["status"]["code"]);
   ASSERT_TRUE(jd["body"]["predictions"].IsArray());
-  ASSERT_EQ(2,jd["body"]["predictions"][0]["classes"].Size());
-  std::string age = jd["body"]["predictions"][0]["classes"][0]["cat"].GetString();
+  ASSERT_EQ(2, jd["body"]["predictions"][0]["classes"].Size());
+  std::string age
+      = jd["body"]["predictions"][0]["classes"][0]["cat"].GetString();
   ASSERT_TRUE(age == "29");
 }

--- a/tests/ut-tfapi.cc
+++ b/tests/ut-tfapi.cc
@@ -31,67 +31,97 @@
 using namespace dd;
 
 static std::string ok_str = "{\"status\":{\"code\":200,\"msg\":\"OK\"}}";
-static std::string created_str = "{\"status\":{\"code\":201,\"msg\":\"Created\"}}";
-static std::string bad_param_str = "{\"status\":{\"code\":400,\"msg\":\"BadRequest\"}}";
-static std::string not_found_str = "{\"status\":{\"code\":404,\"msg\":\"NotFound\"}}";
+static std::string created_str
+    = "{\"status\":{\"code\":201,\"msg\":\"Created\"}}";
+static std::string bad_param_str
+    = "{\"status\":{\"code\":400,\"msg\":\"BadRequest\"}}";
+static std::string not_found_str
+    = "{\"status\":{\"code\":404,\"msg\":\"NotFound\"}}";
 
 static std::string incept_repo = "../examples/tf/inception/";
 
-TEST(tfapi,service_predict)
+TEST(tfapi, service_predict)
 {
   // create service
   JsonAPI japi;
   std::string sname = "imgserv";
-  std::string jstr = "{\"mllib\":\"tensorflow\",\"description\":\"my classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\"" +  incept_repo + "\"},\"parameters\":{\"input\":{\"connector\":\"image\",\"height\":224,\"width\":224,\"inputlayer\":\"InputImage\"},\"mllib\":{\"nclasses\":1001}}}";
-  std::string joutstr = japi.jrender(japi.service_create(sname,jstr));
-  ASSERT_EQ(created_str,joutstr);
+  std::string jstr
+      = "{\"mllib\":\"tensorflow\",\"description\":\"my "
+        "classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\""
+        + incept_repo
+        + "\"},\"parameters\":{\"input\":{\"connector\":\"image\",\"height\":"
+          "224,\"width\":224,\"inputlayer\":\"InputImage\"},\"mllib\":{"
+          "\"nclasses\":1001}}}";
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
 
   // predict
-  std::string jpredictstr = "{\"service\":\"imgserv\",\"parameters\":{\"output\":{\"best\":3}},\"data\":[\"" + incept_repo + "grace_hopper.jpg\"]}";
+  std::string jpredictstr = "{\"service\":\"imgserv\",\"parameters\":{"
+                            "\"output\":{\"best\":3}},\"data\":[\""
+                            + incept_repo + "grace_hopper.jpg\"]}";
   joutstr = japi.jrender(japi.service_predict(jpredictstr));
   JDoc jd;
   std::cout << "joutstr=" << joutstr << std::endl;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
-  ASSERT_EQ(200,jd["status"]["code"]);
+  ASSERT_EQ(200, jd["status"]["code"]);
   ASSERT_TRUE(jd["body"]["predictions"].IsArray());
-  std::string cl1 = jd["body"]["predictions"][0]["classes"][0]["cat"].GetString();
+  std::string cl1
+      = jd["body"]["predictions"][0]["classes"][0]["cat"].GetString();
   ASSERT_TRUE(cl1 == "n03763968 military uniform");
-  ASSERT_TRUE(jd["body"]["predictions"][0]["classes"][0]["prob"].GetDouble() > 0.4);
+  ASSERT_TRUE(jd["body"]["predictions"][0]["classes"][0]["prob"].GetDouble()
+              > 0.4);
 
   // predict batch
-  jpredictstr = "{\"service\":\"imgserv\",\"parameters\":{\"output\":{\"best\":3}},\"data\":[\"" + incept_repo + "grace_hopper.jpg\",\"" + incept_repo + "cat.jpg\"]}";
+  jpredictstr = "{\"service\":\"imgserv\",\"parameters\":{\"output\":{"
+                "\"best\":3}},\"data\":[\""
+                + incept_repo + "grace_hopper.jpg\",\"" + incept_repo
+                + "cat.jpg\"]}";
   joutstr = japi.jrender(japi.service_predict(jpredictstr));
   std::cout << "joutstr=" << joutstr << std::endl;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
-  ASSERT_EQ(200,jd["status"]["code"]);
+  ASSERT_EQ(200, jd["status"]["code"]);
   ASSERT_TRUE(jd["body"]["predictions"].IsArray());
-  ASSERT_EQ(2,jd["body"]["predictions"].Size());
+  ASSERT_EQ(2, jd["body"]["predictions"].Size());
   cl1 = jd["body"]["predictions"][0]["classes"][0]["cat"].GetString();
-  std::string cl2 = jd["body"]["predictions"][1]["classes"][0]["cat"].GetString();
-  ASSERT_TRUE((cl1 == "n03763968 military uniform" && cl2 == "n02123045 tabby, tabby cat")
-	      || (cl1 == "n02123045 tabby, tabby cat" && cl2 == "n03763968 military uniform"));
-  ASSERT_TRUE(jd["body"]["predictions"][0]["classes"][0]["prob"].GetDouble() > 0.4);
-  ASSERT_TRUE(jd["body"]["predictions"][1]["classes"][0]["prob"].GetDouble() > 0.4);
-  }
+  std::string cl2
+      = jd["body"]["predictions"][1]["classes"][0]["cat"].GetString();
+  ASSERT_TRUE((cl1 == "n03763968 military uniform"
+               && cl2 == "n02123045 tabby, tabby cat")
+              || (cl1 == "n02123045 tabby, tabby cat"
+                  && cl2 == "n03763968 military uniform"));
+  ASSERT_TRUE(jd["body"]["predictions"][0]["classes"][0]["prob"].GetDouble()
+              > 0.4);
+  ASSERT_TRUE(jd["body"]["predictions"][1]["classes"][0]["prob"].GetDouble()
+              > 0.4);
+}
 
-TEST(tfapi,service_predict_unsup)
+TEST(tfapi, service_predict_unsup)
 {
   // create service
   JsonAPI japi;
   std::string sname = "imgserv";
-  std::string jstr = "{\"mllib\":\"tensorflow\",\"description\":\"my classifier\",\"type\":\"unsupervised\",\"model\":{\"repository\":\"" +  incept_repo + "\"},\"parameters\":{\"input\":{\"connector\":\"image\",\"height\":224,\"width\":224,\"inputlayer\":\"InputImage\"},\"mllib\":{\"nclasses\":1001}}}";
-  std::string joutstr = japi.jrender(japi.service_create(sname,jstr));
-  ASSERT_EQ(created_str,joutstr);
+  std::string jstr
+      = "{\"mllib\":\"tensorflow\",\"description\":\"my "
+        "classifier\",\"type\":\"unsupervised\",\"model\":{\"repository\":\""
+        + incept_repo
+        + "\"},\"parameters\":{\"input\":{\"connector\":\"image\",\"height\":"
+          "224,\"width\":224,\"inputlayer\":\"InputImage\"},\"mllib\":{"
+          "\"nclasses\":1001}}}";
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
 
   // predict
-  std::string jpredictstr = "{\"service\":\"imgserv\",\"parameters\":{\"mllib\":{\"extract_layer\":\"InceptionV1/InceptionV1/Mixed_5c/concat\"}},\"data\":[\"" + incept_repo + "grace_hopper.jpg\"]}";
+  std::string jpredictstr
+      = "{\"service\":\"imgserv\",\"parameters\":{\"mllib\":{\"extract_"
+        "layer\":\"InceptionV1/InceptionV1/Mixed_5c/concat\"}},\"data\":[\""
+        + incept_repo + "grace_hopper.jpg\"]}";
   joutstr = japi.jrender(japi.service_predict(jpredictstr));
   JDoc jd;
-  //std::cout << "joutstr=" << joutstr << std::endl;
+  // std::cout << "joutstr=" << joutstr << std::endl;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
-  ASSERT_EQ(200,jd["status"]["code"]);
-  ASSERT_EQ(50176,jd["body"]["predictions"][0]["vals"].Size());
+  ASSERT_EQ(200, jd["status"]["code"]);
+  ASSERT_EQ(50176, jd["body"]["predictions"][0]["vals"].Size());
 }

--- a/tests/ut-torchapi.cc
+++ b/tests/ut-torchapi.cc
@@ -29,83 +29,113 @@
 using namespace dd;
 
 static std::string ok_str = "{\"status\":{\"code\":200,\"msg\":\"OK\"}}";
-static std::string created_str = "{\"status\":{\"code\":201,\"msg\":\"Created\"}}";
-static std::string bad_param_str = "{\"status\":{\"code\":400,\"msg\":\"BadRequest\"}}";
-static std::string not_found_str = "{\"status\":{\"code\":404,\"msg\":\"NotFound\"}}";
+static std::string created_str
+    = "{\"status\":{\"code\":201,\"msg\":\"Created\"}}";
+static std::string bad_param_str
+    = "{\"status\":{\"code\":400,\"msg\":\"BadRequest\"}}";
+static std::string not_found_str
+    = "{\"status\":{\"code\":404,\"msg\":\"NotFound\"}}";
 
 static std::string incept_repo = "../examples/torch/resnet50_torch/";
-static std::string bert_classif_repo = "../examples/torch/bert_inference_torch/";
-static std::string bert_train_repo = "../examples/torch/bert_training_torch_140_transformers_251/";
-static std::string bert_train_data = "../examples/torch/bert_training_torch_140_transformers_251/data/";
+static std::string bert_classif_repo
+    = "../examples/torch/bert_inference_torch/";
+static std::string bert_train_repo
+    = "../examples/torch/bert_training_torch_140_transformers_251/";
+static std::string bert_train_data
+    = "../examples/torch/bert_training_torch_140_transformers_251/data/";
 
 TEST(torchapi, service_predict)
 {
-    // create service
-    JsonAPI japi;
-    std::string sname = "imgserv";
-    std::string jstr = "{\"mllib\":\"torch\",\"description\":\"resnet-50\",\"type\":\"supervised\",\"model\":{\"repository\":\"" +  incept_repo + "\"},\"parameters\":{\"input\":{\"connector\":\"image\",\"height\":224,\"width\":224,\"rgb\":true,\"scale\":0.0039}}}";
-    std::string joutstr = japi.jrender(japi.service_create(sname,jstr));
-    ASSERT_EQ(created_str,joutstr);
+  // create service
+  JsonAPI japi;
+  std::string sname = "imgserv";
+  std::string jstr
+      = "{\"mllib\":\"torch\",\"description\":\"resnet-50\",\"type\":"
+        "\"supervised\",\"model\":{\"repository\":\""
+        + incept_repo
+        + "\"},\"parameters\":{\"input\":{\"connector\":\"image\",\"height\":"
+          "224,\"width\":224,\"rgb\":true,\"scale\":0.0039}}}";
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
 
-    // predict
-    std::string jpredictstr = "{\"service\":\"imgserv\",\"parameters\":{\"input\":{\"height\":224,\"width\":224,\"rgb\":true,\"scale\":0.0039},\"output\":{\"best\":1}},\"data\":[\"" + incept_repo + "cat.jpg\"]}";
-    joutstr = japi.jrender(japi.service_predict(jpredictstr));
-    JDoc jd;
-    std::cout << "joutstr=" << joutstr << std::endl;
-    jd.Parse(joutstr.c_str());
-    ASSERT_TRUE(!jd.HasParseError());
-    ASSERT_EQ(200,jd["status"]["code"]);
-    ASSERT_TRUE(jd["body"]["predictions"].IsArray());
-    std::string cl1 = jd["body"]["predictions"][0]["classes"][0]["cat"].GetString();
-    ASSERT_TRUE(cl1 == "n02123045 tabby, tabby cat");
-    ASSERT_TRUE(jd["body"]["predictions"][0]["classes"][0]["prob"].GetDouble() > 0.3);
+  // predict
+  std::string jpredictstr
+      = "{\"service\":\"imgserv\",\"parameters\":{\"input\":{\"height\":224,"
+        "\"width\":224,\"rgb\":true,\"scale\":0.0039},\"output\":{\"best\":1}}"
+        ",\"data\":[\""
+        + incept_repo + "cat.jpg\"]}";
+  joutstr = japi.jrender(japi.service_predict(jpredictstr));
+  JDoc jd;
+  std::cout << "joutstr=" << joutstr << std::endl;
+  jd.Parse(joutstr.c_str());
+  ASSERT_TRUE(!jd.HasParseError());
+  ASSERT_EQ(200, jd["status"]["code"]);
+  ASSERT_TRUE(jd["body"]["predictions"].IsArray());
+  std::string cl1
+      = jd["body"]["predictions"][0]["classes"][0]["cat"].GetString();
+  ASSERT_TRUE(cl1 == "n02123045 tabby, tabby cat");
+  ASSERT_TRUE(jd["body"]["predictions"][0]["classes"][0]["prob"].GetDouble()
+              > 0.3);
 }
 
 TEST(torchapi, service_predict_txt_classification)
 {
-    // create service
-    JsonAPI japi;
-    std::string sname = "txtserv";
-    std::string jstr = "{\"mllib\":\"torch\",\"description\":\"bert\",\"type\":\"supervised\",\"model\":{\"repository\":\""
-        + bert_classif_repo + "\"},\"parameters\":{\"input\":{\"connector\":\"txt\",\"ordered_words\":true,"
-        "\"wordpiece_tokens\":true,\"punctuation_tokens\":true,\"sequence\":512}}}";
-    std::string joutstr = japi.jrender(japi.service_create(sname,jstr));
-    ASSERT_EQ(created_str,joutstr);
+  // create service
+  JsonAPI japi;
+  std::string sname = "txtserv";
+  std::string jstr = "{\"mllib\":\"torch\",\"description\":\"bert\",\"type\":"
+                     "\"supervised\",\"model\":{\"repository\":\""
+                     + bert_classif_repo
+                     + "\"},\"parameters\":{\"input\":{\"connector\":\"txt\","
+                       "\"ordered_words\":true,"
+                       "\"wordpiece_tokens\":true,\"punctuation_tokens\":true,"
+                       "\"sequence\":512}}}";
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
 
-    // predict
-    std::string jpredictstr = "{\"service\":\"txtserv\",\"parameters\":{\"output\":{\"best\":1}},\"data\":["
-        "\"Get the official USA poly ringtone or colour flag on your mobile for tonights game! Text TONE or FLAG to 84199. Optout txt ENG STOP Box39822 W111WX £1.50\"]}";
-    joutstr = japi.jrender(japi.service_predict(jpredictstr));
-    JDoc jd;
-    std::cout << "joutstr=" << joutstr << std::endl;
-    jd.Parse(joutstr.c_str());
-    ASSERT_TRUE(!jd.HasParseError());
-    ASSERT_EQ(200, jd["status"]["code"]);
-    ASSERT_TRUE(jd["body"]["predictions"].IsArray());
-    std::string cl1 = jd["body"]["predictions"][0]["classes"][0]["cat"].GetString();
-    ASSERT_TRUE(cl1 == "spam");
-    ASSERT_TRUE(jd["body"]["predictions"][0]["classes"][0]["prob"].GetDouble() > 0.7);
+  // predict
+  std::string jpredictstr
+      = "{\"service\":\"txtserv\",\"parameters\":{\"output\":{\"best\":1}},"
+        "\"data\":["
+        "\"Get the official USA poly ringtone or colour flag on your mobile "
+        "for tonights game! Text TONE or FLAG to 84199. Optout txt ENG STOP "
+        "Box39822 W111WX £1.50\"]}";
+  joutstr = japi.jrender(japi.service_predict(jpredictstr));
+  JDoc jd;
+  std::cout << "joutstr=" << joutstr << std::endl;
+  jd.Parse(joutstr.c_str());
+  ASSERT_TRUE(!jd.HasParseError());
+  ASSERT_EQ(200, jd["status"]["code"]);
+  ASSERT_TRUE(jd["body"]["predictions"].IsArray());
+  std::string cl1
+      = jd["body"]["predictions"][0]["classes"][0]["cat"].GetString();
+  ASSERT_TRUE(cl1 == "spam");
+  ASSERT_TRUE(jd["body"]["predictions"][0]["classes"][0]["prob"].GetDouble()
+              > 0.7);
 }
 
-TEST(inputconn, txt_tokenize_ordered_words) {
-    std::string str = "everything runs fine, right?";
-    TxtInputFileConn tifc;
-    tifc._ordered_words = true;
-    tifc._wordpiece_tokens = true;
-    tifc._punctuation_tokens = true;
+TEST(inputconn, txt_tokenize_ordered_words)
+{
+  std::string str = "everything runs fine, right?";
+  TxtInputFileConn tifc;
+  tifc._ordered_words = true;
+  tifc._wordpiece_tokens = true;
+  tifc._punctuation_tokens = true;
 
-    tifc._vocab["every"] = Word();
-    tifc._vocab["##ing"] = Word();
-    tifc._vocab["##thing"] = Word();
-    tifc._vocab["fine"] = Word();
-    tifc._vocab[","] = Word();
-    tifc._vocab["?"] = Word();
-    tifc._vocab["right"] = Word();
+  tifc._vocab["every"] = Word();
+  tifc._vocab["##ing"] = Word();
+  tifc._vocab["##thing"] = Word();
+  tifc._vocab["fine"] = Word();
+  tifc._vocab[","] = Word();
+  tifc._vocab["?"] = Word();
+  tifc._vocab["right"] = Word();
 
-    tifc.parse_content(str,1);
-    TxtOrderedWordsEntry &towe = *dynamic_cast<TxtOrderedWordsEntry*>(tifc._txt.at(0));
-    std::vector<std::string> tokens{"every", "##thing", "[UNK]", "fine", ",", "right", "?"};
-    ASSERT_EQ(tokens, towe._v);
+  tifc.parse_content(str, 1);
+  TxtOrderedWordsEntry &towe
+      = *dynamic_cast<TxtOrderedWordsEntry *>(tifc._txt.at(0));
+  std::vector<std::string> tokens{ "every", "##thing", "[UNK]", "fine",
+                                   ",",     "right",   "?" };
+  ASSERT_EQ(tokens, towe._v);
 }
 
 // Training tests
@@ -114,77 +144,97 @@ TEST(inputconn, txt_tokenize_ordered_words) {
 
 TEST(torchapi, service_train_txt_lm)
 {
-    // create service
-    JsonAPI japi;
-    std::string sname = "txtserv";
-    std::string jstr = "{\"mllib\":\"torch\",\"description\":\"bert\",\"type\":\"supervised\",\"model\":{\"repository\":\""
-        + bert_train_repo + "\"},\"parameters\":{\"input\":{\"connector\":\"txt\",\"ordered_words\":true,"
-        "\"wordpiece_tokens\":true,\"punctuation_tokens\":true,\"sequence\":512},\"mllib\":{\"template\":\"bert\","
-        "\"self_supervised\":\"mask\",\"finetuning\":true,\"gpu\":true}}}";
-    std::string joutstr = japi.jrender(japi.service_create(sname,jstr));
-    ASSERT_EQ(created_str,joutstr);
+  // create service
+  JsonAPI japi;
+  std::string sname = "txtserv";
+  std::string jstr
+      = "{\"mllib\":\"torch\",\"description\":\"bert\",\"type\":"
+        "\"supervised\",\"model\":{\"repository\":\""
+        + bert_train_repo
+        + "\"},\"parameters\":{\"input\":{\"connector\":\"txt\",\"ordered_"
+          "words\":true,"
+          "\"wordpiece_tokens\":true,\"punctuation_tokens\":true,\"sequence\":"
+          "512},\"mllib\":{\"template\":\"bert\","
+          "\"self_supervised\":\"mask\",\"finetuning\":true,\"gpu\":true}}}";
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
 
-    // train
-    std::string jtrainstr = "{\"service\":\"txtserv\",\"async\":false,\"parameters\":{"
-        "\"mllib\":{\"solver\":{\"iterations\":3,\"base_lr\":1e-5,\"iter_size\":2,\"solver_type\":\"ADAM\"},\"net\":{\"batch_size\":2}},"
+  // train
+  std::string jtrainstr
+      = "{\"service\":\"txtserv\",\"async\":false,\"parameters\":{"
+        "\"mllib\":{\"solver\":{\"iterations\":3,\"base_lr\":1e-5,\"iter_"
+        "size\":2,\"solver_type\":\"ADAM\"},\"net\":{\"batch_size\":2}},"
         "\"input\":{\"shuffle\":true,\"test_split\":0.25},"
-        "\"output\":{\"measure\":[\"f1\",\"acc\"]}},\"data\":[\"" + bert_train_data + "\"]}";
-    joutstr = japi.jrender(japi.service_train(jtrainstr));
-    JDoc jd;
-    std::cout << "joutstr=" << joutstr << std::endl;
-    jd.Parse(joutstr.c_str());
-    ASSERT_TRUE(!jd.HasParseError());
-    ASSERT_EQ(201, jd["status"]["code"]);
-    ASSERT_TRUE(jd["body"]["measure"]["iteration"] == 3) << "iterations";
-    // This assertion is non-deterministic
-    // ASSERT_TRUE(jd["body"]["measure"]["train_loss"].GetDouble() > 1.0) << "train_loss";
-    ASSERT_TRUE(jd["body"]["measure"]["acc"].GetDouble() <= 1) << "accuracy";
-    ASSERT_TRUE(jd["body"]["measure"]["f1"].GetDouble() <= 1) << "f1";
-    fileops::remove_file(bert_train_repo,"checkpoint-3.pt");
-    fileops::remove_file(bert_train_repo,"solver-3.pt");
-    fileops::remove_file(bert_train_repo,"checkpoint-2.pt");
-    fileops::remove_file(bert_train_repo,"solver-2.pt");
-    fileops::remove_file(bert_train_repo,"checkpoint-1.pt");
-    fileops::remove_file(bert_train_repo,"solver-1.pt");
+        "\"output\":{\"measure\":[\"f1\",\"acc\"]}},\"data\":[\""
+        + bert_train_data + "\"]}";
+  joutstr = japi.jrender(japi.service_train(jtrainstr));
+  JDoc jd;
+  std::cout << "joutstr=" << joutstr << std::endl;
+  jd.Parse(joutstr.c_str());
+  ASSERT_TRUE(!jd.HasParseError());
+  ASSERT_EQ(201, jd["status"]["code"]);
+  ASSERT_TRUE(jd["body"]["measure"]["iteration"] == 3) << "iterations";
+  // This assertion is non-deterministic
+  // ASSERT_TRUE(jd["body"]["measure"]["train_loss"].GetDouble() > 1.0) <<
+  // "train_loss";
+  ASSERT_TRUE(jd["body"]["measure"]["acc"].GetDouble() <= 1) << "accuracy";
+  ASSERT_TRUE(jd["body"]["measure"]["f1"].GetDouble() <= 1) << "f1";
+  fileops::remove_file(bert_train_repo, "checkpoint-3.pt");
+  fileops::remove_file(bert_train_repo, "solver-3.pt");
+  fileops::remove_file(bert_train_repo, "checkpoint-2.pt");
+  fileops::remove_file(bert_train_repo, "solver-2.pt");
+  fileops::remove_file(bert_train_repo, "checkpoint-1.pt");
+  fileops::remove_file(bert_train_repo, "solver-1.pt");
 }
 
 TEST(torchapi, service_train_txt_classification)
 {
-    // create service
-    JsonAPI japi;
-    std::string sname = "txtserv";
-    std::string jstr = "{\"mllib\":\"torch\",\"description\":\"bert\",\"type\":\"supervised\",\"model\":{\"repository\":\""
-        + bert_train_repo + "\"},\"parameters\":{\"input\":{\"connector\":\"txt\",\"ordered_words\":true,"
-        "\"wordpiece_tokens\":true,\"punctuation_tokens\":true,\"sequence\":512},\"mllib\":{\"template\":\"bert\","
-        "\"nclasses\":2,\"finetuning\":true,\"gpu\":true}}}";
-    std::string joutstr = japi.jrender(japi.service_create(sname,jstr));
-    ASSERT_EQ(created_str,joutstr);
+  // create service
+  JsonAPI japi;
+  std::string sname = "txtserv";
+  std::string jstr = "{\"mllib\":\"torch\",\"description\":\"bert\",\"type\":"
+                     "\"supervised\",\"model\":{\"repository\":\""
+                     + bert_train_repo
+                     + "\"},\"parameters\":{\"input\":{\"connector\":\"txt\","
+                       "\"ordered_words\":true,"
+                       "\"wordpiece_tokens\":true,\"punctuation_tokens\":true,"
+                       "\"sequence\":512},\"mllib\":{\"template\":\"bert\","
+                       "\"nclasses\":2,\"finetuning\":true,\"gpu\":true}}}";
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
 
-    // train
-    std::string jtrainstr = "{\"service\":\"txtserv\",\"async\":false,\"parameters\":{"
-        "\"mllib\":{\"solver\":{\"iterations\":3,\"base_lr\":1e-5,\"iter_size\":2,\"solver_type\":\"ADAM\"},\"net\":{\"batch_size\":2}},"
+  // train
+  std::string jtrainstr
+      = "{\"service\":\"txtserv\",\"async\":false,\"parameters\":{"
+        "\"mllib\":{\"solver\":{\"iterations\":3,\"base_lr\":1e-5,\"iter_"
+        "size\":2,\"solver_type\":\"ADAM\"},\"net\":{\"batch_size\":2}},"
         "\"input\":{\"shuffle\":true,\"test_split\":0.25},"
-        "\"output\":{\"measure\":[\"f1\",\"acc\",\"mcll\",\"cmdiag\",\"cmfull\"]}},\"data\":[\"" + bert_train_data + "\"]}";
-    joutstr = japi.jrender(japi.service_train(jtrainstr));
-    JDoc jd;
-    std::cout << "joutstr=" << joutstr << std::endl;
-    jd.Parse(joutstr.c_str());
-    ASSERT_TRUE(!jd.HasParseError());
-    ASSERT_EQ(201, jd["status"]["code"]);
-    ASSERT_TRUE(abs(jd["body"]["measure"]["iteration"].GetDouble() - 3) < 0.00001) << "iterations";
-    // This assertion is non-deterministic
-    // ASSERT_TRUE(jd["body"]["measure"]["train_loss"].GetDouble() > 1.0) << "train_loss";
-    ASSERT_TRUE(jd["body"]["measure"]["acc"].GetDouble() <= 1) << "accuracy";
-    ASSERT_TRUE(jd["body"]["measure"]["f1"].GetDouble() <= 1) << "f1";
-    fileops::remove_file(bert_train_repo,"checkpoint-3.ptw");
-    fileops::remove_file(bert_train_repo,"checkpoint-3.pt");
-    fileops::remove_file(bert_train_repo,"solver-3.pt");
-    fileops::remove_file(bert_train_repo,"checkpoint-1.ptw");
-    fileops::remove_file(bert_train_repo,"checkpoint-1.pt");
-    fileops::remove_file(bert_train_repo,"solver-1.pt");
-    fileops::remove_file(bert_train_repo,"checkpoint-2.ptw");
-    fileops::remove_file(bert_train_repo,"checkpoint-2.pt");
-    fileops::remove_file(bert_train_repo,"solver-2.pt");
+        "\"output\":{\"measure\":[\"f1\",\"acc\",\"mcll\",\"cmdiag\","
+        "\"cmfull\"]}},\"data\":[\""
+        + bert_train_data + "\"]}";
+  joutstr = japi.jrender(japi.service_train(jtrainstr));
+  JDoc jd;
+  std::cout << "joutstr=" << joutstr << std::endl;
+  jd.Parse(joutstr.c_str());
+  ASSERT_TRUE(!jd.HasParseError());
+  ASSERT_EQ(201, jd["status"]["code"]);
+  ASSERT_TRUE(abs(jd["body"]["measure"]["iteration"].GetDouble() - 3)
+              < 0.00001)
+      << "iterations";
+  // This assertion is non-deterministic
+  // ASSERT_TRUE(jd["body"]["measure"]["train_loss"].GetDouble() > 1.0) <<
+  // "train_loss";
+  ASSERT_TRUE(jd["body"]["measure"]["acc"].GetDouble() <= 1) << "accuracy";
+  ASSERT_TRUE(jd["body"]["measure"]["f1"].GetDouble() <= 1) << "f1";
+  fileops::remove_file(bert_train_repo, "checkpoint-3.ptw");
+  fileops::remove_file(bert_train_repo, "checkpoint-3.pt");
+  fileops::remove_file(bert_train_repo, "solver-3.pt");
+  fileops::remove_file(bert_train_repo, "checkpoint-1.ptw");
+  fileops::remove_file(bert_train_repo, "checkpoint-1.pt");
+  fileops::remove_file(bert_train_repo, "solver-1.pt");
+  fileops::remove_file(bert_train_repo, "checkpoint-2.ptw");
+  fileops::remove_file(bert_train_repo, "checkpoint-2.pt");
+  fileops::remove_file(bert_train_repo, "solver-2.pt");
 }
 
 #endif

--- a/tests/ut-xgbapi.cc
+++ b/tests/ut-xgbapi.cc
@@ -32,9 +32,12 @@
 using namespace dd;
 
 static std::string ok_str = "{\"status\":{\"code\":200,\"msg\":\"OK\"}}";
-static std::string created_str = "{\"status\":{\"code\":201,\"msg\":\"Created\"}}";
-static std::string bad_param_str = "{\"status\":{\"code\":400,\"msg\":\"BadRequest\"}}";
-static std::string not_found_str = "{\"status\":{\"code\":404,\"msg\":\"NotFound\"}}";
+static std::string created_str
+    = "{\"status\":{\"code\":201,\"msg\":\"Created\"}}";
+static std::string bad_param_str
+    = "{\"status\":{\"code\":400,\"msg\":\"BadRequest\"}}";
+static std::string not_found_str
+    = "{\"status\":{\"code\":404,\"msg\":\"NotFound\"}}";
 
 static std::string forest_repo = "../examples/all/forest_type/";
 static std::string n20_repo = "../examples/all/n20/";
@@ -44,137 +47,213 @@ static std::string iterations_forest = "10";
 static std::string iterations_n20 = "10";
 static std::string iterations_sflare = "100";
 
-TEST(xgbapi,service_train_csv)
+TEST(xgbapi, service_train_csv)
 {
   JsonAPI japi;
   std::string sname = "my_service";
-  std::string jstr = "{\"mllib\":\"xgboost\",\"description\":\"my classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\"" +  forest_repo + "\"},\"parameters\":{\"input\":{\"connector\":\"csv\"},\"mllib\":{\"nclasses\":7}}}";
-  std::string joutstr = japi.jrender(japi.service_create(sname,jstr));
-  ASSERT_EQ(created_str,joutstr);
+  std::string jstr
+      = "{\"mllib\":\"xgboost\",\"description\":\"my "
+        "classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\""
+        + forest_repo
+        + "\"},\"parameters\":{\"input\":{\"connector\":\"csv\"},\"mllib\":{"
+          "\"nclasses\":7}}}";
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
 
   // assert json blob file
   std::cerr << forest_repo + "/" + JsonAPI::_json_blob_fname << std::endl;
-  ASSERT_TRUE(fileops::file_exists(forest_repo + "/" + JsonAPI::_json_blob_fname));
-  
+  ASSERT_TRUE(
+      fileops::file_exists(forest_repo + "/" + JsonAPI::_json_blob_fname));
+
   // train
-  std::string jtrainstr = "{\"service\":\"" + sname + "\",\"async\":false,\"parameters\":{\"input\":{\"label\":\"Cover_Type\",\"id\":\"Id\",\"test_split\":0.1,\"label_offset\":-1,\"shuffle\":true},\"mllib\":{\"iterations\":" + iterations_forest + ",\"objective\":\"multi:softprob\",\"gpu\":true},\"output\":{\"measure\":[\"acc\",\"mcll\",\"f1\",\"cmdiag\",\"cmfull\"]}},\"data\":[\"" + forest_repo + "train.csv\"]}";
+  std::string jtrainstr
+      = "{\"service\":\"" + sname
+        + "\",\"async\":false,\"parameters\":{\"input\":{\"label\":\"Cover_"
+          "Type\",\"id\":\"Id\",\"test_split\":0.1,\"label_offset\":-1,"
+          "\"shuffle\":true},\"mllib\":{\"iterations\":"
+        + iterations_forest
+        + ",\"objective\":\"multi:softprob\",\"gpu\":true},\"output\":{"
+          "\"measure\":[\"acc\",\"mcll\",\"f1\",\"cmdiag\",\"cmfull\"]}},"
+          "\"data\":[\""
+        + forest_repo + "train.csv\"]}";
   joutstr = japi.jrender(japi.service_train(jtrainstr));
   std::cout << "joutstr=" << joutstr << std::endl;
   JDoc jd;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_TRUE(jd.HasMember("status"));
-  ASSERT_EQ(201,jd["status"]["code"].GetInt());
-  ASSERT_EQ("Created",jd["status"]["msg"]);
+  ASSERT_EQ(201, jd["status"]["code"].GetInt());
+  ASSERT_EQ("Created", jd["status"]["msg"]);
   ASSERT_TRUE(jd.HasMember("head"));
-  ASSERT_EQ("/train",jd["head"]["method"]);
+  ASSERT_EQ("/train", jd["head"]["method"]);
   ASSERT_TRUE(jd["head"]["time"].GetDouble() >= 0);
   ASSERT_TRUE(jd.HasMember("body"));
   ASSERT_TRUE(jd["body"].HasMember("measure"));
   ASSERT_TRUE(jd["body"]["measure"].HasMember("f1"));
   ASSERT_TRUE(jd["body"]["measure"]["f1"].GetDouble() > 0.7);
-  ASSERT_EQ(jd["body"]["measure"]["accp"].GetDouble(),jd["body"]["measure"]["acc"].GetDouble());
+  ASSERT_EQ(jd["body"]["measure"]["accp"].GetDouble(),
+            jd["body"]["measure"]["acc"].GetDouble());
   ASSERT_TRUE(jd["body"]["measure"].HasMember("cmdiag"));
-  ASSERT_EQ(7,jd["body"]["measure"]["cmdiag"].Size());
+  ASSERT_EQ(7, jd["body"]["measure"]["cmdiag"].Size());
   ASSERT_TRUE(jd["body"]["measure"]["cmdiag"][0].GetDouble() >= 0);
   ASSERT_TRUE(jd["body"]["measure"]["cmfull"][1]["1"].Size());
 
   // predict from data, with header and id
-  std::string mem_data_head = "Id,Elevation,Aspect,Slope,Horizontal_Distance_To_Hydrology,Vertical_Distance_To_Hydrology,Horizontal_Distance_To_Roadways,Hillshade_9am,Hillshade_Noon,Hillshade_3pm,Horizontal_Distance_To_Fire_Points,Wilderness_Area1,Wilderness_Area2,Wilderness_Area3,Wilderness_Area4,Soil_Type1,Soil_Type2,Soil_Type3,Soil_Type4,Soil_Type5,Soil_Type6,Soil_Type7,Soil_Type8,Soil_Type9,Soil_Type10,Soil_Type11,Soil_Type12,Soil_Type13,Soil_Type14,Soil_Type15,Soil_Type16,Soil_Type17,Soil_Type18,Soil_Type19,Soil_Type20,Soil_Type21,Soil_Type22,Soil_Type23,Soil_Type24,Soil_Type25,Soil_Type26,Soil_Type27,Soil_Type28,Soil_Type29,Soil_Type30,Soil_Type31,Soil_Type32,Soil_Type33,Soil_Type34,Soil_Type35,Soil_Type36,Soil_Type37,Soil_Type38,Soil_Type39,Soil_Type40";
-  std::string mem_data = "0,2499,326,7,300,88,480,202,232,169,1676,0,0,0,1,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0";
-  std::string jpredictstr = "{\"service\":\""+ sname + "\",\"parameters\":{\"input\":{\"connector\":\"csv\",\"id\":\"Id\",\"scale\":false},\"output\":{\"best\":3}},\"data\":[\"" + mem_data_head + "\",\"" + mem_data + "\"]}";
+  std::string mem_data_head
+      = "Id,Elevation,Aspect,Slope,Horizontal_Distance_To_Hydrology,Vertical_"
+        "Distance_To_Hydrology,Horizontal_Distance_To_Roadways,Hillshade_9am,"
+        "Hillshade_Noon,Hillshade_3pm,Horizontal_Distance_To_Fire_Points,"
+        "Wilderness_Area1,Wilderness_Area2,Wilderness_Area3,Wilderness_Area4,"
+        "Soil_Type1,Soil_Type2,Soil_Type3,Soil_Type4,Soil_Type5,Soil_Type6,"
+        "Soil_Type7,Soil_Type8,Soil_Type9,Soil_Type10,Soil_Type11,Soil_Type12,"
+        "Soil_Type13,Soil_Type14,Soil_Type15,Soil_Type16,Soil_Type17,Soil_"
+        "Type18,Soil_Type19,Soil_Type20,Soil_Type21,Soil_Type22,Soil_Type23,"
+        "Soil_Type24,Soil_Type25,Soil_Type26,Soil_Type27,Soil_Type28,Soil_"
+        "Type29,Soil_Type30,Soil_Type31,Soil_Type32,Soil_Type33,Soil_Type34,"
+        "Soil_Type35,Soil_Type36,Soil_Type37,Soil_Type38,Soil_Type39,Soil_"
+        "Type40";
+  std::string mem_data
+      = "0,2499,326,7,300,88,480,202,232,169,1676,0,0,0,1,0,0,0,0,0,1,0,0,0,0,"
+        "0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0";
+  std::string jpredictstr
+      = "{\"service\":\"" + sname
+        + "\",\"parameters\":{\"input\":{\"connector\":\"csv\",\"id\":\"Id\","
+          "\"scale\":false},\"output\":{\"best\":3}},\"data\":[\""
+        + mem_data_head + "\",\"" + mem_data + "\"]}";
   joutstr = japi.jrender(japi.service_predict(jpredictstr));
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_TRUE(jd.HasMember("status"));
-  ASSERT_EQ(200,jd["status"]["code"].GetInt());
-  std::string cat0 = jd["body"]["predictions"][0]["classes"][0]["cat"].GetString(); // XXX: true cat is 3, which is 2 here with the label offset
-  std::string cat1 = jd["body"]["predictions"][0]["classes"][1]["cat"].GetString();
-  ASSERT_TRUE("2"==cat0||"2"==cat1);
-  
+  ASSERT_EQ(200, jd["status"]["code"].GetInt());
+  std::string cat0 = jd["body"]["predictions"][0]["classes"][0]["cat"]
+                         .GetString(); // XXX: true cat is 3, which is 2 here
+                                       // with the label offset
+  std::string cat1
+      = jd["body"]["predictions"][0]["classes"][1]["cat"].GetString();
+  ASSERT_TRUE("2" == cat0 || "2" == cat1);
+
   // predict from data, omitting header and sample id
-  std::string mem_data2 = "2499,326,7,300,88,480,202,232,169,1676,0,0,0,1,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0";
-  jpredictstr = "{\"service\":\""+ sname + "\",\"parameters\":{\"input\":{\"connector\":\"csv\",\"scale\":false},\"output\":{\"best\":3}},\"data\":[\"" + mem_data2 + "\"]}";
+  std::string mem_data2
+      = "2499,326,7,300,88,480,202,232,169,1676,0,0,0,1,0,0,0,0,0,1,0,0,0,0,0,"
+        "0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0";
+  jpredictstr = "{\"service\":\"" + sname
+                + "\",\"parameters\":{\"input\":{\"connector\":\"csv\","
+                  "\"scale\":false},\"output\":{\"best\":3}},\"data\":[\""
+                + mem_data2 + "\"]}";
   joutstr = japi.jrender(japi.service_predict(jpredictstr));
   std::cout << "joutstr=" << joutstr << std::endl;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_TRUE(jd.HasMember("status"));
-  ASSERT_EQ(200,jd["status"]["code"].GetInt());
-  cat0 = jd["body"]["predictions"][0]["classes"][0]["cat"].GetString(); // XXX: true cat is 3, which is 2 here with the label offset
+  ASSERT_EQ(200, jd["status"]["code"].GetInt());
+  cat0 = jd["body"]["predictions"][0]["classes"][0]["cat"]
+             .GetString(); // XXX: true cat is 3, which is 2 here with the
+                           // label offset
   cat1 = jd["body"]["predictions"][0]["classes"][1]["cat"].GetString();
-  ASSERT_TRUE("2"==cat0||"2"==cat1);
-  
+  ASSERT_TRUE("2" == cat0 || "2" == cat1);
+
   // remove service
   jstr = "{\"clear\":\"lib\"}";
-  joutstr = japi.jrender(japi.service_delete(sname,jstr));
-  ASSERT_EQ(ok_str,joutstr);
+  joutstr = japi.jrender(japi.service_delete(sname, jstr));
+  ASSERT_EQ(ok_str, joutstr);
 
   // assert json blob file is still there (or gone if clear=full)
-  ASSERT_TRUE(fileops::file_exists(forest_repo + "/" + JsonAPI::_json_blob_fname));
+  ASSERT_TRUE(
+      fileops::file_exists(forest_repo + "/" + JsonAPI::_json_blob_fname));
 }
 
-TEST(xgbapi,service_train_txt)
+TEST(xgbapi, service_train_txt)
 {
   // create service
   JsonAPI japi;
   std::string n20_repo_loc = "n20";
-  mkdir(n20_repo_loc.c_str(),0777);
+  mkdir(n20_repo_loc.c_str(), 0777);
   std::string sname = "my_service";
-  std::string jstr = "{\"mllib\":\"xgboost\",\"description\":\"my classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\"" +  n20_repo_loc + "\"},\"parameters\":{\"input\":{\"connector\":\"txt\"},\"mllib\":{\"nclasses\":20}}}";
-  std::string joutstr = japi.jrender(japi.service_create(sname,jstr));
-  ASSERT_EQ(created_str,joutstr);
+  std::string jstr
+      = "{\"mllib\":\"xgboost\",\"description\":\"my "
+        "classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\""
+        + n20_repo_loc
+        + "\"},\"parameters\":{\"input\":{\"connector\":\"txt\"},\"mllib\":{"
+          "\"nclasses\":20}}}";
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
 
   // train
-  std::string jtrainstr = "{\"service\":\"" + sname + "\",\"async\":false,\"parameters\":{\"input\":{\"test_split\":0.2,\"shuffle\":true,\"min_count\":10,\"min_word_length\":3,\"count\":false},\"mllib\":{\"iterations\":" + iterations_n20 + ",\"objective\":\"multi:softprob\",\"gpu\":true},\"output\":{\"measure\":[\"acc\",\"mcll\",\"f1\"]}},\"data\":[\"" + n20_repo + "news20\"]}";
+  std::string jtrainstr
+      = "{\"service\":\"" + sname
+        + "\",\"async\":false,\"parameters\":{\"input\":{\"test_split\":0.2,"
+          "\"shuffle\":true,\"min_count\":10,\"min_word_length\":3,\"count\":"
+          "false},\"mllib\":{\"iterations\":"
+        + iterations_n20
+        + ",\"objective\":\"multi:softprob\",\"gpu\":true},\"output\":{"
+          "\"measure\":[\"acc\",\"mcll\",\"f1\"]}},\"data\":[\""
+        + n20_repo + "news20\"]}";
   joutstr = japi.jrender(japi.service_train(jtrainstr));
   std::cout << "joutstr=" << joutstr << std::endl;
   JDoc jd;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_TRUE(jd.HasMember("status"));
-  ASSERT_EQ(201,jd["status"]["code"].GetInt());
-  ASSERT_EQ("Created",jd["status"]["msg"]);
+  ASSERT_EQ(201, jd["status"]["code"].GetInt());
+  ASSERT_EQ("Created", jd["status"]["msg"]);
   ASSERT_TRUE(jd.HasMember("head"));
-  ASSERT_EQ("/train",jd["head"]["method"]);
+  ASSERT_EQ("/train", jd["head"]["method"]);
   ASSERT_TRUE(jd["head"]["time"].GetDouble() >= 0);
   ASSERT_TRUE(jd.HasMember("body"));
   ASSERT_TRUE(jd["body"]["measure"].HasMember("f1"));
   ASSERT_TRUE(jd["body"]["measure"]["acc"].GetDouble() >= 0.7);
-  ASSERT_EQ(jd["body"]["measure"]["accp"].GetDouble(),jd["body"]["measure"]["acc"].GetDouble());
+  ASSERT_EQ(jd["body"]["measure"]["accp"].GetDouble(),
+            jd["body"]["measure"]["acc"].GetDouble());
 
   // predict with measure
-  std::string jpredictstr = "{\"service\":\"" + sname + "\",\"parameters\":{\"mllib\":{},\"output\":{\"measure\":[\"f1\"]}},\"data\":[\"" + n20_repo +"news20\"]}";
+  std::string jpredictstr = "{\"service\":\"" + sname
+                            + "\",\"parameters\":{\"mllib\":{},\"output\":{"
+                              "\"measure\":[\"f1\"]}},\"data\":[\""
+                            + n20_repo + "news20\"]}";
   joutstr = japi.jrender(japi.service_predict(jpredictstr));
   std::cout << "joutstr=" << joutstr << std::endl;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_TRUE(jd.HasMember("status"));
-  ASSERT_EQ(200,jd["status"]["code"].GetInt());
+  ASSERT_EQ(200, jd["status"]["code"].GetInt());
   ASSERT_TRUE(jd.HasMember("body"));
   ASSERT_TRUE(jd["body"].HasMember("measure"));
   ASSERT_TRUE(jd["body"]["measure"]["f1"].GetDouble() >= 0.6);
-  
+
   // remove service
   jstr = "{\"clear\":\"full\"}";
-  joutstr = japi.jrender(japi.service_delete(sname,jstr));
-  ASSERT_EQ(ok_str,joutstr);
+  joutstr = japi.jrender(japi.service_delete(sname, jstr));
+  ASSERT_EQ(ok_str, joutstr);
   rmdir(n20_repo_loc.c_str());
 }
 
-TEST(xgbapi,service_train_csv_mt_regression)
+TEST(xgbapi, service_train_csv_mt_regression)
 {
   // create service
   JsonAPI japi;
   std::string sflare_repo_loc = "sflare";
-  mkdir(sflare_repo_loc.c_str(),0777);
+  mkdir(sflare_repo_loc.c_str(), 0777);
   std::string sname = "my_service";
-  std::string jstr = "{\"mllib\":\"xgboost\",\"description\":\"my classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\"" +  sflare_repo_loc + "\"},\"parameters\":{\"input\":{\"connector\":\"csv\"},\"mllib\":{\"regression\":true,\"ntargets\":1}}}";
-  std::string joutstr = japi.jrender(japi.service_create(sname,jstr));
-  ASSERT_EQ(created_str,joutstr);
+  std::string jstr
+      = "{\"mllib\":\"xgboost\",\"description\":\"my "
+        "classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\""
+        + sflare_repo_loc
+        + "\"},\"parameters\":{\"input\":{\"connector\":\"csv\"},\"mllib\":{"
+          "\"regression\":true,\"ntargets\":1}}}";
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
 
   // train
-  std::string jtrainstr = "{\"service\":\"" + sname + "\",\"async\":false,\"parameters\":{\"input\":{\"test_split\":0.1,\"shuffle\":true,\"label\":[\"x_class\"],\"separator\":\",\",\"scale\":true,\"categoricals\":[\"class_code\",\"code_spot\",\"code_spot_distr\"]},\"mllib\":{\"objective\":\"reg:linear\",\"gpu\":true,\"iterations\":" + iterations_sflare + "},\"output\":{\"measure\":[\"eucll\"]}},\"data\":[\"" + sflare_repo + "flare.csv\"]}";
+  std::string jtrainstr
+      = "{\"service\":\"" + sname
+        + "\",\"async\":false,\"parameters\":{\"input\":{\"test_split\":0.1,"
+          "\"shuffle\":true,\"label\":[\"x_class\"],\"separator\":\",\","
+          "\"scale\":true,\"categoricals\":[\"class_code\",\"code_spot\","
+          "\"code_spot_distr\"]},\"mllib\":{\"objective\":\"reg:linear\","
+          "\"gpu\":true,\"iterations\":"
+        + iterations_sflare
+        + "},\"output\":{\"measure\":[\"eucll\"]}},\"data\":[\"" + sflare_repo
+        + "flare.csv\"]}";
   std::cerr << "jtrainstr=" << jtrainstr << std::endl;
   joutstr = japi.jrender(japi.service_train(jtrainstr));
   std::cout << "joutstr=" << joutstr << std::endl;
@@ -182,10 +261,10 @@ TEST(xgbapi,service_train_csv_mt_regression)
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_TRUE(jd.HasMember("status"));
-  ASSERT_EQ(201,jd["status"]["code"].GetInt());
-  ASSERT_EQ("Created",jd["status"]["msg"]);
+  ASSERT_EQ(201, jd["status"]["code"].GetInt());
+  ASSERT_EQ("Created", jd["status"]["msg"]);
   ASSERT_TRUE(jd.HasMember("head"));
-  ASSERT_EQ("/train",jd["head"]["method"]);
+  ASSERT_EQ("/train", jd["head"]["method"]);
   ASSERT_TRUE(jd["head"]["time"].GetDouble() >= 0);
   ASSERT_TRUE(jd.HasMember("body"));
   ASSERT_TRUE(jd["body"]["measure"].HasMember("eucll"));
@@ -193,27 +272,40 @@ TEST(xgbapi,service_train_csv_mt_regression)
   ASSERT_TRUE(jd["body"]["parameters"]["input"].HasMember("max_vals"));
   ASSERT_TRUE(jd["body"]["parameters"]["input"].HasMember("min_vals"));
 
-  std::string str_min_vals = japi.jrender(jd["body"]["parameters"]["input"]["min_vals"]);
-  std::string str_max_vals = japi.jrender(jd["body"]["parameters"]["input"]["max_vals"]);
-  std::string str_categoricals = japi.jrender(jd["body"]["parameters"]["input"]["categoricals_mapping"]);
+  std::string str_min_vals
+      = japi.jrender(jd["body"]["parameters"]["input"]["min_vals"]);
+  std::string str_max_vals
+      = japi.jrender(jd["body"]["parameters"]["input"]["max_vals"]);
+  std::string str_categoricals = japi.jrender(
+      jd["body"]["parameters"]["input"]["categoricals_mapping"]);
   std::cerr << "categoricals=" << str_categoricals << std::endl;
-  
+
   // predict
-  std::string sflare_data_head = "class_code,code_spot,code_spot_distr,act,evo,prev_act,hist,reg,area,larg_area,x,y,z";
+  std::string sflare_data_head = "class_code,code_spot,code_spot_distr,act,"
+                                 "evo,prev_act,hist,reg,area,larg_area,x,y,z";
   std::string sflare_data = "B,X,O,1,2,1,1,2,1,1,0,0,0";
-  std::string jpredictstr = "{\"service\":\""+ sname + "\",\"parameters\":{\"input\":{\"connector\":\"csv\",\"scale\":true,\"min_vals\":" + str_min_vals + ",\"max_vals\":" + str_max_vals + ",\"categoricals_mapping\":" + str_categoricals + "},\"output\":{}},\"data\":[\"" + sflare_data_head + "\",\"" + sflare_data + "\"]}";
+  std::string jpredictstr = "{\"service\":\"" + sname
+                            + "\",\"parameters\":{\"input\":{\"connector\":"
+                              "\"csv\",\"scale\":true,\"min_vals\":"
+                            + str_min_vals + ",\"max_vals\":" + str_max_vals
+                            + ",\"categoricals_mapping\":" + str_categoricals
+                            + "},\"output\":{}},\"data\":[\""
+                            + sflare_data_head + "\",\"" + sflare_data
+                            + "\"]}";
   joutstr = japi.jrender(japi.service_predict(jpredictstr));
   std::cout << "joutstr=" << joutstr << std::endl;
   jd.Parse(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
-  ASSERT_EQ(200,jd["status"]["code"]);
+  ASSERT_EQ(200, jd["status"]["code"]);
   std::string uri = jd["body"]["predictions"][0]["uri"].GetString();
-  ASSERT_EQ("1",uri);
-  ASSERT_TRUE(fabs(jd["body"]["predictions"][0]["vector"][0]["val"].GetDouble()) > 0.0);
-  
+  ASSERT_EQ("1", uri);
+  ASSERT_TRUE(
+      fabs(jd["body"]["predictions"][0]["vector"][0]["val"].GetDouble())
+      > 0.0);
+
   // remove service
   jstr = "{\"clear\":\"full\"}";
-  joutstr = japi.jrender(japi.service_delete(sname,jstr));
-  ASSERT_EQ(ok_str,joutstr);
+  joutstr = japi.jrender(japi.service_delete(sname, jstr));
+  ASSERT_EQ(ok_str, joutstr);
   rmdir(sflare_repo_loc.c_str());
 }

--- a/tools/git-pre-commit-hook
+++ b/tools/git-pre-commit-hook
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+format_file() {
+  file="${1}"
+
+  [ ${file#src/} == ${file} ] && return  # don't startswith src/
+  [ ${file#src/ext} != ${file} ] && return  # startswith src/ext
+
+  if [ -f $file ]; then
+    clang-format -style file -i ${1}
+    git add ${1}
+  fi
+}
+
+case "${1}" in
+  --about )
+    echo "Runs clang-format on source files"
+    ;;
+  * )
+    for file in `git diff-index --cached --name-only HEAD | grep -iE '\.(cpp|cc|h|hpp)$' ` ; do
+      format_file "${file}"
+    done
+    ;;
+esac


### PR DESCRIPTION
The code currently mixes tab and space indenting.

Having the code style defined into a file is usually good practice, as
we can use tools to do it automatically.

This change proposes use clang-format to do it. It provides predefined
rules following LLVM/Google/Mozilla/GNU code style that can be tweaked.

I try to create a .clang-format configuration that just fix the
tab/space mix and keep the rest as-is as much I can.

Currently all cpp/hpp/h are formatted except those in src/ext.

The code formatting will be checked Jenkins.
It also can be run with: `cmake .. && make clang-format`

cmake also install automatically a pre-commit hook to format the code.
It can be disabled with `INSTALL_GIT_HOOKS=OFF`

llvm provide some basic integration for editor:

https://clang.llvm.org/docs/ClangFormat.html#vim-integration
https://clang.llvm.org/docs/ClangFormat.html#emacs-integration

But you can also use other tools like:

https://github.com/SavchenkoValeriy/emacs-clang-format-plus
