### PR TITLE
fix: build with -DUSE_TENSORRT_OSS=ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -889,9 +889,9 @@ if (USE_TENSORRT)
 	set(TENSORRT_LIBS protobuf nvinfer nvparsers nvinfer_plugin nvonnxparser )
 
   else()
-    set(TENSORRT_LIB_DIR ${CMAKE_BINARY_DIR}/tensorrt-oss/src/tensorrt-oss-build ${TENSORRT_LIB_DIR})
+    set(TENSORRT_LIB_DIR ${CMAKE_BINARY_DIR}/tensorrt-oss/bin/ ${TENSORRT_LIB_DIR})
     include_directories(${CMAKE_CURRENT_BINARY_DIR})
-	set(TENSORRT_LIBS protobuf nvinfer nvcaffeparser nvinfer_plugin nvonnxparser )
+	set(TENSORRT_LIBS protobuf nvinfer nvparsers nvcaffeparser nvinfer_plugin nvonnxparser )
 
     if (EXISTS "${TRTTESTDIR}/libnvinfer.so.7")
       set(TENSORRT_COMMIT 9a9cae75e7155b2114454f37ccc49eca9d3352dc)

--- a/ci/Jenkinsfile.unittests
+++ b/ci/Jenkinsfile.unittests
@@ -22,7 +22,7 @@ rm -f examples-*.tar
       steps {
         sh '''
 export PATH="/usr/lib/ccache/:$PATH"
-cd build && cmake .. -DBUILD_TESTS=ON -DUSE_CUDNN=ON -DUSE_SIMSEARCH=ON -DUSE_TSNE=ON -DUSE_XGBOOST=ON -DUSE_TORCH=ON -DUSE_NCNN=ON -DUSE_TENSORRT=ON -DCUDA_ARCH="-gencode arch=compute_61,code=sm_61"
+cd build && cmake .. -DBUILD_TESTS=ON -DUSE_CUDNN=ON -DUSE_SIMSEARCH=ON -DUSE_TSNE=ON -DUSE_XGBOOST=ON -DUSE_TORCH=ON -DUSE_NCNN=ON -DUSE_TENSORRT=ON -DUSE_TENSORRT_OSS=ON -DCUDA_ARCH="-gencode arch=compute_61,code=sm_61"
 '''
       }
     }


### PR DESCRIPTION
Sets Jenkins to build with TENSORRT_OSS as default since it's now the
most recent and advanced.