### PR TITLE
fix: set caffe smooth l1 loss threshold to 1

### DIFF
--- a/src/backends/caffe/caffelib.cc
+++ b/src/backends/caffe/caffelib.cc
@@ -391,8 +391,7 @@ namespace dd
                     else if (_loss == "L1")
                       {
                         lparam->set_type("SmoothL1Loss");
-                        lparam->mutable_smooth_l1_loss_param()->set_sigma(
-                            10.0);
+                        lparam->mutable_smooth_l1_loss_param()->set_sigma(1.0);
                       }
                     else if (_loss == "sigmoid")
                       {


### PR DESCRIPTION
Huber loss has threshold set to 1.

One issue to be careful about is whether we do use normalized targets in time-series regression typically. And in that case, this PR should be updated with a configurable `sigma_l1` parameter for the smooth l1 loss.

References : 
- https://stats.stackexchange.com/questions/351874/how-to-interpret-smooth-l1-loss
- https://pytorch.org/docs/stable/generated/torch.nn.SmoothL1Loss.html#torch.nn.SmoothL1Loss