### PR TITLE
feat(torch): Add multigpu support for native models training

### DIFF
--- a/ci/Jenkinsfile.unittests
+++ b/ci/Jenkinsfile.unittests
@@ -75,11 +75,28 @@ ccache -s
           python3 -c 'import torch, sys; c=torch.cuda.device_count() ; print(f"CUDA VISIBLE GPU: {c}"); sys.exit(bool(c == 0 ))'
           echo
           echo "****************************"
-          cd build && ctest -V -E "http"
+          cd build && ctest -V -E "http|multigpu"
           '''
           }
       }
     }
+/*
+    stage('Tests multi-GPU') {
+      steps {
+        lock(resource: null, label: 'gpu', variable: 'LOCKED_GPU', quantity: 2) {
+          sh '''
+          export CUDA_VISIBLE_DEVICES=$(echo ${LOCKED_GPU} | sed "s/GPU //g")
+          echo "****************************"
+          echo
+          python3 -c 'import torch, sys; c=torch.cuda.device_count() ; print(f"CUDA VISIBLE GPU: {c}"); sys.exit(bool(c < 2))'
+          echo
+          echo "****************************"
+          cd build && ctest -V -E "http" -R "multigpu"
+          '''
+          }
+      }
+    }
+*/
   }
   post {
     always {

--- a/docs/api.md
+++ b/docs/api.md
@@ -734,7 +734,7 @@ General:
 Parameter       | Type   | Optional | Default | Description
 ---------       | ----   | -------- | ------- | -----------
 gpu             | bool   | yes      | false   | whether to use gpu
-gpuid           | int    | yes      | false   | id of gpu to use, defaults to -1 meaning all available
+gpuid           | int or array | yes | 0      | GPU id, use single int for single GPU, `-1` for using all GPUs, and array e.g. `[1,3]` for selecting among multiple GPUs
 nclasses        | int    | yes      | none    | if set to some int, add a classifier (linear/fullyConnected) with correposnding number of classes after torch traced model
 self_supervised | string | yes      | ""      | self-supervised mode: "mask" for masked language model
 embedding_size  | int    | yes      | 768     | embedding size for NLP models
@@ -1106,7 +1106,7 @@ test_batch_size | int  | yes      | N/A     | Prediction batch size (the server 
 Parameter     | Type   | Optional | Default | Description
 ---------     | ----   | -------- | ------- | -----------
 gpu           | bool   | yes      | false   | Whether to use GPU
-gpuid         | int    | yes      | -1      | GPU id, use single int for single GPU, `-1` for using all GPUs.
+gpuid         | int or array | yes | 0      | GPU id, use single int for single GPU, `-1` for using all GPUs, and array e.g. `[1,3]` for selecting among multiple GPUs
 extract_layer | string | yes      | ""      | in bert models "hidden_state" allows to extract raw hidden_states values to return as output. Requires the service to be declared as 'unsupervised'
 
 

--- a/src/backends/torch/native/native_net.h
+++ b/src/backends/torch/native/native_net.h
@@ -32,7 +32,7 @@
 namespace dd
 {
 
-  class NativeModule : public torch::nn::Module
+  class NativeModule : public virtual torch::nn::Module
   {
   public:
     /**
@@ -64,9 +64,7 @@ namespace dd
      */
     virtual std::vector<std::string> extractable_layers() const = 0;
 
-    virtual ~NativeModule()
-    {
-    }
+    virtual ~NativeModule() = default;
 
     virtual torch::Tensor cleanup_output(torch::Tensor output) = 0;
 
@@ -75,6 +73,11 @@ namespace dd
         = 0;
 
     virtual void update_input_connector(TorchInputInterface &inputc) = 0;
+  };
+
+  template <typename T>
+  class NativeModuleImpl : public NativeModule, public torch::nn::Cloneable<T>
+  {
   };
 }
 

--- a/src/backends/torch/native/templates/nbeats.cc
+++ b/src/backends/torch/native/templates/nbeats.cc
@@ -292,6 +292,7 @@ namespace dd
 
   void NBeats::create_nbeats()
   {
+    _stacks.clear();
     float back_step = 1.0 / (float)(_backcast_length);
     for (unsigned int i = 0; i < _backcast_length; ++i)
       _backcast_linspace.push_back(back_step * static_cast<float>(i));
@@ -347,6 +348,11 @@ namespace dd
     _fcn = register_module("fcn", torch::nn::Linear(_data_size, _output_size));
     _finit = register_buffer(
         "finit", torch::zeros({ 1, _backcast_length, _data_size }));
+  }
+
+  void NBeats::reset()
+  {
+    create_nbeats();
   }
 
   torch::Tensor NBeats::forward(torch::Tensor x)

--- a/src/backends/torch/torchlib.h
+++ b/src/backends/torch/torchlib.h
@@ -86,8 +86,11 @@ namespace dd
     std::string _template; /**< template identifier (recurrent/bert/gpt2...)*/
     bool _finetuning = false; /**< add a custom layer (classif/regression...)
                                  after model */
-    torch::Device _device
-        = torch::Device("cpu"); /**<  where to execute model */
+    torch::Device _main_device
+        = torch::Device("cpu"); /**<  the main device where the module lives */
+    std::vector<torch::Device>
+        _devices; /**< all the devices used during training (e.g. for multi-gpu
+                     training) */
     bool _masked_lm = false;    /**< enable MLM self supervised pre training*/
     bool _seq_training = false; /**< true for bert/gpt2*/
     bool _classification = false; /**< select classification type problem*/

--- a/src/backends/torch/torchmodule.h
+++ b/src/backends/torch/torchmodule.h
@@ -23,6 +23,9 @@
 #ifndef TORCH_MODULE_H
 #define TORCH_MODULE_H
 
+// TODO this should normally be defined by pytorch
+#define AT_PARALLEL_OPENMP 1
+
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #include <torch/torch.h>
@@ -31,6 +34,8 @@
 #include "torchgraphbackend.h"
 #include "native/native_net.h"
 #include <torch/script.h>
+#include <torch/nn/pimpl.h>
+#include <torch/nn/parallel/data_parallel.h>
 
 namespace dd
 {
@@ -48,6 +53,14 @@ namespace dd
      * \brief forward (inference) pass over the network
      */
     c10::IValue forward(std::vector<c10::IValue> source);
+
+    /**
+     * \brief forward pass using the devices given in parameters.
+     * If more than one device is given, this method performs a multigpu
+     * forward.
+     */
+    c10::IValue forward_on_devices(std::vector<c10::IValue> source,
+                                   const std::vector<torch::Device> &devices);
 
     /**
      * \brief forward (inference) until extract_layer, return value of

--- a/src/backends/torch/torchutils.cc
+++ b/src/backends/torch/torchutils.cc
@@ -101,5 +101,23 @@ namespace dd
       return torch::from_blob(&values[0], at::IntList{ val_size }, at::kLong)
           .clone();
     }
+
+    std::vector<c10::IValue> unwrap_c10_vector(const c10::IValue &output)
+    {
+      if (output.isTensorList())
+        {
+          auto elems = output.toTensorList();
+          return std::vector<c10::IValue>(elems.begin(), elems.end());
+        }
+      else if (output.isTuple())
+        {
+          auto &elems = output.toTuple()->elements();
+          return std::vector<c10::IValue>(elems.begin(), elems.end());
+        }
+      else
+        {
+          return { output };
+        }
+    }
   }
 }

--- a/src/backends/torch/torchutils.h
+++ b/src/backends/torch/torchutils.h
@@ -90,6 +90,8 @@ namespace dd
     void add_parameters(std::shared_ptr<torch::jit::script::Module> module,
                         std::vector<torch::Tensor> &params,
                         bool requires_grad = true);
+
+    std::vector<c10::IValue> unwrap_c10_vector(const c10::IValue &output);
   }
 }
 #endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,9 +6,21 @@ include_directories(${GTEST_INCLUDE_DIRS})
 
 # Optional libraries can be passed (stored in ARGN)
 function (REGISTER_TEST _NAME _FILE)
-  add_executable(${_NAME} ${_FILE})
-  target_link_libraries(${_NAME} ${COMMON_LINK_LIBS} gtest gtest_main ${ARGN})
-  add_test(NAME ${_NAME} COMMAND ${_NAME})
+  if (NOT TARGET ${_NAME})
+    add_executable(${_NAME} ${_FILE})
+    target_link_libraries(${_NAME} ${COMMON_LINK_LIBS} gtest gtest_main ${ARGN})
+  endif()
+
+  add_test(NAME ${_NAME} COMMAND ${_NAME} "--gtest_filter=-*multigpu*")
+endfunction ()
+
+function (REGISTER_TEST_MULTIGPU _NAME _FILE)
+  if (NOT TARGET ${_NAME})
+    add_executable(${_NAME} ${_FILE})
+    target_link_libraries(${_NAME} ${COMMON_LINK_LIBS} gtest gtest_main ${ARGN})
+  endif()
+
+  add_test(NAME ${_NAME}_multigpu COMMAND ${_NAME} "--gtest_filter=*multigpu*")
 endfunction ()
 
 function (DOWNLOAD_DATASET _NAME _URL _WORKDIR _DEST _IN)
@@ -318,6 +330,7 @@ if (GTEST_FOUND)
 
     if(USE_JSON_API)
       REGISTER_TEST(ut_torchapi ut-torchapi.cc)
+      REGISTER_TEST_MULTIGPU(ut_torchapi ut-torchapi.cc)
     endif()
     REGISTER_TEST(ut_graph ut-graph.cc)
   endif()


### PR DESCRIPTION
This PR adds multi-GPU support to model training with libtorch, and uses NBeats implementation as a testbed + unit tests.