### PR TITLE
Support for torch training by reading large image datasets directly from lists of files and targets

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -78,8 +78,8 @@ if (USE_TORCH)
 	generators/net_caffe_recurrent.cc
     backends/torch/torchlib.cc
     backends/torch/torchmodel.cc
-    backends/torch/torchinputconns.cc
     backends/torch/torchdataset.cc
+    backends/torch/torchinputconns.cc
     backends/torch/db.cpp
     backends/torch/db_lmdb.cpp
     backends/torch/native/templates/nbeats.cc

--- a/src/backends/torch/torchdataset.h
+++ b/src/backends/torch/torchdataset.h
@@ -59,7 +59,7 @@ namespace dd
     int64_t _current_index
         = 0; /**< current index for batch parallel data extraction */
     std::string _backend; /**< db backend (currently only lmdb supported= */
-    bool _db;             /**< is data in db ? */
+    bool _db = false;     /**< is data in db ? */
     int32_t _batches_per_transaction
         = 10; /**< number of batches per db transaction */
     std::shared_ptr<db::Transaction> _txn;   /**< db transaction pointer */
@@ -68,11 +68,15 @@ namespace dd
   public:
     std::shared_ptr<db::DB> _dbData; /**< db data */
     std::vector<int64_t> _indices;   /**< id/key  of data points */
+    std::vector<std::pair<std::string, std::vector<double>>>
+        _lfiles; /**< list of files */
 
     std::vector<TorchBatch> _batches; /**< Vector containing the whole dataset
                                          (the "cached data") */
     std::string _dbFullName;          /**< db filename */
-    InputConnectorStrategy *_inputc = nullptr;
+    InputConnectorStrategy *_inputc
+        = nullptr;               /**< back ptr to input connector. */
+    bool _classification = true; /**< whether a classification dataset. */
 
     /**
      * \brief empty constructor
@@ -89,7 +93,8 @@ namespace dd
           _current_index(d._current_index), _backend(d._backend), _db(d._db),
           _batches_per_transaction(d._batches_per_transaction), _txn(d._txn),
           _logger(d._logger), _dbData(d._dbData), _indices(d._indices),
-          _batches(d._batches), _dbFullName(d._dbFullName), _inputc(d._inputc)
+          _lfiles(d._lfiles), _batches(d._batches), _dbFullName(d._dbFullName),
+          _inputc(d._inputc), _classification(d._classification)
     {
     }
 
@@ -156,6 +161,15 @@ namespace dd
     }
 
     /**
+     * \brief set list of files
+     */
+    void set_list(
+        const std::vector<std::pair<std::string, std::vector<double>>> &lfiles)
+    {
+      _lfiles = lfiles;
+    }
+
+    /**
      * \brief setter for _logger
      */
     void set_logger(std::shared_ptr<spdlog::logger> logger)
@@ -184,7 +198,8 @@ namespace dd
      */
     bool empty() const
     {
-      return (!_db && cache_size() == 0) || (_db && _dbFullName.empty());
+      return (!_db && cache_size() == 0 && _lfiles.empty())
+             || (_db && _dbFullName.empty());
     }
 
     /**

--- a/src/backends/torch/torchdataset.h
+++ b/src/backends/torch/torchdataset.h
@@ -31,6 +31,11 @@
 
 #include "backends/torch/db.hpp"
 #include "backends/torch/db_lmdb.hpp"
+
+#include "inputconnectorstrategy.h"
+#include "torchutils.h"
+
+#include <opencv2/opencv.hpp>
 #include <random>
 
 namespace dd
@@ -67,6 +72,7 @@ namespace dd
     std::vector<TorchBatch> _batches; /**< Vector containing the whole dataset
                                          (the "cached data") */
     std::string _dbFullName;          /**< db filename */
+    InputConnectorStrategy *_inputc = nullptr;
 
     /**
      * \brief empty constructor
@@ -83,7 +89,7 @@ namespace dd
           _current_index(d._current_index), _backend(d._backend), _db(d._db),
           _batches_per_transaction(d._batches_per_transaction), _txn(d._txn),
           _logger(d._logger), _dbData(d._dbData), _indices(d._indices),
-          _batches(d._batches), _dbFullName(d._dbFullName)
+          _batches(d._batches), _dbFullName(d._dbFullName), _inputc(d._inputc)
     {
     }
 
@@ -201,6 +207,17 @@ namespace dd
      * \brief Split a percentage of this dataset
      */
     TorchDataset split(double start, double stop);
