### PR TITLE
fix: tensorrt max workspace size overflow

### DIFF
--- a/src/backends/tensorrt/tensorrtlib.cc
+++ b/src/backends/tensorrt/tensorrtlib.cc
@@ -131,8 +131,9 @@ namespace dd
 
     if (ad.has("maxWorkspaceSize"))
       {
-        _max_workspace_size
-            = ad.get("maxWorkspaceSize").get<int>() * (1 << 20);
+        _max_workspace_size = ad.get("maxWorkspaceSize").get<int>();
+        size_t meg = 1 << 20;
+        _max_workspace_size *= meg;
         this->_logger->info("setting max workspace size to {}",
                             _max_workspace_size);
       }

--- a/src/backends/tensorrt/tensorrtlib.h
+++ b/src/backends/tensorrt/tensorrtlib.h
@@ -111,7 +111,7 @@ namespace dd
     int _dla = -1;
     nvinfer1::DataType _datatype = nvinfer1::DataType::kFLOAT;
     int _max_batch_size = 48;
-    int _max_workspace_size = 1 << 30; // 1GB
+    size_t _max_workspace_size = 1 << 30; // 1GB
     int _top_k
         = 200; // top_k parameters in ssd in dede templates, can be overriden
     std::string _engineFileName = "TRTengine";


### PR DESCRIPTION
Fixes overflow due to wrong type for `_max_workspace_size` and weird behavior with the shifted `(1<<20)` scaling.