### PR TITLE
feat(torch/nbeats): allow different sizes for backcast and forecast ,…

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -743,6 +743,10 @@ embedding_size  | int    | yes      | 768     | embedding size for NLP models
 freeze_traced   | bool   | yes      | false   | Freeze the traced part of the net during finetuning (e.g. for classification)
 template        | string | yes      | ""      | for language models, either "bert" or "gpt2", "recurrent" for LSTM-like models (including autoencoder), "nbeats" for nbeats model
 regression | bool            | yes                      | false   | Whether the model is a regressor
+timesteps     | int            | yes      | N/A            | Number of timesteps for time models (LSTM/NBEATS...) : this sets the length of sequences that will be given for learning, every timestep contains inputs and outputs as defined by the csv/csvts connector
+offset        | int            | yes      | N/A            | Offset beween start point of sequences with connector `cvsts`, defining the overlap of input series
+forecast_timesteps      | int            | yes      | N/A       | for nbeats model, this gives the length of the forecast
+backcast_timesteps      | int            | yes      | N/A       | for nbeats model, this gives the length of the backcast
 
 
 Model instantiation parameters:

--- a/src/backends/torch/native/native_net.h
+++ b/src/backends/torch/native/native_net.h
@@ -71,8 +71,6 @@ namespace dd
     virtual torch::Tensor loss(std::string loss, torch::Tensor input,
                                torch::Tensor output, torch::Tensor target)
         = 0;
-
-    virtual void update_input_connector(TorchInputInterface &inputc) = 0;
   };
 
   template <typename T>

