### PR TITLE
chore(torch): define explicit assignment operators

### DIFF
--- a/src/backends/torch/native/templates/nbeats.h
+++ b/src/backends/torch/native/templates/nbeats.h
@@ -78,6 +78,25 @@ namespace dd
       {
       }
 
+      BlockImpl &operator=(const BlockImpl &b)
+      {
+        torch::nn::Module::operator=(b);
+        _units = b._units;
+        _thetas_dim = b._thetas_dim;
+        _data_size = b._data_size;
+        _backcast_length = b._backcast_length;
+        _forecast_length = b._forecast_length;
+        _share_thetas = b._share_thetas;
+
+        _fc1 = b._fc1;
+        _fc2 = b._fc2;
+        _fc3 = b._fc3;
+        _fc4 = b._fc4;
+        _theta_b_fc = b._theta_b_fc;
+        _theta_f_fc = b._theta_f_fc;
+        return *this;
+      }
+
       void reset()
       {
         init_block();
@@ -123,13 +142,20 @@ namespace dd
       {
       }
 
+      SeasonalityBlockImpl &operator=(const SeasonalityBlockImpl &b)
+      {
+        BlockImpl::operator=(b);
+        _bS = b._bS;
+        _fS = b._fS;
+        return *this;
+      }
+
       SeasonalityBlockImpl &operator=(SeasonalityBlockImpl &&b)
       {
         // This operator is used when NBeats is cloned (e.g. for multigpu).
         // bT and fT are not copied because they are set by NBeats::reset()
         // With the default operator, unwanted copy of bT and fT resulting
         // in them having the wrong device id.
-        torch::nn::Module::operator=(b);
         BlockImpl::operator=(b);
         return *this;
       }
@@ -165,13 +191,20 @@ namespace dd
       {
       }
 
+      TrendBlockImpl &operator=(const TrendBlockImpl &b)
+      {
+        BlockImpl::operator=(b);
+        _bT = b._bT;
+        _fT = b._fT;
+        return *this;
+      }
+
       TrendBlockImpl &operator=(TrendBlockImpl &&b)
       {
         // This operator is used when NBeats is cloned (e.g. for multigpu).
         // bT and fT are not copied because they are set by NBeats::reset()
         // With the default operator, unwanted copy of bT and fT resulting
         // in them having the wrong device id.
-        torch::nn::Module::operator=(b);
         BlockImpl::operator=(b);
         return *this;
       }
@@ -203,10 +236,17 @@ namespace dd
       }
 
       GenericBlockImpl(const GenericBlockImpl &b)
-          : torch::nn::Module(b), BlockImpl(b)
+          : torch::nn::Module(b), BlockImpl(b), _backcast_fc(b._backcast_fc),
+            _forecast_fc(b._forecast_fc)
       {
-        _backcast_fc = b._backcast_fc;
+      }
+
+      GenericBlockImpl &operator=(const GenericBlockImpl &b)
+      {
+        BlockImpl::operator=(b);
         _forecast_fc = b._forecast_fc;
+        _backcast_fc = b._backcast_fc;
+        return *this;
       }
 
       void reset() override

--- a/src/backends/torch/native/templates/vit.h
+++ b/src/backends/torch/native/templates/vit.h
@@ -55,8 +55,19 @@ namespace dd
       {
       }
 
-      ~MLPImpl()
+      MLPImpl &operator=(const MLPImpl &m)
       {
+        torch::nn::Module::operator=(m);
+        _input_dim = m._input_dim;
+        _hidden_dim = m._hidden_dim;
+        _output_dim = m._output_dim;
+        _act = m._act;
+        _drop = m._drop;
+
+        _fc1 = m._fc1;
+        _fc2 = m._fc2;
+        _drop1 = m._drop1;
+        return *this;
       }
 
       void reset()
@@ -106,8 +117,24 @@ namespace dd
       {
       }
 
