### PR TITLE
Multiple test sets

### DIFF
--- a/src/backends/caffe/caffelib.cc
+++ b/src/backends/caffe/caffelib.cc
@@ -1856,7 +1856,8 @@ namespace dd
 
                 if (m != "cmdiag" && m != "cmfull" && m != "clacc"
                     && m != "labels" && m != "cliou" && m != "precisions"
-                    && m != "recalls" && m != "f1s")
+                    && m != "recalls" && m != "f1s" && m != "test_id"
+                    && m != "test_name")
                   // do not report confusion matrix in server logs
                   {
                     double mval = meas_obj.get(m).get<double>();

--- a/src/backends/torch/torchdataset.cc
+++ b/src/backends/torch/torchdataset.cc
@@ -499,7 +499,7 @@ namespace dd
 
     try
       {
-        if (dimg.read_file(fname))
+        if (dimg.read_file(fname, -1))
           {
             this->_logger->error("Uri failed: {}", fname);
           }
@@ -531,7 +531,7 @@ namespace dd
 
     try
       {
-        if (dimg.read_file(fname))
+        if (dimg.read_file(fname, -1))
           {
             this->_logger->error("Uri failed: {}", fname);
           }
@@ -608,5 +608,82 @@ namespace dd
         ++n;
       }
     return targett;
+  }
+
+  void TorchMultipleDataset::add_db_elt(const size_t &set_id,
+                                        const int64_t &index,
+                                        const std::string &data,
+                                        const std::string &target)
+  {
+    _datasets[set_id].add_db_elt(index, data, target);
+  }
+
+  int TorchMultipleDataset::add_image_file(const size_t id,
+                                           const std::string &fname,
+                                           const int &target,
+                                           const int &height, const int &width)
+  {
+    return _datasets[id].add_image_file(fname, target, height, width);
+  }
+
+  int TorchMultipleDataset::add_image_file(const size_t id,
+                                           const std::string &fname,
+                                           const std::vector<double> &target,
+                                           const int &height, const int &width)
+  {
+    return _datasets[id].add_image_file(fname, target, height, width);
+  }
+
+  void TorchMultipleDataset::set_list(
+      const std::vector<
+          std::vector<std::pair<std::string, std::vector<double>>>> &lsfiles)
+  {
+    for (size_t i = 0; i < lsfiles.size(); ++i)
+      _datasets[i].set_list(lsfiles[i]);
+  }
+
+  void TorchMultipleDataset::add_tests_names(
+      const std::vector<std::string> &longnames)
+  {
+    _datasets.resize(_datasets.size() + longnames.size());
+    _datasets_names.resize(_datasets_names.size() + longnames.size());
+    _dbFullNames.resize(_dbFullNames.size() + longnames.size());
+    for (size_t i = 0; i < longnames.size(); ++i)
+      {
+        _datasets_names[_datasets_names.size() - longnames.size() + i]
+            = fileops::shortname(longnames[i]);
+        set_db_name(_dbFullNames.size() - longnames.size() + i, longnames[i]);
+        init_set(_datasets.size() - longnames.size() + i);
+      }
+  }
+
+  void TorchMultipleDataset::add_test_name(std::string longname)
+  {
+    std::string name = fileops::shortname(longname);
+    _datasets.resize(_datasets.size() + 1);
+    _datasets_names.resize(_datasets_names.size() + 1);
+    _datasets_names[_datasets_names.size() - 1] = name;
+    if (_db)
+      {
+        _dbFullNames.resize(_dbFullNames.size() + 1);
+        set_db_name(_dbFullNames.size() - 1);
+      }
+    init_set(_datasets.size() - 1);
+  }
+
+  void TorchMultipleDataset::add_db_name(std::string dblongname)
+  {
+    std::string dbname = fileops::shortname(dblongname);
+    _datasets.resize(_datasets.size() + 1);
+    _datasets_names.resize(_datasets_names.size() + 1);
+    if (!_db)
+      {
+        throw InputConnectorBadParamException(
+            "trying to add a db name while dataset is not of type db");
+      }
+    _dbFullNames.resize(_dbFullNames.size() + 1);
+    _dbFullNames[_dbFullNames.size() - 1] = dblongname;
+    test_name_from_db_name(_datasets.size() - 1);
+    init_set(_datasets.size() - 1);
   }
 }

