### PR TITLE
Graph lstm autoencoder

### DIFF
--- a/src/backends/caffe/caffelib.cc
+++ b/src/backends/caffe/caffelib.cc
@@ -3812,8 +3812,18 @@ namespace dd
                 ->mutable_filler()
                 ->set_value(1.0 / (float)_ntargets / (float)batch_size);
           }
+        for (int i = 0; i < np->layers_size(); i++)
+          {
+            caffe::LayerParameter *lp = np->mutable_layer(i);
+            if (lp->has_dummy_data_param())
+              {
+                lp->mutable_dummy_data_param()->mutable_shape(0)->set_dim(
+                    0, batch_size);
+                lp->mutable_dummy_data_param()->mutable_shape(1)->set_dim(
+                    0, batch_size);
+              }
+          }
       }
-
     // caffe::WriteProtoToTextFile(*np,sp.net().c_str());
     sp.clear_net();
   }
@@ -3832,6 +3842,16 @@ namespace dd
     if (orig_timesteps == timesteps)
       return false;
     lparam->mutable_memory_data_param()->set_channels(timesteps);
+    // also update timesteps in case of autoencoder
+    for (unsigned int i = 0; i < deploy_net_param.layer_size(); ++i)
+      {
+        caffe::LayerParameter *lp = deploy_net_param.mutable_layer(i);
+        if (lp->has_tile_param())
+          {
+            lp->mutable_tile_param()->set_tiles(timesteps);
+            break;
+          }
+      }
     caffe::WriteProtoToTextFile(deploy_net_param, deploy_file);
     return true;
   }
@@ -3993,8 +4013,8 @@ namespace dd
             ->set_dim(2, inputc._sequence_txt);
       }
 
-    // if autoencoder, set the last inner product layer output number to input
-    // size (i.e. inputc.channels())
+    // if autoencoder, set the last inner product layer output number to
+    // input size (i.e. inputc.channels())
     if (_autoencoder && this->_inputc._timeserie)
       {
         int k = net_param.layer_size();
@@ -4048,6 +4068,17 @@ namespace dd
               {
                 lparam->mutable_loss_param()->set_ignore_label(ignore_label);
               }
+          }
+      }
+
+    // update tile number with time steps (autoencoder)
+    for (unsigned int i = 0; i < net_param.layer_size(); ++i)
+      {
+        caffe::LayerParameter *lp = net_param.mutable_layer(i);
+        if (lp->has_tile_param())
+          {
+            lp->mutable_tile_param()->set_tiles(timesteps);
+            break;
           }
       }
 
@@ -4151,6 +4182,17 @@ namespace dd
           deploy_net_param.mutable_layer(0)
               ->mutable_transform_param()
               ->set_crop_size(_crop_size);
+      }
+
+    // update tile number with time steps (autoencoder)
+    for (unsigned int i = 0; i < deploy_net_param.layer_size(); ++i)
+      {
+        caffe::LayerParameter *lp = deploy_net_param.mutable_layer(i);
+        if (lp->has_tile_param())
+          {
+            lp->mutable_tile_param()->set_tiles(timesteps);
+            break;
+          }
       }
 
     caffe::WriteProtoToTextFile(net_param, net_file);
@@ -4380,8 +4422,8 @@ namespace dd
       }
     // fix class numbers
     // this procedure looks for the first bottom layer with a 'num_output'
