### PR TITLE
fix: ONNX tensorrt engine with correct enqueueV2

### DIFF
--- a/src/backends/tensorrt/tensorrtlib.h
+++ b/src/backends/tensorrt/tensorrtlib.h
@@ -138,6 +138,9 @@ namespace dd
     int _outputIndex0;
     int _outputIndex1;
 
+    bool _explicit_batch
+        = false; /**< whether TRT uses explicit batch model (ONNX). */
+
     std::vector<float> _floatOut;
     std::vector<int> _keepCount;
 


### PR DESCRIPTION
Fixes + exception if wrong batch size wrt to existing model + correctly caught exception if `enqueue` fails.