### PR TITLE
feat(ml): added vision tranformer (ViT) as torch native template

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -83,6 +83,7 @@ if (USE_TORCH)
     backends/torch/db.cpp
     backends/torch/db_lmdb.cpp
     backends/torch/native/templates/nbeats.cc
+    backends/torch/native/templates/vit.cc
     backends/torch/native/native_factory.cc
 	basegraph.cc
 	caffegraphinput.cc

--- a/src/backends/torch/native/native_factory.cc
+++ b/src/backends/torch/native/native_factory.cc
@@ -53,13 +53,24 @@ namespace dd
       return nullptr;
   }
 
+  template <>
+  NativeModule *NativeFactory::from_template<ImgTorchInputFileConn>(
+      const std::string tdef, const APIData template_params,
+      const ImgTorchInputFileConn &inputc)
+  {
+    (void)template_params;
+    (void)inputc;
+    if (tdef.find("vit") != std::string::npos)
+      {
+        return new ViT(inputc, template_params);
+      }
+    else
+      return nullptr;
+  }
+
   template NativeModule *
   NativeFactory::from_template(const std::string tdef,
                                const APIData template_params,
                                const TxtTorchInputFileConn &inputc);
 
-  template NativeModule *
-  NativeFactory::from_template(const std::string tdef,
-                               const APIData template_params,
-                               const ImgTorchInputFileConn &inputc);
 }

--- a/src/backends/torch/native/native_factory.h
+++ b/src/backends/torch/native/native_factory.h
@@ -24,6 +24,7 @@
 
 #include "native_net.h"
 #include "./templates/nbeats.h"
+#include "./templates/vit.h"
 #include "../torchinputconns.h"
 #include "apidata.h"
 
@@ -39,7 +40,8 @@ namespace dd
 
     static bool valid_template_def(std::string tdef)
     {
-      if (tdef.find("nbeats") != std::string::npos)
+      if (tdef.find("nbeats") != std::string::npos
+          || tdef.find("vit") != std::string::npos)
         return true;
       return false;
     }