--- a/src/backends/torch/torchlib.h
+++ b/src/backends/torch/torchlib.h
@@ -79,7 +79,11 @@ namespace dd
     int predict(const APIData &ad, APIData &out);
 
     int test(const APIData &ad, TInputConnectorStrategy &inputc,
-             TorchDataset &dataset, int batch_size, APIData &out);
+             TorchMultipleDataset &datasets, int batch_size, APIData &out);
+
+    int test(const APIData &ad, TInputConnectorStrategy &inputc,
+             TorchDataset &dataset, int batch_size, APIData &out,
+             size_t test_id = 0, const std::string &test_name = "");
 
   public:
     unsigned int _nclasses = 0; /**< number of classes*/
@@ -105,8 +109,8 @@ namespace dd
                             implementations (traced/native/graph...)*/
 
     std::vector<std::string>
-        _best_metrics;         /**< metric to use for saving best model */
-    double _best_metric_value; /**< best metric value  */
+        _best_metrics; /**< metric to use for saving best model */
+    std::vector<double> _best_metric_values; /**< best metric values  */
 
   private:
     /**
@@ -117,8 +121,9 @@ namespace dd
     /**
      * \brief generates a file containing best iteration so far
      */
-    int64_t save_if_best(APIData &meas_out, int64_t elapsed_it,
-                         TorchSolver &tsolver, int64_t best_to_remove);
+    int64_t save_if_best(const size_t test_id, APIData &meas_out,
+                         int64_t elapsed_it, TorchSolver &tsolver,
+                         std::vector<int64_t> best_iteration_numbers);
 
     /**
      * snapshop current optimizer state

--- a/src/backends/torch/torchsolver.h
+++ b/src/backends/torch/torchsolver.h
@@ -77,8 +77,10 @@ namespace dd
      */
 
     int resume(const APIData &ad_mllib, const TorchModel &mlmodel,
-               const torch::Device &main_device, double &best_metric_value,
-               int64_t &best_iteration_number);
+               const torch::Device &main_device,
+               std::vector<double> &best_metric_values,
+               std::vector<int64_t> &best_iteration_number,
+               const std::vector<std::string> &set_names);
 
     /**
      * \brief zero_grad() indirection in order to mimic native optimizer

--- a/src/backends/xgb/xgbinputconns.cc
+++ b/src/backends/xgb/xgbinputconns.cc
@@ -182,9 +182,22 @@ namespace dd
         if (_m->Info().num_nonzero_ == 0)
           throw InputConnectorBadParamException(
               "no data could be found processing XGBoost CSV input");
-        _mtest = std::shared_ptr<xgboost::DMatrix>(
-            create_from_mat(_csvdata_test));
-        _csvdata_test.clear();
+        // MULTIPLE TEST SETS : we consider here only 1 test set
+        if (_csvdata_tests.size() > 1)
+          {
+            _logger->error(
+                "multiple test sets not supported by xgboost backend yet");
+            throw InputConnectorBadParamException(
+                "multiple test sets not supported by xgboost backend yet");
+          }
+
+        if (!_csvdata_tests.empty())
+          {
+            _mtest = std::shared_ptr<xgboost::DMatrix>(
+                create_from_mat(_csvdata_tests[0]));
+            _csvdata_tests[0].clear();
+            _csvdata_tests.clear();
+          }
       }
     else
       {
@@ -299,9 +312,23 @@ namespace dd
 
     _m = std::shared_ptr<xgboost::DMatrix>(create_from_mat(_txt));
     destroy_txt_entries(_txt);
-    if (!_test_txt.empty())
-      _mtest = std::shared_ptr<xgboost::DMatrix>(create_from_mat(_test_txt));
-    destroy_txt_entries(_test_txt);
+    // MULTIPLE TEST SETS : we consider here only 1 test set
+    if (_tests_txt.size() > 1)
+      {
+        _logger->error(
+            "multiple test sets not supported by xgboost backend yet");
+        throw InputConnectorBadParamException(
+            "multiple test sets not supported by xgboost backend yet");
+      }
+    if (!_tests_txt.empty() && !_tests_txt[0].empty())
+      _mtest
+          // MULTIPLE TEST SETS : we consider here only 1 test set
+          = std::shared_ptr<xgboost::DMatrix>(create_from_mat(_tests_txt[0]));
+    // MULTIPLE TEST SETS : we consider here only 1 test set
+    // destroy_txt_entries(_test_txt);
+    for (auto tt : _tests_txt)
+      destroy_txt_entries(tt);
+    _tests_txt.clear();
   }
 
   xgboost::DMatrix *TxtXGBInputFileConn::create_from_mat(

--- a/src/backends/xgb/xgblib.cc
+++ b/src/backends/xgb/xgblib.cc
@@ -352,9 +352,10 @@ namespace dd
             std::vector<std::string> meas_str = meas_obj.list_keys();
             for (auto m : meas_str)
               {
-                if (m != "cmdiag" && m != "cmfull"
-                    && m != "labels") // do not report confusion matrix in
-                                      // server logs
+                if (m != "cmdiag" && m != "cmfull" && m != "labels"
+                    && m != "test_id"
+                    && m != "test_name") // do not report confusion matrix in
+                                         // server logs
                   {
                     double mval = meas_obj.get(m).get<double>();
                     this->_logger->info("{}={}", m, mval);

--- a/src/csvinputfileconn.h
+++ b/src/csvinputfileconn.h
@@ -46,11 +46,12 @@ namespace dd
     {
     }
 
-    int read_file(const std::string &fname);
+    int read_file(const std::string &fname, int test_id);
     int read_db(const std::string &fname);
     int read_mem(const std::string &content);
-    int read_dir(const std::string &dir)
+    int read_dir(const std::string &dir, int test_id)
     {
+      (void)test_id;
       throw InputConnectorBadParamException(
           "uri " + dir + " is a directory, requires a CSV file");
     }
@@ -449,10 +450,13 @@ namespace dd
      * @param id
      * @param vals
      */
