### PR TITLE
fix: wrong NCNN bbox output scaling

### DIFF
--- a/src/backends/caffe/caffelib.cc
+++ b/src/backends/caffe/caffelib.cc
@@ -3186,8 +3186,8 @@ namespace dd
                       }
                     else
                       {
-                        this->_logger->error(
-                            "couldn't find original image size for {}", uri);
+                        throw MLLibInternalException(
+                            "Couldn't find original image size for " + uri);
                       }
                     bool leave = false;
                     int curi = -1;

--- a/src/backends/ncnn/ncnninputconns.h
+++ b/src/backends/ncnn/ncnninputconns.h
@@ -52,6 +52,8 @@ namespace dd
     std::vector<int> _timeseries_lengths;
     bool _continuation = false;
     int _ntargets;
+    std::unordered_map<std::string, std::pair<int, int>>
+        _imgs_size; /**< image sizes, used in detection. */
   };
 
   class ImgNCNNInputFileConn : public ImgInputFileConn,
@@ -128,6 +130,8 @@ namespace dd
             }
         }
       _ids.push_back(this->_uris.at(0));
+      _imgs_size.insert(std::pair<std::string, std::pair<int, int>>(
+          this->_ids.at(0), this->_images_size.at(0)));
     }
 
     double unscale_res(double res, int nout)

--- a/src/backends/ncnn/ncnnlib.cc
+++ b/src/backends/ncnn/ncnnlib.cc
@@ -281,6 +281,21 @@ namespace dd
 
     if (bbox == true)
       {
+        std::string uri = inputc._ids.at(0);
+        auto bit = inputc._imgs_size.find(uri);
+        int rows = 1;
+        int cols = 1;
+        if (bit != inputc._imgs_size.end())
+          {
+            // original image size
+            rows = (*bit).second.first;
+            cols = (*bit).second.second;
+          }
+        else
+          {
+            throw MLLibInternalException(
+                "Couldn't find original image size for " + uri);
+          }
         for (int i = 0; i < inputc._out.h; i++)
           {
             const float *values = inputc._out.row(i);
@@ -291,14 +306,10 @@ namespace dd
             probs.push_back(values[1]);
 
             APIData ad_bbox;
-            ad_bbox.add("xmin",
-                        static_cast<double>(values[2] * inputc.width()));
-            ad_bbox.add("ymin",
-                        static_cast<double>(values[3] * inputc.height()));
-            ad_bbox.add("xmax",
-                        static_cast<double>(values[4] * inputc.width()));
-            ad_bbox.add("ymax",
-                        static_cast<double>(values[5] * inputc.height()));
+            ad_bbox.add("xmin", static_cast<double>(values[2] * (cols - 1)));
+            ad_bbox.add("ymin", static_cast<double>(values[3] * (rows - 1)));
+            ad_bbox.add("xmax", static_cast<double>(values[4] * (cols - 1)));
+            ad_bbox.add("ymax", static_cast<double>(values[5] * (rows - 1)));
             bboxes.push_back(ad_bbox);
           }
       }


### PR DESCRIPTION
We could have `_img_sizes` in the main image data connector instead.