### PR TITLE
fix: missing continuation indicator layer patch for NCNN

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -685,6 +685,7 @@ if (USE_NCNN)
     ${NCNN_PATCHES_PATH}/ncnn_lstm_cont.patch
     ${NCNN_PATCHES_PATH}/ncnn_variable_h.patch
     ${NCNN_PATCHES_PATH}/ncnn_flatten_axis.patch
+    ${NCNN_PATCHES_PATH}/ncnn_cont_indic.patch
     )
 
   set(NCNN_VERSION "20201218")

--- a/patches/ncnn/ncnn_cont_indic.patch
+++ b/patches/ncnn/ncnn_cont_indic.patch
@@ -1,0 +1,128 @@
+From 0c5c6073b3b9555d8ad748da519a2df433cc9baa Mon Sep 17 00:00:00 2001
+From: Emmanuel Benazera <emmanuel.benazera@jolibrain.com>
+Date: Fri, 22 Jan 2021 20:42:06 +0100
+Subject: [PATCH] continuation indicator
+
+---
+ src/CMakeLists.txt                  |  1 +
+ src/layer/continuationindicator.cpp | 51 +++++++++++++++++++++++++++++
+ src/layer/continuationindicator.h   | 37 +++++++++++++++++++++
+ 3 files changed, 89 insertions(+)
+ create mode 100644 src/layer/continuationindicator.cpp
+ create mode 100644 src/layer/continuationindicator.h
+
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 5b3dd7a4..28a4f1aa 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -124,6 +124,7 @@ ncnn_add_layer(Yolov3DetectionOutput)
+ ncnn_add_layer(PSROIPooling)
+ ncnn_add_layer(ROIAlign)
+ ncnn_add_layer(Packing)
++ncnn_add_layer(ContinuationIndicator)
+ ncnn_add_layer(Requantize)
+ ncnn_add_layer(Cast)
+ ncnn_add_layer(HardSigmoid)
+diff --git a/src/layer/continuationindicator.cpp b/src/layer/continuationindicator.cpp
+new file mode 100644
+index 00000000..6ec0eaa0
+--- /dev/null
++++ b/src/layer/continuationindicator.cpp
+@@ -0,0 +1,51 @@
++//
++// Addition by Jolibrain
++//
++// Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
++// in compliance with the License. You may obtain a copy of the License at
++//
++// https://opensource.org/licenses/BSD-3-Clause
++//
++// Unless required by applicable law or agreed to in writing, software distributed
++// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
++// CONDITIONS OF ANY KIND, either express or implied. See the License for the
++// specific language governing permissions and limitations under the License.
++
++#include "continuationindicator.h"
++#include <iostream>
++
++namespace ncnn {
++
++  DEFINE_LAYER_CREATOR(ContinuationIndicator)
++  
++  ContinuationIndicator::ContinuationIndicator()
++  {
++    one_blob_only = true;
++    support_inplace = false;
++    support_vulkan = false;
++  }
++
++  int ContinuationIndicator::load_param(const ParamDict &pd)
++  {
++    time_step = pd.get(0, 0);
++    axis = pd.get(1, 0);
++    return 0;
++  }
++
++  int ContinuationIndicator::forward(const Mat &bottom_blob, Mat &top_blob, const Option &opt) const
++  {
++    size_t elemsize = bottom_blob.elemsize;
++    top_blob.create(1, time_step, elemsize, opt.blob_allocator);
++    float *tbc = top_blob.channel(0);
++    
++    for (int t=0;t<time_step;++t)
++      {
++	for (size_t b=0;b<elemsize;++b)
++	  {
++	    *tbc++ = t == 0 ? 0.0f : 1.0f;
++	  }
++      }
++    return 0;
++  }
++  
++}
+diff --git a/src/layer/continuationindicator.h b/src/layer/continuationindicator.h
+new file mode 100644
+index 00000000..eb9ddd9e
+--- /dev/null
++++ b/src/layer/continuationindicator.h
+@@ -0,0 +1,37 @@
++//
++// Addition by Jolibrain
++//
++// Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
++// in compliance with the License. You may obtain a copy of the License at
++//
++// https://opensource.org/licenses/BSD-3-Clause
++//
++// Unless required by applicable law or agreed to in writing, software distributed
++// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
++// CONDITIONS OF ANY KIND, either express or implied. See the License for the
++// specific language governing permissions and limitations under the License.
++
++#ifndef LAYER_CONTINUATION_H
++#define LAYER_CONTINUATION_H
++
++#include "layer.h"
++
++namespace ncnn {
++
++  class ContinuationIndicator : public Layer
++  {
++  public:
++    ContinuationIndicator();
++
++    virtual int load_param(const ParamDict &pd);
++
++    virtual int forward(const Mat &bottom_blob, Mat &top_blob, const Option &opt) const;
++
++  public:
++    int time_step;
++    int axis;
++  };
++  
++}
++
++#endif
+-- 
+2.17.1
+


### PR DESCRIPTION
This is what causes #1151 but does not solve the OCR model conversion issue.