-    virtual void add_test_csvline(const std::string &id,
+    virtual void add_test_csvline(const unsigned int test_set_id,
+                                  const std::string &id,
                                   std::vector<double> &vals)
     {
-      _csvdata_test.emplace_back(id, std::move(vals));
+      if (_csvdata_tests.size() <= test_set_id)
+        _csvdata_tests.resize(test_set_id + 1);
+      _csvdata_tests[test_set_id].emplace_back(id, std::move(vals));
     }
 
     /**
@@ -474,8 +478,8 @@ namespace dd
           if (fileops::file_exists(_uris.at(0))) // training from file
             {
               _csv_fname = _uris.at(0);
-              if (_uris.size() > 1)
-                _csv_test_fname = _uris.at(1);
+              for (unsigned int i = 1; i < _uris.size(); ++i)
+                _csv_test_fnames.push_back(_uris.at(i));
             }
           else // training from memory
             {
@@ -514,7 +518,14 @@ namespace dd
                 }
               shuffle_data(_csvdata);
               if (_test_split > 0.0)
-                split_data(_csvdata, _csvdata_test);
+                {
+                  std::vector<CSVline> testdata_split;
+                  split_data(_csvdata, testdata_split);
+                  // insert at first pos, so if user passses test sets + split,
+                  // splitted one is first
+                  _csvdata_tests.insert(_csvdata_tests.begin(),
+                                        testdata_split);
+                }
               // std::cerr << "data split test size=" << _csvdata_test.size()
               // << " / remaining data size=" << _csvdata.size() << std::endl;
               if (!_ignored_columns.empty() || !_categoricals.empty())
@@ -590,9 +601,9 @@ namespace dd
       return _csvdata.size();
     }
 
-    int test_batch_size() const
+    int test_batch_size(unsigned int test_set_id) const
     {
-      return _csvdata_test.size();
+      return _csvdata_tests[test_set_id].size();
     }
 
     int feature_size() const
@@ -752,8 +763,9 @@ namespace dd
     // options
     bool _shuffle = false;
     std::mt19937 _g;
-    std::string _csv_fname;          /**< csv main filename. */
-    std::string _csv_test_fname;     /**< csv test filename (optional). */
+    std::string _csv_fname; /**< csv main filename. */
+    std::vector<std::string>
+        _csv_test_fnames;            /**< csv test filename (optional). */
     std::list<std::string> _columns; /**< list of csv columns. */
     std::vector<std::string> _label; /**< list of label columns. */
     std::unordered_map<std::string, int> _label_set;
@@ -784,7 +796,7 @@ namespace dd
 
     // data
     std::vector<CSVline> _csvdata;
-    std::vector<CSVline> _csvdata_test;
+    std::vector<std::vector<CSVline>> _csvdata_tests;
     std::string _db_fname;
   };
 }