-    // field and rename the layer so that its weights can be reinitialized and
-    // the net finetuned
+    // field and rename the layer so that its weights can be reinitialized
+    // and the net finetuned
     int k = net_param.layer_size();
     for (int l = net_param.layer_size() - 1; l > 0; l--)
       {
@@ -4429,8 +4471,8 @@ namespace dd
     APIData ad_net = ad.getobj("parameters").getobj("mllib").getobj("net");
     if (ad_net.has("batch_size"))
       {
-        // adjust batch size so that it is a multiple of the number of training
-        // samples (Caffe requirement)
+        // adjust batch size so that it is a multiple of the number of
+        // training samples (Caffe requirement)
         user_batch_size = batch_size = test_batch_size
             = ad_net.get("batch_size").get<int>();
         if (ad_net.has("test_batch_size"))
@@ -4440,8 +4482,8 @@ namespace dd
         this->_logger->info("user batch_size={} / inputc batch_size=",
                             batch_size, inputc.batch_size());
 
-        // code below is required when Caffe (weirdly) requires the batch size
-        // to be a multiple of the training dataset size.
+        // code below is required when Caffe (weirdly) requires the batch
+        // size to be a multiple of the training dataset size.
         if (!inputc._ctc && !inputc._segmentation
             && !(!inputc._db
                  && typeid(inputc) == typeid(ImgCaffeInputFileConn)))
@@ -4565,9 +4607,9 @@ namespace dd
               mltype = "rois";
             break;
           }
-        if (ltype == "ContinuationIndicator") // XXX: CTC layer does not appear
-                                              // in deploy file, this is a hack
-                                              // used by our LSTMs
+        if (ltype == "ContinuationIndicator") // XXX: CTC layer does not
+                                              // appear in deploy file, this
+                                              // is a hack used by our LSTMs
           {
             mltype = "ctc";
             break;
@@ -4579,7 +4621,8 @@ namespace dd
           {
             mltype = "segmentation";
             has_deconv = true;
-            // we don't break since some detection tasks may use deconvolutions
+            // we don't break since some detection tasks may use
+            // deconvolutions
           }
         if (!has_deconv && ltype == "Sigmoid" && l == net->layers().size() - 1)
           {
@@ -4766,8 +4809,8 @@ namespace dd
                   }
                 catch (std::exception &e)
                   {
-                    this->_logger->warn(
-                        "dice contour size unrecognized, (odd) int expected");
+                    this->_logger->warn("dice contour size unrecognized, "
+                                        "(odd) int expected");
                   }
               }
             if (contourdata.has("amplitude"))
@@ -4779,8 +4822,8 @@ namespace dd
                   }
                 catch (std::exception &e)
                   {
-                    this->_logger->warn(
-                        "dice contour amplitude unrecognized, float expected");
+                    this->_logger->warn("dice contour amplitude "
+                                        "unrecognized, float expected");
                   }
               }
             this->_logger->warn(

--- a/src/backends/torch/torchlib.cc
+++ b/src/backends/torch/torchlib.cc
@@ -335,7 +335,7 @@ namespace dd
           {
             caffe::NetParameter net_param;
             configure_recurrent_template(lib_ad, this->_inputc, net_param,
-                                         this->_logger);
+                                         this->_logger, true);
             torch_write_proto_to_text_file(net_param, dest_net);
           }
         else

--- a/src/basegraph.cc
+++ b/src/basegraph.cc
@@ -257,6 +257,13 @@ namespace dd
           outputdim.push_back(_graph[inputs[0]].dim[i]);
         outputdim.push_back(_graph[producer].num_output);
       }
+    else if (_graph[producer].type == "Tile")
+      {
+        // BIG FAT WARNING : this is a hack for tile in autoencoders only
+        // because exposed hidden ouputs are computed as of full size
+        outputdim.push_back(_graph[inputs[0]].dim[1]); // timesteps
+        outputdim.push_back(_graph[inputs[0]].dim[2]); // hidden_size
+      }
     return std::tie(inputdim, outputdim);
   }
 
@@ -265,6 +272,7 @@ namespace dd
     auto es = boost::in_edges(v, _graph);
     auto eit = es.first;
     BaseGraph::Vertex producer = boost::source(*eit, _graph);
+
     auto newdims = compute_dims_from_producer(producer);
     update_alloc_status(newdims, producer);
     _graph[producer].dim = std::get<1>(newdims);

--- a/src/caffegraphinput.cc
+++ b/src/caffegraphinput.cc
@@ -82,6 +82,9 @@ namespace dd
     else
       firstl = ninput + 3;
 
+    if (net.layer(firstl).type() == "DummyData")
+      firstl++;
+
     caffe::LayerParameter lparam = net.layer(firstl);
     if (lparam.type() != "LSTM" && lparam.type() != "RNN"
         && lparam.type() != "InnerProduct")
@@ -131,7 +134,8 @@ namespace dd
             std::vector<BaseGraph::Vertex> vi = add_inputs(v, inputs);
 
             std::vector<std::string> outputs;
