### PR TITLE
feat: add access log for oat++

### DIFF
--- a/src/http/controller.hpp
+++ b/src/http/controller.hpp
@@ -59,13 +59,15 @@ public:
   {
     info->summary = "Retreive server information";
   }
-  ENDPOINT("GET", "info", get_info, QUERIES(QueryParams, queryParams))
+  ENDPOINT("GET", "info", get_info,
+           REQUEST(std::shared_ptr<IncomingRequest>, req),
+           QUERIES(QueryParams, queryParams))
   {
     // TODO(sileht): why do serialize the query string to char*
     // to later get again a APIData...
     std::string jsonstr = _oja->uri_query_to_json(queryParams);
     auto janswer = _oja->info(jsonstr);
-    return _oja->jdoc_to_response(janswer);
+    return _oja->jdoc_to_response(req, janswer);
   }
 
   ENDPOINT_INFO(get_service)
@@ -73,10 +75,11 @@ public:
     info->summary = "Retreive a service detail";
   }
   ENDPOINT("GET", "services/{service-name}", get_service,
+           REQUEST(std::shared_ptr<IncomingRequest>, req),
            PATH(oatpp::String, service_name, "service-name"))
   {
     auto janswer = _oja->service_status(service_name.get()->std_str());
-    return _oja->jdoc_to_response(janswer);
+    return _oja->jdoc_to_response(req, janswer);
   }
 
   ENDPOINT_INFO(create_service)
@@ -84,12 +87,13 @@ public:
     info->summary = "Create a service";
   }
   ENDPOINT("POST", "services/{service-name}", create_service,
+           REQUEST(std::shared_ptr<IncomingRequest>, req),
            PATH(oatpp::String, service_name, "service-name"),
            BODY_STRING(oatpp::String, service_data))
   {
     auto janswer = _oja->service_create(service_name.get()->std_str(),
                                         service_data.get()->std_str());
-    return _oja->jdoc_to_response(janswer);
+    return _oja->jdoc_to_response(req, janswer);
   }
 
   ENDPOINT_INFO(update_service)
@@ -98,25 +102,27 @@ public:
     info->hide = true;
   }
   ENDPOINT("PUT", "services/{service-name}", update_service,
+           REQUEST(std::shared_ptr<IncomingRequest>, req),
            PATH(oatpp::String, service_name, "service-name"),
            BODY_STRING(oatpp::String, service_data))
   {
     auto janswer = _oja->service_create(service_name.get()->std_str(),
                                         service_data.get()->std_str());
-    return _oja->jdoc_to_response(janswer);
+    return _oja->jdoc_to_response(req, janswer);
   }
   ENDPOINT_INFO(delete_service)
   {
     info->summary = "Delete a service";
   }
   ENDPOINT("DELETE", "services/{service-name}", delete_service,
+           REQUEST(std::shared_ptr<IncomingRequest>, req),
            PATH(oatpp::String, service_name, "service-name"),
            QUERIES(QueryParams, queryParams))
   {
     std::string jsonstr = _oja->uri_query_to_json(queryParams);
     auto janswer
         = _oja->service_delete(service_name.get()->std_str(), jsonstr);
-    return _oja->jdoc_to_response(janswer);
+    return _oja->jdoc_to_response(req, janswer);
   }
 
   ENDPOINT_INFO(predict)
@@ -124,31 +130,36 @@ public:
     info->summary = "Predict";
   }
   ENDPOINT("POST", "predict", predict,
+           REQUEST(std::shared_ptr<IncomingRequest>, req),
            BODY_STRING(oatpp::String, predict_data))
   {
     auto janswer = _oja->service_predict(predict_data.get()->std_str());
-    return _oja->jdoc_to_response(janswer);
+    return _oja->jdoc_to_response(req, janswer);
   }
 
   ENDPOINT_INFO(get_train)
   {
     info->summary = "Retreive a training status";
   }
-  ENDPOINT("GET", "train", get_train, QUERIES(QueryParams, queryParams))
+  ENDPOINT("GET", "train", get_train,
+           REQUEST(std::shared_ptr<IncomingRequest>, req),
+           QUERIES(QueryParams, queryParams))
   {
     std::string jsonstr = _oja->uri_query_to_json(queryParams);
     auto janswer = _oja->service_train_status(jsonstr);
-    return _oja->jdoc_to_response(janswer);
+    return _oja->jdoc_to_response(req, janswer);
   }
 
   ENDPOINT_INFO(post_train)
   {
     info->summary = "Do a training";
   }
-  ENDPOINT("POST", "train", post_train, BODY_STRING(oatpp::String, train_data))
+  ENDPOINT("POST", "train", post_train,
+           REQUEST(std::shared_ptr<IncomingRequest>, req),
+           BODY_STRING(oatpp::String, train_data))
   {
     auto janswer = _oja->service_train(train_data.get()->std_str());
-    return _oja->jdoc_to_response(janswer);
+    return _oja->jdoc_to_response(req, janswer);
   }
 
   ENDPOINT_INFO(put_train)
@@ -156,20 +167,25 @@ public:
     // Don't document PUT, it's a dup of POST, maybe deprecate it later
     info->hide = true;
   }
