### PR TITLE
feat: custom & improved torch multi-gpu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -713,6 +713,7 @@ if (USE_TORCH)
     ${PYTORCH_PATCHES_PATH}/pytorch_16_logging.patch
     ${PYTORCH_PATCHES_PATH}/pytorch_14_namespace.patch
     ${PYTORCH_PATCHES_PATH}/pytorch_16_fatbin.patch
+    ${PYTORCH_PATCHES_PATH}/pytorch_16_module_public.patch
   )
 
   message(STATUS "Configuring libtorch")

--- a/patches/pytorch/pytorch_16_module_public.patch
+++ b/patches/pytorch/pytorch_16_module_public.patch
@@ -1,0 +1,13 @@
+diff --git a/torch/csrc/api/include/torch/nn/module.h b/torch/csrc/api/include/torch/nn/module.h
+index 313e331da3..32bd2e3b8a 100644
+--- a/torch/csrc/api/include/torch/nn/module.h
++++ b/torch/csrc/api/include/torch/nn/module.h
+@@ -538,7 +538,7 @@ class TORCH_API Module : public std::enable_shared_from_this<Module> {
+       "`FORWARD_HAS_DEFAULT_ARGS` macro to do so.");
+   }
+ 
+- private:
++ public:
+   // Friend classes.
+ 
+   template <typename Derived>

--- a/src/backends/torch/data_parallel.h
+++ b/src/backends/torch/data_parallel.h
@@ -1,0 +1,94 @@
+#pragma once
+
+#include <torch/cuda.h>
+#include <torch/nn/module.h>
+#include <torch/nn/pimpl.h>
+#include <torch/types.h>
+
+#include <torch/csrc/autograd/functions/comm.h>
+#include <torch/csrc/autograd/functions/utils.h>
+#include <ATen/core/functional.h>
+
+#include <ATen/Device.h>
+#include <ATen/Parallel.h>
+#include <c10/core/TensorOptions.h>
+#include <c10/util/Exception.h>
+
+#include <cstddef>
+#include <exception>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+namespace dd
+{
+  namespace parallel
+  {
+
+    template <typename ModuleType>
+    std::vector<ModuleType>
+        _replicas; /**< holder of module replica pointers. */
+
+    /**
+     * \brief Customized torch data_parallel to avoid deep module replication
+     * in two situations:
+     *      - When the weights to be copied are already on the same device as
+     * target.
+     *      - When successive iterations do accumulate over the loss and no
+     * weight update is required. This allows using `iter_size` to spend more
+     * time on every GPU, accumulating the loss over large batches.
+     */
+    template <typename ModuleType>
+    Tensor dd_data_parallel(ModuleType module, Tensor input,
+                            optional<std::vector<Device>> devices = nullopt,
+                            optional<Device> output_device = nullopt,
+                            int64_t dim = 0, bool replicate = true)
+    {
+      if (!devices)
+        {
+          const auto device_count = torch::cuda::device_count();
+          TORCH_CHECK(device_count > 0,
+                      "Expected at least one CUDA device to be available");
+          devices = std::vector<Device>();
+          devices->reserve(device_count);
+          for (size_t index = 0; index < device_count; ++index)
+            {
+              devices->emplace_back(kCUDA, index);
+            }
+        }
+      if (!output_device)
+        {
+          output_device = devices->front();
+        }
+
+      if (devices->size() == 1)
+        {
+          module->to(devices->front());
+          input = input.to(devices->front());
+          return module->forward(std::move(input)).to(*output_device);
+        }
+
+      autograd::Scatter scatter(*devices, /*chunk_sizes=*/nullopt, dim);
+      auto scattered_inputs
+          = fmap<Tensor>(scatter.apply({ std::move(input) }));
+      // Input tensor might not be big enough to scale across all available
+      // devices
+      if (scattered_inputs.size() < devices->size())
+        {
+          devices->resize(scattered_inputs.size(),
+                          Device(DeviceType::COMPILE_TIME_MAX_DEVICE_TYPES));
+        }
+
+      if (replicate)
+        _replicas<ModuleType> = torch::nn::parallel::replicate(module,
+                                                               *devices);
+
+      auto outputs = torch::nn::parallel::parallel_apply(
+          _replicas<ModuleType>, scattered_inputs, *devices);
+      return autograd::Gather(*output_device, dim)
+          .apply(fmap<autograd::Variable>(std::move(outputs)))
+          .front();
+    }
+
+  } // namespace parallel
+} // namespace dd

--- a/src/backends/torch/native/native_net.h
+++ b/src/backends/torch/native/native_net.h
@@ -29,6 +29,10 @@
 
 #include "../torchinputconns.h"
 
+using namespace torch;
+using namespace torch::nn;
+using namespace c10;
+
 namespace dd
 {
 
@@ -76,8 +80,117 @@ namespace dd
         = 0;
   };
 
