### PR TITLE
fix(torch/timeseries): do not double read query data

### DIFF
--- a/src/backends/torch/torchinputconns.cc
+++ b/src/backends/torch/torchinputconns.cc
@@ -942,7 +942,6 @@ namespace dd
     APIData ad_input = ad.getobj("parameters").getobj("input");
 
     init(ad_input);
-    get_data(ad);
 
     try
       {


### PR DESCRIPTION
get_data() is done at the very beginning of CSVTS::transform, these are remains of some very old refactor around the init() just above