### PR TITLE
fix(csv): remove trailing \n from header if there are any

### DIFF
--- a/src/csvinputfileconn.cc
+++ b/src/csvinputfileconn.cc
@@ -242,6 +242,9 @@ namespace dd
   {
     hline.erase(std::remove(hline.begin(), hline.end(), '\r'),
                 hline.end()); // remove ^M if any
+    hline.erase(std::remove(hline.begin(), hline.end(), '\n'),
+                hline.end()); // remove \n if any (in case of hline coming
+                              // direclty from mem, and not parsed by line)
     std::stringstream sg(hline);
     std::string col;
 


### PR DESCRIPTION
=> robustify in case of data passed from mem