--- a/src/backends/torch/torchinputconns.cc
+++ b/src/backends/torch/torchinputconns.cc
@@ -640,6 +640,14 @@ namespace dd
 
   void CSVTSTorchInputFileConn::set_datadim(bool is_test_data)
   {
+    if ((_forecast_timesteps < 0 || _backcast_timesteps < 0) && _timesteps < 0)
+      {
+        std::string errmsg
+            = "no value given to [forecast_|backcast_|]timesteps";
+        this->_logger->error(errmsg);
+        throw InputConnectorBadParamException(errmsg);
+      }
+
     if (_train && _ntargets != _label.size())
       {
         _logger->warn(
@@ -658,6 +666,9 @@ namespace dd
       _datadim = _csvtsdata_test[0][0]._v.size();
     else
       _datadim = _csvtsdata[0][0]._v.size();
+
+    if (_ntargets == 0 && _forecast_timesteps > 0)
+      _ntargets = _datadim;
 
     std::vector<int> lpos = _label_pos;
     _label_pos.clear();
@@ -729,28 +740,137 @@ namespace dd
       }
     else
       {
-        // in test mode, prevent connector to split serie in training chunks
-        // but for nbeats
-        if (!_split_ts_for_predict)
-          _timesteps = _csvtsdata[0].size();
+        // in test mode, prevent connector to create different series based on
+        // offset
+        if (_timesteps > 0)
+          _offset = _timesteps;
+        else
+          _offset = _backcast_timesteps + _forecast_timesteps;
         fill_dataset(_dataset, false);
         _csvtsdata.clear();
         _csvtsdata_test.clear();
       }
   }
 
-  void CSVTSTorchInputFileConn::fill_dataset(TorchDataset &dataset,
-                                             bool use_csvtsdata_test)
+  void CSVTSTorchInputFileConn::add_data_instance_forecast(
+      const long int tstart, const int vecindex, TorchDataset &dataset,
+      const std::vector<CSVline> &seq)
   {
-    _ids.clear();
-    // we have _csvtsdata and csvtsdata_test to put into TorchDataset _dataset
-    // , _test_dataset
-    std::vector<std::vector<CSVline>> *data;
-    if (use_csvtsdata_test)
-      data = &this->_csvtsdata_test;
-    else
-      data = &this->_csvtsdata;
+    std::vector<at::Tensor> data_sequence;
+    if (_fnames.size() > static_cast<unsigned int>(vecindex))
+      _ids.push_back(_fnames[vecindex] + " #" + std::to_string(tstart) + "_"
+                     + std::to_string(tstart + _forecast_timesteps
+                                      + _backcast_timesteps - 1));
+    for (long int ti = tstart; ti < tstart + _backcast_timesteps; ++ti)
+      {
+        std::vector<double> datavec;
+        for (int di = 0; di < this->_datadim; ++di)
+          datavec.push_back(seq[ti]._v[di]);
+        at::Tensor data
+            = torch::from_blob(&datavec[0], at::IntList{ _datadim },
+                               torch::kFloat64)
+                  .clone()
+                  .to(torch::kFloat32);
+        data_sequence.push_back(data);
+      }
+    at::Tensor dst = torch::stack(data_sequence);
 
+    if (static_cast<int>(seq.size())
+        >= _backcast_timesteps + _forecast_timesteps + tstart)
+      {
+        std::vector<at::Tensor> pred_sequence;
+        for (long int ti = tstart + _backcast_timesteps;
+             ti < tstart + _backcast_timesteps + _forecast_timesteps; ++ti)
+          {
+            std::vector<double> predvec;
+            for (int di = 0; di < this->_datadim; ++di)
+              predvec.push_back(seq[ti]._v[di]);
+            at::Tensor pred
+                = torch::from_blob(&predvec[0], at::IntList{ _datadim },
+                                   torch::kFloat64)
+                      .clone()
+                      .to(torch::kFloat32);
+            pred_sequence.push_back(pred);
+          }
+        at::Tensor pst = torch::stack(pred_sequence);
+        dataset.add_batch({ dst }, { pst });
+      }
+    else // we are in inference mode, not forecast available
+      dataset.add_batch({ dst }, {});
+  }
+
+  void CSVTSTorchInputFileConn::discard_warn(int vecindex,
+                                             unsigned int seq_size, bool test)
+  {
+    int tsteps = _timesteps > 0 ? _timesteps
+                                : _backcast_timesteps + _forecast_timesteps;
+    std::string errmsg = "data does not contains enough timesteps, "
+                         "discarding (seq_size:"
+                         + std::to_string(seq_size)
+                         + " timesteps:" + std::to_string(tsteps);
+    if (test)
+      {
+        if (static_cast<unsigned int>(vecindex) < _test_fnames.size())
+          errmsg = "file " + _test_fnames[vecindex]
+                   + " does not contains enough timesteps, "
+                     "discarding";
+      }
+    else
+      {
+        if (static_cast<unsigned int>(vecindex) < _fnames.size())
+          errmsg = "file " + _fnames[vecindex]
+                   + " does not contains enough timesteps, "
+                     "discarding";
+      }
+    _tilogger->warn(errmsg);
+  }
+
+  void CSVTSTorchInputFileConn::fill_dataset_forecast(TorchDataset &dataset,
+                                                      bool test)
+  {
+    std::vector<std::vector<CSVline>> &data
+        = test ? this->_csvtsdata_test : this->_csvtsdata;
+
+    int vecindex = -1;
+
+    for (const std::vector<CSVline> &seq : data)
+      {
+        vecindex++;
+        if (_train)
+          {
+            long int tstart = 0;
+            if (static_cast<long int>(seq.size())
+                < _backcast_timesteps + _forecast_timesteps)
+              {
+                discard_warn(vecindex, seq.size(), test);
+                continue;
+              }
+            for (; tstart + _backcast_timesteps + _forecast_timesteps
+                   < static_cast<long int>(seq.size());
+                 tstart += _offset)
+              add_data_instance_forecast(tstart, vecindex, dataset, seq);
+            if (tstart < static_cast<long int>(seq.size()) - 1)
+              add_data_instance_forecast(seq.size() - _backcast_timesteps
+                                             - _forecast_timesteps,
+                                         vecindex, dataset, seq);
+          }
+        else // predict
+          {
+            if (static_cast<long int>(seq.size()) < _backcast_timesteps)
+              {
+                discard_warn(vecindex, seq.size(), test);
+                continue;
+              }
+            add_data_instance_forecast(seq.size() - _backcast_timesteps,
+                                       vecindex, dataset, seq);
+          }
+      }
+  }
+
+  void CSVTSTorchInputFileConn::add_data_instance_labels(
+      const long int tstart, const int vecindex, TorchDataset &dataset,
+      const std::vector<CSVline> &seq)
+  {
     unsigned int label_size = _label_pos.size();
     if (static_cast<int>(label_size) >= _datadim)
       {
@@ -762,100 +882,83 @@ namespace dd
         throw InputConnectorBadParamException(errmsg);
       }
     unsigned int data_size = _datadim - label_size;
-    int vecindex = -1;
+    std::vector<at::Tensor> data_sequence;
+    std::vector<at::Tensor> label_sequence;
+    if (_fnames.size() > static_cast<unsigned int>(vecindex))
+      {
+        if (_train)
+          _ids.push_back(_fnames[vecindex] + " #" + std::to_string(tstart)
+                         + "_" + std::to_string(tstart + _timesteps - 1));
+        else // in predict mode we do not split
+          _ids.push_back(_fnames[vecindex] + " #" + std::to_string(tstart)
+                         + "_" + std::to_string(seq.size() - 1));
+      }
+    for (long int ti = tstart; ti < tstart + _timesteps; ++ti)
+      {
+        std::vector<double> datavec;
+        std::vector<double> labelvec;
 
-    for (std::vector<CSVline> &seq : *data)
+        for (unsigned int li = 0; li < label_size; ++li)
+          labelvec.push_back(seq[ti]._v[_label_pos[li]]);
+        for (int di = 0; di < this->_datadim; ++di)
+          if (std::find(_label_pos.begin(), _label_pos.end(), di)
+              == _label_pos.end())
+            datavec.push_back(seq[ti]._v[di]);
+
+        at::Tensor data
+            = torch::from_blob(&datavec[0], at::IntList{ data_size },
+                               torch::kFloat64)
+                  .clone()
+                  .to(torch::kFloat32);
+        at::Tensor label
+            = torch::from_blob(&labelvec[0], at::IntList{ label_size },
+                               torch::kFloat64)
+                  .clone()
+                  .to(torch::kFloat32);
+        data_sequence.push_back(data);
+        label_sequence.push_back(label);
+      }
+    at::Tensor dst = torch::stack(data_sequence);
+    at::Tensor lst = torch::stack(label_sequence);
+    dataset.add_batch({ dst }, { lst });
+  }
+
+  void CSVTSTorchInputFileConn::fill_dataset_labels(TorchDataset &dataset,
+                                                    bool test)
+  {
+    int vecindex = -1;
+    std::vector<std::vector<CSVline>> &data
+        = test ? this->_csvtsdata_test : this->_csvtsdata;
+
+    for (const std::vector<CSVline> &seq : data)
       {
         vecindex++;
         long int tstart = 0;
         if (static_cast<long int>(seq.size()) < _timesteps)
           {
-            if (use_csvtsdata_test)
-              _tilogger->warn(
-                  "file " + _test_fnames[vecindex]
-                  + " does not contains enough timesteps, discarding");
-            else
-              _tilogger->warn(
-                  "file " + _fnames[vecindex]
-                  + " does not contains enough timesteps, discarding");
+            discard_warn(vecindex, seq.size(), test);
             continue;
           }
         for (; tstart + _timesteps < static_cast<long int>(seq.size());
              tstart += _offset)
-          // construct timeseries here	, using timesteps and offset
-          // from data pointer above
-          {
-            std::vector<at::Tensor> data_sequence;
-            std::vector<at::Tensor> label_sequence;
-            _ids.push_back(_fnames[vecindex] + " #" + std::to_string(tstart)
-                           + "_" + std::to_string(tstart + _timesteps - 1));
-            for (long int ti = tstart; ti < tstart + _timesteps; ++ti)
-              {
-                std::vector<double> datavec;
-                std::vector<double> labelvec;
-
-                for (unsigned int li = 0; li < label_size; ++li)
-                  labelvec.push_back(seq[ti]._v[_label_pos[li]]);
-                for (int di = 0; di < this->_datadim - 1; ++di)
-                  if (std::find(_label_pos.begin(), _label_pos.end(), di)
-                      == _label_pos.end())
-                    datavec.push_back(seq[ti]._v[di]);
-
-                at::Tensor data
-                    = torch::from_blob(&datavec[0], at::IntList{ data_size },
-                                       torch::kFloat64)
-                          .clone()
-                          .to(torch::kFloat32);
-                at::Tensor label
-                    = torch::from_blob(&labelvec[0], at::IntList{ label_size },
-                                       torch::kFloat64)
-                          .clone()
-                          .to(torch::kFloat32);
-                data_sequence.push_back(data);
-                label_sequence.push_back(label);
-              }
-            at::Tensor dst = torch::stack(data_sequence);
-            at::Tensor lst = torch::stack(label_sequence);
-            dataset.add_batch({ dst }, { lst });
-          }
-        if (tstart < static_cast<long int>(seq.size()) - 1
-            && static_cast<long int>(seq.size()) >= _timesteps)
-          {
-            std::vector<at::Tensor> data_sequence;
-            std::vector<at::Tensor> label_sequence;
-
-            tstart = seq.size() - _timesteps;
-            if (_fnames.size() > static_cast<unsigned int>(vecindex))
-              _ids.push_back(_fnames[vecindex] + " #" + std::to_string(tstart)
-                             + "_" + std::to_string(tstart + _timesteps - 1));
-            for (int ti = tstart; ti < tstart + _timesteps; ++ti)
-              {
-                std::vector<double> datavec;
-                std::vector<double> labelvec;
-                for (unsigned int li = 0; li < label_size; ++li)
-                  labelvec.push_back(seq[ti]._v[_label_pos[li]]);
-                for (int di = 0; di < this->_datadim - 1; ++di)
-                  if (std::find(_label_pos.begin(), _label_pos.end(), di)
-                      == _label_pos.end())
-                    datavec.push_back(seq[ti]._v[di]);
-
-                at::Tensor data
-                    = torch::from_blob(&datavec[0], at::IntList{ data_size },
-                                       torch::kFloat64)
-                          .clone()
-                          .to(torch::kFloat32);
-                at::Tensor label
-                    = torch::from_blob(&labelvec[0], at::IntList{ label_size },
-                                       torch::kFloat64)
-                          .clone()
-                          .to(torch::kFloat32);
-                data_sequence.push_back(data);
-                label_sequence.push_back(label);
-              }
-            dataset.add_batch({ torch::stack(data_sequence) },
-                              { torch::stack(label_sequence) });
-          }
+          add_data_instance_labels(tstart, vecindex, dataset, seq);
+        if (tstart < static_cast<long int>(seq.size()) - 1)
+          add_data_instance_labels(seq.size() - _timesteps, vecindex, dataset,
+                                   seq);
       }
+  }
+
+  void CSVTSTorchInputFileConn::fill_dataset(TorchDataset &dataset,
+                                             bool use_csvtsdata_test)
+  {
+    _ids.clear();
+    // we have _csvtsdata and csvtsdata_test to put into TorchDataset
+    // _dataset , _test_dataset
+
+    if (_forecast_timesteps != -1)
+      fill_dataset_forecast(dataset, use_csvtsdata_test);
+    else
+      fill_dataset_labels(dataset, use_csvtsdata_test);
     dataset.reset();
   }
 }

