### PR TITLE
docs: Fix documentation for scale in ImageInputConntector

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -186,7 +186,7 @@ histogram_equalization | bool | yes      | false   | Whether to equalize the ima
 mean           | float        | yes      | 128     | mean pixel value to be subtracted to input image
 mean           | array of int | yes      | N/A     | mean pixel value per channel to be subtracted to input image
 std            | float        | yes      | 128     | standard pixel value deviation to be applied to input image
-scale	       | float	      | yes	 | 1.0	   | whether to scale the size of an image
+scale	       | float	      | yes	 | 1.0	   | Multiply value of each pixel by a factor
 scale_min      | float        | yes	 | 600     | min scaling dim size
 scale_max      | float        | yes      | 1000    | max scaling dim size
 segmentation   | bool         | yes      | false   | whether to setup an image connector for a segmentation task (`caffe` only)
@@ -579,7 +579,7 @@ histogram_equalization | bool | yes      | false   | Whether to equalize the ima
 mean           | float        | yes      | 128     | mean pixel value to be subtracted to input image
 mean           | array of int | yes      | N/A     | mean pixel value per channel to be subtracted to input image
 std            | float        | yes      | 128     | standard pixel value deviation to be applied to input image
-scale	       | float	      | yes	 | 1.0	   | whether to scale the size of an image
+scale	       | float	      | yes	 | 1.0	   | Multiply value of each pixel by a factor
 scale_min      | float        | yes	 | 600     | min scaling dim size
 scale_max      | float        | yes      | 1000    | max scaling dim size
 test_split   | real | yes      | 0       | Test split part of the dataset


### PR DESCRIPTION
Fix issue #869
I did not remove `scale_min` & `scale_max` because they may be used for some models (detectron ? see commit https://github.com/jolibrain/deepdetect/commit/8d3a16525ce1ee56f204b6d27c3b898aa96d5e5a)