### PR TITLE
fix(torch/timeseries): in case of db, correctly finalize db

### DIFF
--- a/src/backends/torch/torchdataset.cc
+++ b/src/backends/torch/torchdataset.cc
@@ -28,6 +28,8 @@ namespace dd
 {
   void TorchDataset::db_finalize()
   {
+    if (!_db)
+      return;
     if (_current_index % _batches_per_transaction != 0)
       {
         _txn->Commit();

--- a/src/backends/torch/torchinputconns.cc
+++ b/src/backends/torch/torchinputconns.cc
@@ -846,10 +846,12 @@ namespace dd
         _ids.clear();
         fill_dataset(_dataset, _csvtsdata);
         _csvtsdata.clear();
+        _dataset.db_finalize();
         check_tests_sizes(_csvtsdata_tests.size(), _csv_test_fnames.size());
         _test_datasets.add_tests_names(_csv_test_fnames);
         for (size_t i = 0; i < _csvtsdata_tests.size(); ++i)
           fill_dataset(_test_datasets[i], _csvtsdata_tests[i], i);
+        _test_datasets.db_finalize();
         _csvtsdata_tests.clear();
       }
     else
@@ -1087,5 +1089,4 @@ namespace dd
       fill_dataset_labels(dataset, csvtsdata, test_id);
     dataset.reset();
   }
-
 }

--- a/src/backends/torch/torchinputconns.h
+++ b/src/backends/torch/torchinputconns.h
@@ -102,8 +102,8 @@ namespace dd
       _tilogger = logger;
       if (ad_in.has("shuffle"))
         _dataset.set_shuffle(ad_in.get("shuffle").get<bool>());
-      if (ad_in.has("db") && ad_in.get("db").get<bool>())
-        _db = true;
+      if (ad_in.has("db"))
+        _db = ad_in.get("db").get<bool>();
       _dataset.set_db_params(_db, _backend, model_repo + "/train");
       _dataset.set_logger(logger);
       _test_datasets.set_db_params(_db, _backend, model_repo + "/test");

--- a/tests/ut-torchapi.cc
+++ b/tests/ut-torchapi.cc
@@ -1106,6 +1106,136 @@ TEST(torchapi, service_train_csvts_nbeats)
   rmdir(csvts_nbeats_repo.c_str());
 }
 
