### PR TITLE
feat(ml): tensorrt support for regression models

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1223,6 +1223,7 @@ measure              | array  | yes      | empty   | Output measures requested, 
 template             | string | yes      | empty   | Output template in Mustache format
 confidence_threshold | double | yes      | 0.0     | only returns classifications or detections with probability strictly above threshold
 bbox                 | bool   | yes      | false   | returns bounding boxes around object when using an object detection model
+regression           | bool   | yes      | false   | whether the output of a model is a regression target (i.e. vector of one or more floats)
 
 The variables that are usable in the output template format are those from the standard JSON output. See the [output template](#output-templates) dedicated section for more details and examples.
 

--- a/src/backends/tensorrt/tensorrtlib.h
+++ b/src/backends/tensorrt/tensorrtlib.h
@@ -127,11 +127,12 @@ namespace dd
 
     bool _bbox = false;
     bool _ctc = false;
+    bool _regression = false;
+    bool _timeserie = false;
 
     std::vector<void *> _buffers;
 
     bool _TRTContextReady = false;
-    bool _timeserie = false;
 
     int _inputIndex;
     int _outputIndex0;


### PR DESCRIPTION
This PR adds support for compiling models that end with a regression head. It hasn't been added to the unit tests since we don't have image regression models in our examples set yet.