### PR TITLE
ci: don't use copyArtifacts

### DIFF
--- a/ci/Jenkinsfile.unittests
+++ b/ci/Jenkinsfile.unittests
@@ -3,7 +3,7 @@ pipeline {
     dockerfile {
       label 'gpu'
       filename 'ci/devel.Dockerfile'
-      args "-v /var/lib/jenkins/.ccache:/ccache -e CCACHE_DIR=/ccache --runtime nvidia"
+      args "-v /var/lib/jenkins/.ccache:/ccache -v /var/lib/jenkins/jobs/deepdetect-prebuilt-cache/branches/master/builds:/prebuilt -e CCACHE_DIR=/ccache --runtime nvidia"
     }
   }
   stages {
@@ -22,12 +22,10 @@ pipeline {
       }
       steps {
         script {
-          try {
-            copyArtifacts(projectName: 'deepdetect-prebuilt-cache/master')
-          } catch (err) {
-            echo "artefact copy fail, skipping it"
-            echo err.getMessage();
-          }
+          sh '''
+          prebuilt_version=$(awk '/^lastSuccessfulBuild/{print $2}' /prebuilt/permalinks)
+          rsync -a --progress /prebuilt/${prebuilt_version}/archive/build/ build/
+          '''
         }
       }
     }

--- a/ci/devel.Dockerfile
+++ b/ci/devel.Dockerfile
@@ -31,6 +31,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     git \
     ccache \
     automake \
+    rsync \
     clang-format-10 \
     build-essential \
     openjdk-8-jdk \


### PR DESCRIPTION
This methods is slow and doesn't work well across ci nodes.

Instead we manually copy files and all nodes will have the prebuilt
cache synced by the prebuilt cache builder itself.