+
+    /*-- image tools --*/
+    int add_image_file(const std::string &fname, const int &target,
+                       const int &height, const int &width);
+    int add_image_file(const std::string &fname,
+                       const std::vector<double> &target, const int &height,
+                       const int &width);
+    at::Tensor image_to_tensor(const cv::Mat &bgr, const int &height,
+                               const int &width);
+    at::Tensor target_to_tensor(const int &target);
+    at::Tensor target_to_tensor(const std::vector<double> &target);
 
   private:
     /**

--- a/src/backends/torch/torchinputconns.cc
+++ b/src/backends/torch/torchinputconns.cc
@@ -191,7 +191,8 @@ namespace dd
 
         for (size_t i = 0; i < this->_images.size(); ++i)
           {
-            _dataset.add_batch({ image_to_tensor(this->_images[i]) });
+            _dataset.add_batch({ _dataset.image_to_tensor(this->_images[i],
+                                                          _height, _width) });
           }
       }
     else // if (!_train)
@@ -267,13 +268,14 @@ namespace dd
                 // Read data
                 for (const std::pair<std::string, int> &lfile : lfiles)
                   {
-                    add_image_file<int>(_dataset, lfile.first, lfile.second);
+                    _dataset.add_image_file(lfile.first, lfile.second, _height,
+                                            _width);
                   }
 
                 for (const std::pair<std::string, int> &lfile : test_lfiles)
                   {
-                    add_image_file<int>(_test_dataset, lfile.first,
-                                        lfile.second);
+                    _test_dataset.add_image_file(lfile.first, lfile.second,
+                                                 _height, _width);
                   }
 
                 // Write corresp file
@@ -309,15 +311,15 @@ namespace dd
                 for (const std::pair<std::string, std::vector<double>> &lfile :
                      lfiles)
                   {
-                    add_image_file<std::vector<double>>(_dataset, lfile.first,
-                                                        lfile.second);
+                    _dataset.add_image_file(lfile.first, lfile.second, _height,
+                                            _width);
                   }
 
                 for (const std::pair<std::string, std::vector<double>> &lfile :
                      test_lfiles)
                   {
-                    add_image_file<std::vector<double>>(
-                        _test_dataset, lfile.first, lfile.second);
+                    _test_dataset.add_image_file(lfile.first, lfile.second,
+                                                 _height, _width);
                   }
               }
           }
@@ -330,7 +332,7 @@ namespace dd
       }
   }
 
-  template <typename T>
+  /*template <typename T>
   int ImgTorchInputFileConn::add_image_file(TorchDataset &dataset,
                                             const std::string &fname, T target)
   {
@@ -414,7 +416,7 @@ namespace dd
         ++n;
       }
     return targett;
-  }
+    }*/
 
   template <typename T>
   void ImgTorchInputFileConn::split_dataset(

--- a/src/backends/torch/torchinputconns.cc
+++ b/src/backends/torch/torchinputconns.cc
@@ -308,18 +308,26 @@ namespace dd
                   }
 
                 // Read data
-                for (const std::pair<std::string, std::vector<double>> &lfile :
-                     lfiles)
+                if (_db)
                   {
-                    _dataset.add_image_file(lfile.first, lfile.second, _height,
-                                            _width);
-                  }
+                    for (const std::pair<std::string, std::vector<double>>
+                             &lfile : lfiles)
+                      {
+                        _dataset.add_image_file(lfile.first, lfile.second,
+                                                _height, _width);
+                      }
 
-                for (const std::pair<std::string, std::vector<double>> &lfile :
-                     test_lfiles)
+                    for (const std::pair<std::string, std::vector<double>>
+                             &lfile : test_lfiles)
+                      {
+                        _test_dataset.add_image_file(lfile.first, lfile.second,
+                                                     _height, _width);
+                      }
+                  }
+                else
                   {
-                    _test_dataset.add_image_file(lfile.first, lfile.second,
-                                                 _height, _width);
+                    _dataset.set_list(lfiles);
+                    _test_dataset.set_list(test_lfiles);
                   }
               }
           }

--- a/src/backends/torch/torchinputconns.h
+++ b/src/backends/torch/torchinputconns.h
@@ -261,17 +261,6 @@ namespace dd
      * \brief read data given apiData
      */
     void transform(const APIData &ad);
-
-  private:
-    /*template <typename T>
-    int add_image_file(TorchDataset &dataset, const std::string &fname,
-                       T target);
-
-    at::Tensor image_to_tensor(const cv::Mat &bgr);
-
-    at::Tensor target_to_tensor(const int &target);
-
-    at::Tensor target_to_tensor(const std::vector<double> &target);*/
   };
 
   /**
@@ -286,6 +275,8 @@ namespace dd
      */
     TxtTorchInputFileConn() : TxtInputFileConn()
     {
+      _dataset._inputc = this;
+      _test_dataset._inputc = this;
       _vocab_sep = '\t';
       set_transaction_size(TORCH_TEXT_TRANSACTION_SIZE);
     }
