### PR TITLE
fix(torch): Fix conditions to add classification head.

### DIFF
--- a/src/imginputfileconn.h
+++ b/src/imginputfileconn.h
@@ -519,9 +519,10 @@ namespace dd
     ImgInputFileConn(const ImgInputFileConn &i)
         : InputConnectorStrategy(i), _width(i._width), _height(i._height),
           _crop_width(i._crop_width), _crop_height(i._crop_height), _bw(i._bw),
-          _unchanged_data(i._unchanged_data), _test_split(i._test_split),
-          _mean(i._mean), _has_mean_scalar(i._has_mean_scalar),
-          _scale(i._scale), _scaled(i._scaled), _scale_min(i._scale_min),
+          _rgb(i._rgb), _unchanged_data(i._unchanged_data),
+          _test_split(i._test_split), _mean(i._mean),
+          _has_mean_scalar(i._has_mean_scalar), _scale(i._scale),
+          _scaled(i._scaled), _scale_min(i._scale_min),
           _scale_max(i._scale_max), _keep_orig(i._keep_orig),
           _interp(i._interp)
 #ifdef USE_CUDA_CV

--- a/tests/ut-torchapi.cc
+++ b/tests/ut-torchapi.cc
@@ -78,8 +78,7 @@ TEST(torchapi, service_predict)
   // predict
   std::string jpredictstr
       = "{\"service\":\"imgserv\",\"parameters\":{\"input\":{\"height\":224,"
-        "\"width\":224,\"rgb\":true,\"scale\":0.0039},\"output\":{\"best\":1}}"
-        ",\"data\":[\""
+        "\"width\":224},\"output\":{\"best\":1}},\"data\":[\""
         + incept_repo + "cat.jpg\"]}";
   joutstr = japi.jrender(japi.service_predict(jpredictstr));
   JDoc jd;


### PR DESCRIPTION
Classification head was added if there was a traced model, which was not the expected behavior in some cases. It was also added on prediction models in some cases, making them totally useless.

Now the classification layer is added only if we are training with `finetuning:true`.

EDIT: Not sure why it makes nbeats tests fail, I will check that out
EDIT: Seems like the nbeats issue happens randomly, I saved the backtrace for further investigation. This is not related to this PR.