--- a/src/csvtsinputfileconn.h
+++ b/src/csvtsinputfileconn.h
@@ -47,10 +47,10 @@ namespace dd
     {
     }
 
-    int read_file(const std::string &fname, bool is_test_data = false);
+    int read_file(const std::string &fname, int test_set_id);
     int read_db(const std::string &fname);
     int read_mem(const std::string &content);
-    int read_dir(const std::string &dir);
+    int read_dir(const std::string &dir, int test_id);
 
     DDCsv _ddcsv;
     CSVTSInputFileConn *_cifc = nullptr;
@@ -77,7 +77,7 @@ namespace dd
 
     CSVTSInputFileConn(const CSVTSInputFileConn &i)
         : CSVInputFileConn(i), _csvtsdata(i._csvtsdata),
-          _csvtsdata_test(i._csvtsdata_test)
+          _csvtsdata_tests(i._csvtsdata_tests)
     {
       this->_scale_between_minus1_and_1 = i._scale_between_minus1_and_1;
       this->_dont_scale_labels = i._dont_scale_labels;
@@ -172,15 +172,15 @@ namespace dd
      * \brief transfers data read by the CSV connector to _csvtsdata holder
      * @param is_test_data whether data is from test set
      */
-    void push_csv_to_csvts(const bool &is_test_data = false);
+    void push_csv_to_csvts(int test_id = 0);
 
     std::string _boundsfname
         = "bounds.dat"; /**< variables min/max bounds filename. */
 
     std::vector<std::vector<CSVline>> _csvtsdata;
-    std::vector<std::vector<CSVline>> _csvtsdata_test;
+    std::vector<std::vector<std::vector<CSVline>>> _csvtsdata_tests;
     std::vector<std::string> _fnames;
-    std::vector<std::string> _test_fnames;
+    std::vector<std::vector<std::string>> _test_fnames;
   };
 }
 

--- a/src/imginputfileconn.h
+++ b/src/imginputfileconn.h
@@ -274,8 +274,9 @@ namespace dd
     }
 
     // data acquisition
