### PR TITLE
fix: -Werror=deprecated-copy gcc 9.3

### DIFF
--- a/src/apidata.cc
+++ b/src/apidata.cc
@@ -107,12 +107,7 @@ namespace dd
   }
 
   /*- APIData -*/
-  APIData::APIData(const JVal &jval)
-  {
-    fromJVal(jval);
-  }
-
-  void APIData::fromJVal(const JVal &jval)
+  void APIData::fromRapidJson(const JVal &jval)
   {
     for (rapidjson::Value::ConstMemberIterator cit = jval.MemberBegin();
          cit != jval.MemberEnd(); ++cit)
@@ -126,7 +121,8 @@ namespace dd
           }
         else if (cit->value.IsObject())
           {
-            APIData ad(jval[cit->name.GetString()]);
+            APIData ad;
+            ad.fromRapidJson(jval[cit->name.GetString()]);
             std::vector<APIData> vad = { ad };
             add(cit->name.GetString(), vad);
           }
@@ -176,7 +172,7 @@ namespace dd
                     for (rapidjson::SizeType i = 0; i < jarr.Size(); i++)
                       {
                         APIData nad;
-                        nad.fromJVal(jarr[i]);
+                        nad.fromRapidJson(jarr[i]);
                         vad.push_back(nad);
                       }
                     add(cit->name.GetString(), vad);

--- a/src/apidata.h
+++ b/src/apidata.h
@@ -137,29 +137,6 @@ namespace dd
   {
   public:
     /**
-     * \brief empty constructor
-     */
-    APIData()
-    {
-    }
-
-    /**
-     * \brief constructor from rapidjson JSON object, see dd_types.h
-     */
-    APIData(const JVal &jval);
-
-    APIData(const APIData &ad) : _data(ad._data)
-    {
-    }
-
-    /**
-     * \brief destructor
-     */
-    ~APIData()
-    {
-    }
-
-    /**
      * \brief add key / object to data object
      * @param key string unique key
      * @param val variant value
@@ -280,7 +257,7 @@ namespace dd
      * \brief converts rapidjson JSON to APIData
      * @param jval JSON object
      */
-    void fromJVal(const JVal &jval);
+    void fromRapidJson(const JVal &jval);
 
     /**
      * \brief converts APIData to rapidjson JSON document

--- a/src/jsonapi.cc
+++ b/src/jsonapi.cc
@@ -382,7 +382,7 @@ namespace dd
         APIData ad;
         try
           {
-            ad = APIData(d);
+            ad.fromRapidJson(d);
             if (ad.has("status"))
               status = ad.get("status").get<bool>();
           }
@@ -477,7 +477,7 @@ namespace dd
           description = d["description"].GetString();
 
         // model parameters (mandatory).
-        ad = APIData(d);
+        ad.fromRapidJson(d);
         ad_model = ad.getobj("model");
         APIData ad_param = ad.getobj("parameters");
         if (ad_param.has("output"))
@@ -1048,7 +1048,7 @@ namespace dd
     try
       {
         if (!jstr.empty())
-          ad = APIData(d);
+          ad.fromRapidJson(d);
       }
     catch (RapidjsonException &e)
       {
@@ -1104,7 +1104,7 @@ namespace dd
     APIData ad_data;
     try
       {
-        ad_data = APIData(d);
+        ad_data.fromRapidJson(d);
       }
     catch (RapidjsonException &e)
       {
@@ -1237,7 +1237,7 @@ namespace dd
     APIData ad;
     try
       {
-        ad = APIData(d);
+        ad.fromRapidJson(d);
       }
     catch (RapidjsonException &e)
       {
@@ -1340,7 +1340,7 @@ namespace dd
     APIData ad;
     try
       {
-        ad = APIData(d);
+        ad.fromRapidJson(d);
       }
     catch (RapidjsonException &e)
       {
@@ -1472,7 +1472,7 @@ namespace dd
     APIData ad;
     try
       {
-        ad = APIData(d);
+        ad.fromRapidJson(d);
       }
     catch (RapidjsonException &e)
       {
@@ -1523,7 +1523,7 @@ namespace dd
     APIData ad_data;
     try
       {
-        ad_data = APIData(d);
+        ad_data.fromRapidJson(d);
       }
     catch (RapidjsonException &e)
       {
@@ -1650,7 +1650,7 @@ namespace dd
       }
     try
       {
-        ad = APIData(d);
+        ad.fromRapidJson(d);
       }
     catch (RapidjsonException &e)
       {

--- a/src/mlmodel.h
+++ b/src/mlmodel.h
@@ -318,7 +318,7 @@ namespace dd
       APIData adcj;
       try
         {
-          adcj = APIData(d);
+          adcj.fromRapidJson(d);
         }
       catch (RapidjsonException &e)
         {

--- a/tests/ut-apidata.cc
+++ b/tests/ut-apidata.cc
@@ -101,7 +101,8 @@ TEST(apidata, to_from_json)
   ASSERT_EQ(prob1, jd["classes"][0]["prob"].GetDouble());
 
   // to APIData
-  APIData nad(jd);
+  APIData nad;
+  nad.fromRapidJson(jd);
   ASSERT_EQ("string", nad.get("string").get<std::string>());
   ASSERT_EQ(2.3, nad.get("double").get<double>());
   ASSERT_EQ(true, nad.get("bool").get<bool>());

--- a/tests/ut-conn.cc
+++ b/tests/ut-conn.cc
@@ -633,7 +633,8 @@ TEST(inputconn, csv_read_categoricals)
   JDoc d;
   d.Parse<rapidjson::kParseNanAndInfFlag>(json_categorical_mapping.c_str());
   ASSERT_FALSE(d.HasParseError());
-  APIData ap(d);
+  APIData ap;
+  ap.fromRapidJson(d);
   ASSERT_EQ(1, ap.size());
   ASSERT_TRUE(ap.has("categoricals_mapping"));
   APIData ap_cm = ap.getobj("categoricals_mapping");


### PR DESCRIPTION
This just uses default APIData constructors instead of have to defined
all copy/move semantics.

Instead of using the special constructor for RapidJson, we just call the
fromRapidJson() method when needed.
