### PR TITLE
Feat crop action new params

### DIFF
--- a/src/http/controller.hpp
+++ b/src/http/controller.hpp
@@ -202,7 +202,7 @@ public:
   {
     info->summary = "Run a chain";
   }
-  ENDPOINT("POST", "chains/{chain-name}", create_chain,
+  ENDPOINT("POST", "chain/{chain-name}", create_chain,
            PATH(oatpp::String, chain_name, "chain-name"),
            BODY_STRING(oatpp::String, chain_data))
   {


### PR DESCRIPTION
New chain crop action parameters:
- `to_rgb` and `to_bgr` to accomodate passing crops between models that take different input formats
- `fixed_width` and `fixed_height` to allow cropping a fixed number of pixels around the original bounding box