### PR TITLE
feat: tentative refactor of torch native backend interface with templates

### DIFF
--- a/src/backends/torch/native/native_factory.h
+++ b/src/backends/torch/native/native_factory.h
@@ -12,15 +12,15 @@ namespace dd
   {
   public:
     template <class TInputConnectorStrategy>
-    static NativeModule *from_template(const std::string tdef,
-                                       const APIData template_params,
-                                       const TInputConnectorStrategy &inputc)
-    {
-      (void)(tdef);
-      (void)(template_params);
-      (void)(inputc);
-      return nullptr;
-    }
+      static native_variant_type from_template(std::string tdef,
+					       APIData template_params,
+					       TInputConnectorStrategy &inputc)
+   {
+     (void)tdef;
+     (void)inputc;
+     (void)template_params;
+     throw std::exception();
+   }
 
     static bool valid_template_def(std::string tdef)
     {
@@ -37,19 +37,27 @@ namespace dd
     }
   };
 
-  template <>
-  NativeModule *NativeFactory::from_template<CSVTSTorchInputFileConn>(
-      const std::string tdef, const APIData template_params,
-      const CSVTSTorchInputFileConn &inputc)
+  template<>
+    native_variant_type NativeFactory::from_template<CSVTSTorchInputFileConn>(
+  //native_variant_type NativeFactory::from_template(
+						   std::string tdef, APIData template_params,
+						   CSVTSTorchInputFileConn &inputc)
   {
     if (tdef.find("nbeats") != std::string::npos)
       {
         std::vector<std::string> p = template_params.get("template_params")
-                                         .get<std::vector<std::string>>();
-        return new NBeats(inputc, p);
+	  .get<std::vector<std::string>>();
+        return std::make_shared<NBeats>(inputc, p);
       }
-    else
-      return nullptr;
-  }
+      else
+	{
+	  // beware
+	  //return torch::nn::Module();//NativeModule();
+	  throw std::exception();
+	  //return nullptr;
+	}
+    }
+  
+  
 }
 #endif

--- a/src/backends/torch/native/native_net.h
+++ b/src/backends/torch/native/native_net.h
@@ -2,73 +2,200 @@
 #define NATIVE_NET_H
 
 #include "torch/torch.h"