+TEST(torchapi, service_train_csvts_nbeats_db)
+{
+  setenv("CUBLAS_WORKSPACE_CONFIG", ":4096:8", true);
+  torch::manual_seed(torch_seed);
+  at::globalContext().setDeterministic(true);
+
+  // create service
+  JsonAPI japi;
+  std::string sname = "nbeats";
+  std::string csvts_data = sinus + "train";
+  std::string csvts_test = sinus + "test";
+  std::string csvts_predict = sinus + "predict";
+  std::string csvts_nbeats_repo = "csvts_nbeats";
+  mkdir(csvts_nbeats_repo.c_str(), 0777);
+
+  std::string jstr
+      = "{\"mllib\":\"torch\",\"description\":\"nbeats\",\"type\":"
+        "\"supervised\",\"model\":{\"repository\":\""
+        + csvts_nbeats_repo
+        + "\"},\"parameters\":{\"input\":{\"db\":true,\"connector\":\"csvts\","
+          "\"ignore\":["
+          "\"output\"],\"backcast_timesteps\":50,\"forecast_timesteps\":50},"
+          "\"mllib\":{\"template\":\"nbeats\","
+          "\"template_params\":{\"stackdef\":[\"t2\",\"s4\",\"g3\",\"b3\"]},"
+          "\"loss\":\"L1\"}}}";
+
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
+
+  // train
+  std::string jtrainstr
+      = "{\"service\":\"" + sname
+        + "\",\"async\":false,\"parameters\":{\"input\":{\"db\":true,\"seed\":"
+          "12345,\"shuffle\":true,"
+          "\"separator\":\",\",\"scale\":true,\"backcast_timesteps\":50,"
+          "\"forecast_timesteps\":50,\"ignore\":["
+          "\"output\"]},\"mllib\":{\"gpu\":false,\"solver\":{\"iterations\":"
+        + iterations_nbeats_cpu
+        + ",\"test_interval\":10,\"base_lr\":0.1,\"snapshot\":500,\"test_"
+          "initialization\":false,\"solver_type\":\"ADAM\"},\"net\":{\"batch_"
+          "size\":2,\"test_batch_"
+          "size\":10}},\"output\":{\"measure\":[\"L1\",\"L2\"]}},\"data\":[\""
+        + csvts_data + "\",\"" + csvts_test + "\"]}";
+
+  std::cerr << "jtrainstr=" << jtrainstr << std::endl;
+  joutstr = japi.jrender(japi.service_train(jtrainstr));
+  std::cout << "joutstr=" << joutstr << std::endl;
+  JDoc jd;
+  jd.Parse(joutstr.c_str());
+  ASSERT_TRUE(!jd.HasParseError());
+  ASSERT_TRUE(jd.HasMember("status"));
+  ASSERT_EQ(201, jd["status"]["code"].GetInt());
+  ASSERT_EQ("Created", jd["status"]["msg"]);
+  ASSERT_TRUE(jd.HasMember("head"));
+  ASSERT_EQ("/train", jd["head"]["method"]);
+  ASSERT_TRUE(jd["head"]["time"].GetDouble() >= 0);
+  ASSERT_TRUE(jd.HasMember("body"));
+  ASSERT_TRUE(jd["body"]["measure"].HasMember("train_loss"));
+  ASSERT_TRUE(fabs(jd["body"]["measure"]["train_loss"].GetDouble()) > 0);
+  ASSERT_TRUE(jd["body"]["measure"].HasMember("L1_mean_error"));
+  ASSERT_TRUE(jd["body"]["measure"]["L1_max_error_0"].GetDouble() > 0.0);
+  ASSERT_TRUE(jd["body"]["parameters"]["input"].HasMember("max_vals"));
+  ASSERT_TRUE(jd["body"]["parameters"]["input"].HasMember("min_vals"));
+
+  std::string str_min_vals
+      = japi.jrender(jd["body"]["parameters"]["input"]["min_vals"]);
+  std::string str_max_vals
+      = japi.jrender(jd["body"]["parameters"]["input"]["max_vals"]);
+
+  //  predict
+  std::string jpredictstr
+      = "{\"service\":\"" + sname
+        + "\",\"parameters\":{\"input\":{\"db\":false,\"backcast_timesteps\":"
+          "50,\"forecast_"
+          "timesteps\":50,\"connector\":"
+          "\"csvts\",\"scale\":true,\"ignore\":[\"output\"],\"continuation\":"
+          "true,\"min_vals\":"
+        + str_min_vals + ",\"max_vals\":" + str_max_vals
+        + "},\"output\":{}},\"data\":[\"" + csvts_predict + "\"]}";
+  joutstr = japi.jrender(japi.service_predict(jpredictstr));
+  std::cout << "joutstr=" << joutstr << std::endl;
+  jd.Parse(joutstr.c_str());
+  ASSERT_TRUE(!jd.HasParseError());
+  ASSERT_EQ(200, jd["status"]["code"]);
+  std::string uri = jd["body"]["predictions"][0]["uri"].GetString();
+  ASSERT_EQ("../examples/all/sinus/predict/seq_2.csv #0_99", uri);
+  ASSERT_TRUE(jd["body"]["predictions"][0]["series"].IsArray());
+  ASSERT_TRUE(jd["body"]["predictions"][0]["series"][0]["out"][0].GetDouble()
+              >= -1.5);
+
+  // predict from memory
+  std::stringstream mem_data;
+  for (int i = 0; i < 50; ++i)
+    {
+      if (i != 0)
+        mem_data << "\\n";
+      mem_data << i << "," << i;
+    }
+
+  jpredictstr = "{\"service\":\"" + sname
+                + "\",\"parameters\":{\"input\":{\"db\":"
+                  "false,\"backcast_timesteps\":"
+                  "50,\"forecast_"
+                  "timesteps\":50,\"connector\":"
+                  "\"csvts\",\"scale\":true,"
+                  "\"ignore\":[\"output\"],"
+                  "\"continuation\":"
+                  "true,\"min_vals\":"
+                + str_min_vals + ",\"max_vals\":" + str_max_vals
+                + "},\"output\":{}},\"data\":[\"input,output\", \""
+                + mem_data.str() + "\"]}";
+
+  joutstr = japi.jrender(japi.service_predict(jpredictstr));
+  std::cout << "joutstr=" << joutstr << std::endl;
+  jd.Parse(joutstr.c_str());
+  ASSERT_TRUE(!jd.HasParseError());
+  ASSERT_EQ(200, jd["status"]["code"]);
+  uri = jd["body"]["predictions"][0]["uri"].GetString();
+  ASSERT_EQ("0", uri);
+  ASSERT_TRUE(jd["body"]["predictions"][0]["series"].IsArray());
+  ASSERT_TRUE(jd["body"]["predictions"][0]["series"].Size() == 50);
+  ASSERT_TRUE(jd["body"]["predictions"][0]["series"][0]["out"][0].IsDouble());
+
+  //  remove service
+  jstr = "{\"clear\":\"full\"}";
+  joutstr = japi.jrender(japi.service_delete(sname, jstr));
+  ASSERT_EQ(ok_str, joutstr);
+  rmdir(csvts_nbeats_repo.c_str());
+}
+
 TEST(torchapi, service_train_csvts_nbeats_multiple_testsets)
 {
   torch::manual_seed(torch_seed);


### PR DESCRIPTION
this PR allows to use csvts + db
(not completely usefull combination: all csvts are read before being put into db, some more work is needed to put them into db one after the other. ATM only interesting property is to release CPU memory after putting them into db)
also add ut