### PR TITLE
refactor: native as pure virtual

### DIFF
--- a/src/backends/torch/native/native_net.h
+++ b/src/backends/torch/native/native_net.h
@@ -13,13 +13,34 @@ namespace dd
     virtual ~NativeModule()
     {
     }
+
+    virtual void to(torch::Device device, bool non_blocking = false) = 0;
+    virtual void to(torch::Dtype dtype, bool non_blocking = false) = 0;
+    virtual void to(torch::Device device, torch::Dtype dtype,
+                    bool non_blocking = false)
+        = 0;
+    virtual torch::Tensor cleanup_output(torch::Tensor output) = 0;
+    virtual torch::Tensor loss(std::string loss, torch::Tensor input,
+                               torch::Tensor output, torch::Tensor target)
+        = 0;
+
+    virtual void update_input_connector(TorchInputInterface &inputc) = 0;
+
+  protected:
+    torch::Dtype _dtype
+        = torch::kFloat32; /**< type of data stored in tensors */
+    torch::Device _device
+        = torch::DeviceType::CPU; /**< device to compute on */
+
     /**
      * \brief see torch::module::to
      * @param device cpu / gpu
      * @param non_blocking
      */
-    virtual void to(torch::Device device, bool non_blocking = false)
+    virtual void _generic_to(torch::Device device,
+                             bool non_blocking = false) final
     {
+
       torch::nn::Module::to(device, non_blocking);
       _device = device;
     }
@@ -29,7 +50,8 @@ namespace dd
      * @param dtype : torch::kFloat32 or torch::kFloat64
      * @param non_blocking
      */
-    virtual void to(torch::Dtype dtype, bool non_blocking = false)
+    virtual void _generic_to(torch::Dtype dtype,
+                             bool non_blocking = false) final
     {
       torch::nn::Module::to(dtype, non_blocking);
       _dtype = dtype;
@@ -41,33 +63,13 @@ namespace dd
      * @param dtype : torch::kFloat32 or torch::kFloat64
      * @param non_blocking
      */
-    virtual void to(torch::Device device, torch::Dtype dtype,
-                    bool non_blocking = false)
+    virtual void _generic_to(torch::Device device, torch::Dtype dtype,
+                             bool non_blocking = false) final
     {
       torch::nn::Module::to(device, dtype, non_blocking);
       _device = device;
       _dtype = dtype;
     }
-
-    virtual torch::Tensor cleanup_output(torch::Tensor output)
-    {
-      return output;
-    }
-
-    virtual torch::Tensor loss(std::string loss, torch::Tensor input,
-                               torch::Tensor output, torch::Tensor target)
-        = 0;
-
-    virtual void update_input_connector(TorchInputInterface &inputc)
-    {
-      (void)(inputc);
-    }
-
-  protected:
-    torch::Dtype _dtype
-        = torch::kFloat32; /**< type of data stored in tensors */
-    torch::Device _device
-        = torch::DeviceType::CPU; /**< device to compute on */
   };
 }
 

--- a/src/backends/torch/native/templates/nbeats.h
+++ b/src/backends/torch/native/templates/nbeats.h
@@ -290,8 +290,7 @@ namespace dd
 
     virtual void to(torch::Device device, bool non_blocking = false)
     {
-      torch::nn::Module::to(device, non_blocking);
-      _device = device;
+      this->_generic_to(device, non_blocking);
       for (unsigned int i = 0; i < _stack_types.size(); ++i)
         {
           Stack s = _stacks[i];
@@ -323,8 +322,7 @@ namespace dd
      */
     virtual void to(torch::Dtype dtype, bool non_blocking = false)
     {
-      torch::nn::Module::to(dtype, non_blocking);
-      _dtype = dtype;
+      this->_generic_to(dtype, non_blocking);
       for (unsigned int i = 0; i < _stack_types.size(); ++i)
         {
           Stack s = _stacks[i];
@@ -358,9 +356,7 @@ namespace dd
     virtual void to(torch::Device device, torch::Dtype dtype,
                     bool non_blocking = false)
     {
-      torch::nn::Module::to(device, dtype, non_blocking);
-      _device = device;
-      _dtype = dtype;
+      this->_generic_to(device, dtype, non_blocking);
       for (unsigned int i = 0; i < _stack_types.size(); ++i)
         {
           Stack s = _stacks[i];
@@ -427,7 +423,6 @@ namespace dd
     std::vector<Stack> _stacks;
     std::vector<int> _thetas_dims = NBEATS_DEFAULT_THETAS;
     torch::nn::Linear _fcn{ nullptr };
-    torch::Device _device = torch::Device("cpu");
     std::vector<float> _backcast_linspace;
     std::vector<float> _forecast_linspace;
     std::tuple<torch::Tensor, torch::Tensor> create_sin_basis(int thetas_dim);


### PR DESCRIPTION
This uses pure virtual and virtual final to ensure
some methods must be implemented and some can't.

And when you need to use generic/common code it's explicit not magic.
