### PR TITLE
fix(torch): reload solver params on device from current learning, not previous one

### DIFF
--- a/src/backends/torch/torchlib.cc
+++ b/src/backends/torch/torchlib.cc
@@ -471,7 +471,7 @@ namespace dd
 
     int it = 0;
     // reload solver and set it value accordingly
-    it = tsolver.load(this->_mlmodel._sstate);
+    it = tsolver.load(this->_mlmodel._sstate, _device);
     tsolver.zero_grad();
     _module.train();
 

--- a/src/backends/torch/torchmodule.cc
+++ b/src/backends/torch/torchmodule.cc
@@ -75,6 +75,7 @@ namespace dd
     try
       {
         _graph = std::make_shared<CaffeToTorch>(model._proto);
+        _graph->to(_device);
       }
     catch (std::exception &e)
       {
@@ -107,7 +108,7 @@ namespace dd
         _logger->info("loading " + tmodel._native);
         try
           {
-            torch::load(_native, tmodel._native);
+            torch::load(_native, tmodel._native, _device);
           }
         catch (std::exception &e)
           {

--- a/src/backends/torch/torchsolver.cc
+++ b/src/backends/torch/torchsolver.cc
@@ -128,7 +128,7 @@ namespace dd
     torch::save(*_optimizer, sfile);
   }
 
-  int TorchSolver::load(std::string sstate)
+  int TorchSolver::load(std::string sstate, torch::Device device)
   {
     if (!sstate.empty())
       {
@@ -140,7 +140,7 @@ namespace dd
         _logger->info("loading " + sstate);
         try
           {
-            torch::load(*_optimizer, sstate);
+            torch::load(*_optimizer, sstate, device);
           }
         catch (std::exception &e)
           {

--- a/src/backends/torch/torchsolver.h
+++ b/src/backends/torch/torchsolver.h
@@ -42,7 +42,7 @@ namespace dd
     void configure(APIData ad_solver);
     void create(TorchModule &module);
 
-    int load(std::string sstate);
+    int load(std::string sstate, torch::Device device);
     void save(std::string sfile);
 
     void zero_grad()


### PR DESCRIPTION
this PR forces to reload solver state on device ask for by API. It was loaded on device were it was computed leading to error if this device did not exist (learning on gpuid3 then trying to resume on host with only 3 gpus). It was certainly messing around also if resuming on another device 