+#include "templates/nbeats.h"
 
 namespace dd
 {
-
-  class NativeModule : public torch::nn::Module
+  
+  typedef mapbox::util::variant<
+    //NativeModule,
+    std::shared_ptr<NBeats>
+    > native_variant_type;
+  
+  class visitor_to_device
   {
   public:
-    virtual torch::Tensor forward(torch::Tensor x) = 0;
-    virtual ~NativeModule()
-    {
-    }
-    /**
-     * \brief see torch::module::to
-     * @param device cpu / gpu
-     * @param non_blocking
-     */
-    virtual void to(torch::Device device, bool non_blocking = false)
-    {
-      torch::nn::Module::to(device, non_blocking);
-      _device = device;
-    }
+    visitor_to_device() {}
+    ~visitor_to_device() {}
 
-    /**
-     * \brief see torch::module::to
-     * @param dtype : torch::kFloat32 or torch::kFloat64
-     * @param non_blocking
-     */
-    virtual void to(torch::Dtype dtype, bool non_blocking = false)
-    {
-      torch::nn::Module::to(dtype, non_blocking);
-      _dtype = dtype;
-    }
-
-    /**
-     * \brief see torch::module::to
-     * @param device cpu / gpu
-     * @param dtype : torch::kFloat32 or torch::kFloat64
-     * @param non_blocking
-     */
-    virtual void to(torch::Device device, torch::Dtype dtype,
-                    bool non_blocking = false)
-    {
-      torch::nn::Module::to(device, dtype, non_blocking);
-      _device = device;
-      _dtype = dtype;
-    }
-
-    virtual torch::Tensor cleanup_output(torch::Tensor output)
-    {
-      return output;
-    }
-
-    virtual torch::Tensor loss(std::string loss, torch::Tensor input,
-                               torch::Tensor output, torch::Tensor target)
-        = 0;
-
-    virtual void update_input_connector(TorchInputInterface &inputc)
-    {
-      (void)(inputc);
-    }
-
-  protected:
-    torch::Dtype _dtype
-        = torch::kFloat32; /**< type of data stored in tensors */
-    torch::Device _device
-        = torch::DeviceType::CPU; /**< device to compute on */
+    template <typename T> void operator()(T &nativem)
+      {
+	nativem->to(_device);
+      }
+    torch::Device _device = torch::DeviceType::CPU;
   };
-}
+
+  class visitor_to_type
+  {
+  public:
+    visitor_to_type() {}
+    ~visitor_to_type() {}
+
+    template <typename T> void operator()(T &nativem)
+      {
+	nativem->to(_dtype);
+      }
+    torch::Dtype _dtype = torch::kFloat32;
+  };
+
+  class visitor_to_device_type
+  {
+  public:
+    visitor_to_device_type() {}
+    ~visitor_to_device_type() {}
+
+    template <typename T> void operator()(T &nativem)
+      {
+	nativem->to(_device,_dtype);
+      }
+    torch::Device _device = torch::DeviceType::CPU;
+    torch::Dtype _dtype = torch::kFloat32;
+  };
+
+  class visitor_forward
+  {
+  public:
+    visitor_forward() {}
+    ~visitor_forward() {}
+
+    template <typename T> void operator()(T &nativem)
+      {
+	_out = nativem->forward(_source);
+      }
+
+    torch::Tensor _source;
+    torch::Tensor _out;
+  };
+
+  class visitor_parameters
+  {
+  public:
+    visitor_parameters() {}
+    ~visitor_parameters() {}
+
+    template <typename T> void operator()(T &nativem)
+      {
+	_params = nativem->parameters();
+      }
+
+    std::vector<torch::Tensor> _params;
+  };
+
+  class visitor_native_load
+  {
+  public:
+    visitor_native_load() {}
+    ~visitor_native_load() {}
+
+    template <typename T> void operator()(T &nativem)
+      {	
+	torch::load(nativem, _fname);
+	/*std::shared_ptr<torch::nn::Module> m = std::make_shared<torch::nn::Module>(nativem);
+	  torch::load(m, _fname);*/
+      }
+    std::string _fname;
+  };
+
+  class visitor_native_save
+  {
+  public:
+    visitor_native_save() {}
+    ~visitor_native_save() {}
+
+    template <typename T> void operator()(T &nativem)
+      {	
+	torch::save(nativem, _fname);
+	/*std::shared_ptr<torch::nn::Module> m = std::make_shared<torch::nn::Module>(nativem);
+	  torch::save(m, _fname);*/
+      }
+    std::string _fname;
+  };
+
+  class visitor_native_load_device
+  {
+  public:
+    visitor_native_load_device() {}
+    ~visitor_native_load_device() {}
+
+    template <typename T> void operator()(T &nativem)
+      {
+	torch::load(nativem, _fname, _device);
+      }
+
+    std::string _fname;
+    torch::Device _device = torch::DeviceType::CPU;
+  };
+  
+  class visitor_native_eval
+  {
+  public:
+    visitor_native_eval() {}
+    ~visitor_native_eval() {}
+
+    template <typename T> void operator()(T &nativem)
+      {
+	nativem->eval();
+      }
+  };
+
+  class visitor_native_train
+  {
+  public:
+    visitor_native_train() {}
+    ~visitor_native_train() {}
+
+    template <typename T> void operator()(T &nativem)
+      {
+	nativem->train();
+      }
+  };
+
+  class visitor_native_loss
+  {
+  public:
+    visitor_native_loss() {}
+    ~visitor_native_loss() {}
+
+    template <typename T> void operator()(T &nativem)
+      {
+	_loutput = nativem->loss(_loss, _input, _output, _target);
+      }
+
+    std::string _loss;
+    torch::Tensor _input;
+    torch::Tensor _output;
+    torch::Tensor _target;
+    torch::Tensor _loutput;
+  };
+
+  template<class TInputConnectorStrategy>
+  class visitor_native_input_conn
+  {
+  public:
+    visitor_native_input_conn() {}
+    ~visitor_native_input_conn() {}
+
+    template <typename T> void operator()(T &nativem)
+      {
+	nativem->update_input_connector(_inputc);
+      }
+
+    TInputConnectorStrategy _inputc;
+  };
+
+  class visitor_native_output
+  {
+  public:
+    visitor_native_output() {}
+    ~visitor_native_output() {}
+
+    template <typename T> void operator()(T &nativem)
+      {
+	_output = nativem->cleanup_output(_output);
+      }
+
+    torch::Tensor _output;
+  };
+}  
 
 #endif

--- a/src/backends/torch/native/templates/nbeats.h
+++ b/src/backends/torch/native/templates/nbeats.h
@@ -7,13 +7,13 @@
 #pragma GCC diagnostic pop
 #include "../../torchinputconns.h"
 #include "mllibstrategy.h"