--- a/src/backends/torch/torchinputconns.h
+++ b/src/backends/torch/torchinputconns.h
@@ -71,8 +71,7 @@ namespace dd
     TorchInputInterface(const TorchInputInterface &i)
         : _lm_params(i._lm_params), _dataset(i._dataset),
           _test_dataset(i._test_dataset), _input_format(i._input_format),
-          _ntargets(i._ntargets), _tilogger(i._tilogger), _db(i._db),
-          _split_ts_for_predict(i._split_ts_for_predict)
+          _ntargets(i._ntargets), _tilogger(i._tilogger), _db(i._db)
     {
     }
 
@@ -174,8 +173,6 @@ namespace dd
     std::string _backend
         = "lmdb"; /**< db backend (currently only lmdb is supported) */
     std::string _correspname = "corresp.txt"; /**< "corresp file default name*/
-    bool _split_ts_for_predict
-        = false; /**< prevent to split timeseries in predict mode */
   };
 
   /**
@@ -432,7 +429,9 @@ namespace dd
      */
     CSVTSTorchInputFileConn(const CSVTSTorchInputFileConn &i)
         : CSVTSInputFileConn(i), TorchInputInterface(i), _offset(i._offset),
-          _timesteps(i._timesteps), _datadim(i._datadim)
+          _timesteps(i._timesteps), _datadim(i._datadim),
+          _forecast_timesteps(i._forecast_timesteps),
+          _backcast_timesteps(i._backcast_timesteps)
     {
       _dataset._inputc = this;
       _test_dataset._inputc = this;
@@ -495,14 +494,44 @@ namespace dd
                 }
             }
         }