+  template <typename Derived>
+  class DDCloneable : public virtual torch::nn::Module
+  {
+  public:
+    virtual ~DDCloneable() = default;
+    using Module::Module;
+
+    /// `reset()` must perform initialization of all members with reference
+    /// semantics, most importantly parameters, buffers and submodules.
+    virtual void reset() = 0;
+
+    // selective cloning
+    std::shared_ptr<Module> clone(const optional<Device> &device
+                                  = nullopt) const override
+    {
+      NoGradGuard no_grad;
+
+      const auto &self = static_cast<const Derived &>(*this);
+
+      bool first_iter = true;
+      std::shared_ptr<Derived> copy;
+      auto hit = _copies.begin();
+      if ((hit = _copies.find(device->str())) == _copies.end())
+        {
+          copy = std::make_shared<Derived>(self);
+          copy->parameters_.clear();
+          copy->buffers_.clear();
+          copy->children_.clear();
+          copy->reset();
+
+          // store copy
+          _copies.insert(std::pair<std::string, std::shared_ptr<Derived>>(
+              device->str(), copy));
+        }
+      else
+        {
+          // retrieve copy
+          copy = (*hit).second;
+          first_iter = false;
+        }
+
+      TORCH_CHECK(
+          copy->parameters_.size() == this->parameters_.size(),
+          "The cloned module does not have the same number of "
+          "parameters as the original module after calling reset(). "
+          "Are you sure you called register_parameter() inside reset() "
+          "and not the constructor?");
+      for (const auto &parameter : named_parameters(/*recurse=*/false))
+        {
+          auto &tensor = *parameter;
+          auto data = device && tensor.device() != *device ? tensor.to(*device)
+                                                           : tensor;
+          if (first_iter)
+            copy->parameters_[parameter.key()].set_data(data);
+          else
+            copy->parameters_[parameter.key()].copy_(data);
+        }
+
+      TORCH_CHECK(copy->buffers_.size() == this->buffers_.size(),
+                  "The cloned module does not have the same number of "
+                  "buffers as the original module after calling reset(). "
+                  "Are you sure you called register_buffer() inside reset() "
+                  "and not the constructor?");
+      for (const auto &buffer : named_buffers(/*recurse=*/false))
+        {
+          auto &tensor = *buffer;
+          auto data = device && tensor.device() != *device ? tensor.to(*device)
+                                                           : tensor;
+          if (first_iter)
+            copy->buffers_[buffer.key()].set_data(data);
+          else
+            copy->buffers_[buffer.key()].copy_(data);
+        }
+
+      TORCH_CHECK(
+          copy->children_.size() == this->children_.size(),
+          "The cloned module does not have the same number of "
+          "child modules as the original module after calling reset(). "
+          "Are you sure you called register_module() inside reset() "
+          "and not the constructor?");
+
+#pragma omp parallel for
+      // for (const auto &child : this->children_)
+      for (size_t i = 0; i < this->children_.size(); i++)
+        {
+          auto child = this->children_[i];
+          copy->children_[child.key()]->clone_(*child.value(), device);
+        }
+      return copy;
+    }
+
+  private:
+    void clone_(Module &other, const optional<Device> &device) final
+    {
+      // Here we are *pretty* certain that `other's` type is `Derived` (because
+      // it was registered under the same name as `this`), but you never know
+      // what crazy things `reset()` does, so `dynamic_cast` just to be safe.
+      auto clone = std::dynamic_pointer_cast<Derived>(other.clone(device));
+      TORCH_CHECK(
+          clone != nullptr,
+          "Attempted to clone submodule, but it is of a "
+          "different type than the submodule it was to be cloned into");
+      static_cast<Derived &>(*this) = std::move(*clone);
+    }
+
+    mutable std::unordered_map<std::string, std::shared_ptr<Derived>>
+        _copies; /**< deep module copies holder, key is device string. */
+  };
+
   template <typename T>
-  class NativeModuleImpl : public NativeModule, public torch::nn::Cloneable<T>
+  class NativeModuleImpl : public NativeModule, public DDCloneable<T>
   {
   };
 }

--- a/src/backends/torch/native/templates/nbeats.h
+++ b/src/backends/torch/native/templates/nbeats.h
@@ -106,7 +106,7 @@ namespace dd
     typedef torch::nn::ModuleHolder<BlockImpl> Block;
 
     class SeasonalityBlockImpl : public BlockImpl,
