### PR TITLE
fix(torch): add error message when repository contains multiple models

### DIFF
--- a/src/backends/torch/torchmodule.cc
+++ b/src/backends/torch/torchmodule.cc
@@ -470,6 +470,12 @@ namespace dd
 
   void TorchModule::load(TorchModel &model)
   {
+    if (!model._native.empty() && !model._proto.empty())
+      {
+        throw MLLibBadParamException(
+            "Found both native and graph model in repository");
+      }
+
     if (!model._traced.empty() && model._proto.empty())
       traced_model_load(model);
 


### PR DESCRIPTION
I spent a long time figuring out why my native model was returning an empty tensor, only to realize their was a `recurent.prototxt` in the repo, probably added by mistake.

This PR adds an error message to make things more explicit.