--- a/src/backends/torch/native/templates/vit.cc
+++ b/src/backends/torch/native/templates/vit.cc
@@ -1,0 +1,304 @@
+/**
+ * DeepDetect
+ * Copyright (c) 2020 Jolibrain
+ * Author:  Emmanuel Benazera <emmanuel.benazera@jolibrain.com>
+ *
+ * This file is part of deepdetect.
+ *
+ * deepdetect is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * deepdetect is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with deepdetect.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "vit.h"
+#include <iostream>
+
+namespace dd
+{
+  /*-- MLPImpl --*/
+  void ViT::MLPImpl::init_block()
+  {
+    if (!_output_dim)
+      _output_dim = _input_dim;
+    if (!_hidden_dim)
+      _hidden_dim = _input_dim;
+
+    _fc1 = register_module("fc1", torch::nn::Linear(_input_dim, _hidden_dim));
+    _fc2 = register_module("fc2", torch::nn::Linear(_hidden_dim, _output_dim));
+    _drop1 = register_module(
+        "drop1", torch::nn::Dropout(torch::nn::DropoutOptions(_drop)));
+  }
+
+  torch::Tensor ViT::MLPImpl::forward(torch::Tensor x)
+  {
+    x = _fc1(x);
+    x = torch::gelu(x);
+    x = _drop1(x);
+    x = _fc2(x);
+    x = _drop1(x);
+    return x;
+  }
+
+  /*-- AttentionImpl --*/
+  void ViT::AttentionImpl::init_block()
+  {
+    _head_dim = std::floor(_dim / _num_heads);
+    if (_qk_scale > 0.0)
+      _scale = _qk_scale;
+    else
+      _scale = std::pow(_head_dim, -0.5);
+
+    _qkv = register_module(
+        "qkv", torch::nn::Linear(
+                   torch::nn::LinearOptions(_dim, _dim * 3).bias(_qkv_bias)));
+    _attn_drop = register_module(
+        "attn_drop",
+        torch::nn::Dropout(torch::nn::DropoutOptions(_attn_drop_val)));
+    _proj = register_module("proj", torch::nn::Linear(_dim, _dim));
+    _proj_drop = register_module(
+        "proj_drop",
+        torch::nn::Dropout(torch::nn::DropoutOptions(_proj_drop_val)));
+  }
+
+  torch::Tensor ViT::AttentionImpl::forward(torch::Tensor x)
+  {
+    std::vector<long int> shape = x.sizes().vec();
+    long int B = shape[0];
+    long int N = shape[1];
+    long int C = shape[2];
+    long int C2 = std::floor(C / _num_heads);
+    auto qkv = _qkv(x)
+                   .reshape({ B, N, 3, _num_heads, C2 })
+                   .permute({ 2, 0, 3, 1, 4 });
+    auto q = qkv[0];
+    auto k = qkv[1];
+    auto v = qkv[2];
+
+    auto attn = q.matmul(k.transpose(-2, -1)) * _scale;
+    attn = torch::softmax(attn, -1);
+    attn = _attn_drop(attn);
+
+    x = attn.matmul(v).transpose(1, 2).reshape({ B, N, C });
+    x = _proj(x);
+    x = _proj_drop(x);
+
+    return x;
+  }
+
+  /*-- BlockImpl --*/
+  void ViT::BlockImpl::init_block(const double &mlp_ratio,
+                                  const bool &qkv_bias, const double &qk_scale,
+                                  const double &drop_val,
+                                  const double &attn_drop_val,
+                                  const double &drop_path,
+                                  const std::string &act)
+  {
+    _norm1 = register_module(
+        "norm1", torch::nn::LayerNorm(torch::nn::LayerNormOptions({ _dim })));
+
+    _attn = register_module("attn",
+                            Attention(_dim, _num_heads, qkv_bias, qk_scale,
+                                      attn_drop_val, drop_val));
+    // no droppath for now
+    (void)drop_path;
+    _norm2 = register_module(
+        "norm2", torch::nn::LayerNorm(torch::nn::LayerNormOptions({ _dim })));
+
+    unsigned int mlp_hidden_dim = static_cast<int>(_dim * mlp_ratio);
+    _mlp = register_module("mlp", MLP(_dim, mlp_hidden_dim, 0, act, drop_val));
+  }
+
+  torch::Tensor ViT::BlockImpl::forward(torch::Tensor x)
+  {
+    x = x + _attn(_norm1(x));
+    x + _mlp(_norm2(x));
+    return x;
+  }
+
+  /*-- PatchEmbedImpl --*/
+  void ViT::PatchEmbedImpl::init_block(const int &img_size,
+                                       const int &patch_size)
+  {
+    _img_size = std::make_pair<unsigned int, unsigned int>(img_size, img_size);
+    _patch_size
+        = std::make_pair<unsigned int, unsigned int>(patch_size, patch_size);
+    _num_patches = std::floor(_img_size.second / _patch_size.second)
+                   * std::floor(_img_size.first / _patch_size.first);
+
+    _proj = register_module(
+        "proj", torch::nn::Conv2d(
+                    torch::nn::Conv2dOptions(_in_chans, _embed_dim, patch_size)
+                        .stride(patch_size)));
+  }
+
+  torch::Tensor ViT::PatchEmbedImpl::forward(torch::Tensor x)
+  {
+    x = _proj(x).flatten(2).transpose(1, 2);
+    return x;
+  }
+
+  /*-- ViTImpl --*/
+  void ViT::get_params_and_init_block(const ImgTorchInputFileConn &inputc,
+                                      const APIData &ad_params)
+  {
+    int patch_size = 16;
+    int in_chans = inputc._bw ? 1 : 3;
+    int embed_dim = 768;
+    int num_heads = 12;
+    double mlp_ratio = 4.0;
+    bool qkv_bias = false;
+    double qk_scale = -1.0;
+    double drop_rate = 0.0;
+    double attn_drop_rate = 0.0;
+
+    _img_size = inputc.width();
+    _num_classes = 2;
+    if (ad_params.has("nclasses"))
+      _num_classes = ad_params.get("nclasses").get<int>();
+    _depth = 12;
+
+    if (ad_params.has("dropout"))
+      drop_rate = attn_drop_rate = ad_params.get("dropout").get<double>();
+
+    std::string vit_flavor = "vit_base_patch16";
+    if (ad_params.has("vit_flavor"))
+      vit_flavor = ad_params.get("vit_flavor").get<std::string>();
+
+    if (vit_flavor == "vit_small_patch16")
+      {
+        _depth = 8;
+        num_heads = 8;
+        mlp_ratio = 3.0;
+      }
+    else if (vit_flavor == "vit_base_patch16")
+      {
+        qkv_bias = true;
+      }
+    else if (vit_flavor == "vit_base_patch32")
+      {
+        patch_size = 32;
+        qkv_bias = true;
+      }
+    else if (vit_flavor == "vit_large_patch16")
+      {
+        embed_dim = 1024;
+        _depth = 24;
+        num_heads = 16;
+        qkv_bias = true;
+      }
+    else if (vit_flavor == "vit_large_patch32")
+      {
+        patch_size = 32;
+        embed_dim = 1024;
+        _depth = 24;
+        num_heads = 16;
+        qkv_bias = true;
+      }
+    else if (vit_flavor == "vit_huge_patch16")
+      {
+        embed_dim = 1280;
+        _depth = 32;
+        num_heads = 16;
+      }
+    else if (vit_flavor == "vit_huge_patch32")
+      {
+        patch_size = 32;
+        embed_dim = 1280;
+        _depth = 32;
+        num_heads = 16;
+      }
+    else if (vit_flavor == "vit_mini_patch16")
+      {
+        _depth = 4;
+        num_heads = 4;
+        mlp_ratio = 1.0;
+        embed_dim = 256;
+      }
+    else if (vit_flavor == "vit_mini_patch32")
+      {
+        patch_size = 32;
+        _depth = 4;
+        num_heads = 4;
+        mlp_ratio = 1.0;
+        embed_dim = 256;
+      }
+    else
+      {
+        throw MLLibBadParamException("unknown ViT flavor " + vit_flavor);
+      }
+    init_block(_img_size, patch_size, in_chans, embed_dim, num_heads,
+               mlp_ratio, qkv_bias, qk_scale, drop_rate, attn_drop_rate);
+  }
+
+  void ViT::init_block(const int &img_size, const int &patch_size,
+                       const int &in_chans, const int &embed_dim,
+                       const int &num_heads, const double &mlp_ratio,
+                       const double &qkv_bias, const double &qk_scale,
+                       const double &drop_rate, const double &attn_drop_rate)
+  {
+    _num_features = embed_dim;
+    _patch_embed = register_module(
+        "patch_embed", PatchEmbed(img_size, patch_size, in_chans, embed_dim));
+    unsigned int num_patches = _patch_embed->_num_patches;
+
+    _cls_token
+        = register_parameter("cls_token", torch::randn({ 1, 1, embed_dim }));
+    _pos_embed = register_parameter(
+        "pos_embed", torch::randn({ 1, num_patches + 1, embed_dim }));
+    _pos_drop = register_module(
+        "pos_drop", torch::nn::Dropout(torch::nn::DropoutOptions(drop_rate)));
+
+    for (unsigned int d = 0; d < _depth; ++d)
+      {
+        _blocks.push_back(
+            register_module("block_" + std::to_string(d),
+                            Block(embed_dim, num_heads, mlp_ratio, qkv_bias,
+                                  qk_scale, drop_rate, attn_drop_rate, 0.0)));
+      }
+    _norm = register_module(
+        "norm",
+        torch::nn::LayerNorm(torch::nn::LayerNormOptions({ embed_dim })));
+
+    _head
+        = register_module("head", torch::nn::Linear(embed_dim, _num_classes));
+  }
+
+  torch::Tensor ViT::forward_features(torch::Tensor x)
+  {
+    unsigned int B = x.sizes()[0];
+    x = _patch_embed(x);
+
+    auto cls_tokens = _cls_token.expand({ B, -1, -1 });
+    x = torch::cat({ cls_tokens, x }, 1);
+    x = x + _pos_embed;
+    x = _pos_drop(x);
+
+    for (auto &blk : _blocks)
+      {
+        // blk->pretty_print(std::cout);
+        // x = blk->as<Block>()(x);
+        x = blk->forward(x);
+      }
+
+    x = _norm(x);
+    x = torch::narrow(x, 1, 0, 1); // x[:,0]
+    return x;
+  }
+
+  torch::Tensor ViT::forward(torch::Tensor x)
+  {
+    x = forward_features(x);
+    x = _head(x);
+    x = x.reshape({ x.sizes()[0], _num_classes }); // custom
+    return x;
+  }
+}

