### PR TITLE
fix(csvts): correctly store and print test file names

### DIFF
--- a/src/backends/torch/torchinputconns.cc
+++ b/src/backends/torch/torchinputconns.cc
@@ -995,9 +995,14 @@ namespace dd
         long int tstart = 0;
         if (static_cast<long int>(seq.size()) < _timesteps)
           {
-            _tilogger->warn(
-                "file " + _fnames[vecindex]
-                + " does not contains enough timesteps, discarding");
+            if (use_csvtsdata_test)
+              _tilogger->warn(
+                  "file " + _test_fnames[vecindex]
+                  + " does not contains enough timesteps, discarding");
+            else
+              _tilogger->warn(
+                  "file " + _fnames[vecindex]
+                  + " does not contains enough timesteps, discarding");
             continue;
           }
         for (; tstart + _timesteps < static_cast<long int>(seq.size());

--- a/src/csvtsinputfileconn.cc
+++ b/src/csvtsinputfileconn.cc
@@ -36,7 +36,10 @@ namespace dd
         _cifc->read_csv(fname, true);
         _cifc->_csv_test_fname = testfname;
         _cifc->push_csv_to_csvts(is_test_data);
-        _cifc->_fnames.push_back(fname);
+        if (is_test_data)
+          _cifc->_test_fnames.push_back(fname);
+        else
+          _cifc->_fnames.push_back(fname);
         return 0;
       }
     else

--- a/src/csvtsinputfileconn.h
+++ b/src/csvtsinputfileconn.h
@@ -146,6 +146,7 @@ namespace dd
     std::vector<std::vector<CSVline>> _csvtsdata;
     std::vector<std::vector<CSVline>> _csvtsdata_test;
     std::vector<std::string> _fnames;
+    std::vector<std::string> _test_fnames;
 
     int _boundsprecision = 15;
   };


### PR DESCRIPTION
this PR is a small fix on stored file names ins csvts input file names, it is necessary per new warning that raises if some file is too short to build even one timeserie