-                                 public Cloneable<SeasonalityBlockImpl>
+                                 public DDCloneable<SeasonalityBlockImpl>
     {
     public:
       SeasonalityBlockImpl(int units, int thetas_dim, int backcast_length,
@@ -148,7 +148,7 @@ namespace dd
 
     typedef torch::nn::ModuleHolder<SeasonalityBlockImpl> SeasonalityBlock;
 
-    class TrendBlockImpl : public BlockImpl, public Cloneable<TrendBlockImpl>
+    class TrendBlockImpl : public BlockImpl, public DDCloneable<TrendBlockImpl>
     {
     public:
       TrendBlockImpl(int units, int thetas_dim, int backcast_length,
@@ -191,7 +191,7 @@ namespace dd
     typedef torch::nn::ModuleHolder<TrendBlockImpl> TrendBlock;
 
     class GenericBlockImpl : public BlockImpl,
-                             public Cloneable<GenericBlockImpl>
+                             public DDCloneable<GenericBlockImpl>
     {
     public:
       GenericBlockImpl(int units, int thetas_dim, int backcast_length,

--- a/src/backends/torch/native/templates/vit.h
+++ b/src/backends/torch/native/templates/vit.h
@@ -36,7 +36,7 @@ namespace dd
   class ViT : public NativeModuleImpl<ViT>
   {
 
-    class MLPImpl : public torch::nn::Cloneable<MLPImpl>
+    class MLPImpl : public DDCloneable<MLPImpl>
     {
     public:
       MLPImpl(const int &input_dim, const int &hidden_dim,
@@ -82,7 +82,7 @@ namespace dd
 
     typedef torch::nn::ModuleHolder<MLPImpl> MLP;
 
-    class AttentionImpl : public torch::nn::Cloneable<AttentionImpl>
+    class AttentionImpl : public DDCloneable<AttentionImpl>
     {
     public:
       AttentionImpl(const int &dim, const int &num_heads = 8,
@@ -193,7 +193,7 @@ namespace dd
 
     typedef torch::nn::ModuleHolder<BlockImpl> Block;
 
-    class PatchEmbedImpl : public torch::nn::Cloneable<PatchEmbedImpl>
+    class PatchEmbedImpl : public DDCloneable<PatchEmbedImpl>
     {
     public:
       PatchEmbedImpl(const int &img_size = 224, const int &patch_size = 16,

--- a/src/backends/torch/torchlib.cc
+++ b/src/backends/torch/torchlib.cc
@@ -624,8 +624,10 @@ namespace dd
             Tensor y_pred;
             try
               {
+                bool replicate
+                    = (batch_id == 0 || (batch_id + 1) % iter_size == 0);
                 y_pred = torch_utils::to_tensor_safe(
-                    _module.forward_on_devices(in_vals, _devices));
+                    _module.forward_on_devices(in_vals, _devices, replicate));
               }
             catch (std::exception &e)
               {

--- a/src/backends/torch/torchmodule.cc
+++ b/src/backends/torch/torchmodule.cc
@@ -296,7 +296,8 @@ namespace dd
 
   c10::IValue
   TorchModule::forward_on_devices(std::vector<c10::IValue> source,
-                                  const std::vector<torch::Device> &devices)
+                                  const std::vector<torch::Device> &devices,
+                                  const bool &replicate)
   {
     // Normal forward if only one device
     if (devices.size() <= 1)
@@ -314,8 +315,9 @@ namespace dd
       }
     if (_native)
       {
-        return torch::nn::parallel::data_parallel(
-            _native, torch_utils::to_tensor_safe(source[0]), devices, _device);
+        return parallel::dd_data_parallel(
+            _native, torch_utils::to_tensor_safe(source[0]), devices, _device,
+            0 /*dim*/, replicate);
       }
     if (_traced)
       {

--- a/src/backends/torch/torchmodule.h
+++ b/src/backends/torch/torchmodule.h
@@ -36,6 +36,7 @@
 #include <torch/script.h>
 #include <torch/nn/pimpl.h>
 #include <torch/nn/parallel/data_parallel.h>
+#include "data_parallel.h"
 
 namespace dd
 {
@@ -60,7 +61,8 @@ namespace dd
      * forward.
      */
     c10::IValue forward_on_devices(std::vector<c10::IValue> source,
-                                   const std::vector<torch::Device> &devices);
+                                   const std::vector<torch::Device> &devices,
+                                   const bool &replicate = false);
 
     /**
      * \brief forward (inference) until extract_layer, return value of


### PR DESCRIPTION
This PR modifies libtorch default C++ data parallel multi-gpu distribution mode with the following speed-ups:
~- do not deep clone modules if source and target devices are the same~
- only deep clone modules on the first multi-gpu iteration
- do not recopy weights across gpus when using multiple forward passes over multiple batches (using `iter_size`).

The C++ libtorch data parallel implementation is notoriously slow, see https://github.com/pytorch/pytorch/issues/40581 and this PR speeds things up a bit. 

Next step would be a pure C++ DDP implementation.

Note: this PR patches pytorch 1.6 to make `clone_` and other module's inner members accessible.