### PR TITLE
ci: compile deepdetect inside a docker image

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1029,16 +1029,18 @@ endif()
 file(GLOB_RECURSE ALL_SOURCE_FILES src/*.cpp src/*.hpp src/*.h src/*.c tests/*.cc src/*.cc)
 list(FILTER ALL_SOURCE_FILES EXCLUDE REGEX "^${CMAKE_SOURCE_DIR}/src/ext/.*$")
 
+
+find_program(CLANG_FORMAT_BIN clang-format-10 clang-format)
 add_custom_target(
         clang-format
-        COMMAND clang-format
+        COMMAND ${CLANG_FORMAT_BIN}
         -style=file
         -i
         ${ALL_SOURCE_FILES}
 )
 add_custom_target(
         clang-format-check
-        COMMAND clang-format
+        COMMAND ${CLANG_FORMAT_BIN}
         --dry-run
         --Werror
         --ferror-limit=10

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -816,18 +816,18 @@ if (USE_TENSORRT)
 
   if (JETSON)
     set(TRTTESTDIR /usr/lib/aarch64-linux-gnu)
-      set(TENSORRT_LIB_DIR  /usr/lib/aarch64-linux-gnu)
-      set(TENSORRT_INC_DIR ${PROTOBUF_INCLUDE_DIR} /usr/include/aarch64-linux-gnu)
+    set(TENSORRT_LIB_DIR /usr/lib/aarch64-linux-gnu)
+    set(TENSORRT_INC_DIR /usr/include/aarch64-linux-gnu)
   elseif(DEFINED TENSORRT_DIR)
     set(TRTTESTDIR ${TENSORRT_DIR}/lib)
-      set(TENSORRT_LIB_DIR  ${TENSORRT_DIR}/lib )
-      set(TENSORRT_INC_DIR ${PROTOBUF_INCLUDE_DIR} ${TENSORRT_DIR}/include)
+    set(TENSORRT_LIB_DIR  ${TENSORRT_DIR}/lib )
+    set(TENSORRT_INC_DIR ${TENSORRT_DIR}/include)
   elseif (DEFINED TENSORRT_LIB_DIR AND DEFINED TENSORRT_INC_DIR)
     set(TRTTESTDIR TENSORRT_LIB_DIR)
   else()
     set(TRTTESTDIR /usr/lib/x86_64-linux-gnu)
-      set(TENSORRT_LIB_DIR  /usr/lib/x86_64-linux-gnu)
-      set(TENSORRT_INC_DIR ${PROTOBUF_INCLUDE_DIR} /usr/include/x86_64-linux-gnu)
+    set(TENSORRT_LIB_DIR  /usr/lib/x86_64-linux-gnu)
+    set(TENSORRT_INC_DIR /usr/include/x86_64-linux-gnu)
   endif()
 
   if (NOT EXISTS "${TRTTESTDIR}/libnvinfer.so")
@@ -878,6 +878,8 @@ if (USE_TENSORRT)
       INSTALL_COMMAND ""
     )
 
+    # Use our tensorrt-oss header versions first
+    include_directories(SYSTEM ${CMAKE_BINARY_DIR}/tensorrt-oss/src/tensorrt-oss/include)
     include_directories(${TENSORRT_INC_DIR})
 endif()
 

--- a/ci/Jenkinsfile.prebuilt-cache
+++ b/ci/Jenkinsfile.prebuilt-cache
@@ -1,6 +1,11 @@
-
 pipeline {
-  agent any
+  agent {
+    dockerfile {
+      label 'gpu'
+      filename 'ci/devel.Dockerfile'
+      args "-v /var/lib/jenkins/.ccache:/ccache -e CCACHE_DIR=/ccache --runtime nvidia"
+    }
+  }
   stages {
     stage('Init') {
       steps {

--- a/ci/Jenkinsfile.unittests
+++ b/ci/Jenkinsfile.unittests
@@ -1,5 +1,11 @@
 pipeline {
-  agent { node { label 'gpu' } }
+  agent {
+    dockerfile {
+      label 'gpu'
+      filename 'ci/devel.Dockerfile'
+      args "-v /var/lib/jenkins/.ccache:/ccache -e CCACHE_DIR=/ccache --runtime nvidia"
+    }
+  }
   stages {
     stage('Init') {
       steps {
@@ -53,6 +59,7 @@ cmake .. \
         sh 'cd build && make clang-format-check'
       }
     }
+
     stage('Check python client') {
       steps {
         sh 'cd clients/python/ && tox -e pep8,py36,py27'

--- a/ci/devel.Dockerfile
+++ b/ci/devel.Dockerfile
@@ -1,0 +1,119 @@
+# syntax = docker/dockerfile:1.0-experimental
+
+ARG DD_UBUNTU_VERSION=18.04
+ARG DD_CUDA_VERSION=10.2
+ARG DD_CUDNN_VERSION=7
+ARG DD_TENSORRT_VERSION=7.1.3-1+cuda10.2
+
+FROM nvidia/cuda:${DD_CUDA_VERSION}-cudnn${DD_CUDNN_VERSION}-devel-ubuntu${DD_UBUNTU_VERSION}
+
+ARG DD_UBUNTU_VERSION
+ARG DD_CUDA_VERSION
+ARG DD_CUDNN_VERSION
+ARG DD_TENSORRT_VERSION
+
+RUN echo UBUNTU_VERSION=${DD_UBUNTU_VERSION} >> /image-info
+RUN echo CUDA_VERSION=${DD_CUDA_VERSION} >> /image-info
+RUN echo CUDNN_VERSION=${DD_CUDNN_VERSION} >> /image-info
+RUN echo TENSORRT_VERSION=${DD_TENSORRT_VERSION} >> /image-info
+
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update -y && apt-get install -y python-dev apt-transport-https ca-certificates gnupg software-properties-common wget curl
+RUN curl https://apt.kitware.com/keys/kitware-archive-latest.asc | apt-key add -
+RUN apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main'
+
+# python2 pycompile + docker-buildkit is a bit buggy, it's slow as hell, so disable it for dev
+# bug closed as won't fix as python2 is eol: https://github.com/docker/for-linux/issues/502
+RUN cp /bin/true /usr/bin/pycompile
+
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update -y && apt-get install -y \
+    git \
+    ccache \
+    automake \
+    clang-format-10 \
+    build-essential \
+    openjdk-8-jdk \
+    pkg-config \
+    cmake \
+    zip \
+    g++ \
+    gcc-7 g++-7 \
+    zlib1g-dev \
+    libgoogle-glog-dev \
+    libgflags-dev \
+    libeigen3-dev \
+    libopencv-dev \
+    libboost-dev \
+    libboost-filesystem-dev \
+    libboost-thread-dev \
+    libboost-system-dev \
+    libboost-stacktrace-dev \
+    libboost-iostreams-dev \
+    libboost-program-options-dev \
+    libboost-test-dev \
+    libboost-regex-dev \
+    libboost-date-time-dev \
+    libboost-chrono-dev \
+    libssl-dev \
+    libgtest-dev \
+    libcurlpp-dev \
+    libcurl4-openssl-dev \
+    protobuf-compiler \
+    libopenblas-dev \
+    libhdf5-dev \
+    libprotobuf-dev \
+    libleveldb-dev \
+    libsnappy-dev \
+    liblmdb-dev \
+    libutfcpp-dev \
+    rapidjson-dev \
+    libmapbox-variant-dev \
+    autoconf \
+    libtool-bin \
+    python-numpy \
+    python-future \
+    python-yaml \
+    python-typing \
+    swig \
+    curl \
+    unzip \
+    libspdlog-dev \
+    python-setuptools \
+    python-dev \
+    python-tox \
+    python3-dev \
+    python3-pip \
+    python-wheel \
+    python-pip \
+    python-six \
+    python-enum34 \
+    python3-yaml \
+    unzip \
+    libgoogle-perftools-dev \
+    curl \
+    libspdlog-dev \
+    libarchive-dev \
+    bash-completion \
+    schedtool \
+    util-linux \
+    libnvparsers7=${DD_TENSORRT_VERSION} \
+    libnvparsers-dev=${DD_TENSORRT_VERSION} \
+    libnvinfer7=${DD_TENSORRT_VERSION} \
+    libnvinfer-dev=${DD_TENSORRT_VERSION}
+
+RUN for url in \
+        https://github.com/bazelbuild/bazel/releases/download/0.24.1/bazel_0.24.1-linux-x86_64.deb \
+        ; do curl -L -s -o /tmp/p.deb $url && dpkg -i /tmp/p.deb && rm -rf /tmp/p.deb; done
+
+RUN pip3 install torch
+
+# ubuntu GTEST ugly packaging
+WORKDIR /usr/src/gtest
+RUN cmake .
+RUN make -j8
+RUN make install
+
+RUN apt clean -y
+RUN echo "[user]\n    email = jenkins@deepdetect.com\n    name = Deepdetect Jenkins Bot\n" > /etc/gitconfig
+WORKDIR /root


### PR DESCRIPTION
## chore: prefer clang-format-10

ubuntu 18.04 does not ship clang-format symlink for clang-format-10 by
default

## fix(build): fix tensorrt-oss include


## ci: compile deepdetect inside a docker image
