### PR TITLE
fix(torch/timeseries): unscale prediction output if needed

### DIFF
--- a/src/backends/torch/torchlib.h
+++ b/src/backends/torch/torchlib.h
@@ -204,6 +204,9 @@ namespace dd
     void snapshot(int64_t elapsed_it, torch::optim::Optimizer &optimizer);
 
     void remove_model(int64_t it);
+
+    double unscale(double val, unsigned int k,
+                   const TInputConnectorStrategy &inputc);
   };
 }
 


### PR DESCRIPTION
this PR unscale the output at prediction time, exaclty as in caffe backend. This step was previously wrongly skipped