-      ~AttentionImpl()
+      AttentionImpl &operator=(const AttentionImpl &a)
       {
+        torch::nn::Module::operator=(a);
+        _dim = a._dim;
+        _num_heads = a._num_heads;
+        _qkv_bias = a._qkv_bias;
+        _qk_scale = a._qk_scale;
+        _attn_drop_val = a._attn_drop_val;
+        _proj_drop_val = a._proj_drop_val;
+        _realformer = a._realformer;
+
+        _scale = a._scale;
+        _head_dim = a._head_dim;
+        _qkv = a._qkv;
+        _attn_drop = a._attn_drop;
+        _proj = a._proj;
+        _proj_drop = a._proj_drop;
+        return *this;
       }
 
       void reset()
@@ -132,12 +159,12 @@ namespace dd
       double _scale = 1.0;
       unsigned int _head_dim = 0;
 
+      bool _realformer = false;
+
       torch::nn::Linear _qkv{ nullptr };
       torch::nn::Dropout _attn_drop{ nullptr };
       torch::nn::Linear _proj{ nullptr };
       torch::nn::Dropout _proj_drop{ nullptr };
-
-      bool _realformer = false;
     };
 
     typedef torch::nn::ModuleHolder<AttentionImpl> Attention;
@@ -166,8 +193,23 @@ namespace dd
       {
       }
 
-      ~BlockImpl()
+      BlockImpl &operator=(const BlockImpl &b)
       {
+        torch::nn::Module::operator=(b);
+        _dim = b._dim;
+        _num_heads = b._num_heads;
+        _mlp_ratio = b._mlp_ratio;
+        _qkv_bias = b._qkv_bias;
+        _qk_scale = b._qk_scale;
+        _drop_val = b._drop_val;
+        _attn_drop_val = b._attn_drop_val;
+        _realformer = b._realformer;
+
+        _norm1 = b._norm1;
+        _attn = b._attn;
+        _norm2 = b._norm2;
+        _mlp = b._mlp;
+        return *this;
       }
 
       void reset()
@@ -222,8 +264,16 @@ namespace dd
       {
       }
 
-      ~PatchEmbedImpl()
+      PatchEmbedImpl &operator=(const PatchEmbedImpl &p)
       {
+        torch::nn::Module::operator=(p);
+        _img_size = p._img_size;
+        _patch_size = p._patch_size;
+        _in_chans = p._in_chans;
+        _embed_dim = p._embed_dim;
+
+        _proj = p._proj;
+        return *this;
       }
 
       void reset()
@@ -284,9 +334,33 @@ namespace dd
     {
     }
 
-    virtual ~ViT()
+    ViT &operator=(const ViT &v)
     {
+      torch::nn::Module::operator=(v);
+      _img_size = v._img_size;
+      _patch_size = v._patch_size;
+      _in_chans = v._in_chans;
+      _num_classes = v._num_classes;
+      _embed_dim = v._embed_dim;
+      _depth = v._depth;
+      _num_heads = v._num_heads;
+      _mlp_ratio = v._mlp_ratio;
+      _qkv_bias = v._qkv_bias;
+      _qk_scale = v._qk_scale;
+      _drop_rate = v._drop_rate;
+      _attn_drop_rate = v._attn_drop_rate;
+
+      _patch_embed = v._patch_embed;
+      _cls_token = v._cls_token;
+      _pos_embed = v._pos_embed;
+      _pos_drop = v._pos_drop;
+      _blocks = v._blocks;
+      _norm = v._norm;
+      _head = v._head;
+      return *this;
     }
+
+    virtual ~ViT() = default;
 
     void reset() override
     {


### PR DESCRIPTION
This should fix the warnings. It seems like implicit move assignment operator does not trigger the warning, I think the move assignment operator is replaced by the copy assignment operator when it is not defined, hence no warning.

In C++ there are no simple ways to implement default copy constructor with user defined behavior for some class fields, if we implement the copy constructor we have to copy every parameter manually, which is error prone. For classes with many parameters like TorchMllib for example, I think we could take advantage of the default move constructor to avoid trivial mistakes, like forgetting to move one class field in the move constructor. It could be done in a future refactor.