### PR TITLE
fix: add support and automated processing of categorical variables in timeseries data

### DIFF
--- a/src/backends/caffe/caffeinputconns.h
+++ b/src/backends/caffe/caffeinputconns.h
@@ -894,8 +894,7 @@ namespace dd
     int read_file(const std::string &fname, bool is_test_data = false);
     int read_db(const std::string &fname);
     int read_mem(const std::string &content);
-    int read_dir(const std::string &dir, bool is_test_data = false,
-                 bool update_bounds = true);
+    int read_dir(const std::string &dir);
 
     DDCsvTS _ddcsvts;
     CSVTSCaffeInputFileConn *_cifc = nullptr;

--- a/src/csvinputfileconn.h
+++ b/src/csvinputfileconn.h
@@ -482,6 +482,8 @@ namespace dd
 
     void read_header(std::string &hline);
 
+    void fillup_categoricals(std::ifstream &csv_file);
+
     void read_csv_line(const std::string &hline, const std::string &delim,
                        std::vector<double> &vals, std::string &column_id,
                        int &nlines);

--- a/src/csvtsinputfileconn.h
+++ b/src/csvtsinputfileconn.h
@@ -47,8 +47,7 @@ namespace dd
     int read_file(const std::string &fname, bool is_test_data = false);
     int read_db(const std::string &fname);
     int read_mem(const std::string &content);
-    int read_dir(const std::string &dir, bool is_test_data = false,
-                 bool allow_read_test = true, bool update_bounds = true);
+    int read_dir(const std::string &dir);
 
     DDCsv _ddcsv;
     CSVTSInputFileConn *_cifc = nullptr;
@@ -117,16 +116,25 @@ namespace dd
       return 1;
     }
 
+    /**
+     * \brief merge the local and argument categorical variable list and
+     * values, both maps end up containing the merged variables.
+     * @param categoricals list of categoricals to be merged
+     */
+    void merge_categoricals(
+        std::unordered_map<std::string, CCategorical> &categoricals);
+
+    /**
+     * \brief merge the local min/max values into the argument vectors
+     * @param min_vals min bounds to be updated
+     * @param max_vals max bounds to be updated
+     */
+    void merge_min_max(std::vector<double> &min_vals,
+                       std::vector<double> &max_vals);
+
     // read min max values, return false if not present
     bool deserialize_bounds(bool force = false);
     void serialize_bounds();
-
-    /*   std::string s = "Boost,\"C++ Libraries\""; */
-    /*   boost::escaped_list_separator<char> els('\\',_delim,'\"\''); */
-    /*   tokenizer<boost::escaped_list_separator<char> tok(s,els); */
-    /*   for (const auto &t : tok) */
-    /*     std::cout << t << '\n'; */
-    /* } */
 
     void response_params(APIData &out);
 


### PR DESCRIPTION
This PR should fix #837. 

It adds support for categorical variables when training from time-series (in multiple CSV files format). This works both with and without using the underlying `db` with caffe typically.

~~TODO: this is untested with torch backend for timeseries at the moment.~~
Works fine with torch backend.