### PR TITLE
Pull request for Werror

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,7 @@ if (${PB_GENERATOR_SYSTEM})
 endif()
 
 
-set(CMAKE_CXX_FLAGS "-g -Wall -Wextra -fopenmp -O2 -fPIC -std=c++14 -DUSE_OPENCV -DUSE_LMDB -fdiagnostics-color=always")
+set(CMAKE_CXX_FLAGS "-g -Wall -Wextra -Werror -fopenmp -O2 -fPIC -std=c++14 -DUSE_OPENCV -DUSE_LMDB -fdiagnostics-color=always")
 
 if (USE_COMMAND_LINE)
   if (NOT USE_CAFFE)

--- a/src/backends/ncnn/caffe2ncnn.cc
+++ b/src/backends/ncnn/caffe2ncnn.cc
@@ -337,7 +337,7 @@ static bool read_proto_from_binary(const char *filepath,
   google::protobuf::io::IstreamInputStream input(&fs);
   google::protobuf::io::CodedInputStream codedstr(&input);
 
-  codedstr.SetTotalBytesLimit(INT_MAX, INT_MAX / 2);
+  codedstr.SetTotalBytesLimit(INT_MAX);
 
   bool success = message->ParseFromCodedStream(&codedstr);
 

--- a/src/backends/ncnn/caffe2ncnn.cc
+++ b/src/backends/ncnn/caffe2ncnn.cc
@@ -32,6 +32,7 @@
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #include "src/caffe.pb.h"
 #pragma GCC diagnostic pop
 #include "upgrade_proto.hpp"

--- a/src/backends/ncnn/upgrade_proto.cpp
+++ b/src/backends/ncnn/upgrade_proto.cpp
@@ -5,7 +5,12 @@
 #include <map>
 #include <string>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #include "src/caffe.pb.h"
+#pragma GCC diagnostic pop
+
 #include "upgrade_proto.hpp"
 
 bool NetNeedsUpgrade(const caffe::NetParameter &net_param)

--- a/src/backends/ncnn/upgrade_proto.hpp
+++ b/src/backends/ncnn/upgrade_proto.hpp
@@ -3,7 +3,11 @@
 
 #include <string>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #include "src/caffe.pb.h"
+#pragma GCC diagnostic pop
 
 // Return true iff the net is not the current version.
 bool NetNeedsUpgrade(const caffe::NetParameter &net_param);

--- a/src/backends/tensorrt/protoUtils.cc
+++ b/src/backends/tensorrt/protoUtils.cc
@@ -27,7 +27,12 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <unistd.h>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #include "src/caffe.pb.h"
+#pragma GCC diagnostic pop
 
 using google::protobuf::io::CodedInputStream;
 using google::protobuf::io::CodedOutputStream;

--- a/src/backends/tensorrt/tensorrtlib.cc
+++ b/src/backends/tensorrt/tensorrtlib.cc
@@ -156,6 +156,10 @@ namespace dd
 
     model_type(this->_mlmodel._def, this->_mltype);
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    /* NOTE(sileht): nvinfer1::createInferBuilder is deprecated */
+
     _builder = std::shared_ptr<nvinfer1::IBuilder>(
         nvinfer1::createInferBuilder(trtLogger),
         [=](nvinfer1::IBuilder *b) { b->destroy(); });
@@ -211,6 +215,7 @@ namespace dd
             _builder->setFp16Mode(false);
           }
       }
+#pragma GCC diagnostic push
   }
 
   template <class TInputConnectorStrategy, class TOutputConnectorStrategy,

--- a/src/backends/tensorrt/tensorrtlib.cc
+++ b/src/backends/tensorrt/tensorrtlib.cc
@@ -17,7 +17,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
-
+//
 #include "outputconnectorstrategy.h"
 #include "tensorrtlib.h"
 #include "utils/apitools.h"
@@ -251,7 +251,6 @@ namespace dd
     cudaSetDevice(_gpuid);
 
     APIData ad_output = ad.getobj("parameters").getobj("output");
-    int blank_label = -1;
     std::string out_blob = "prob";
     TInputConnectorStrategy inputc(this->_inputc);
 
