### PR TITLE
feat(trains-status): add tflops to body.measures

### DIFF
--- a/src/mllibstrategy.h
+++ b/src/mllibstrategy.h
@@ -330,23 +330,17 @@ namespace dd
     void collect_measures(APIData &ad) const
     {
       APIData meas;
-      std::lock_guard<std::mutex> lock(_meas_mutex);
-      auto hit = _meas.begin();
-      while (hit != _meas.end())
-        {
-          meas.add((*hit).first, (*hit).second);
-          ++hit;
-        }
-      ad.add("measure", meas);
-    }
 
-    /**
-     * \brief render estimated remaining time
-     * @param ad data object to hold the estimate
-     */
-    void est_remain_time(APIData &out) const
-    {
-      APIData meas = out.getobj("measure");
+      {
+        std::lock_guard<std::mutex> lock(_meas_mutex);
+        auto hit = _meas.begin();
+        while (hit != _meas.end())
+          {
+            meas.add((*hit).first, (*hit).second);
+            ++hit;
+          }
+      }
+
       if (meas.has("remain_time"))
         {
           int est_remain_time
@@ -360,8 +354,9 @@ namespace dd
                 + "h:" + std::to_string(minutes)
                 + "m:" + std::to_string(seconds) + "s";
           meas.add("remain_time_str", est_remain_time_str);
-          out.add("measure", meas);
         }
+
+      ad.add("measure", meas);
     }
 
     TInputConnectorStrategy

--- a/src/mllibstrategy.h
+++ b/src/mllibstrategy.h
@@ -356,6 +356,8 @@ namespace dd
           meas.add("remain_time_str", est_remain_time_str);
         }
 
+      meas.add("flops", this->_model_flops);
+
       ad.add("measure", meas);
     }
 

--- a/src/mlservice.h
+++ b/src/mlservice.h
@@ -227,7 +227,6 @@ namespace dd
                   if (status == std::future_status::timeout)
                     {
                       this->collect_measures(jad);
-                      this->est_remain_time(jad);
                       std::chrono::time_point<std::chrono::system_clock> trun
                           = std::chrono::system_clock::now();
                       jad.add("time",
@@ -375,7 +374,6 @@ namespace dd
               jmrepo.add("repository", this->_mlmodel._repo);
               out.add("model", jmrepo);
               this->collect_measures(out);
-              this->est_remain_time(out);
               std::chrono::time_point<std::chrono::system_clock> trun
                   = std::chrono::system_clock::now();
               out.add("time", std::chrono::duration_cast<std::chrono::seconds>(


### PR DESCRIPTION
## chore(trains-status): remove useless method

It doesn't make sense to have separate methods
collect_measures() and est_remain_time(). And we need to call them in a
row to generate `remain_time_str` key.

## feat(trains-status): add tflops to body.measures

The tflops measure was available for a service, but not during the
training.

This change adds it to the training status.

Fixes #785
