### PR TITLE
fix: ignore JSON conversion throw in partial chains output

### DIFF
--- a/src/apidata.h
+++ b/src/apidata.h
@@ -472,18 +472,15 @@ namespace dd
     void operator()(const std::vector<cv::Mat> &vcv)
     {
       (void)vcv;
-      // Not Implemented
-      throw DataConversionException(
-          "JSON conversion of std::vector<cv::Mat> is not supported");
+      // ignore this datatype for output, until output JSON API structure is
+      // automatically validated.
     }
 
     void operator()(const std::vector<std::pair<int, int>> &vpi)
     {
       (void)vpi;
-      // Not Implemented
-      throw DataConversionException(
-          "JSON conversion of std::vector<std::pair<int,int>> is not "
-          "supported");
+      // ignore this datatype for output, until output JSON API structure is
+      // automatically validated.
     }
 
     void operator()(const std::vector<APIData> &vad)


### PR DESCRIPTION
This PR fixes execution of `chains` that are only partially executed. This is because the inner APIData structure is not cleaned up and remains in a partial state that was throwing on JSON conversion.

This is not optimal but fixes chains and falls back to previous behavior (ignoring unsupported types upon JSON conversion)