--- a/src/backends/torch/native/templates/vit.h
+++ b/src/backends/torch/native/templates/vit.h
@@ -1,0 +1,276 @@
+/**
+ * DeepDetect
+ * Copyright (c) 2020 Jolibrain
+ * Author:  Emmanuel Benazera <emmanuel.benazera@jolibrain.com>
+ *
+ * This file is part of deepdetect.
+ *
+ * deepdetect is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * deepdetect is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with deepdetect.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef VIT_H
+#define VIT_H
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#include "torch/torch.h"
+#pragma GCC diagnostic pop
+#include "../../torchinputconns.h"
+#include "mllibstrategy.h"
+#include "../native_net.h"
+
+namespace dd
+{
+
+  class ViT : public NativeModule
+  {
+
+    class MLPImpl : public torch::nn::Module
+    {
+    public:
+      MLPImpl(const int &input_dim, const int &hidden_dim,
+              const int &output_dim, const std::string &act = "gelu",
+              const double &drop = 0.0)
+          : _input_dim(input_dim), _hidden_dim(hidden_dim),
+            _output_dim(output_dim), _act(act), _drop(drop)
+      {
+        init_block();
+      }
+
+      ~MLPImpl()
+      {
+      }
+
+      torch::Tensor forward(torch::Tensor x);
+
+    protected:
+      void init_block();
+
+      unsigned int _input_dim = 0;
+      unsigned int _hidden_dim = 0;
+      unsigned int _output_dim = 0;
+      std::string _act = "gelu";
+      double _drop = 0.0;
+
+      torch::nn::Linear _fc1{ nullptr };
+      torch::nn::Linear _fc2{ nullptr };
+      torch::nn::Dropout _drop1{ nullptr };
+    };
+
+    typedef torch::nn::ModuleHolder<MLPImpl> MLP;
+
+    class AttentionImpl : public torch::nn::Module
+    {
+    public:
+      AttentionImpl(const int &dim, const int &num_heads = 8,
+                    const bool &qkv_bias = false,
+                    const double &qk_scale = -1.0,
+                    const double &attn_drop_val = 0.0,
+                    const double &proj_drop_val = 0.0)
+          : _dim(dim), _num_heads(num_heads), _qkv_bias(qkv_bias),
+            _qk_scale(qk_scale), _attn_drop_val(attn_drop_val),
+            _proj_drop_val(proj_drop_val)
+      {
+        init_block();
+      }
+
+      ~AttentionImpl()
+      {
+      }
+
+      torch::Tensor forward(torch::Tensor x);
+
+    protected:
+      void init_block();
+
+      unsigned int _dim;
+      unsigned int _num_heads = 8;
+      bool _qkv_bias = false;
+      double _qk_scale = -1.0;
+      double _attn_drop_val = 0.0;
+      double _proj_drop_val = 0.0;
+
+      double _scale = 1.0;
+      unsigned int _head_dim = 0;
+
+      torch::nn::Linear _qkv{ nullptr };
+      torch::nn::Dropout _attn_drop{ nullptr };
+      torch::nn::Linear _proj{ nullptr };
+      torch::nn::Dropout _proj_drop{ nullptr };
+    };
+
+    typedef torch::nn::ModuleHolder<AttentionImpl> Attention;
+
+    class BlockImpl : public torch::nn::Module
+    {
+    public:
+      BlockImpl(const int &dim, const int &num_heads,
+                const double &mlp_ratio = 4.0, const bool &qkv_bias = false,
+                const double &qk_scale = -1.0, const double &drop_val = 0.0,
+                const double &attn_drop_val = 0.0,
+                const double &drop_path = 0.0, const std::string &act = "gelu")
+          : _dim(dim), _num_heads(num_heads)
+      {
+        init_block(mlp_ratio, qkv_bias, qk_scale, drop_val, attn_drop_val,
+                   drop_path, act);
+      }
+
+      ~BlockImpl()
+      {
+      }
+
+      torch::Tensor forward(torch::Tensor x);
+
+    protected:
+      void init_block(const double &mlp_ratio, const bool &qkv_bias,
+                      const double &qk_scale, const double &drop,
+                      const double &attn_drop, const double &drop_path,
+                      const std::string &act);
+
+      unsigned int _dim = 0;
+      unsigned int _num_heads = 0;
+
+      torch::nn::LayerNorm _norm1{ nullptr };
+      Attention _attn{ nullptr };
+      torch::nn::LayerNorm _norm2{ nullptr };
+      MLP _mlp{ nullptr };
+    };
+
+    typedef torch::nn::ModuleHolder<BlockImpl> Block;
+
+    class PatchEmbedImpl : public torch::nn::Module
+    {
+    public:
+      PatchEmbedImpl(const int &img_size = 224, const int &patch_size = 16,
+                     const int &in_chans = 3, const int &embed_dim = 768)
+          : _in_chans(in_chans), _embed_dim(embed_dim)
+      {
+        init_block(img_size, patch_size);
+      }
+
+      ~PatchEmbedImpl()
+      {
+      }
+
+      torch::Tensor forward(torch::Tensor x);
+
+      unsigned int _num_patches = 0;
+
+    protected:
+      void init_block(const int &img_size, const int &patch_size);
+
+      std::pair<unsigned int, unsigned int> _img_size;
+      std::pair<unsigned int, unsigned int> _patch_size;
+      unsigned int _in_chans = 3;
+      unsigned int _embed_dim = 768;
+
+      torch::nn::Conv2d _proj{ nullptr };
+    };
+
+    typedef torch::nn::ModuleHolder<PatchEmbedImpl> PatchEmbed;
+
+    // TODO: Hybrid embed
+
+  public:
+    ViT(const int &img_size = 224, const int &patch_size = 16,
+        const int &in_chans = 3, const int &num_classes = 2,
+        const int &embed_dim = 768, const int &depth = 12,
+        const int &num_heads = 12, const double &mlp_ratio = 4.0,
+        const bool &qkv_bias = false, const double &qk_scale = -1.0,
+        const double &drop_rate = 0.0, const double &attn_drop_rate = 0.0)
+        : _img_size(img_size), _num_classes(num_classes), _depth(depth)
+    {
+      init_block(_img_size, patch_size, in_chans, embed_dim, num_heads,
+                 mlp_ratio, qkv_bias, qk_scale, drop_rate, attn_drop_rate);
+    }
+
+    ViT(const ImgTorchInputFileConn &inputc, const APIData &ad_params)
+    {
+      get_params_and_init_block(inputc, ad_params);
+    }
+
+    virtual ~ViT()
+    {
+    }
+
+    void get_params_and_init_block(const ImgTorchInputFileConn &inputc,
+                                   const APIData &ad_params);
+
+    virtual torch::Tensor forward(torch::Tensor x);
+
+    torch::Tensor forward_features(torch::Tensor x);
+
+    virtual torch::Tensor extract(torch::Tensor x, std::string extract_layer)
+    {
+      (void)x;
+      (void)extract_layer;
+      return torch::Tensor();
+    }
+
+    virtual bool extractable(std::string extract_layer) const
+    {
+      (void)extract_layer;
+      return false;
+    }
+
+    virtual std::vector<std::string> extractable_layers() const
+    {
+      return std::vector<std::string>();
+    }
+
+    virtual torch::Tensor cleanup_output(torch::Tensor output)
+    {
+      return output;
+    }
+
+    virtual torch::Tensor loss(std::string loss, torch::Tensor input,
+                               torch::Tensor output, torch::Tensor target)
+    {
+      (void)loss;
+      (void)input;
+      (void)output;
+      (void)target;
+      return torch::Tensor();
+    }
+
+    virtual void update_input_connector(TorchInputInterface &inputc)
+    {
+      (void)inputc;
+    }
+
+  protected:
+    void init_block(const int &img_size, const int &patch_size,
+                    const int &in_chans, const int &embed_dim,
+                    const int &num_heads, const double &mlp_ratio,
+                    const double &qkv_bias, const double &qk_scale,
+                    const double &drop_rate, const double &attn_drop_rate);
+
+    unsigned int _img_size = 224;
+    unsigned int _num_classes;
+    unsigned int _depth = 12;
+    unsigned int _num_features;
+
+    PatchEmbed _patch_embed{ nullptr };
+    torch::Tensor _cls_token;
+    torch::Tensor _pos_embed;
+    torch::nn::Dropout _pos_drop{ nullptr };
+    // torch::nn::ModuleList _blocks;
+    std::vector<Block> _blocks;
+    torch::nn::LayerNorm _norm{ nullptr };
+    torch::nn::Linear _head{ nullptr };
+  };
+
+}
+
+#endif

--- a/src/backends/torch/torchlib.cc
+++ b/src/backends/torch/torchlib.cc
@@ -274,7 +274,12 @@ namespace dd
       }
     else if (!_template.empty())
       {
-        throw MLLibBadParamException("template");
+        if (NativeFactory::valid_template_def(_template))
+          _module.create_native_template<TInputConnectorStrategy>(
+              _template, lib_ad, this->_inputc, this->_mlmodel, _main_device);
+        else
+          throw MLLibBadParamException("invalid torch model template "
+                                       + _template);
       }
 
     if (_classification)

--- a/src/backends/torch/torchmodule.cc
+++ b/src/backends/torch/torchmodule.cc
@@ -159,23 +159,33 @@ namespace dd
   }
 
   template <class TInputConnectorStrategy>
-  void TorchModule::post_transform(const std::string tmpl,
-                                   const APIData &template_params,
-                                   const TInputConnectorStrategy &inputc,
-                                   const TorchModel &tmodel,
-                                   const torch::Device &device)
+  void TorchModule::create_native_template(
+      const std::string &tmpl, const APIData &lib_ad,
+      const TInputConnectorStrategy &inputc, const TorchModel &tmodel,
+      const torch::Device &device)
   {
-    _device = device;
+    _device = device; // TODO: should be set with set_device elsewhere
     this->_native = std::shared_ptr<NativeModule>(
-        NativeFactory::from_template<TInputConnectorStrategy>(
-            tmpl, template_params, inputc));
+        NativeFactory::from_template<TInputConnectorStrategy>(tmpl, lib_ad,
+                                                              inputc));
 
     if (_native)
       {
         _logger->info("created net using template " + tmpl);
         native_model_load(tmodel);
       }
+  }
 
+  template <class TInputConnectorStrategy>
+  void TorchModule::post_transform(const std::string tmpl,
+                                   const APIData &template_params,
+                                   const TInputConnectorStrategy &inputc,
+                                   const TorchModel &tmodel,
+                                   const torch::Device &device)
+  {
+    if (!_native)
+      create_native_template<TInputConnectorStrategy>(tmpl, template_params,
+                                                      inputc, tmodel, device);
     if (_graph)
       {
         std::vector<long int> dims = inputc._dataset.datasize(0);

--- a/src/backends/torch/torchmodule.h
+++ b/src/backends/torch/torchmodule.h
@@ -127,6 +127,12 @@ namespace dd
      * \brief generic part of hooks below
      */
     template <class TInputConnectorStrategy>