-    int read_file(const std::string &fname)
+    int read_file(const std::string &fname, int test_id)
     {
+      (void)test_id;
       cv::Mat img
           = cv::imread(fname, _unchanged_data ? CV_LOAD_IMAGE_UNCHANGED
                                               : (_bw ? CV_LOAD_IMAGE_GRAYSCALE
@@ -311,8 +312,9 @@ namespace dd
       return 0;
     }
 
-    int read_dir(const std::string &dir)
+    int read_dir(const std::string &dir, int test_id)
     {
+      (void)test_id;
       // list directories in dir
       std::unordered_set<std::string> subdirs;
       if (fileops::list_directory(dir, false, true, false, subdirs))

--- a/src/inputconnectorstrategy.h
+++ b/src/inputconnectorstrategy.h
@@ -51,7 +51,7 @@ namespace dd
     }
 
     int read_element(const std::string &uri,
-                     std::shared_ptr<spdlog::logger> &logger)
+                     std::shared_ptr<spdlog::logger> &logger, int test_id = -1)
     {
       _ctype._logger = logger;
       bool dir = false;
@@ -81,9 +81,9 @@ namespace dd
             return _ctype.read_db(
                 uri); // XXX: db can acutally be a dir (e.g. lmdb)
           else if (dir)
-            return _ctype.read_dir(uri);
+            return _ctype.read_dir(uri, test_id);
           else
-            return _ctype.read_file(uri);
+            return _ctype.read_file(uri, test_id);
         }
       else
         return _ctype.read_mem(uri);

--- a/src/supervisedoutputconnector.h
+++ b/src/supervisedoutputconnector.h
@@ -718,7 +718,8 @@ namespace dd
 
     // measure
     static void measure(const APIData &ad_res, const APIData &ad_out,
-                        APIData &out)
+                        APIData &out, size_t test_id = 0,
+                        const std::string test_name = "")
     {
       APIData meas_out;
       bool tloss = ad_res.has("train_loss");
@@ -1204,7 +1205,21 @@ namespace dd
       if (lr)
         meas_out.add("learning_rate",
                      ad_res.get("learning_rate").get<double>());
-      out.add("measure", meas_out);
+      meas_out.add("test_id", static_cast<int>(test_id));
+      meas_out.add("test_name", test_name);
+      if (test_id == 0)
+        {
+          out.add("measure", meas_out);
+          std::vector<APIData> measures;
+          measures.push_back(meas_out);
+          out.add("measures", measures);
+        }
+      else
+        {
+          std::vector<APIData> measures = out.getv("measures");
+          measures.push_back(meas_out);
+          out.add("measures", measures);
+        }
     }
 
     static void timeSeriesMetrics(const APIData &ad, const int timeseries,

--- a/src/svminputfileconn.cc
+++ b/src/svminputfileconn.cc
@@ -26,8 +26,9 @@ namespace dd
 {
 
   /*- DDSvm -*/
-  int DDSvm::read_file(const std::string &fname)
+  int DDSvm::read_file(const std::string &fname, int test_id)
   {
+    (void)test_id;
     if (_cifc)
       {
         _cifc->read_svm(_adconf, fname);

--- a/src/svminputfileconn.h
+++ b/src/svminputfileconn.h
@@ -40,10 +40,11 @@ namespace dd
     {
     }
 
-    int read_file(const std::string &fname);
+    int read_file(const std::string &fname, int test_id);
     int read_mem(const std::string &content);
-    int read_dir(const std::string &dir)
+    int read_dir(const std::string &dir, int test_id)
     {
+      (void)test_id;
       throw InputConnectorBadParamException(
           "uri " + dir + " is a directory, requires a file in libSVM format");
     }
@@ -155,6 +156,16 @@ namespace dd
               _svm_fname = _uris.at(0);
               if (_uris.size() > 1)
                 _svm_test_fname = _uris.at(1);
+              if (_uris.size() > 2)
+                {
+                  _logger->error(
+                      "multiple test sets not supported for svm for "
+                      "any  backend yet");
+                  throw InputConnectorBadParamException(
+                      "multiple test sets not supported for svm for any  "
+                      "backend "
+                      "yet");
+                }
             }
           if (!_svm_fname.empty()) // when training from file
             {

--- a/src/txtinputfileconn.cc
+++ b/src/txtinputfileconn.cc
@@ -81,8 +81,9 @@ namespace dd
   }
 
   /*- DDTxt -*/
-  int DDTxt::read_file(const std::string &fname)
+  int DDTxt::read_file(const std::string &fname, int test_id)
   {
+    (void)test_id;
     if (!_ctfc)
       {
         return -1;
@@ -113,7 +114,7 @@ namespace dd
     return 0;
   }
 
-  int DDTxt::read_dir(const std::string &dir)
+  int DDTxt::read_dir(const std::string &dir, int test_id)
   {
     if (!_ctfc)
       return -1;
@@ -224,7 +225,7 @@ namespace dd
         std::stringstream buffer;
         buffer << txt_file.rdbuf();
         std::string ct = buffer.str();
-        _ctfc->parse_content(ct, p.second, test_dir);
+        _ctfc->parse_content(ct, p.second, test_id);
       }
 
     // post-processing
@@ -316,7 +317,7 @@ namespace dd
 
   /*- TxtInputFileConn -*/
   void TxtInputFileConn::parse_content(const std::string &content,
-                                       const float &target, const bool &test)
+                                       const float &target, int test_id)
   {
     if (!_train && content.empty())
       throw InputConnectorBadParamException("no text data found");
@@ -396,10 +397,10 @@ namespace dd
                     towe->add_word(w);
                   }
 
-                if (!test)
+                if (test_id < 0)
                   _txt.push_back(towe);
                 else
-                  _test_txt.push_back(towe);
+                  _tests_txt[static_cast<size_t>(test_id)].push_back(towe);
               }
             else
               {
@@ -430,10 +431,10 @@ namespace dd
                       }
                     tbe->add_word(w, 1.0, _count);
                   }
-                if (!test)
+                if (test_id < 0)
                   _txt.push_back(tbe);
                 else
-                  _test_txt.push_back(tbe);
+                  _tests_txt[static_cast<size_t>(test_id)].push_back(tbe);
               }
           }
         else // character-level features