@@ -266,7 +265,8 @@ namespace dd
             if (_ctc)
               {
                 if (ad_output.has("blank_label"))
-                  blank_label = ad_output.get("blank_label").get<int>();
+                  throw MLLibBadParamException(
+                      "blank_label not yet implemented over tensorRT backend");
               }
           }
 

--- a/src/backends/torch/native/templates/nbeats.h
+++ b/src/backends/torch/native/templates/nbeats.h
@@ -1,7 +1,10 @@
 #ifndef NBEATS_H
 #define NBEATS_H
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 #include "torch/torch.h"
+#pragma GCC diagnostic pop
 #include "../../torchinputconns.h"
 #include "mllibstrategy.h"
 #include "../native_net.h"

--- a/src/backends/torch/torchinputconns.cc
+++ b/src/backends/torch/torchinputconns.cc
@@ -155,8 +155,9 @@ namespace dd
     _indices.push_back(index);
   }
 
-  void TorchDataset::write_tensors_to_db(std::vector<at::Tensor> data,
-                                         std::vector<at::Tensor> target)
+  void TorchDataset::write_tensors_to_db(
+      std::vector<at::Tensor> data,
+      __attribute__((unused)) std::vector<at::Tensor> target)
   {
     std::ostringstream dstream;
     torch::save(data, dstream);

--- a/src/backends/torch/torchlib.h
+++ b/src/backends/torch/torchlib.h
@@ -34,6 +34,7 @@
 #include "mllibstrategy.h"
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #include "caffe.pb.h"
 #pragma GCC diagnostic pop
 

--- a/src/backends/xgb/xgb_dmlc_macro_fix.h
+++ b/src/backends/xgb/xgb_dmlc_macro_fix.h
@@ -1,0 +1,32 @@
+/**
+ * DeepDetect
+ * Copyright (c) 2020 Jolibrain
+ * Author: Mehdi Abaakouk <mehdi.abaakouk@jolibrain.com>
+ *
+ * This file is part of deepdetect.
+ *
+ * deepdetect is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * deepdetect is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with deepdetect.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef DMLC_LOGGING_H_
+#undef VLOG
+#undef CHECK
+#undef CHECK_NOTNULL
+#undef CHECK_NE
+#undef CHECK_EQ
+#undef CHECK_GT
+#undef CHECK_GE
+#undef CHECK_LE
+#undef CHECK_LT
+#endif

--- a/src/backends/xgb/xgbinputconns.h
+++ b/src/backends/xgb/xgbinputconns.h
@@ -30,6 +30,7 @@
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
+#include "xgb_dmlc_macro_fix.h"
 #include <dmlc/base.h>
 #include <dmlc/io.h>
 #include <dmlc/build_config.h>

--- a/src/backends/xgb/xgblib.h
+++ b/src/backends/xgb/xgblib.h
@@ -24,8 +24,10 @@
 
 #include "mllibstrategy.h"
 #include "xgbmodel.h"
+
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
+#include "xgb_dmlc_macro_fix.h"
 #include <dmlc/build_config.h>
 #include <xgboost/learner.h>
 #pragma GCC diagnostic pop

--- a/src/caffegraphinput.h
+++ b/src/caffegraphinput.h
@@ -25,6 +25,7 @@
 #include <google/protobuf/text_format.h>
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #include "src/caffe.pb.h"
 #pragma GCC diagnostic pop
 

--- a/src/generators/net_caffe.h
+++ b/src/generators/net_caffe.h
@@ -26,6 +26,7 @@
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #include "caffe.pb.h"
 #pragma GCC diagnostic pop
 #include "dd_spdlog.h"


### PR DESCRIPTION
## chore(build): enable -Werror


## chore(build): fix xgb macro redefined issue


## chore(build): hide maybe-uninitialized for caffe.pb.h

Depending on the version of protoc the warning differ.
So we need to filter all of them.

## chore(build): protobuf::io::CodedInputStream::SetTotalBytesLimit deprecation

second parameter is ignored and deprecated.

## chore(build): mark parameter as unused


## fix: tensorrt does not support blank_label


## chore(build): document deprecation of nvinfer1::createInferBuilder


## chore(build): hide pytorch warning
