### PR TITLE
fix(ci): use unsuccessful instead of failure

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,7 @@ ctest -V -E "http" '''
       success {
           rocketSend(channel: 'build', message: 'Build succeed')
       }
-      failure {
+      unsuccessful {
           rocketSend(channel: 'build', message: 'Build failed')
       }
   }

--- a/ci/Jenkinsfile.pytorch-cache
+++ b/ci/Jenkinsfile.pytorch-cache
@@ -29,7 +29,7 @@ ccache -s
           archiveArtifacts(artifacts: 'pytorch-*.tar', fingerprint: true)
           rocketSend(channel: 'build', message: 'Build succeed')
       }
-      failure {
+      unsuccessful {
           rocketSend(channel: 'build', message: 'Build failed')
       }
   }


### PR DESCRIPTION
This will catch all kind of Jenkins error.