### PR TITLE
ci: downgrade cppnet to 0.11.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -958,8 +958,8 @@ if (USE_HTTP_SERVER)
     ExternalProject_Add(
         cpp-netlib
         PREFIX cpp-netlib
-        URL http://downloads.cpp-netlib.org/0.13.0/cpp-netlib-0.13.0-final.tar.gz
-        URL_HASH SHA256=8cf190034b8dd10423ad63fadcb7e2ab0366625386c9863d7f28e9fb375821c7
+        URL http://downloads.cpp-netlib.org/0.11.2/cpp-netlib-0.11.2-final.tar.gz
+        URL_HASH SHA256=71953379c5a6fab618cbda9ac6639d87b35cab0600a4450a7392bc08c930f2b1
         BUILD_IN_SOURCE true
         CMAKE_ARGS
             -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE
@@ -968,7 +968,8 @@ if (USE_HTTP_SERVER)
         INSTALL_COMMAND ""
     )
     set(HTTP_LIB_DEPS ${CMAKE_BINARY_DIR}/cpp-netlib/src/cpp-netlib/libs/network/src/libcppnetlib-uri.a crypto ssl)
-    set(HTTP_INCLUDE_DIR "SYSTEM ${CMAKE_BINARY_DIR}/cpp-netlib/src/cpp-netlib")
+    set(HTTP_INCLUDE_DIR SYSTEM ${CMAKE_BINARY_DIR}/cpp-netlib/src/cpp-netlib)
+    include_directories(${HTTP_INCLUDE_DIR})
 endif()
 
 # main library, main & tests

--- a/docs/source.md
+++ b/docs/source.md
@@ -4,7 +4,7 @@ Below are instructions for 18.04 LTS. For other Linux and Unix systems, steps ma
 
 Beware of [dependencies](https://github.com/jolibrain/deepdetect/tree/master/docs/dependencies.md), typically on Debian/Ubuntu Linux, do:
 ```
-sudo apt-get install build-essential libgoogle-glog-dev libgflags-dev libeigen3-dev libopencv-dev libboost-all-dev libboost-iostreams-dev libcurlpp-dev libcurl4-openssl-dev protobuf-compiler libopenblas-dev libhdf5-dev libprotobuf-dev libleveldb-dev libsnappy-dev liblmdb-dev libutfcpp-dev cmake libgoogle-perftools-dev unzip python-setuptools python-dev libspdlog-dev python-six python-enum34 libarchive-dev rapidjson-dev libmapbox-variant-dev wget
+sudo apt-get install build-essential libgoogle-glog-dev libgflags-dev libeigen3-dev libopencv-dev libboost-all-dev libboost-iostreams-dev libcurlpp-dev libcurl4-openssl-dev protobuf-compiler libopenblas-dev libhdf5-dev libprotobuf-dev libleveldb-dev libsnappy-dev liblmdb-dev libutfcpp-dev cmake libgoogle-perftools-dev unzip python-setuptools python-dev libspdlog-dev python-six python-enum34 libarchive-dev rapidjson-dev libmapbox-variant-dev wget libboost-test-dev
 ```
 
 With CUDA 10, a more recent version of cmake than that of Ubuntu 18.04 is required, and needs to be installed beforehand:


### PR DESCRIPTION
0.13 don't work correctly with deepdetect.

The build was working on CI because deepdetect was built with the wrong
header and the ABI is compatible.

This downgrade it to 0.11.2 and fix the headers inclusion.
