### PR TITLE
fix: remove unecessary limit setting call to protobuf codedstream

### DIFF
--- a/src/backends/ncnn/caffe2ncnn.cc
+++ b/src/backends/ncnn/caffe2ncnn.cc
@@ -337,8 +337,6 @@ static bool read_proto_from_binary(const char *filepath,
   google::protobuf::io::IstreamInputStream input(&fs);
   google::protobuf::io::CodedInputStream codedstr(&input);
 
-  codedstr.SetTotalBytesLimit(INT_MAX);
-
   bool success = message->ParseFromCodedStream(&codedstr);
 
   fs.close();


### PR DESCRIPTION
comment: default limit is already set to INT_MAX

CPU builds with caffe + ncnn were failing:

```
/opt/deepdetect/src/backends/ncnn/caffe2ncnn.cc: In function 'bool read_proto_from_binary(const char*, caffe::NetParameter*)':
/opt/deepdetect/src/backends/ncnn/caffe2ncnn.cc:340:38: error: no matching function for call to 'google::protobuf::io::CodedInputStream::SetTotalBytesLimit(int)'
   codedstr.SetTotalBytesLimit(INT_MAX);
                                      ^
In file included from /opt/deepdetect/src/backends/ncnn/caffe2ncnn.cc:28:0:
/usr/include/google/protobuf/io/coded_stream.h:386:8: note: candidate: void google::protobuf::io::CodedInputStream::SetTotalBytesLimit(int, int)
   void SetTotalBytesLimit(int total_bytes_limit, int warning_threshold);
        ^~~~~~~~~~~~~~~~~~
/usr/include/google/protobuf/io/coded_stream.h:386:8: note:   candidate expects 2 arguments, 1 provided
make[2]: *** [src/CMakeFiles/ddetect.dir/backends/ncnn/caffe2ncnn.cc.o] Error 1
src/CMakeFiles/ddetect.dir/build.make:782: recipe for target 'src/CMakeFiles/ddetect.dir/backends/ncnn/caffe2ncnn.cc.o' failed
CMakeFiles/Makefile2:337: recipe for target 'src/CMakeFiles/ddetect.dir/all' failed
make[1]: *** [src/CMakeFiles/ddetect.dir/all] Error 2
Makefile:83: recipe for target 'all' failed
make: *** [all] Error 2
The command '/bin/sh -c mkdir build &&     cd build &&     cp -a ../build.sh . &&     ./build.sh' returned a non-zero code: 2
```