+    void create_native_template(const std::string &tmpl, const APIData &lib_ad,
+                                const TInputConnectorStrategy &inputc,
+                                const TorchModel &tmodel,
+                                const torch::Device &device);
+
+    template <class TInputConnectorStrategy>
     void post_transform(const std::string tmpl, const APIData &template_params,
                         const TInputConnectorStrategy &inputc,
                         const TorchModel &tmodel, const torch::Device &device);

--- a/tests/ut-torchapi.cc
+++ b/tests/ut-torchapi.cc
@@ -49,6 +49,8 @@ static std::string resnet50_test_data
 static std::string resnet50_test_image
     = "../examples/torch/resnet50_training_torch/train/cats/cat.102.jpg";
 
+static std::string vit_train_repo = "../examples/torch/vit_training_torch/";
+
 static std::string bert_classif_repo
     = "../examples/torch/bert_inference_torch/";
 static std::string bert_train_repo
@@ -62,6 +64,7 @@ static std::string iterations_nbeats_cpu = "100";
 static std::string iterations_nbeats_gpu = "1000";
 
 static std::string iterations_resnet50 = "2000";
+static std::string iterations_vit = "200";
 
 TEST(torchapi, service_predict)
 {
@@ -1086,6 +1089,7 @@ TEST(torchapi, service_train_clip)
         + "\"},\"parameters\":{\"input\":{\"connector\":\"image\","
           "\"width\":224,\"height\":224,\"db\":true},\"mllib\":{\"nclasses\":"
           "2,\"finetuning\":true,\"gpu\":true}}}";
+
   std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
   ASSERT_EQ(created_str, joutstr);
 
@@ -1130,7 +1134,6 @@ TEST(torchapi, service_train_clip)
   // ASSERT_TRUE(cl1 == "cats");
   ASSERT_TRUE(jd["body"]["predictions"][0]["classes"][0]["prob"].GetDouble()
               > 0.0);
-
   std::unordered_set<std::string> lfiles;
   fileops::list_directory(resnet50_train_repo, true, false, false, lfiles);
   for (std::string ff : lfiles)
@@ -1148,4 +1151,88 @@ TEST(torchapi, service_train_clip)
   fileops::clear_directory(resnet50_train_repo + "test.lmdb");
   fileops::remove_dir(resnet50_train_repo + "train.lmdb");
   fileops::remove_dir(resnet50_train_repo + "test.lmdb");
+}
+
+TEST(torchapi, service_train_vit_images)
+{
+  mkdir(vit_train_repo.c_str(), 0777);
+
+  // Create service
+  JsonAPI japi;
+  std::string sname = "imgserv";
+  std::string jstr
+      = "{\"mllib\":\"torch\",\"description\":\"image\",\"type\":"
+        "\"supervised\",\"model\":{\"repository\":\""
+
+        + vit_train_repo
+        + "\"},\"parameters\":{\"input\":{\"connector\":\"image\","
+          "\"width\":224,\"height\":224,\"db\":true},\"mllib\":{\"nclasses\":"
+          "2,\"template\":\"vit\",\"gpu\":true}}}";
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
+
+  // Train
+  std::string jtrainstr
+      = "{\"service\":\"imgserv\",\"async\":false,\"parameters\":{"
+        "\"mllib\":{\"solver\":{\"iterations\":"
+        + iterations_vit
+        + ",\"base_lr\":1e-5,\"iter_size\":4,\"solver_type\":\"RANGER\","
+          "\"lookahead\":true,\"rectified\":false,\"adabelief\":true,"
+          "\"gradient_centralization\":true,"
+          "\"test_"
+          "interval\":"
+        + iterations_vit
+        + "},\"net\":{\"batch_size\":4},\"nclasses\":2,\"resume\":false},"
+          "\"input\":{\"db\":true,\"shuffle\":true,\"test_split\":0.1},"
+          "\"output\":{\"measure\":[\"f1\",\"acc\"]}},\"data\":[\""
+        + resnet50_train_data + "\",\"" + resnet50_test_data + "\"]}";
+  joutstr = japi.jrender(japi.service_train(jtrainstr));
+  JDoc jd;
+  std::cout << "joutstr=" << joutstr << std::endl;
+  jd.Parse<rapidjson::kParseNanAndInfFlag>(joutstr.c_str());
+  ASSERT_TRUE(!jd.HasParseError());
+  ASSERT_EQ(201, jd["status"]["code"]);
+
+  ASSERT_TRUE(jd["body"]["measure"]["acc"].GetDouble() <= 1) << "accuracy";
+  ASSERT_TRUE(jd["body"]["measure"]["acc"].GetDouble() >= 0.45)
+      << "accuracy good";
+  ASSERT_TRUE(jd["body"]["measure"]["f1"].GetDouble() <= 1) << "f1";
+
+  // Predict
+  std::string jpredictstr
+      = "{\"service\":\"imgserv\",\"parameters\":{\"output\":{\"best\":1}},"
+        "\"data\":[\""
+        + resnet50_test_image + "\"]}";
+
+  joutstr = japi.jrender(japi.service_predict(jpredictstr));
+  jd = JDoc();
+  std::cout << "joutstr=" << joutstr << std::endl;
+  jd.Parse<rapidjson::kParseNanAndInfFlag>(joutstr.c_str());
+  ASSERT_TRUE(!jd.HasParseError());
+  ASSERT_EQ(200, jd["status"]["code"]);
+  ASSERT_TRUE(jd["body"]["predictions"].IsArray());
+  std::string cl1
+      = jd["body"]["predictions"][0]["classes"][0]["cat"].GetString();
+  // Not training for long enough to be 100% sure a cat will be detected
+  // ASSERT_TRUE(cl1 == "cats");
+  ASSERT_TRUE(jd["body"]["predictions"][0]["classes"][0]["prob"].GetDouble()
+              > 0.0);
+
+  std::unordered_set<std::string> lfiles;
+  fileops::list_directory(vit_train_repo, true, false, false, lfiles);
+  for (std::string ff : lfiles)
+    {
+      if (ff.find("checkpoint") != std::string::npos
+          || ff.find("solver") != std::string::npos)
+        remove(ff.c_str());
+    }
+  ASSERT_TRUE(!fileops::file_exists(vit_train_repo + "checkpoint-"
+                                    + iterations_vit + ".ptw"));
+  ASSERT_TRUE(!fileops::file_exists(vit_train_repo + "checkpoint-"
+                                    + iterations_vit + ".pt"));
+
+  fileops::clear_directory(vit_train_repo + "train.lmdb");
+  fileops::clear_directory(vit_train_repo + "test.lmdb");
+  fileops::remove_dir(vit_train_repo + "train.lmdb");
+  fileops::remove_dir(vit_train_repo + "test.lmdb");
 }


### PR DESCRIPTION
This PR adds Vision Transformer (ViT) from https://arxiv.org/abs/2010.11929 as a native C++ model to the DD torch backend. 

The current implementation is adapted from https://github.com/rwightman/pytorch-image-models/blob/master/timm/models/vision_transformer.py

Remaining functionalities to implement:
- [x] passing template parameters to the model constructor
- [x] add unit test