### PR TITLE
fix(torch): load weights only once

### DIFF
--- a/src/backends/torch/torchgraphbackend.cc
+++ b/src/backends/torch/torchgraphbackend.cc
@@ -189,6 +189,7 @@ namespace dd
 
   void TorchGraphBackend::allocate_modules()
   {
+    _allocation_done = false;
     for (BaseGraph::Vertex v : _sortedOps)
       {
         if (!_graph[v].alloc_needed)
@@ -220,6 +221,7 @@ namespace dd
             _modules[opname] = AnyModule(m);
             _graph[v].alloc_needed = false;
             _rnn_has_memories[opname] = false;
+            _allocation_done = true;
           }
         else if (optype == "RNN")
           {
@@ -233,6 +235,7 @@ namespace dd
             _modules[opname] = AnyModule(m);
             _graph[v].alloc_needed = false;
             _rnn_has_memories[opname] = false;
+            _allocation_done = true;
           }
         else if (optype == "InnerProduct")
           {
@@ -243,6 +246,7 @@ namespace dd
                 Linear(LinearOptions(dim(v, 0, 2), num_output(v)).bias(true)));
             _modules[opname] = AnyModule(m);
             _graph[v].alloc_needed = false;
+            _allocation_done = true;
           }
         else if (optype == "Tile")
           _graph[v].alloc_needed = false;

--- a/src/backends/torch/torchgraphbackend.h
+++ b/src/backends/torch/torchgraphbackend.h
@@ -177,10 +177,18 @@ namespace dd
       _parameters_used = false;
     }
 
+    /**
+     * tells if some allocation was done (needs to be called just after
+     * set_inputdim or finalize
+     */
+    bool needs_reload()
+    {
+      return _allocation_done;
+    }
+
   protected:
     /**
      * internal torch module allocation, called whithin (finalize)
-     * @param force
      */
     void allocate_modules();
 
@@ -215,8 +223,9 @@ namespace dd
     std::unordered_map<std::string, bool>
         _rnn_has_memories; /**< true if previsous hidden values are available
                             */
-  };
 
+    bool _allocation_done = false;
+  };
 }
 
 #endif

--- a/src/backends/torch/torchlib.h
+++ b/src/backends/torch/torchlib.h
@@ -142,8 +142,16 @@ namespace dd
                                 the file where the weights are stored */
     unsigned int _nclasses = 0;
 
+    std::shared_ptr<spdlog::logger> _logger; /**< mllib logger. */
+
   private:
     bool _freeze_traced = false; /**< Freeze weights of the traced module */
+    void proto_model_load(const TorchModel &tmodel);
+    void graph_model_load(const TorchModel &tmodel);
+    void native_model_load(const TorchModel &tmodel);
+    void classif_model_load(const TorchModel &tmodel);
+    void traced_model_load(TorchModel &model);
+    void classif_layer_load();
   };
 
   template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
@@ -202,6 +210,11 @@ namespace dd
                          int64_t best_to_remove);
 
     void snapshot(int64_t elapsed_it, torch::optim::Optimizer &optimizer);
+
+    /**
+     * \brief (re) load solver state
+     */
+    void solver_load(std::unique_ptr<torch::optim::Optimizer> &optimizer);
 
     void remove_model(int64_t it);
 

--- a/src/caffegraphinput.cc
+++ b/src/caffegraphinput.cc
@@ -28,6 +28,8 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+#include "mllibstrategy.h"
+
 using google::protobuf::io::CodedInputStream;
 using google::protobuf::io::CodedOutputStream;
 using google::protobuf::io::FileInputStream;
@@ -177,19 +179,19 @@ namespace dd
     return true;
   }
 
-  int CaffeGraphInput::from_proto(std::string filename)
+  void CaffeGraphInput::from_proto(std::string filename)
   {
     caffe::NetParameter net;
     if (!read_proto(filename, &net))
-      return -1;
+      throw MLLibBadParamException("unable to parse protofile");
 
     bool simple_lstm = is_simple_lstm(net);
     if (simple_lstm)
       {
         parse_simple_lstm(net);
-        return 0;
+        return;
       }
-    return 0;
+    throw MLLibBadParamException(
+        "proto file do not contain a proper LSTM/autoencoder");
   }
-
 }

--- a/src/caffegraphinput.h
+++ b/src/caffegraphinput.h
@@ -53,7 +53,7 @@ namespace dd
     /**
      * create basegraph from proto
      */
-    int from_proto(std::string filename);
+    void from_proto(std::string filename);
 
     /**
      * read protofile


### PR DESCRIPTION
this PR tries to cleanup model loading in torchlib.cc, previous version was extra cautious , leading to many unnecessary loadings which caused major slowdowns at inference