### PR TITLE
refactor: make logger torch-friendly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -710,7 +710,8 @@ if (USE_TORCH)
 
   set(PYTORCH_PATCHES
     ${PYTORCH_PATCHES_PATH}/pytorch_15_compile.patch
-    ${PYTORCH_PATCHES_PATH}/pytorch_16_logging.patch
+    ${PYTORCH_PATCHES_PATH}/pytorch_16_new_logger.patch
+    ${PYTORCH_PATCHES_PATH}/pytorch_16_use_new_logger.patch
     ${PYTORCH_PATCHES_PATH}/pytorch_14_namespace.patch
     ${PYTORCH_PATCHES_PATH}/pytorch_16_fatbin.patch
   )
@@ -741,7 +742,7 @@ if (USE_TORCH)
       PATCH_COMMAND test -f ${PYTORCH_COMPLETE} && echo Skipping || git apply ${PYTORCH_PATCHES} && echo Applying ${PYTORCH_PATCHES}
       CONFIGURE_COMMAND ""
       BUILD_COMMAND ""
-      COMMAND test -f ${PYTORCH_COMPLETE} && echo Skipping || PATH=${PROTOBUF_LIB_DIR}:$ENV{PATH} BUILD_CUSTOM_PROTOBUF=0 GLIBCXX_USE_CXX11_ABI=1 BUILD_TEST=0 USE_CUDA=${PYTORCH_USE_CUDA} BUILD_CAFFE2_OPS=0 USE_GLOG=0 CAFFE2_LINK_LOCAL_PROTOBUF=0 MAX_JOBS=8 python3 ../pytorch/tools/build_libtorch.py
+      COMMAND test -f ${PYTORCH_COMPLETE} && echo Skipping || PATH=${PROTOBUF_LIB_DIR}:$ENV{PATH} BUILD_CUSTOM_PROTOBUF=0 GLIBCXX_USE_CXX11_ABI=1 BUILD_TEST=0 USE_CUDA=${PYTORCH_USE_CUDA} BUILD_CAFFE2_OPS=0 USE_DDLOG=1 CAFFE2_LINK_LOCAL_PROTOBUF=0 MAX_JOBS=8 python3 ../pytorch/tools/build_libtorch.py
       INSTALL_COMMAND ""
     )
 

