### PR TITLE
ci: skip only tests with ci:skip

### DIFF
--- a/ci/Jenkinsfile.docker
+++ b/ci/Jenkinsfile.docker
@@ -1,4 +1,4 @@
-String cron_info = BRANCH_NAME == "master" ? "H 22 * * 1-5'" : ""
+String cron_info = BRANCH_NAME == "master" ? "H 22 * * 1-5" : ""
 
 pipeline {
   agent { node { label 'docker' } }

--- a/ci/Jenkinsfile.unittests
+++ b/ci/Jenkinsfile.unittests
@@ -58,6 +58,9 @@ ccache -s
       }
     }
     stage('Tests GPU') {
+      when {
+       expression { !env.CHANGE_ID || pullRequest.labels.findAll { it == "ci:skip" }.size() == 0 }
+      }
       steps {
         lock(resource: null, label: "${NODE_NAME}-gpu", variable: 'LOCKED_GPU', quantity: 1) {
           sh '''
@@ -74,6 +77,9 @@ ccache -s
     }
 /*
     stage('Tests multi-GPU') {
+      when {
+       expression { !env.CHANGE_ID || pullRequest.labels.findAll { it == "ci:skip" }.size() == 0 }
+      }
       steps {
         lock(resource: null, label: 'gpu', variable: 'LOCKED_GPU', quantity: 2) {
           sh '''


### PR DESCRIPTION
## ci: skip only tests with ci:skip

We should always run the job to check at least it build.
It doesn't take too much times.

## ci: fix docker crontab typo
