### PR TITLE
fix: tensorrt input size for caffe source models

### DIFF
--- a/src/backends/tensorrt/protoUtils.cc
+++ b/src/backends/tensorrt/protoUtils.cc
@@ -44,6 +44,26 @@ using google::protobuf::io::ZeroCopyOutputStream;
 namespace dd
 {
 
+  bool findInputDimensions(const std::string &source, int &width, int &height)
+  {
+    caffe::NetParameter net;
+    if (!TRTReadProtoFromTextFile(source.c_str(), &net))
+      return false;
+
+    for (int i = 0; i < net.layer_size(); ++i)
+      {
+        caffe::LayerParameter lparam = net.layer(i);
+        if (lparam.type() == "MemoryData")
+          {
+            width = lparam.memory_data_param().width();
+            height = lparam.memory_data_param().height();
+          }
+        break; // don't go further than first layer.
+      }
+
+    return true;
+  }
+
   int findNClasses(const std::string source, bool bbox)
   {
     caffe::NetParameter net;

--- a/src/backends/tensorrt/protoUtils.h
+++ b/src/backends/tensorrt/protoUtils.h
@@ -33,6 +33,7 @@ namespace dd
      - it add "keep_count" top to DetectionOutput Layer
   */
   int fixProto(const std::string dest, const std::string source);
+  bool findInputDimensions(const std::string &source, int &width, int &height);
   int findNClasses(const std::string source, bool bbox);
   int findTopK(const std::string source);
   bool TRTReadProtoFromTextFile(const char *filename,

--- a/src/backends/tensorrt/tensorrtlib.cc
+++ b/src/backends/tensorrt/tensorrtlib.cc
@@ -83,6 +83,8 @@ namespace dd
   {
     this->_libname = "tensorrt";
     _nclasses = tl._nclasses;
+    _width = tl._width;
+    _height = tl._height;
     _dla = tl._dla;
     _datatype = tl._datatype;
     _max_batch_size = tl._max_batch_size;
@@ -233,6 +235,23 @@ namespace dd
         else
           {
             // default is TF32 (aka 10-bit mantissas round-up)
+          }
+      }
+
+    // check on the input size
+    if (!_timeserie && this->_mlmodel.is_caffe_source())
+      {
+        if (_width == 0 || _height == 0)
+          {
+            this->_logger->info("trying to determine the input size...");
+            if (findInputDimensions(this->_mlmodel._def, _width, _height))
+              {
+                this->_logger->info("found {}x{} as input size", _width,
+                                    _height);
+              }
+            else
+              throw MLLibBadParamException("Could not detect the input size, "
+                                           "specify it from API instead");
           }
       }
   }
@@ -431,10 +450,15 @@ namespace dd
         else if (_regression)
           out_blob = "pred";
 
-        if (_nclasses == 0)
+        if (_nclasses == 0 && this->_mlmodel.is_caffe_source())
           {
-            this->_logger->info("try to determine number of classes...");
+            this->_logger->info("trying to determine number of classes...");
             _nclasses = findNClasses(this->_mlmodel._def, _bbox);
+            if (_nclasses < 0)
+              throw MLLibBadParamException(
+                  "failed detecting the number of classes, specify it through "
+                  "API with nclasses");
+            this->_logger->info("found {} classes", _nclasses);
           }
 
         if (_bbox)
@@ -603,6 +627,17 @@ namespace dd
     this->_stats.transform_end();
 
     this->_stats.inc_inference_count(inputc._batch_size);
+
+    if (!_timeserie && this->_mlmodel.is_caffe_source())
+      {
+        if (inputc.width() != _width || inputc.height() != _height)
+          {
+            throw MLLibBadParamException(
+                "Model height and/or width differ from the input data "
+                "size. Input data size should be "
+                + std::to_string(_width) + "x" + std::to_string(_height));
+          }
+      }
 
     int idoffset = 0;
     std::vector<APIData> vrad;

--- a/src/backends/tensorrt/tensorrtlib.h
+++ b/src/backends/tensorrt/tensorrtlib.h
@@ -108,6 +108,8 @@ namespace dd
 
   public:
     int _nclasses = 0;
+    int _width = 0;  /**< default model width. */
+    int _height = 0; /**< default model height. */
     int _dla = -1;
     nvinfer1::DataType _datatype = nvinfer1::DataType::kFLOAT;
     int _max_batch_size = 48;

--- a/src/backends/tensorrt/tensorrtmodel.cc
+++ b/src/backends/tensorrt/tensorrtmodel.cc
@@ -71,6 +71,10 @@ namespace dd
                 modelf = (*hit);
                 model_t = wt;
               }
+            if ((*hit).find(caffe_model_name) != std::string::npos)
+              _source_type = "caffe";
+            else if ((*hit).find(onnx_model_name) != std::string::npos)
+              _source_type = "onnx";
           }
         else if ((*hit).find("~") != std::string::npos
                  || (*hit).find(".prototxt") == std::string::npos)

--- a/src/backends/tensorrt/tensorrtmodel.h
+++ b/src/backends/tensorrt/tensorrtmodel.h
@@ -53,10 +53,21 @@ namespace dd
 
     int read_from_repository(const std::shared_ptr<spdlog::logger> &logger);
 
+    inline bool is_caffe_source() const
+    {
+      return _source_type == "caffe";
+    }
+
+    inline bool is_onnx_source() const
+    {
+      return _source_type == "onnx";
+    }
+
     std::string _model;
     std::string _def;
     std::string _weights;
     bool _has_mean_file = false;
+    std::string _source_type = "caffe"; // or "onnx"
   };
 }
 

--- a/tests/ut-tensorrtapi.cc
+++ b/tests/ut-tensorrtapi.cc
@@ -148,11 +148,18 @@ TEST(tensorrtapi, service_predict_refinedet)
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_EQ(200, jd["status"]["code"]);
   ASSERT_TRUE(jd["body"]["predictions"].IsArray());
-  /*std::string cl1
-      = jd["body"]["predictions"][0]["classes"][0]["cat"].GetString();
-  ASSERT_TRUE(cl1 == "1");
-  ASSERT_TRUE(jd["body"]["predictions"][0]["classes"][0]["prob"].GetDouble()
-  > 0.4);*/
+
+  // predict with wrong input size
+  jpredictstr
+      = "{\"service\":\"imgserv\",\"parameters\":{\"input\":{\"height\":300,"
+        "\"width\":300},\"output\":{\"bbox\":true}},\"data\":[\""
+        + squeez_repo + "face.jpg\"]}";
+  joutstr = japi.jrender(japi.service_predict(jpredictstr));
+  std::cout << "joutstr=" << joutstr << std::endl;
+  jd.Parse<rapidjson::kParseNanAndInfFlag>(joutstr.c_str());
+  ASSERT_TRUE(!jd.HasParseError());
+  ASSERT_EQ(400, jd["status"]["code"]);
+
   jstr = "{\"clear\":\"lib\"}";
   joutstr = japi.jrender(japi.service_delete(sname, jstr));
   ASSERT_EQ(ok_str, joutstr);


### PR DESCRIPTION
TensorRT was allowing any input size, yielding to hazardous results. Since that for caffe source models, we can actually easily check the model correct size, we impose that it is equal to the requested input size. We can't do it yet for ONNX source models however.