-      _offset = _timesteps;
       if (ad_input.has("timesteps"))
         {
           _timesteps = ad_input.get("timesteps").get<int>();
           _offset = _timesteps;
         }
+
+      if (ad_input.has("forecast_timesteps"))
+        {
+          _forecast_timesteps = ad_input.get("forecast_timesteps").get<int>();
+        }
+
+      if (ad_input.has("backcast_timesteps"))
+        {
+          _backcast_timesteps = ad_input.get("backcast_timesteps").get<int>();
+          _offset = _backcast_timesteps;
+        }
+
       if (ad_input.has("offset"))
         _offset = ad_input.get("offset").get<int>();
+
+      if ((_forecast_timesteps >= 0 && _backcast_timesteps <= 0)
+          || (_forecast_timesteps <= 0 && _backcast_timesteps >= 0))
+        {
+          std::string errmsg
+              = "forecast value and backcast value should be both specified";
+          this->_logger->error(errmsg);
+          throw InputConnectorBadParamException(errmsg);
+        }
+
+      if (_forecast_timesteps > 0 && _forecast_timesteps > _backcast_timesteps)
+        {
+          std::string errmsg = "forecast value "
+                               + std::to_string(_forecast_timesteps)
+                               + "  >= backcast_timesteps "
+                               + std::to_string(_backcast_timesteps);
+          this->_logger->error(errmsg);
+          throw InputConnectorBadParamException(errmsg);
+        }
     }
 
     /**
@@ -510,7 +539,9 @@ namespace dd
      */
     int channels() const
     {
-      return _timesteps;
+      if (_timesteps > 0)
+        return _timesteps;
+      return _forecast_timesteps + _backcast_timesteps;
     }
 
     /**
@@ -529,10 +560,27 @@ namespace dd
       return 1;
     }
 
+  private:
+    void fill_dataset_forecast(TorchDataset &dataset, bool test);
+    void add_data_instance_forecast(const long int tstart, const int vecindex,
+                                    TorchDataset &dataset,
+                                    const std::vector<CSVline> &seq);
+    void fill_dataset_labels(TorchDataset &dataset, bool test);
+    void add_data_instance_labels(const long int tstart, const int vecindex,
+                                  TorchDataset &dataset,
+                                  const std::vector<CSVline> &seq);
+
+    void discard_warn(int vecindex, unsigned int seq_size, bool test);
+
+  public:
     int _offset = -1;    /**< default offset for building sequences: start of
                             sequences is at 0, offset, 2xoffset ... */
     int _timesteps = -1; /**< default empty value for timesteps */
     int _datadim = -1;   /**< default empty value for datapoints */
