### PR TITLE
fix(torch/native): prevent loading weights before instanciating native

### DIFF
--- a/src/backends/torch/torchlib.cc
+++ b/src/backends/torch/torchlib.cc
@@ -196,7 +196,8 @@ namespace dd
 
   void TorchModule::native_model_load(const TorchModel &tmodel)
   {
-    if (!tmodel._native.empty())
+    if (!tmodel._native.empty()
+        && _native != nullptr) //_native has to be instanciated before loading
       {
         _logger->info("loading " + tmodel._native);
         try


### PR DESCRIPTION
naive instantiation is deferred to predict/training time, one should not try to load weight during init_mllib (this happens when predicting only, ie w/o training first)