@@ -296,6 +287,8 @@ namespace dd
         : TxtInputFileConn(i), TorchInputInterface(i), _width(i._width),
           _height(i._height)
     {
+      _dataset._inputc = this;
+      _test_dataset._inputc = this;
       set_transaction_size(TORCH_TEXT_TRANSACTION_SIZE);
     }
 
@@ -308,8 +301,6 @@ namespace dd
      */
     void init(const APIData &ad)
     {
-      _dataset._inputc = this;
-      _test_dataset._inputc = this;
       TxtInputFileConn::init(ad);
       TorchInputInterface::init(ad, _model_repo, _logger);
       fillup_parameters(ad);
@@ -437,6 +428,8 @@ namespace dd
         : CSVTSInputFileConn(i), TorchInputInterface(i), _offset(i._offset),
           _timesteps(i._timesteps), _datadim(i._datadim)
     {
+      _dataset._inputc = this;
+      _test_dataset._inputc = this;
     }
 
     ~CSVTSTorchInputFileConn()
@@ -463,8 +456,6 @@ namespace dd
      */
     void init(const APIData &ad)
     {
-      _dataset._inputc = this;
-      _test_dataset._inputc = this;
       TorchInputInterface::init(ad, _model_repo, _logger);
       fillup_parameters(ad);
     }

--- a/src/backends/torch/torchinputconns.h
+++ b/src/backends/torch/torchinputconns.h
@@ -190,6 +190,8 @@ namespace dd
      */
     ImgTorchInputFileConn() : ImgInputFileConn()
     {
+      _dataset._inputc = this;
+      _test_dataset._inputc = this;
       set_transaction_size(TORCH_IMG_TRANSACTION_SIZE);
     }
 
@@ -199,6 +201,8 @@ namespace dd
     ImgTorchInputFileConn(const ImgTorchInputFileConn &i)
         : ImgInputFileConn(i), TorchInputInterface(i)
     {
+      _dataset._inputc = this;
+      _test_dataset._inputc = this;
       set_transaction_size(TORCH_IMG_TRANSACTION_SIZE);
     }
 
@@ -259,7 +263,7 @@ namespace dd
     void transform(const APIData &ad);
 
   private:
-    template <typename T>
+    /*template <typename T>
     int add_image_file(TorchDataset &dataset, const std::string &fname,
                        T target);
 
@@ -267,7 +271,7 @@ namespace dd
 
     at::Tensor target_to_tensor(const int &target);
 
-    at::Tensor target_to_tensor(const std::vector<double> &target);
+    at::Tensor target_to_tensor(const std::vector<double> &target);*/
   };
 
   /**
@@ -304,6 +308,8 @@ namespace dd
      */
     void init(const APIData &ad)
     {
+      _dataset._inputc = this;
+      _test_dataset._inputc = this;
       TxtInputFileConn::init(ad);
       TorchInputInterface::init(ad, _model_repo, _logger);
       fillup_parameters(ad);
@@ -457,6 +463,8 @@ namespace dd
      */
     void init(const APIData &ad)
     {
+      _dataset._inputc = this;
+      _test_dataset._inputc = this;
       TorchInputInterface::init(ad, _model_repo, _logger);
       fillup_parameters(ad);
     }

--- a/src/backends/torch/torchlib.cc
+++ b/src/backends/torch/torchlib.cc
@@ -442,6 +442,8 @@ namespace dd
     APIData ad_input = ad.getobj("parameters").getobj("input");
     if (ad_input.has("shuffle"))
       inputc._dataset.set_shuffle(ad_input.get("shuffle").get<bool>());
+    inputc._dataset._classification = inputc._test_dataset._classification
+        = _classification;
 
     try
       {
@@ -530,8 +532,10 @@ namespace dd
     TorchDataset eval_dataset;
     if (!inputc._test_dataset.empty())
       {
-        eval_dataset = inputc._test_dataset; //.split(0, 0.1);
+        eval_dataset = inputc._test_dataset;
       }
+    else
+      throw MLLibBadParamException("empty test dataset");
 
     // create solver
     tsolver.create(_module);


### PR DESCRIPTION
~~This is placeholder PR that depends on #924  and #969 and will be rebased after these PRs have been merged.~~

It implements reading data from files. This is complicated by the dependance on input connector `DDImg` on once side and the virtual function `get_batch` from `torch::Dataset` on the other side.

EDIT: this is part of an update to `TorchDataset::get_batch` and images db support with the torch backend. 