--- a/patches/pytorch/pytorch_16_new_logger.patch
+++ b/patches/pytorch/pytorch_16_new_logger.patch
@@ -1,0 +1,283 @@
+diff --git a/c10/util/logging_is_dd_log.h b/c10/util/logging_is_dd_log.h
+new file mode 100644
+index 0000000000..56ebbf9441
+--- /dev/null
++++ b/c10/util/logging_is_dd_log.h
+@@ -0,0 +1,60 @@
++#ifndef DD_LOG_H
++#define DD_LOG_H
++#include <set>
++#include <iomanip>
++
++#include "caffe/llogging.h"
++
++#ifndef VLOG
++#define DEBUG "none"
++static const std::string VLogLevels[4] = {DEBUG, DEBUG, DEBUG, DEBUG};
++#define VLOG(n) LOG(VLogLevels[n])
++#endif
++
++#define LOG_AS_STRING(l, o) \
++  std::stringstream ss;     \
++  ss << o;                  \
++  return l << ss.str();
++
++namespace std {
++
++#define LOG_PAIR(s)                                                 \
++  template <class First, class Second>                              \
++  inline s& operator<<(s& out, const std::pair<First, Second>& p) { \
++    return out << '(' << p.first << ", " << p.second << ')';        \
++  }
++
++LOG_PAIR(std::ostream)
++
++#define LOG_CONTAINER(s, c)                              \
++  template <class... Types>                              \
++  s& operator<<(s& out, const c<Types...>& seq) {        \
++    int i = 0;                                           \
++    for (auto it = seq.begin(); it != seq.end(); ++it) { \
++      if (i++) {                                         \
++        out << ' ';                                      \
++      }                                                  \
++      if (i > 100) {                                     \
++        return out << "...";                             \
++      }                                                  \
++      out << *it;                                        \
++    }                                                    \
++    return out;                                          \
++  }
++
++LOG_CONTAINER(std::ostream, std::vector)
++LOG_CONTAINER(std::ostream, std::map)
++LOG_CONTAINER(std::ostream, std::set)
++} // namespace std
++
++#define VLOG_IS_ON(n) true
++
++namespace c10 {
++bool InitCaffeLogging(int* argc, char** argv);
++void UpdateLoggingLevelsFromFlags();
++
++void ShowLogInfoToStderr();
++
++} // namespace c10
++
++#endif
+diff --git a/caffe/llogging.h b/caffe/llogging.h
+new file mode 100644
+index 0000000000..ff97118ff2
+--- /dev/null
++++ b/caffe/llogging.h
+@@ -0,0 +1,211 @@
++/**
++ * Author: Emmanuel Benazera <beniz@droidnik.fr>
++ */
++
++#ifndef LLOGGING_H
++#define LLOGGING_H
++
++#include <spdlog/spdlog.h>
++#include <boost/algorithm/string.hpp>
++#include <iostream>
++
++class DateLogger {
++ public:
++  DateLogger() {
++#if defined(_MSC_VER)
++    _tzset();
++#endif
++  }
++  const char* HumanDate() {
++#if defined(_MSC_VER)
++    _strtime_s(buffer_, sizeof(buffer_));
++#else
++    time_t time_value = time(NULL);
++    struct tm *pnow;
++#if !defined(_WIN32)
++    struct tm now;
++    pnow = localtime_r(&time_value, &now);
++#else
++    pnow = localtime(&time_value);  // NOLINT(*)
++#endif
++    snprintf(buffer_, sizeof(buffer_), "%02d:%02d:%02d",
++             pnow->tm_hour, pnow->tm_min, pnow->tm_sec);
++#endif
++    return buffer_;
++  }
++
++ private:
++  char buffer_[9];
++};
++
++// avoid fatal checks from glog
++#define CAFFE_THROW_ON_ERROR
++
++// make sure we erase definitions by glog if any
++#undef LOG
++#undef LOG_IF
++#undef CHECK
++#undef CHECK_OP_LOG
++#undef CHECK_EQ
++#undef CHECK_LT
++#undef CHECK_GT
++#undef CHECK_LE
++#undef CHECK_GE
++#undef CHECK_EQ
++#undef CHECK_NE
++#undef CHECK_OP_LOG
++#undef CHECK_NOTNULL
++#undef DCHECK
++#undef DCHECK_LT
++#undef DCHECK_GT
++#undef DCHECK_LE
++#undef DCHECK_GE
++#undef DCHECK_EQ
++#undef DCHECK_NE
++#undef DLOG
++#undef DFATAL
++#undef LOG_DFATAL
++#undef LOG_EVERY_N
++
++#ifdef CAFFE_THROW_ON_ERROR
++#include <sstream>
++#define SSTR( x ) dynamic_cast< std::ostringstream & >( \
++		 ( std::ostringstream() << std::dec << x ) ).str()
++class CaffeErrorException : public std::exception
++{
++public:
++  CaffeErrorException(const std::string &s):_s(s) {}
++  ~CaffeErrorException() throw() {}
++  const char* what() const throw() { return _s.c_str(); }
++  std::string _s;
++};
++
++static std::string INFO="INFO";
++static std::string WARNING="WARNING";
++static std::string ERROR="ERROR";
++static std::string FATAL="FATAL";
++
++#define GLOG_NO_ABBREVIATED_SEVERITIES
++
++#define INFO INFO
++#define WARNING WARNING
++#define ERROR ERROR
++#define FATAL FATAL
++
++static std::ostream nullstream(0);
++
++#define CHECK(condition)						\
++  if (!(condition)) \
++    throw CaffeErrorException(std::string(__FILE__) + ":" + SSTR(__LINE__) + " / Check failed (custom): " #condition ""); \
++  nullstream									\
++  << "Check failed (custom): " #condition " "
++
++#define CHECK_LT(x, y) CHECK((x) < (y))
++#define CHECK_GT(x, y) CHECK((x) > (y))
++#define CHECK_LE(x, y) CHECK((x) <= (y))
++#define CHECK_GE(x, y) CHECK((x) >= (y))
++#define CHECK_EQ(x, y) CHECK((x) == (y))
++#define CHECK_NE(x, y) CHECK((x) != (y))
++
++#define CHECK_OP_LOG(name, op, val1, val2, log) CHECK((val1) op (val2))
++/* #ifdef DEBUG */
++/* #define CHECK_EQ(val1,val2) if (0) std::cerr */
++/* #endif */
++#endif
++
++#define CHECK_NOTNULL(x) \
++  ((x) == NULL ? LOG(FATAL) << "Check  notnull: "  #x << ' ', (x) : (x)) // NOLINT(*)
++
++#ifdef NDEBUG
++#define DCHECK(x) \
++  while (false) CHECK(x)
++#define DCHECK_LT(x, y) \
++  while (false) CHECK((x) < (y))
++#define DCHECK_GT(x, y) \
++  while (false) CHECK((x) > (y))
++#define DCHECK_LE(x, y) \
++  while (false) CHECK((x) <= (y))
++#define DCHECK_GE(x, y) \
++  while (false) CHECK((x) >= (y))
++#define DCHECK_EQ(x, y) \
++  while (false) CHECK((x) == (y))
++#define DCHECK_NE(x, y) \
++  while (false) CHECK((x) != (y))
++#else
++#define DCHECK(x) CHECK(x)
++#define DCHECK_LT(x, y) CHECK((x) < (y))
++#define DCHECK_GT(x, y) CHECK((x) > (y))
++#define DCHECK_LE(x, y) CHECK((x) <= (y))
++#define DCHECK_GE(x, y) CHECK((x) >= (y))
++#define DCHECK_EQ(x, y) CHECK((x) == (y))
++#define DCHECK_NE(x, y) CHECK((x) != (y))
++#endif  // NDEBUG
++
++class CaffeLogger {
++ public:
++  CaffeLogger(const std::string& severity) : _severity(severity) {
++    _console = spdlog::get("pytorch");
++    if (!_console)
++#ifdef USE_SYSLOG
++      _console = spdlog::syslog_logger("pytorch");
++#else
++      _console = spdlog::stdout_logger_mt("pytorch");
++#endif
++  }
++
++  ~CaffeLogger() {
++    if (_severity == "none" || _sstr.str().empty()) // ignore
++    {
++    } else if (_severity == INFO)
++      _console->info(_sstr.str());
++    else if (_severity == WARNING)
++      _console->warn(_sstr.str());
++    else if (_severity == ERROR)
++      _console->error(_sstr.str());
++  }
++
++  std::stringstream& sstream() {
++    if (_severity != FATAL)
++      return _sstr;
++    else
++      throw CaffeErrorException(
++          std::string(__FILE__) + ":" + SSTR(__LINE__) +
++          " / Fatal Caffe error"); // XXX: cannot report the exact location
++    // of the trigger...
++  }
++
++  std::string _severity = INFO;
++  std::shared_ptr<spdlog::logger> _console;
++  std::stringstream _sstr;
++  // std::string _str;
++};
++
++#define LOG(s) CaffeLogger(s).sstream()
++
++#define LOG_IF(s, cond) \
++  if (cond)             \
++    CaffeLogger(s).sstream()
++
++#define LOG_AT_FILE_LINE(s, file, line) \
++  CaffeLogger(s).sstream() << "source file:" << file << "  line: " << line
++
++#ifdef NDEBUG
++
++#define DFATAL(s) CaffeLogger("none").sstream()
++
++#define LOG_DFATAL(s) CaffeLogger("none").sstream()
++
++#define DLOG(s) CaffeLogger("none").sstream()
++
++#else
++#define DFATAL(s) CaffeLogger(FATAL).sstream()
++
++#define LOG_DFATAL(s) CaffeLogger(FATAL).sstream()
++
++#define DLOG(s) CaffeLogger(s).sstream()
++#endif
++
++// Poor man's version...
++#define LOG_EVERY_N(s, n) CaffeLogger(s).sstream()
++
++#endif

--- a/patches/pytorch/pytorch_16_use_new_logger.patch
+++ b/patches/pytorch/pytorch_16_use_new_logger.patch
@@ -1,0 +1,106 @@
+diff --git a/c10/CMakeLists.txt b/c10/CMakeLists.txt
+index 818226cdc8..92c1068a7a 100644
+--- a/c10/CMakeLists.txt
++++ b/c10/CMakeLists.txt
+@@ -15,6 +15,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+ # ---[ Configure macro file.
+ set(C10_USE_GFLAGS ${USE_GFLAGS}) # used in cmake_macros.h.in
+ set(C10_USE_GLOG ${USE_GLOG}) # used in cmake_macros.h.in
++set(C10_USE_DDLOG ${USE_DDLOG}) # used in cmake_macros.h.in
+ set(C10_BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS}) # used in cmake_macros.h.in
+ set(C10_USE_NUMA ${USE_NUMA})
+ configure_file(
+diff --git a/c10/macros/cmake_macros.h.in b/c10/macros/cmake_macros.h.in
+index 5e42506f20..a837bb53cd 100644
+--- a/c10/macros/cmake_macros.h.in
++++ b/c10/macros/cmake_macros.h.in
+@@ -8,6 +8,7 @@
+ #cmakedefine C10_USE_GLOG
+ #cmakedefine C10_USE_GFLAGS
+ #cmakedefine C10_USE_NUMA
++#cmakedefine C10_USE_DDLOG
+ 
+ // Used by libtorch mobile build to enable features that are not enabled by
+ // caffe2 mobile build. Should only use it when necessary as we are committed
+diff --git a/c10/util/Logging.cpp b/c10/util/Logging.cpp
+index 14b336a794..d8dc051ac7 100644
+--- a/c10/util/Logging.cpp
++++ b/c10/util/Logging.cpp
+@@ -135,6 +135,15 @@ C10_DEFINE_int32(v, 0, "Equivalent to glog verbose");
+ C10_DEFINE_bool(logtostderr, false, "Equivalent to glog logtostderr");
+ #endif // !defined(c10_USE_GLOG)
+ 
++#if defined(C10_USE_DDLOG)
++namespace c10 {
++bool InitCaffeLogging(int* argc, char** argv) {
++  return true;
++}
++void UpdateLoggingLevelsFromFlags() {}
++
++} // namespace c10
++#else
+ #ifdef C10_USE_GLOG
+ 
+ // Provide easy access to the above variables, regardless whether GLOG is
+@@ -318,3 +327,5 @@ MessageLogger::~MessageLogger() {
+ } // namespace c10
+ 
+ #endif // !C10_USE_GLOG
++
++#endif // !C10_USE_DDLOG
+diff --git a/c10/util/Logging.h b/c10/util/Logging.h
+index acab3cfecd..438cefeabf 100644
+--- a/c10/util/Logging.h
++++ b/c10/util/Logging.h
+@@ -22,11 +22,15 @@
+ #endif // CAFFE2_LOG_THRESHOLD
+ 
+ // Below are different implementations for glog and non-glog cases.
++#ifdef C10_USE_DDLOG
++#include <c10/util/logging_is_dd_log.h>
++#else
+ #ifdef C10_USE_GLOG
+ #include <c10/util/logging_is_google_glog.h>
+ #else // !C10_USE_GLOG
+ #include <c10/util/logging_is_not_google_glog.h>
+ #endif // C10_USE_GLOG
++#endif // C10_USE_DDLOG
+ 
+ C10_DECLARE_int(caffe2_log_level);
+ C10_DECLARE_bool(caffe2_use_fatal_for_enforce);
+@@ -107,12 +111,12 @@ using EnforceNotMet = ::c10::Error;
+   } while (false)
+ 
+ #define CAFFE_ENFORCE_FINITE(condition, ...)                        \
+-    do {                                                            \
+-      if (C10_UNLIKELY(!(condition))) {                             \
+-        ::c10::ThrowEnforceFiniteNotMet(                            \
++  do {                                                              \
++    if (C10_UNLIKELY(!(condition))) {                               \
++      ::c10::ThrowEnforceFiniteNotMet(                              \
+           __FILE__, __LINE__, #condition, ::c10::str(__VA_ARGS__)); \
+-      }                                                             \
+-    } while (false)
++    }                                                               \
++  } while (false)
+ 
+ #define CAFFE_ENFORCE_WITH_CALLER(condition, ...)                         \
+   do {                                                                    \
+@@ -292,7 +296,7 @@ BINARY_COMP_HELPER(LessEquals, <=)
+  *   // Logs caller info with an arbitrary text event, if there is a usage.
+  *   C10_LOG_API_USAGE_ONCE("my_api");
+  */
+-#define C10_LOG_API_USAGE_ONCE(...)             \
++#define C10_LOG_API_USAGE_ONCE(...)                        \
+   C10_UNUSED static bool C10_ANONYMOUS_VARIABLE(logFlag) = \
+       ::c10::detail::LogAPIUsageFakeReturn(__VA_ARGS__);
+ 
+@@ -303,7 +307,7 @@ C10_API void LogAPIUsage(const std::string& context);
+ namespace detail {
+ // Return value is needed to do the static variable initialization trick
+ C10_API bool LogAPIUsageFakeReturn(const std::string& context);
+-}
++} // namespace detail
+ 
+ } // namespace c10
+ 

--- a/src/backends/torch/torchutils.h
+++ b/src/backends/torch/torchutils.h
@@ -35,6 +35,8 @@
 #pragma GCC diagnostic pop
 #include <torch/script.h>
 
+#include <google/protobuf/message.h>
+
 namespace dd
 {
 

--- a/src/backends/xgb/xgb_dmlc_macro_fix.h
+++ b/src/backends/xgb/xgb_dmlc_macro_fix.h
@@ -20,6 +20,11 @@
  */
 
 #ifndef DMLC_LOGGING_H_
+#undef LOG
+#undef LOG_IF
+#undef DFATAL
+#undef DLOG
+#undef LOG_EVERY_N
 #undef VLOG
 #undef CHECK
 #undef CHECK_NOTNULL


### PR DESCRIPTION
This PR
-  changes implementation of CaffeLogger so that it can be used directly from classes that implement `std::ostream& operator<<(std::ostream& stream, some_class&);`  (see https://github.com/jolibrain/caffe/pull/80 for implementation of the logger only)
- simplifies _a lot_ pytorch patching, hopefully leading to much easier libtorch update to upstream (see https://github.com/jolibrain/deepdetect/pull/1086)
- should not  change its API except for accepting above usage (ie `LOG(INFO) << "message" << some_class_that_implements_above_operator_like_many_in_libtorch;`)
- should not change its behavior elsewhere in dd
