### PR TITLE
fix: handle int64 in conversion from json to APIData

### DIFF
--- a/src/apidata.cc
+++ b/src/apidata.cc
@@ -200,6 +200,10 @@ namespace dd
           {
             add(cit->name.GetString(), cit->value.GetInt());
           }
+        else if (cit->value.IsInt64())
+          {
+            add(cit->name.GetString(), cit->value.GetInt64());
+          }
         else
           {
             throw DataConversionException("conversion error: unknown type");


### PR DESCRIPTION
This was causing the error `Error code 1007: conversion error: unknown type` on resuming model training, due to the `flops` value in `metrics.json` being `long int` aka `int64` for `rapidjson`.