+    int _forecast_timesteps
+        = -1; /**< length of forecast :  if > 0, labels will be ignored */
+    int _backcast_timesteps
+        = -1; /**< length of backcast :  if > 0, labels will be ignored */
   };
 } // namespace dd
 

--- a/src/backends/torch/torchlib.cc
+++ b/src/backends/torch/torchlib.cc
@@ -116,8 +116,17 @@ namespace dd
       {
         if (!inputc._dont_scale_labels)
           {
-            double max = inputc._max_vals[inputc._label_pos[k]];
-            double min = inputc._min_vals[inputc._label_pos[k]];
+            double max, min;
+            if (inputc._label_pos.size() > 0) // labels case
+              {
+                max = inputc._max_vals[inputc._label_pos[k]];
+                min = inputc._min_vals[inputc._label_pos[k]];
+              }
+            else // forecast case
+              {
+                max = inputc._max_vals[k];
+                min = inputc._min_vals[k];
+              }
             if (inputc._scale_between_minus1_and_1)
               val += 0.5;
             val = val * (max - min) + min;
@@ -858,8 +867,6 @@ namespace dd
 
     bool lstm_continuation = false;
     TInputConnectorStrategy inputc(this->_inputc);
-    if (_module._native != nullptr)
-      _module._native->update_input_connector(inputc);
 
     this->_stats.transform_start();
     TOutputConnectorStrategy outputc(this->_outputc);
@@ -1082,8 +1089,7 @@ namespace dd
                     for (int t = 0; t < output.size(1); ++t)
                       {
                         std::vector<double> preds;
-                        for (unsigned int k = 0; k < this->_inputc._ntargets;
-                             ++k)
+                        for (unsigned int k = 0; k < inputc._ntargets; ++k)
                           {
                             double res = output_acc[j][t][k];
                             preds.push_back(unscale(res, k, inputc));
@@ -1202,7 +1208,7 @@ namespace dd
                 std::vector<double> targets;
                 std::vector<double> predictions;
                 for (int t = 0; t < labels.size(1); ++t)
-                  for (unsigned int k = 0; k < this->_inputc._ntargets; ++k)
+                  for (unsigned int k = 0; k < inputc._ntargets; ++k)
                     {
                       targets.push_back(target_acc[j][t][k]);
                       predictions.push_back(output_acc[j][t][k]);
@@ -1275,7 +1281,7 @@ namespace dd
     if (_timeserie)
       {
         ad_res.add("timeserie", true);
-        ad_res.add("timeseries", (int)this->_inputc._ntargets);
+        ad_res.add("timeseries", (int)inputc._ntargets);
       }
     else
       {

--- a/src/csvtsinputfileconn.cc
+++ b/src/csvtsinputfileconn.cc
@@ -476,10 +476,13 @@ namespace dd
 
     out << "ncols: " << _min_vals.size() << std::endl;
     out << "nlabels: " << _label_pos.size() << std::endl;
-    out << "label_pos: ";
-    for (unsigned int i = 0; i < _label_pos.size() - 1; ++i)
-      out << " " << _label_pos[i] << " " << delim;
-    out << " " << _label_pos[_label_pos.size() - 1] << std::endl;
+    if (_label_pos.size() > 0)
+      {
+        out << "label_pos: ";
+        for (unsigned int i = 0; i < _label_pos.size() - 1; ++i)
+          out << " " << _label_pos[i] << " " << delim;
+        out << " " << _label_pos[_label_pos.size() - 1] << std::endl;
+      }
     out << "min_vals: ";
     for (unsigned int i = 0; i < _min_vals.size() - 1; ++i)
       out << " " << std::setprecision(boundsprecision) << _min_vals[i] << " "

--- a/tests/ut-graph.cc
+++ b/tests/ut-graph.cc
@@ -653,7 +653,7 @@ TEST(graphapi, complete_extract_layer)
         + csvts_data + "\",\"" + csvts_test + "\"]}";
   std::cerr << "jtrainstr=" << jtrainstr << std::endl;
   joutstr = japi.jrender(japi.service_train(jtrainstr));
-  std::cout << "joutstr=" << joutstr << std::endl;
+  //  std::cout << "joutstr=" << joutstr << std::endl;
   JDoc jd;
   jd.Parse<rapidjson::kParseNanAndInfFlag>(joutstr.c_str());
   ASSERT_TRUE(!jd.HasParseError());
@@ -693,7 +693,7 @@ TEST(graphapi, complete_extract_layer)
   std::string uri = jd["body"]["predictions"][0]["uri"].GetString();
   ASSERT_EQ("../examples/all/sinus/predict/seq_2.csv #0_998", uri);
   ASSERT_TRUE(jd["body"]["predictions"][0]["vals"].IsArray());
-  ASSERT_EQ(jd["body"]["predictions"][0]["vals"].Size(), 9990);
+  ASSERT_EQ(jd["body"]["predictions"][0]["vals"].Size(), 200);
 
   //  remove service
   jstr = "{\"clear\":\"full\"}";
@@ -781,7 +781,7 @@ TEST(graphapi, complete_extract_layer_gpu)
   std::string uri = jd["body"]["predictions"][0]["uri"].GetString();
   ASSERT_EQ("../examples/all/sinus/predict/seq_2.csv #0_998", uri);
   ASSERT_TRUE(jd["body"]["predictions"][0]["vals"].IsArray());
-  ASSERT_EQ(jd["body"]["predictions"][0]["vals"].Size(), 9990);
+  ASSERT_EQ(jd["body"]["predictions"][0]["vals"].Size(), 200);
 
   //  remove service
   jstr = "{\"clear\":\"full\"}";

--- a/tests/ut-torchapi.cc
+++ b/tests/ut-torchapi.cc
@@ -647,7 +647,7 @@ TEST(torchapi, service_train_csvts_nbeats)
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_EQ(200, jd["status"]["code"]);
   std::string uri = jd["body"]["predictions"][0]["uri"].GetString();
-  ASSERT_EQ("../examples/all/sinus/predict/seq_2.csv #0_49", uri);
+  ASSERT_EQ("../examples/all/sinus/predict/seq_2.csv #0_998", uri);
   ASSERT_TRUE(jd["body"]["predictions"][0]["series"].IsArray());
   ASSERT_TRUE(jd["body"]["predictions"][0]["series"][0]["out"][0].GetDouble()
               >= -1.0);
@@ -707,6 +707,103 @@ TEST(torchapi, service_train_csvts_nbeats_resume_fail)
   ASSERT_EQ("Service Bad Request Error: resuming a model requires a "
             "solverstate file in model repository",
             jd["status"]["dd_msg"]);
+  //  remove service
+  jstr = "{\"clear\":\"full\"}";
+  joutstr = japi.jrender(japi.service_delete(sname, jstr));
+  ASSERT_EQ(ok_str, joutstr);
+  rmdir(csvts_nbeats_repo.c_str());
+}
+
+TEST(torchapi, service_train_csvts_nbeats_forecast)
+{
+  // create service
+  JsonAPI japi;
+  std::string sname = "nbeats";
+  std::string csvts_data = sinus + "train";
+  std::string csvts_test = sinus + "test";
+  std::string csvts_predict = sinus + "predict";
+  std::string csvts_nbeats_repo = "csvts_nbeats";
+  mkdir(csvts_nbeats_repo.c_str(), 0777);
+
+  std::string jstr
+      = "{\"mllib\":\"torch\",\"description\":\"nbeats\",\"type\":"
+        "\"supervised\",\"model\":{\"repository\":\""
+        + csvts_nbeats_repo
+        + "\"},\"parameters\":{\"input\":{\"connector\":\"csvts\","
+          "\"forecast_timesteps\":10,\"ignore\":[\"output\"],\"backcast_"
+          "timesteps\":40},"
+          "\"mllib\":"
+          "{\"template\":"
+          "\"nbeats\","
+          "\"template_params\":[\"t2\",\"s4\",\"g3\",\"b3\"],"
+          "\"loss\":\"L1\"}}}";
+
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
+
+  // train
+  std::string jtrainstr
+      = "{\"service\":\"" + sname
+        + "\",\"async\":false,\"parameters\":{\"input\":{\"shuffle\":true,"
+          "\"separator\":\",\",\"scale\":true,\"backcast_timesteps\":40,"
+          "\"forecast_timesteps\":"
+          "10,\"ignore\":[\"output\"]},\"mllib\":{\"gpu\":false,\"solver\":{"
+          "\"iterations\":"
+        + iterations_nbeats_cpu
+        + ",\"test_interval\":10,\"base_lr\":0.1,\"snapshot\":500,\"test_"
+          "initialization\":false,\"solver_type\":\"ADAM\"},\"net\":{\"batch_"
+          "size\":2,\"test_batch_"
+          "size\":10}},\"output\":{\"measure\":[\"L1\",\"L2\"]}},\"data\":[\""
+        + csvts_data + "\",\"" + csvts_test + "\"]}";
+
+  std::cerr << "jtrainstr=" << jtrainstr << std::endl;
+  joutstr = japi.jrender(japi.service_train(jtrainstr));
+  std::cout << "joutstr=" << joutstr << std::endl;
+  JDoc jd;
+  jd.Parse(joutstr.c_str());
+  ASSERT_TRUE(!jd.HasParseError());
+  ASSERT_TRUE(jd.HasMember("status"));
+  ASSERT_EQ(201, jd["status"]["code"].GetInt());
+  ASSERT_EQ("Created", jd["status"]["msg"]);
+  ASSERT_TRUE(jd.HasMember("head"));
+  ASSERT_EQ("/train", jd["head"]["method"]);
+  ASSERT_TRUE(jd["head"]["time"].GetDouble() >= 0);
+  ASSERT_TRUE(jd.HasMember("body"));
+  ASSERT_TRUE(jd["body"]["measure"].HasMember("train_loss"));
+  ASSERT_TRUE(fabs(jd["body"]["measure"]["train_loss"].GetDouble()) > 0);
+  ASSERT_TRUE(jd["body"]["measure"].HasMember("L1_mean_error"));
+  ASSERT_TRUE(jd["body"]["measure"]["L1_max_error_0"].GetDouble() > 0.0);
+  ASSERT_TRUE(jd["body"]["parameters"]["input"].HasMember("max_vals"));
+  ASSERT_TRUE(jd["body"]["parameters"]["input"].HasMember("min_vals"));
+
+  std::string str_min_vals
+      = japi.jrender(jd["body"]["parameters"]["input"]["min_vals"]);
+  std::string str_max_vals
+      = japi.jrender(jd["body"]["parameters"]["input"]["max_vals"]);
+
+  //  predict
+  std::string jpredictstr = "{\"service\":\"" + sname
+                            + "\",\"parameters\":{\"input\":{\"backcast_"
+                              "timesteps\":40,\"connector\":"
+                              "\"csvts\",\"scale\":true,\"forecast_"
+                              "timesteps\":10,\"ignore\":[\"output\"],"
+                              "\"continuation\":"
+                              "true,\"min_vals\":"
+                            + str_min_vals + ",\"max_vals\":" + str_max_vals
+                            + "},\"output\":{}},\"data\":[\"" + csvts_predict
+                            + "\"]}";
+  joutstr = japi.jrender(japi.service_predict(jpredictstr));
+  std::cout << "joutstr=" << joutstr << std::endl;
+  jd.Parse(joutstr.c_str());
+  ASSERT_TRUE(!jd.HasParseError());
+  ASSERT_EQ(200, jd["status"]["code"]);
+  std::string uri = jd["body"]["predictions"][0]["uri"].GetString();
+  ASSERT_EQ("../examples/all/sinus/predict/seq_2.csv #959_1008", uri);
+  ASSERT_TRUE(jd["body"]["predictions"][0]["series"].IsArray());
+  ASSERT_EQ(jd["body"]["predictions"][0]["series"].Size(), 10);
+  ASSERT_TRUE(jd["body"]["predictions"][0]["series"][0]["out"][0].GetDouble()
+              >= -1.0);
+
   //  remove service
   jstr = "{\"clear\":\"full\"}";
   joutstr = japi.jrender(japi.service_delete(sname, jstr));
@@ -791,7 +888,7 @@ TEST(torchapi, service_train_csvts_nbeats_gpu)
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_EQ(200, jd["status"]["code"]);
   std::string uri = jd["body"]["predictions"][0]["uri"].GetString();
-  ASSERT_EQ("../examples/all/sinus/predict/seq_2.csv #0_49", uri);
+  ASSERT_EQ("../examples/all/sinus/predict/seq_2.csv #0_998", uri);
   ASSERT_TRUE(jd["body"]["predictions"][0]["series"].IsArray());
   ASSERT_TRUE(jd["body"]["predictions"][0]["series"][0]["out"][0].GetDouble()
               >= -1.1);
@@ -893,7 +990,7 @@ TEST(torchapi, service_train_csvts_nbeats_multigpu)
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_EQ(200, jd["status"]["code"]);
   std::string uri = jd["body"]["predictions"][0]["uri"].GetString();
-  ASSERT_EQ("../examples/all/sinus/predict/seq_2.csv #0_49", uri);
+  ASSERT_EQ("../examples/all/sinus/predict/seq_2.csv #0_998", uri);
   ASSERT_TRUE(jd["body"]["predictions"][0]["series"].IsArray());
   ASSERT_TRUE(jd["body"]["predictions"][0]["series"][0]["out"][0].GetDouble()
               >= -1.0);
@@ -943,9 +1040,9 @@ TEST(torchapi, nbeats_extract_layers_simple)
   ASSERT_TRUE(nb.extractable("1:1:fc3"));
   ASSERT_TRUE(nb.extractable("2:0:end"));
 
-  torch::Tensor x = torch::randn({ 2, 50, 1 });
+  torch::Tensor x = torch::randn({ 2, 500, 1 });
   torch::Tensor y = nb.forward(x);
-  ASSERT_EQ(y.sizes(), std::vector<long int>({ 2, 2, 50, 1 }));
+  ASSERT_EQ(y.sizes(), std::vector<long int>({ 2, 550, 1 }));
   torch::Tensor z = nb.extract(x, "2:0:fc1");
   ASSERT_EQ(z.sizes(), std::vector<long int>({ 2, 10 }));
   torch::Tensor t = nb.extract(x, "1:1:end");
@@ -1028,7 +1125,7 @@ TEST(torchapi, nbeats_extract_layer_complete)
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_EQ(200, jd["status"]["code"]);
   std::string uri = jd["body"]["predictions"][0]["uri"].GetString();
-  ASSERT_EQ("../examples/all/sinus/predict/seq_2.csv #0_49", uri);
+  ASSERT_EQ("../examples/all/sinus/predict/seq_2.csv #0_998", uri);
   ASSERT_TRUE(jd["body"]["predictions"][0]["vals"].IsArray());
   ASSERT_EQ(jd["body"]["predictions"].Size(), 20);
   ASSERT_EQ(jd["body"]["predictions"][0]["vals"].Size(), 10);
@@ -1118,7 +1215,7 @@ TEST(torchapi, nbeats_extract_layer_complete_gpu)
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_EQ(200, jd["status"]["code"]);
   std::string uri = jd["body"]["predictions"][0]["uri"].GetString();
-  ASSERT_EQ("../examples/all/sinus/predict/seq_2.csv #0_49", uri);
+  ASSERT_EQ("../examples/all/sinus/predict/seq_2.csv #0_998", uri);
   ASSERT_TRUE(jd["body"]["predictions"][0]["vals"].IsArray());
   ASSERT_EQ(jd["body"]["predictions"].Size(), 20);
   ASSERT_EQ(jd["body"]["predictions"][0]["vals"].Size(), 10);


### PR DESCRIPTION
… also implements minimal change in csvtstorchinputconn in order to do forecast of signals instead of label predicting

API : simply add `params.input.forecast_timesteps:10` and `params.input.backcast:40` this will split timeseries in sequences of length 50  and will use `backcast_timesteps` steps as input data and will output `forecast` steps as output. `labels` will be ignored.

previous API (ie lstm-like: same number of steps for input and output, `timesteps` `labels` predicted based on `timesteps` `inputs` still work)