### PR TITLE
fix: /api/ alias when deployed on deepdetect.com

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,7 +1,7 @@
 ---
 title: API Reference
 layout: api
-
+aliases: [/api/]
 ---
 
 # Introduction


### PR DESCRIPTION
Alias rule allows the redirection of https://www.deepdetect.com/api to https://www.deepdetect.com/server/docs/api/