### PR TITLE
feat(ml): image regression model training with libtorch

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Please join either the community on [Gitter](https://gitter.im/beniz/deepdetect)
 | Classification    | Y     | Y      | Y       | Y        | Y    | Y        | Y          | N/A    | Y    |
 | Object Detection  | Y     | Y      | N       | Y        | Y    | N        | N          | N/A    | Y    |
 | Segmentation      | Y     | N      | N       | N        | N    | N        | N          | N/A    | N    |
-| Regression        | Y     | N      | Y       | N        | N    | N        | N          | N/A    | N    |
+| Regression        | Y     | N      | Y       | N        | N    | Y        | N          | N/A    | N    |
 | Autoencoder       | Y     | N      | N/A     | N        | N    | N        | N          | N/A    | N    |
 | NLP               | Y     | N      | Y       | N        | N    | Y        | N          | Y      | N    |
 | OCR / Seq2Seq     | Y     | N      | N       | N        | Y    | N        | N          | N      | N    |

--- a/docs/api.md
+++ b/docs/api.md
@@ -735,11 +735,13 @@ Parameter       | Type   | Optional | Default | Description
 ---------       | ----   | -------- | ------- | -----------
 gpu             | bool   | yes      | false   | whether to use gpu
 gpuid           | int or array | yes | 0      | GPU id, use single int for single GPU, `-1` for using all GPUs, and array e.g. `[1,3]` for selecting among multiple GPUs
-nclasses        | int    | yes      | none    | if set to some int, add a classifier (linear/fullyConnected) with correposnding number of classes after torch traced model
+nclasses        | int    | yes      | none    | if set to some int, add a classifier (linear/fullyConnected) with corresponding number of classes after torch traced model
+ntargets   | int             | no (regression only)     | N/A     | Number of regression targets
 self_supervised | string | yes      | ""      | self-supervised mode: "mask" for masked language model
 embedding_size  | int    | yes      | 768     | embedding size for NLP models
 freeze_traced   | bool   | yes      | false   | Freeze the traced part of the net during finetuning (e.g. for classification)
 template        | string | yes      | ""      | for language models, either "bert" or "gpt2", "recurrent" for LSTM-like models (including autoencoder), "nbeats" for nbeats model
+regression | bool            | yes                      | false   | Whether the model is a regressor
 
 
 Model instantiation parameters:
@@ -1393,7 +1395,7 @@ layers     | array of int    | yes                      | [50]    | Number of ne
 layers     | array of string | yes                      | [1000]  | Type of layer and number of neurons peer layer: XCRY for X successive convolutional layers of Y filters with activation layers followed by a max pooling layer, an int as a string for specifying the final fully connected layers size, e.g. \["2CR32","2CR64","1000"\] ("convnet" only), ["L50","L50"] means 2 layers of LSTMs with hidden size of 50. ["L100","L100", "T", "L300"] means an lstm autoencoder with encoder composed of 2 LSTM layers of hidden size 100 and decoder is one LSTM layer of hidden size 300 ("recurrent" only)
 activation | string          | yes                      | relu    | Unit activation ("mlp" and "convnet" only), from "sigmoid","tanh","relu","prelu"
 dropout    | real            | yes                      | 0.5     | Dropout rate between layers ("mlp" and "convnet" only)
-regression | bool            | yes                      | false   | Whether the model is a regressor ("mlp" and "convnet" only)
+regression | bool            | yes                      | false   | Whether the model is a regressor
 crop_size  | int             | yes                      | N/A     | Size of random image crops as input images
 rotate     | bool            | yes                      | false   | Whether to apply random rotations to input images
 mirror     | bool            | yes                      | false   | Whether to apply random mirroring of input images

--- a/src/backends/torch/torchinputconns.h
+++ b/src/backends/torch/torchinputconns.h
@@ -415,15 +415,34 @@ namespace dd
                            const std::string &folderPath);
 
     /**
+     * \brief read images from txt list
+     */
+    void read_image_list(
+        std::vector<std::pair<std::string, std::vector<double>>> &lfiles,
+        const std::string &listfilePath);
+
+    /**
+     * \brief split dataset into train and test
+     */
+    template <typename T>
+    void split_dataset(std::vector<std::pair<std::string, T>> &lfiles,
+                       std::vector<std::pair<std::string, T>> &test_lfiles);
+
+    /**
      * \brief read data given apiData
      */
     void transform(const APIData &ad);
 
   private:
