### PR TITLE
docker: don't install headers on gpu runtime image

### DIFF
--- a/docker/cpu.Dockerfile
+++ b/docker/cpu.Dockerfile
@@ -9,7 +9,8 @@ ARG DEEPDETECT_DEFAULT_MODELS=true
 # Install build dependencies
 RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
 
-RUN --mount=type=cache,id=apt_cache_cpu,target=/var/cache/apt --mount=type=cache,id=apt_lib_cpu,target=/var/lib/apt \
+RUN --mount=type=cache,id=dede_cache_lib,sharing=locked,target=/var/cache/apt \
+    --mount=type=cache,id=dede_apt_lib,sharing=locked,target=/var/lib/apt \
     export DEBIAN_FRONTEND=noninteractive && \
     apt-get update -y && apt-get install -y python-dev apt-transport-https ca-certificates gnupg software-properties-common wget curl
 
@@ -21,7 +22,8 @@ RUN apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main'
 # bug closed as won't fix as python2 is eol: https://github.com/docker/for-linux/issues/502
 RUN cp /bin/true /usr/bin/pycompile
 
-RUN --mount=type=cache,id=apt_cache_cpu,target=/var/cache/apt --mount=type=cache,id=apt_lib_cpu,target=/var/lib/apt \
+RUN --mount=type=cache,id=dede_cache_lib,sharing=locked,target=/var/cache/apt \
+    --mount=type=cache,id=dede_apt_lib,sharing=locked,target=/var/lib/apt \
     export DEBIAN_FRONTEND=noninteractive && \
     apt-get update -y && apt-get install -y \
     git \
@@ -119,7 +121,8 @@ LABEL description="DeepDetect deep learning server & API / ${DEEPDETECT_ARCH} ve
 LABEL maintainer="emmanuel.benazera@jolibrain.com"
 
 # Install tools and dependencies
-RUN --mount=type=cache,id=apt_cache_cpu,target=/var/cache/apt --mount=type=cache,id=apt_lib_cpu,target=/var/lib/apt \
+RUN --mount=type=cache,id=dede_cache_lib,sharing=locked,target=/var/cache/apt \
+    --mount=type=cache,id=dede_apt_lib,sharing=locked,target=/var/lib/apt \
     export DEBIAN_FRONTEND=noninteractive && \
     apt-get update -y && apt-get install -y \
     wget \

--- a/docker/gpu.Dockerfile
+++ b/docker/gpu.Dockerfile
@@ -107,7 +107,7 @@ RUN --mount=type=cache,target=/ccache/ mkdir build && cd build && ../build.sh
 RUN ./docker/get_libs.sh
 
 # Build final Docker image
-FROM nvidia/cuda:10.2-cudnn7-devel-ubuntu18.04 AS runtime
+FROM nvidia/cuda:10.2-cudnn7-runtime-ubuntu18.04 AS runtime
 
 ARG DEEPDETECT_ARCH=gpu
 

--- a/docker/gpu.Dockerfile
+++ b/docker/gpu.Dockerfile
@@ -9,7 +9,8 @@ ARG DEEPDETECT_DEFAULT_MODELS=true
 # Install build dependencies
 RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
 
-RUN --mount=type=cache,id=apt_cache_gpu,target=/var/cache/apt --mount=type=cache,id=apt_lib_gpu,target=/var/lib/apt \
+RUN --mount=type=cache,id=dede_cache_lib,sharing=locked,target=/var/cache/apt \
+    --mount=type=cache,id=dede_apt_lib,sharing=locked,target=/var/lib/apt \
     export DEBIAN_FRONTEND=noninteractive && \
     apt-get update -y && apt-get install -y python-dev apt-transport-https ca-certificates gnupg software-properties-common wget curl
 
@@ -21,7 +22,8 @@ RUN apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main'
 # bug closed as won't fix as python2 is eol: https://github.com/docker/for-linux/issues/502
 RUN cp /bin/true /usr/bin/pycompile
 
-RUN --mount=type=cache,id=apt_cache_gpu,target=/var/cache/apt --mount=type=cache,id=apt_lib_gpu,target=/var/lib/apt \
+RUN --mount=type=cache,id=dede_cache_lib,sharing=locked,target=/var/cache/apt \
+    --mount=type=cache,id=dede_apt_lib,sharing=locked,target=/var/lib/apt \
     export DEBIAN_FRONTEND=noninteractive && \
     apt-get update -y && apt-get install -y \
     git \
@@ -119,7 +121,8 @@ LABEL description="DeepDetect deep learning server & API / ${DEEPDETECT_ARCH} ve
 LABEL maintainer="emmanuel.benazera@jolibrain.com"
 
 # Install tools and dependencies
-RUN --mount=type=cache,id=apt_cache_gpu,target=/var/cache/apt --mount=type=cache,id=apt_lib_gpu,target=/var/lib/apt \
+RUN --mount=type=cache,id=dede_cache_lib,sharing=locked,target=/var/cache/apt \
+    --mount=type=cache,id=dede_apt_lib,sharing=locked,target=/var/lib/apt \
     export DEBIAN_FRONTEND=noninteractive && \
     apt-get update -y && apt-get install -y \
     wget \

--- a/docker/gpu_tensorrt.Dockerfile
+++ b/docker/gpu_tensorrt.Dockerfile
@@ -9,7 +9,8 @@ ARG DEEPDETECT_DEFAULT_MODELS=true
 # Install build dependencies
 RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
 
