### PR TITLE
fix: update caffe cudnn engine without template

### DIFF
--- a/src/backends/caffe/caffelib.cc
+++ b/src/backends/caffe/caffelib.cc
@@ -1286,6 +1286,9 @@ namespace dd
       }
     else // model template instantiation is defered until training call
       {
+#ifdef USE_CUDNN
+        update_protofile_engine(ad);
+#endif
         create_model(true);
       }
 
@@ -4165,6 +4168,8 @@ namespace dd
   {
 
     std::string deploy_file = this->_mlmodel._repo + "/deploy.prototxt";
+    if (!fileops::file_exists(deploy_file))
+      return;
     caffe::NetParameter deploy_net_param;
     caffe::ReadProtoFromTextFile(deploy_file, &deploy_net_param);
     update_protofile_engine(deploy_net_param, ad);


### PR DESCRIPTION
Allows modifying the underlying cudnn execution strategy from the DD API on trained models, for inference.