### PR TITLE
refactor: register internal matrices in nbeats, makes code a lot simpler

### DIFF
--- a/src/backends/torch/native/native_net.h
+++ b/src/backends/torch/native/native_net.h
@@ -41,61 +41,14 @@ namespace dd
     virtual ~NativeModule()
     {
     }
-    /**
-     * \brief see torch::module::to
-     * @param device cpu / gpu
-     * @param non_blocking
-     */
-    virtual void to(torch::Device device, bool non_blocking = false)
-    {
-      torch::nn::Module::to(device, non_blocking);
-      _device = device;
-    }
 
-    /**
-     * \brief see torch::module::to
-     * @param dtype : torch::kFloat32 or torch::kFloat64
-     * @param non_blocking
-     */
-    virtual void to(torch::Dtype dtype, bool non_blocking = false)
-    {
-      torch::nn::Module::to(dtype, non_blocking);
-      _dtype = dtype;
-    }
-
-    /**
-     * \brief see torch::module::to
-     * @param device cpu / gpu
-     * @param dtype : torch::kFloat32 or torch::kFloat64
-     * @param non_blocking
-     */
-    virtual void to(torch::Device device, torch::Dtype dtype,
-                    bool non_blocking = false)
-    {
-      torch::nn::Module::to(device, dtype, non_blocking);
-      _device = device;
-      _dtype = dtype;
-    }
-
-    virtual torch::Tensor cleanup_output(torch::Tensor output)
-    {
-      return output;
-    }
+    virtual torch::Tensor cleanup_output(torch::Tensor output) = 0;
 
     virtual torch::Tensor loss(std::string loss, torch::Tensor input,
                                torch::Tensor output, torch::Tensor target)
         = 0;
 
-    virtual void update_input_connector(TorchInputInterface &inputc)
-    {
-      (void)(inputc);
-    }
-
-  protected:
-    torch::Dtype _dtype
-        = torch::kFloat32; /**< type of data stored in tensors */
-    torch::Device _device
-        = torch::DeviceType::CPU; /**< device to compute on */
+    virtual void update_input_connector(TorchInputInterface &inputc) = 0;
   };
 }
 


### PR DESCRIPTION
this PR makes nbeats use torch registration of constant matrices, makes all explicit calls to "to" superfluous