-RUN --mount=type=cache,id=apt_cache_gpu_tensorrt,target=/var/cache/apt --mount=type=cache,id=apt_lib_gpu_tensorrt,target=/var/lib/apt \
+RUN --mount=type=cache,id=dede_cache_lib,sharing=locked,target=/var/cache/apt \
+    --mount=type=cache,id=dede_apt_lib,sharing=locked,target=/var/lib/apt \
     export DEBIAN_FRONTEND=noninteractive && \
     apt-get update -y && apt-get install -y python-dev apt-transport-https ca-certificates gnupg software-properties-common wget curl
 
@@ -21,7 +22,8 @@ RUN apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main'
 # bug closed as won't fix as python2 is eol: https://github.com/docker/for-linux/issues/502
 RUN cp /bin/true /usr/bin/pycompile
 
-RUN --mount=type=cache,id=apt_cache_gpu_tensorrt,target=/var/cache/apt --mount=type=cache,id=apt_lib_gpu_tensorrt,target=/var/lib/apt \
+RUN --mount=type=cache,id=dede_cache_lib,sharing=locked,target=/var/cache/apt \
+    --mount=type=cache,id=dede_apt_lib,sharing=locked,target=/var/lib/apt \
     export DEBIAN_FRONTEND=noninteractive && \
     apt-get update -y && apt-get install -y \
     git \
@@ -119,7 +121,8 @@ LABEL description="DeepDetect deep learning server & API / ${DEEPDETECT_ARCH} ve
 LABEL maintainer="emmanuel.benazera@jolibrain.com"
 
 # Install tools and dependencies
-RUN --mount=type=cache,id=apt_cache_gpu_tensorrt,target=/var/cache/apt --mount=type=cache,id=apt_lib_gpu_tensorrt,target=/var/lib/apt \
+RUN --mount=type=cache,id=dede_cache_lib,sharing=locked,target=/var/cache/apt \
+    --mount=type=cache,id=dede_apt_lib,sharing=locked,target=/var/lib/apt \
     export DEBIAN_FRONTEND=noninteractive && \
     apt-get update -y && apt-get install -y \
     wget \

--- a/docker/sync_gpu_dockerfiles.sh
+++ b/docker/sync_gpu_dockerfiles.sh
@@ -2,23 +2,29 @@
 
 here=$(dirname $(readlink -f $0))
 
-declare -A images
-images[gpu]="nvidia/cuda:10.2-cudnn7-devel-ubuntu18.04"
+declare -A runtime_images
+runtime_images[gpu]="nvidia/cuda:10.2-cudnn7-runtime-ubuntu18.04"
 # Ubuntu 18.04+cuda 10.2.80 + cuDNN 7.6.5 + TensorRT 7.0.0
 # https://docs.nvidia.com/deeplearning/tensorrt/container-release-notes/rel_20-03.html#rel_20-03
-images[gpu_tensorrt]="nvcr.io/nvidia/tensorrt:20.03-py3"
+runtime_images[gpu_tensorrt]="nvcr.io/nvidia/tensorrt:20.03-py3"
+
+declare -A devel_images
+devel_images[gpu]="nvidia/cuda:10.2-cudnn7-devel-ubuntu18.04"
+devel_images[gpu_tensorrt]="nvcr.io/nvidia/tensorrt:20.03-py3"
 
 declare -A builds
 builds[gpu_tensorrt]="tensorrt"
 
-for dest in "${!images[@]}" ; do
-    image=${images[$dest]}
+for dest in "${!runtime_images[@]}" ; do
+    runtime_image=${runtime_images[$dest]}
+    devel_image=${devel_images[$dest]}
     build=${builds[$dest]}
 
     [ ! "$build" ] && build="default"
 
     sed \
-        -e "s,FROM [^ ]*,FROM ${image},g" \
+        -e "s,FROM [^ ]* AS build,FROM ${devel_image} AS build,g" \
+        -e "s,FROM [^ ]* AS runtime,FROM ${runtime_image} AS runtime,g" \
         -e "s,ARG DEEPDETECT_ARCH=.*,ARG DEEPDETECT_ARCH=gpu,g" \
         -e "s,ARG DEEPDETECT_BUILD=.*,ARG DEEPDETECT_BUILD=${build},g" \
         -e "s/\(apt_\(cache\|lib\)\)_cpu/\1_${dest}/g" \

--- a/docker/sync_gpu_dockerfiles.sh
+++ b/docker/sync_gpu_dockerfiles.sh
@@ -27,6 +27,5 @@ for dest in "${!runtime_images[@]}" ; do
         -e "s,FROM [^ ]* AS runtime,FROM ${runtime_image} AS runtime,g" \
         -e "s,ARG DEEPDETECT_ARCH=.*,ARG DEEPDETECT_ARCH=gpu,g" \
         -e "s,ARG DEEPDETECT_BUILD=.*,ARG DEEPDETECT_BUILD=${build},g" \
-        -e "s/\(apt_\(cache\|lib\)\)_cpu/\1_${dest}/g" \
         $here/cpu.Dockerfile > $here/${dest}.Dockerfile
 done


### PR DESCRIPTION
## docker: don't install headers on gpu runtime image


## ci: fix race issue with docker apt cache
