### PR TITLE
feat(ml): retain_graph control via API for torch autograd

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -741,6 +741,7 @@ ntargets   | int             | no (regression only)     | N/A     | Number of re
 self_supervised | string | yes      | ""      | self-supervised mode: "mask" for masked language model
 embedding_size  | int    | yes      | 768     | embedding size for NLP models
 freeze_traced   | bool   | yes      | false   | Freeze the traced part of the net during finetuning (e.g. for classification)
+retain_graph	| bool	 | yes	    | false   | Whether to use `retain_graph` with torch autograd
 template        | string | yes      | ""      | for language models, either "bert" or "gpt2", "recurrent" for LSTM-like models (including autoencoder), "nbeats" for nbeats model
 regression | bool            | yes                      | false   | Whether the model is a regressor
 timesteps     | int            | yes      | N/A            | Number of timesteps for time models (LSTM/NBEATS...) : this sets the length of sequences that will be given for learning, every timestep contains inputs and outputs as defined by the csv/csvts connector

--- a/src/backends/torch/torchlib.cc
+++ b/src/backends/torch/torchlib.cc
@@ -550,6 +550,10 @@ namespace dd
           }
       }
 
+    bool retain_graph = ad_mllib.has("retain_graph")
+                            ? ad_mllib.get("retain_graph").get<bool>()
+                            : false;
+
     if (iter_size <= 0)
       iter_size = 1;
 
@@ -692,7 +696,9 @@ namespace dd
 
             double loss_val = loss.item<double>();
             train_loss += loss_val;
-            loss.backward();
+            loss.backward({},
+                          /*retain_graph=*/c10::optional<bool>(retain_graph),
+                          /*create_graph=*/false);
             auto tstop = steady_clock::now();
             last_it_time
                 += duration_cast<milliseconds>(tstop - tstart).count();


### PR DESCRIPTION
Equivalent to the `retain_graph=True` in Pytorch.