### PR TITLE
feat(torch): native models can load weights from any jit file

### DIFF
--- a/src/backends/torch/torchmodule.cc
+++ b/src/backends/torch/torchmodule.cc
@@ -122,7 +122,8 @@ namespace dd
         _logger->info("loading " + tmodel._native);
         try
           {
-            torch::load(_native, tmodel._native, _device);
+            torch_utils::load_weights(*_native, tmodel._native, _device,
+                                      _logger);
           }
         catch (std::exception &e)
           {

--- a/src/backends/torch/torchutils.h
+++ b/src/backends/torch/torchutils.h
@@ -94,6 +94,14 @@ namespace dd
                         bool requires_grad = true);
 
     std::vector<c10::IValue> unwrap_c10_vector(const c10::IValue &output);
+
+    void copy_weights(const torch::jit::script::Module &from,
+                      torch::nn::Module &to, const torch::Device &device,
+                      std::shared_ptr<spdlog::logger> logger = nullptr);
+
+    void load_weights(torch::nn::Module &module, const std::string &filename,
+                      const torch::Device &device,
+                      std::shared_ptr<spdlog::logger> logger = nullptr);
   }
 }
 #endif


### PR DESCRIPTION
Added a function "copy_weights" to copy common weights from a
script module to a nn::Module. Weights that do not match are
ignored, and printed to the logs as warning.