### PR TITLE
Pull request for oat-default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,8 +56,8 @@ OPTION(BUILD_TESTS "Should the tests be built")
 OPTION(BUILD_TOOLS "Should the tools be built")
 OPTION(USE_COMMAND_LINE "build command line JSON API" ON)
 OPTION(USE_JSON_API "build internal JSON API" ON)
-OPTION(USE_HTTP_SERVER "build http JSON API " ON)
-OPTION(USE_HTTP_SERVER_OATPP "use OAT instead cpp-netlib" OFF)
+OPTION(USE_HTTP_SERVER "build cppnet-lib version of http JSON API " ON)
+OPTION(USE_HTTP_SERVER_OATPP "build oatpp version of http JSON API" ON)
 
 # Get the current working branch
 execute_process(

--- a/main/dede.cc
+++ b/main/dede.cc
@@ -86,10 +86,10 @@ int main(int argc, char *argv[])
     case 0:
 #if defined(USE_HTTP_SERVER) || defined(USE_HTTP_SERVER_OATPP)
       {
-#ifdef USE_HTTP_SERVER
-        DeepDetect<HttpJsonAPI> dd;
-#else
+#ifdef USE_HTTP_SERVER_OATPP
         DeepDetect<OatppJsonAPI> dd;
+#else
+        DeepDetect<HttpJsonAPI> dd;
 #endif // USE_HTTP_SERVER_OATPP
         dd.boot(argc, argv);
       }

--- a/main/dede.cc
+++ b/main/dede.cc
@@ -19,6 +19,8 @@
  * along with deepdetect.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <iostream>
+
 #include "deepdetect.h"
 #ifdef USE_COMMAND_LINE
 #ifdef USE_CAFFE
@@ -45,7 +47,7 @@ using namespace dd;
 
 DEFINE_int32(jsonapi, 0,
              "whether to use the JSON command line API ("
-#ifdef USE_HTTP_SERVER
+#if defined(USE_HTTP_SERVER) || defined(USE_HTTP_SERVER_OATPP)
              "0: HTTP server JSON "
 #endif // USE_HTTP_SERVER
 #ifdef USE_COMMAND_LINE
@@ -59,8 +61,18 @@ DEFINE_int32(jsonapi, 0,
 #ifdef USE_HTTP_SERVER_OATPP
              "3: HTTP server JSON (oat++ version)"
 #endif // USE_HTTP_SERVER_OATPP
+#ifdef USE_HTTP_SERVER
+             "4: HTTP server JSON (cppnetlib version)"
+#endif // USE_HTTP_SERVER
 
 );
+
+void invalid_jsonapi_flag(const std::string option)
+{
+  std::cerr << "--jsonapi=" << FLAGS_jsonapi
+            << " is unavailable. deepdetect has been compiled without "
+            << option << std::endl;
+}
 
 int main(int argc, char *argv[])
 {
@@ -69,39 +81,78 @@ int main(int argc, char *argv[])
   rabit::Init(argc, argv);
 #endif // USE_XGBOOST
 
+  switch (FLAGS_jsonapi)
+    {
+    case 0:
+#if defined(USE_HTTP_SERVER) || defined(USE_HTTP_SERVER_OATPP)
+      {
 #ifdef USE_HTTP_SERVER
-  if (FLAGS_jsonapi == 0)
-    {
-      DeepDetect<HttpJsonAPI> dd;
-      dd.boot(argc, argv);
-    }
-#endif // USE_HTTP_SERVER
-#ifdef USE_COMMANDLINE
-#ifdef USE_CAFFE
-  if (FLAGS_jsonapi == 2)
-    {
-      DeepDetect<CommandLineAPI> dd;
-      dd.boot(argc, argv);
-    }
-#endif // USE_CAFFE
-#ifdef USE_JSON_API
-  if (FLAGS_jsonapi == 1)
-    {
-      DeepDetect<CommandLineJsonAPI> dd;
-      dd.boot(argc, argv);
-    }
-#endif // USE_JSON_API
-#endif // USE_COMMANDLINE
+        DeepDetect<HttpJsonAPI> dd;
+#else
+        DeepDetect<OatppJsonAPI> dd;
+#endif // USE_HTTP_SERVER_OATPP
+        dd.boot(argc, argv);
+      }
+      break;
+#else
+      invalid_jsonapi_flag("USE_HTTP_SERVER OR USE_HTTP_SERVER_OATPP");
+      return 1;
+#endif // USE_HTTP_SERVER OR USE_HTTP_SERVER_OATPP
 
+    case 1:
+#if defined(USE_JSON_API) && defined(USE_COMMANDLINE)
+      {
+        DeepDetect<CommandLineJsonAPI> dd;
+        dd.boot(argc, argv);
+      }
+      break;
+#else // USE_JSON_API
+      invalid_jsonapi_flag("USE_JSON_API and USE_COMMANDLINE");
+      return 1;
+#endif // USE_JSON_API
+
+    case 2:
+#if defined(USE_CAFFE) && defined(USE_COMMANDLINE)
+      {
+        DeepDetect<CommandLineAPI> dd;
+        dd.boot(argc, argv);
+      }
+      break;
+#else // USE_CAFFE
+      invalid_jsonapi_flag("USE_CAFFE and USE_COMMANDLINE");
+      return 1;
+#endif // USE_CAFFE
+
+    case 3:
 #ifdef USE_HTTP_SERVER_OATPP
-  if (FLAGS_jsonapi == 3)
-    {
-      DeepDetect<OatppJsonAPI> dd;
-      dd.boot(argc, argv);
-    }
+      {
+        DeepDetect<OatppJsonAPI> dd;
+        dd.boot(argc, argv);
+      }
+      break;
+#else // USE_HTTP_SERVER_OATPP
+      invalid_jsonapi_flag("USE_HTTP_SERVER_OATPP");
+      return 1;
 #endif // USE_HTTP_SERVER_OATPP
 
+    case 4:
+#ifdef USE_HTTP_SERVER
+      {
+        DeepDetect<HttpJsonAPI> dd;
+        dd.boot(argc, argv);
+      }
+      break;
+#else // USE_HTTP_SERVER
+      invalid_jsonapi_flag("USE_HTTP_SERVER");
+      return 1;
+#endif // USE_HTTP_SERVER
+
+    default:
+      std::cerr << "--jsonapi value is invalid" << std::endl;
+      return 1;
+    }
 #ifdef USE_XGBOOST
   rabit::Finalize();
 #endif
+  return 0;
 }

--- a/src/oatppjsonapi.cc
+++ b/src/oatppjsonapi.cc
@@ -46,7 +46,6 @@ namespace dd
 
   OatppJsonAPI::OatppJsonAPI() : JsonAPI()
   {
-    _logger = spdlog::get("api-oatpp");
   }
 
   OatppJsonAPI::~OatppJsonAPI()

--- a/src/oatppjsonapi.cc
+++ b/src/oatppjsonapi.cc
@@ -20,6 +20,7 @@
  */
 
 #include <csignal>
+#include <boost/stacktrace.hpp>
 
 #include "oatppjsonapi.h"
 #include "http/app_component.hpp"
@@ -242,6 +243,13 @@ namespace dd
       }
   }
 