+    template <typename T>
     int add_image_file(TorchDataset &dataset, const std::string &fname,
-                       int target);
+                       T target);
 
     at::Tensor image_to_tensor(const cv::Mat &bgr);
+
+    at::Tensor target_to_tensor(const int &target);
+
+    at::Tensor target_to_tensor(const std::vector<double> &target);
   };
 
   /**

--- a/src/backends/torch/torchlib.h
+++ b/src/backends/torch/torchlib.h
@@ -94,6 +94,7 @@ namespace dd
     bool _masked_lm = false;    /**< enable MLM self supervised pre training*/
     bool _seq_training = false; /**< true for bert/gpt2*/
     bool _classification = false; /**< select classification type problem*/
+    bool _regression = false;     /**< select regression type problem. */
     bool _timeserie = false;      /**< select timeserie type problem*/
     std::string _loss = "";       /**< selected loss*/
 

--- a/src/backends/torch/torchmodule.h
+++ b/src/backends/torch/torchmodule.h
@@ -85,11 +85,11 @@ namespace dd
     void freeze_traced(bool freeze);
 
     /**
-     *  \brief Add linear model at the end of module. Automatically detects
-     * size of the last layer thanks to the provided example output.
+     * \brief Add linear model at the end of module. Automatically detects size
+     * of the last layer thanks to the provided example output.
      */
-    void setup_classification(int nclasses,
-                              std::vector<c10::IValue> input_example);
+    void setup_linear_layer(int nclasses,
+                            std::vector<c10::IValue> input_example);
 
     /**
      * \brief gives all learnable parameters
@@ -183,18 +183,16 @@ namespace dd
     std::shared_ptr<NativeModule>
         _native; /**< native module : directly written in C++ */
 
-    torch::nn::Linear _classif
-        = nullptr; /**< classification layer to append at end of net */
+    torch::nn::Linear _linear = nullptr;
 
-    torch::Device _device; /**< device to compute on */
-    int _classif_in = 0;   /**<id of the input of the classification layer */
+    torch::Device _device;
+    int _linear_in = 0; /**<id of the input of the final linear layer */
     bool _hidden_states = false; /**< Take BERT hidden states as input. */
 
-    bool _require_classif_layer
-        = false; /**< flag to see if we need a classif layer */
+    bool _require_linear_layer = false;
     std::string
-        _classif_layer_file;    /**< if require_classif_layer == true, this is
-                           the file where the weights are stored */
+        _linear_layer_file;     /** < if require_linear_layer == true, this is
+                                    the file where the weights are stored */
     unsigned int _nclasses = 0; /**< number of classes */
 
     std::shared_ptr<spdlog::logger> _logger; /**< mllib logger. */
@@ -218,9 +216,9 @@ namespace dd
     void native_model_load(const TorchModel &tmodel);
 
     /**
-     * load classif model  weights from pt format
+     * load linear model weights from pt format
      */
-    void classif_model_load(const TorchModel &tmodel);
+    void linear_model_load(const TorchModel &tmodel);
 
     /**
      * load traced net (def + weights) from  pt format
@@ -228,9 +226,9 @@ namespace dd
     void traced_model_load(TorchModel &model);
 
     /**
-     * load classif layer weights only from pt format
+     * load linear layer weights only from pt format
      */
-    void classif_layer_load();
+    void linear_layer_load();
   };
 }
 #endif


### PR DESCRIPTION
This PR adds support regression on image models with the `torch` model.

This includes the reading of datasets in the standard DD form of a list of image path and regression targets.

On the side it slightly refactors the dynamic adding of a linear layer on top of of a pretrained torch model, since this is applicable to both `classification` and `regression` cases.