### PR TITLE
docs: remove IRC link

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ DeepDetect relies on external machine learning libraries through a very generic 
 | Dlib       | N        | Y          | Y              | Y         |   N       |   N        | N           | N           |N |
 | TensorRT   | N/A      | Y          | Y              | Y         |   N       |   N        | N           | N           |N |
 | NCNN       | N/A      | Y          | Y              | Y         |   N       |   N        | N           | Y           |Y |
-| Libtorch   | Y        | Y          | Y              | N         |   N       |   N        | N           | N           |N | 
+| Libtorch   | Y        | Y          | Y              | N         |   N       |   N        | N           | N           |N |
 
 
 #### GPU support per library
@@ -59,7 +59,7 @@ DeepDetect implements support for supervised and unsupervised deep learning of i
 
 #### Support
 
-Please join either the community on [Gitter](https://gitter.im/beniz/deepdetect) or on IRC Freenode #deepdetect, where we help users get through with installation, API, neural nets and connection to external applications.
+Please join either the community on [Gitter](https://gitter.im/beniz/deepdetect), where we help users get through with installation, API, neural nets and connection to external applications.
 
 #### Supported Platforms
 


### PR DESCRIPTION
nobody is connected on IRC channel, so we shouldn't promote it.