-  ENDPOINT("PUT", "train", put_train, BODY_STRING(oatpp::String, train_data))
+  ENDPOINT("PUT", "train", put_train,
+           REQUEST(std::shared_ptr<IncomingRequest>, req),
+
+           BODY_STRING(oatpp::String, train_data))
   {
     auto janswer = _oja->service_train(train_data.get()->std_str());
-    return _oja->jdoc_to_response(janswer);
+    return _oja->jdoc_to_response(req, janswer);
   }
   ENDPOINT_INFO(delete_train)
   {
     info->summary = "Delete a training";
   }
-  ENDPOINT("DELETE", "train", delete_train, QUERIES(QueryParams, queryParams))
+  ENDPOINT("DELETE", "train", delete_train,
+           REQUEST(std::shared_ptr<IncomingRequest>, req),
+           QUERIES(QueryParams, queryParams))
   {
     std::string jsonstr = _oja->uri_query_to_json(queryParams);
     auto janswer = _oja->service_train_delete(jsonstr);
-    return _oja->jdoc_to_response(janswer);
+    return _oja->jdoc_to_response(req, janswer);
   }
 
   ENDPOINT_INFO(create_chain)
@@ -177,12 +193,13 @@ public:
     info->summary = "Run a chain";
   }
   ENDPOINT("POST", "chains/{chain-name}", create_chain,
+           REQUEST(std::shared_ptr<IncomingRequest>, req),
            PATH(oatpp::String, chain_name, "chain-name"),
            BODY_STRING(oatpp::String, chain_data))
   {
     auto janswer = _oja->service_chain(chain_name.get()->std_str(),
                                        chain_data.get()->std_str());
-    return _oja->jdoc_to_response(janswer);
+    return _oja->jdoc_to_response(req, janswer);
   }
 
   ENDPOINT_INFO(update_chain)
@@ -191,12 +208,13 @@ public:
     info->hide = true;
   }
   ENDPOINT("PUT", "chain/{chain-name}", update_chain,
+           REQUEST(std::shared_ptr<IncomingRequest>, req),
            PATH(oatpp::String, chain_name, "chain-name"),
            BODY_STRING(oatpp::String, chain_data))
   {
     auto janswer = _oja->service_chain(chain_name.get()->std_str(),
                                        chain_data.get()->std_str());
-    return _oja->jdoc_to_response(janswer);
+    return _oja->jdoc_to_response(req, janswer);
   }
 };
 

--- a/src/oatppjsonapi.cc
+++ b/src/oatppjsonapi.cc
@@ -31,6 +31,7 @@
 #include "oatpp/web/protocol/http/outgoing/ResponseFactory.hpp"
 #include "oatpp/web/server/HttpConnectionHandler.hpp"
 #include "oatpp/web/server/HttpRouter.hpp"
+#include "oatpp/web/server/api/ApiController.hpp"
 #include "oatpp/network/tcp/server/ConnectionProvider.hpp"
 #include "oatpp/parser/json/mapping/ObjectMapper.hpp"
 #include "oatpp/core/macro/component.hpp"
@@ -165,9 +166,11 @@ namespace dd
   }
 
   std::shared_ptr<oatpp::web::protocol::http::outgoing::Response>
-  OatppJsonAPI::jdoc_to_response(const JDoc &janswer)
+  OatppJsonAPI::jdoc_to_response(
+      const std::shared_ptr<
+          oatpp::web::server::api::ApiController::IncomingRequest> &request,
+      const JDoc &janswer)
   {
-
     int outcode = janswer["status"]["code"].GetInt();
     std::string stranswer;
     // if output template, fillup with rendered template.
@@ -218,6 +221,30 @@ namespace dd
               }
           }
       }
+
+    // TODO(sileht): START
+    // Replace hack by a oatpp ResponseInterceptor when 1.2.5 is released
+    if (request)
+      {
+        auto req = request->getStartingLine();
+        std::string access_log = req.protocol.std_str() + " \""
+                                 + req.method.std_str() + " "
+                                 + req.path.std_str() + "\"";
+        std::string service;
+        if (janswer.HasMember("head"))
+          {
+            if (janswer["head"].HasMember("service"))
+              service = janswer["head"]["service"].GetString();
+          }
+        if (!service.empty())
+          access_log += " " + service;
+        access_log += " " + std::to_string(outcode);
+        if (outcode == 200 || outcode == 201)
+          _logger->info(access_log);
+        else
+          _logger->error(access_log);
+      }
+    // TODO(sileht): END
 
     auto response = oatpp::web::protocol::http::outgoing::ResponseFactory::
         createResponse(oatpp::web::protocol::http::Status(outcode, ""),

--- a/src/oatppjsonapi.h
+++ b/src/oatppjsonapi.h
@@ -26,6 +26,7 @@
 #include "oatpp/network/Server.hpp"
 #include "oatpp/web/protocol/http/Http.hpp"
 #include "oatpp/web/protocol/http/outgoing/Response.hpp"
+#include "oatpp/web/server/api/ApiController.hpp"
 
 namespace dd
 {
@@ -42,7 +43,10 @@ namespace dd
     std::string
     uri_query_to_json(oatpp::web::protocol::http::QueryParams queryParams);
     std::shared_ptr<oatpp::web::protocol::http::outgoing::Response>
-    jdoc_to_response(const JDoc &janswer);
+    jdoc_to_response(
+        const std::shared_ptr<
+            oatpp::web::server::api::ApiController::IncomingRequest> &request,
+        const JDoc &janswer);
   };
 }
 


### PR DESCRIPTION
This is a partial implementation, HTTP 404 returned by oatpp itself are
not yet logged.

We wait 1.2.5 version of oat++ that provides a hook designed to
do access log (`responseInterceptors`).