@@ -484,10 +485,10 @@ namespace dd
                   }
                 while (str_i < end && seq < _sequence);
               }
-            if (!test)
+            if (test_id < 0)
               _txt.push_back(tce);
             else
-              _test_txt.push_back(tce);
+              _tests_txt[static_cast<size_t>(test_id)].push_back(tce);
             std::cerr << "\rloaded text samples=" << _txt.size();
           }
       }

--- a/src/utils/fileops.hpp
+++ b/src/utils/fileops.hpp
@@ -428,6 +428,43 @@ namespace dd
 
       return 0;
     }
+
+    /**
+     * gives id (for test set tpyically) from file or dir name
+     * ie   /path/to/test_data1  => test_data1
+     *      /path/to/test_data2/ => test_data2
+     */
+    static std::string shortname(const std::string &fullname)
+    {
+      bool trailing_slash = false;
+      std::size_t sepPos = fullname.rfind("/");
+
+      if (sepPos == fullname.size() - 1)
+        {
+          sepPos = fullname.substr(0, fullname.size() - 1).rfind("/");
+          trailing_slash = true;
+        }
+      if (sepPos != std::string::npos)
+        {
+          if (trailing_slash)
+            return fullname.substr(sepPos + 1, fullname.size() - sepPos - 2);
+          return fullname.substr(sepPos + 1, fullname.size() - sepPos - 1);
+        }
+      return fullname;
+    }
+
+    /**
+     * insert suffix before .ext ie  /path/to/filename.ext =>
+     * /path/to/filenamesuffix.ext
+     */
+    static std::string insert_suffix(std::string suffix, std::string filename)
+    {
+      size_t lastindex = filename.find_last_of(".");
+      std::string rawname = filename.substr(0, lastindex);
+      std::string ext = filename.substr(lastindex, filename.size());
+      return rawname + suffix + ext;
+    }
+
 #endif
   };
 }

--- a/src/utils/utils.hpp
+++ b/src/utils/utils.hpp
@@ -54,6 +54,17 @@ namespace dd
       return true;
     }
 
+    static bool unique(int64_t val, std::vector<int64_t> vec)
+    {
+      size_t count = 0;
+      for (int64_t v : vec)
+        {
+          if (v == val)
+            count++;
+        }
+      return count == 1;
+    }
+
 #ifdef WIN32
     static int my_hardware_concurrency()
     {

--- a/tests/ut-graph.cc
+++ b/tests/ut-graph.cc
@@ -217,7 +217,7 @@ TEST(graphapi, intermediate_lstm_train)
   inputc.transform(ad);
 
   ASSERT_EQ(inputc._dataset.cache_size(), 485);
-  ASSERT_EQ(inputc._test_dataset.cache_size(), 10);
+  ASSERT_EQ(inputc._test_datasets[0].cache_size(), 10);
 
   auto batchoptional
       = inputc._dataset.get_batch({ inputc._dataset.cache_size() });


### PR DESCRIPTION
this PR adds support for multiple test sets for torch backend.
example call:
```
data: ["path/to/train/set", "path/to/first/test/set", "path/to/second/test/set", ....]
```
support for csvts, img, txt (ie everything supported by torch mllib atm)