-            outputs.push_back(lparam.top(0));
+            for (unsigned int i = 0; i < lparam.top_size(); ++i)
+              outputs.push_back(lparam.top(i));
             std::vector<BaseGraph::Vertex> vo = add_outputs(v, outputs);
             set_output_name(lparam.top(0));
           }
@@ -155,6 +159,18 @@ namespace dd
             outputs.push_back(lparam.top(0));
             std::vector<BaseGraph::Vertex> vo = add_outputs(v, outputs);
             set_output_name(lparam.top(0));
+          }
+        else if (lparam.type() == "Tile")
+          {
+            Vertex v = add_layer(lparam.name(), lparam.type());
+            std::vector<std::string> inputs;
+            inputs.push_back(lparam.bottom(0));
+            add_inputs(v, inputs);
+            std::vector<std::string> outputs;
+            outputs.push_back(lparam.top(0));
+            add_outputs(v, outputs);
+            set_output_name(lparam.top(0));
+            _graph[v].axis = lparam.tile_param().axis();
           }
       }
 

--- a/src/generators/net_caffe_recurrent.h
+++ b/src/generators/net_caffe_recurrent.h
@@ -49,9 +49,10 @@ namespace dd
                          const double &dropout_ratio,
                          const std::string weight_filler,
                          const std::string bias_filler,
-                         const std::string &type, const int id);
+                         const std::string &type, const int id,
+                         bool expose_hidden = false);
 
-    void configure_net(const APIData &ad_mllib);
+    void configure_net(const APIData &ad_mllib, bool expose_hidden = false);
 
     void add_concat(caffe::NetParameter *net_params, std::string name,
                     std::string top, std::vector<std::string> bottoms,
@@ -72,6 +73,9 @@ namespace dd
                     const std::string weight_filler,
                     const std::string bias_filler, int nout, int nin);
 
+    void add_tile(caffe::NetParameter *net_param, const std::string layer_name,
+                  const std::string bottom_name, const std::string top_name);
+
     void parse_recurrent_layers(const std::vector<std::string> &layers,
                                 std::vector<std::string> &r_layers,
                                 std::vector<int> &h_sizes);
@@ -80,6 +84,7 @@ namespace dd
     const std::string _lstm_str = "L";
     const std::string _rnn_str = "R";
     const std::string _affine_str = "A";
+    const std::string _tile_str = "T";
   };
 
   /**
@@ -92,8 +97,8 @@ namespace dd
   void configure_recurrent_template(const APIData &ad,
                                     TInputConnectorStrategy &inputc,
                                     caffe::NetParameter &net_param,
-                                    std::shared_ptr<spdlog::logger> &logger);
-
+                                    std::shared_ptr<spdlog::logger> &logger,
+                                    bool expose_hidden = false);
 }
 
 #endif


### PR DESCRIPTION
this PR adds support for lstm autoencoders using graph/torch API

API follows classical LSTM call:
service creation 
```
curl -X PUT "http://localhost:8800/services/autoencoder" -d '{
        "mllib":"torch",
        "description":"lstm_autoencoder",
         "type":"supervised",
         "model": {
             "repository":"/path/to/repo"
         },
        "parameters" : {
             "input": { 
                "connector":"csvts",
                "label":["output"] 
             },
             "mllib" : {
                "template" : "recurrent",
                 "layers":["L10","L10","T","L10"],
                 "loss":"L1"
             }
       }
}'
```
`T` means Tile, original caffe layer name that repeats one blob along a dimension. Here last hidden value of the encoder is  repeated / tiled to serve as input for all decoder inputs. 

exemple training:
```
curl -X POST "http://localhost:8800/train" -d '{
         "service":"autoencoder", 
          "async":true,
          "parameters" : {
              "input" : {
                  "shuffle":true,"                                                                                                                                        
                   "separator":",",
                    "scale":true,
                     "timesteps":200,
                    "label":["output"]  
                },
              "mllib" : { 
                  "gpu":true,
                  "solver" : {
                      "iterations":100, 
                      "test_interval":10,
                      "base_lr":0.01,
                      "snapshot":10,
                      "test_initialization":false
                   },
                   "net": { 
                      "batch_size":100,
                      "test_batch_size":10
                    }
               },
              "output" : {
                  "measure":["L1","L2"] 
               }
          },
         "data":["/path/to/train/data", "/path/to/test/data"]
}                                                                                                                                 
```
 