+  void OatppJsonAPI::abort(int signum)
+  {
+    std::signal(signum, SIG_DFL);
+    std::cout << boost::stacktrace::stacktrace() << std::endl;
+    std::raise(SIGABRT);
+  }
+
   void OatppJsonAPI::run()
   {
     AppComponent components; // Create scope Environment
@@ -275,9 +283,12 @@ namespace dd
       _logger->info("Allowing origin from {}", FLAGS_allow_origin);
 
     std::signal(SIGINT, terminate);
+    std::signal(SIGSEGV, abort);
+    std::signal(SIGABRT, abort);
     _server->run();
     _logger->info("DeepDetect HTTP server stopped");
   }
+
   int OatppJsonAPI::boot(int argc, char *argv[])
   {
     (void)argv;

--- a/src/oatppjsonapi.h
+++ b/src/oatppjsonapi.h
@@ -40,6 +40,7 @@ namespace dd
     int boot(int argc, char *argv[]);
     void run();
     static void terminate(int signal);
+    static void abort(int param);
     std::string
     uri_query_to_json(oatpp::web::protocol::http::QueryParams queryParams);
     std::shared_ptr<oatpp::web::protocol::http::outgoing::Response>

--- a/src/oatppjsonapi.h
+++ b/src/oatppjsonapi.h
@@ -31,8 +31,6 @@ namespace dd
 {
   class OatppJsonAPI : public JsonAPI
   {
-    std::shared_ptr<spdlog::logger> _logger;
-
   public:
     OatppJsonAPI();
     ~OatppJsonAPI();


### PR DESCRIPTION
## fix: raise error is jsonapi is invalid


## feat: use oatpp by default


## feat: enable backtrace on segfault for oatpp


## fix(oatpp): use parent _logger object
