### PR TITLE
fix: caffe linkage with our spdlog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,6 +192,8 @@ if (BUILD_SPDLOG)
         INSTALL_COMMAND ""
     )
     set(SPDLOG_LIB_DEPS ${CMAKE_BINARY_DIR}/spdlog/src/spdlog/libspdlog.a)
+    set(SPDLOG_CAFFE_LIB_DIR ${CMAKE_BINARY_DIR}/spdlog/src/spdlog)
+    set(SPDLOG_CAFFE_LIB_DEPS :libspdlog.a)
     set(SPDLOG_INCLUDE_DIR ${CMAKE_BINARY_DIR}/spdlog/src/spdlog/include)
     include_directories(SYSTEM ${SPDLOG_INCLUDE_DIR})
 endif()
@@ -624,9 +626,10 @@ elseif(USE_CAFFE)
         echo "USE_SYSLOG:=${USE_SYSLOG}" >> Makefile.config &&
         echo "DEBUG:=${CAFFE_DEBUG}" >> Makefile.config &&
         echo "INCLUDE_DIRS+=${SPDLOG_INCLUDE_DIR}" >> Makefile.config &&
-        echo "LIBRARIES+=${SPDLOG_LIB_DEPS}" >> Makefile.config &&
         echo "INCLUDE_DIRS+=${PROTOBUF_INCLUDE_DIR}" >> Makefile.config &&
         echo "CUDA_ARCH:=${CUDA_ARCH}" >> Makefile.config &&
+        echo "LIBRARIES+=${SPDLOG_CAFFE_LIB_DEPS}" >> Makefile.config &&
+        echo "LIBRARY_DIRS+=${SPDLOG_CAFFE_LIB_DIR}" >> Makefile.config &&
         echo "LIBRARY_DIRS+=${PROTOBUF_LIB_DIR}" >> Makefile.config
     BUILD_COMMAND 
         ${CMAKE_COMMAND} -E env LD_LIBRARY_PATH=${PROTOBUF_LIB_DIR}:$ENV{LD_LIBRARY_PATH} PATH=${PROTOBUF_LIB_DIR}:$ENV{PATH} make -j${N} proto &&


### PR DESCRIPTION
This is needed to build on ubuntu20.04