### PR TITLE
Pull request for protobuf-fix

### DIFF
--- a/src/backends/ncnn/caffe2ncnn.cc
+++ b/src/backends/ncnn/caffe2ncnn.cc
@@ -337,7 +337,7 @@ static bool read_proto_from_binary(const char *filepath,
   google::protobuf::io::IstreamInputStream input(&fs);
   google::protobuf::io::CodedInputStream codedstr(&input);
 
-  codedstr.SetTotalBytesLimit(INT_MAX);
+  codedstr.SetTotalBytesLimit(INT_MAX, INT_MAX / 2);
 
   bool success = message->ParseFromCodedStream(&codedstr);
 

--- a/src/backends/ncnn/caffe2ncnn.cc
+++ b/src/backends/ncnn/caffe2ncnn.cc
@@ -337,7 +337,17 @@ static bool read_proto_from_binary(const char *filepath,
   google::protobuf::io::IstreamInputStream input(&fs);
   google::protobuf::io::CodedInputStream codedstr(&input);
 
+  /** NOTE(sileht): old version of protobuf need the second argument
+   * but protobuf shipped with caffe2/pytorch/tf have the second argument
+   * ignored and deprecated.
+   * At some point, we should just select one version of protobuf and make
+   * everybody use it to support only one version. And don't depends on which
+   * the backends are enabled
+   */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   codedstr.SetTotalBytesLimit(INT_MAX, INT_MAX / 2);
+#pragma GCC diagnostic pop
 
   bool success = message->ParseFromCodedStream(&codedstr);
 


### PR DESCRIPTION
## revert: "chore(build): protobuf::io::CodedInputStream::SetTotalBytesLimit deprecation"

This reverts commit 57e8ba22d4471682dd8e16bcf21bb0f424346fc6.

## fix: ignore protobuf::io::CodedInputStream::SetTotalBytesLimit deprecation

until we drop usage of ubuntu 18.04 system version of protobuf we have
to ignore this deprecation.