-#include "../native_net.h"
+//#include "../native_net.h"
 
 namespace dd
 {
-  class NBeats : public NativeModule
+  class NBeats : public torch::nn::Module
   {
-
+    
     enum BlockType
     {
       seasonality,
@@ -45,7 +45,7 @@ namespace dd
 
       torch::Tensor first_forward(torch::Tensor x);
 
-      virtual void to(torch::Device device, bool non_blocking = false)
+      void to(torch::Device device, bool non_blocking = false)
       {
         torch::nn::Module::to(device, non_blocking);
         _device = device;
@@ -56,7 +56,7 @@ namespace dd
        * @param dtype : torch::kFloat32 or torch::kFloat64
        * @param non_blocking
        */
-      virtual void to(torch::Dtype dtype, bool non_blocking = false)
+      void to(torch::Dtype dtype, bool non_blocking = false)
       {
         torch::nn::Module::to(dtype, non_blocking);
         _dtype = dtype;
@@ -68,12 +68,12 @@ namespace dd
        * @param dtype : torch::kFloat32 or torch::kFloat64
        * @param non_blocking
        */
-      virtual void to(torch::Device device, torch::Dtype dtype,
+      void to(torch::Device device, torch::Dtype dtype,
                       bool non_blocking = false)
       {
         torch::nn::Module::to(device, dtype, non_blocking);
         _device = device;
-        _dtype = dtype;
+	_dtype = dtype;
       }
 
     protected:
@@ -198,7 +198,8 @@ namespace dd
       update_params(inputc);
       create_nbeats();
     }
-    NBeats()
+
+  NBeats()
         : _data_size(1), _output_size(1), _backcast_length(50),
           _forecast_length(10), _hidden_layer_units(1024),
           _nb_blocks_per_stack(3), _share_weights_in_stack(false),
@@ -265,7 +266,7 @@ namespace dd
         }
     }
 
-    virtual void to(torch::Device device, bool non_blocking = false)
+    void to(torch::Device device, bool non_blocking = false)
     {
       torch::nn::Module::to(device, non_blocking);
       _device = device;
@@ -298,7 +299,7 @@ namespace dd
      * @param dtype : torch::kFloat32 or torch::kFloat64
      * @param non_blocking
      */
-    virtual void to(torch::Dtype dtype, bool non_blocking = false)
+    void to(torch::Dtype dtype, bool non_blocking = false)
     {
       torch::nn::Module::to(dtype, non_blocking);
       _dtype = dtype;
@@ -332,7 +333,7 @@ namespace dd
      * @param dtype : torch::kFloat32 or torch::kFloat64
      * @param non_blocking
      */
-    virtual void to(torch::Device device, torch::Dtype dtype,
+    void to(torch::Device device, torch::Dtype dtype,
                     bool non_blocking = false)
     {
       torch::nn::Module::to(device, dtype, non_blocking);
@@ -362,14 +363,14 @@ namespace dd
       _fcn->to(device, dtype);
     }
 
-    virtual torch::Tensor forward(torch::Tensor x);
+    torch::Tensor forward(torch::Tensor x);
 
-    virtual torch::Tensor cleanup_output(torch::Tensor output)
+    torch::Tensor cleanup_output(torch::Tensor output)
     {
       return torch::chunk(output, 2, 0)[1].flatten(0, 1);
     }
 
-    virtual torch::Tensor loss(std::string loss, torch::Tensor input,
+    torch::Tensor loss(std::string loss, torch::Tensor input,
                                torch::Tensor output, torch::Tensor target)
     {
       std::vector<torch::Tensor> chunks = torch::chunk(output, 2, 0);
@@ -383,12 +384,12 @@ namespace dd
       throw MLLibBadParamException("unknown loss " + loss);
     }
 
-    virtual void update_input_connector(TorchInputInterface &inputc)
+    void update_input_connector(TorchInputInterface &inputc)
     {
       inputc._split_ts_for_predict = true;
     }
 
-    virtual ~NBeats()
+    ~NBeats()
     {
     }
 
@@ -404,7 +405,6 @@ namespace dd
     std::vector<Stack> _stacks;
     std::vector<int> _thetas_dims;
     torch::nn::Linear _fcn{ nullptr };
-    torch::Device _device = torch::Device("cpu");
     std::vector<float> _backcast_linspace;
     std::vector<float> _forecast_linspace;
     std::tuple<torch::Tensor, torch::Tensor> create_sin_basis(int thetas_dim);
@@ -415,6 +415,11 @@ namespace dd
     std::string _season_str = "s";
     std::string _generic_str = "g";
     std::string _nbblock_str = "b";
+
+    torch::Dtype _dtype
+      = torch::kFloat32; /**< type of data stored in tensors */
+    torch::Device _device
+      = torch::DeviceType::CPU; /**< device to compute on */
   };
 }
 #endif

--- a/src/backends/torch/torchlib.h
+++ b/src/backends/torch/torchlib.h
@@ -118,9 +118,11 @@ namespace dd
     std::shared_ptr<TorchGraphBackend>
         _graph; /**< graph module : torchgraphbackend has same interface as
                    torch::module */
-    std::shared_ptr<NativeModule>
-        _native; /**< native module : directly written in C++ */
+    /*std::shared_ptr<NativeModule>
+      _native;*/ /**< native module : directly written in C++ */
 
+    std::shared_ptr<native_variant_type> _native = nullptr;
+    
     torch::nn::Linear _classif = nullptr;
 
     torch::Device _device;


### PR DESCRIPTION
This PR is an example of a possible refactoring of the torch C++ interface for native models in DD. 

Advantages :
- all compile-time checks of native models regarding required functions
- no virtual functions outside of torch internals (forward, ...)

Drawbacks:
- code is made more complicated via visitors etc.. for the variant
- doesn't fully work at the moment, see below.

At the moment, the `load` & `save` of torch models are not working, for a reason that is not too clear to me (pointer / virtual internal stuff to `torch::load` typically when applied to an object from the `native_variant_type` variant type list. Thus test fails after training a native model since the loading step doesn't work. If the step is removed, since the model is already in memory after training, tests do proceed.

I believe feedback on this alternative to the current solution could be useful in order to properly design DD's torch C++ backend so that it gracefully handles the 3 types of models: graph, torchscript modules, and C++ native.