### PR TITLE
fix: ddimg logger ptr

### DIFF
--- a/src/imginputfileconn.h
+++ b/src/imginputfileconn.h
@@ -550,6 +550,7 @@ namespace dd
 #ifdef USE_CUDA_CV
       dimg._cuda = _cuda;
 #endif
+      dimg._logger = _logger;
     }
 
     int feature_size() const


### PR DESCRIPTION
This fixes crashes in torch image connector when some image paths are wrong / not reachable.