### PR TITLE
fix(caffe/cudnn): force default engine option in case of cudnn not compiled in

### DIFF
--- a/src/backends/caffe/caffelib.h
+++ b/src/backends/caffe/caffelib.h
@@ -231,11 +231,9 @@ namespace dd
   private:
     void update_protofile_classes(caffe::NetParameter &net_param);
 
-#ifdef USE_CUDNN
     void update_protofile_engine(const APIData &ad);
     void update_protofile_engine(caffe::NetParameter &net_param,
                                  const APIData &ad);
-#endif
 
     void update_protofiles_one_hot(caffe::NetParameter &net_param);
 
@@ -332,7 +330,6 @@ namespace dd
     caffe::P2PSync<float> *_sync = nullptr;
     std::vector<boost::shared_ptr<caffe::P2PSync<float>>> _syncs;
   };
-
 }
 
 #endif


### PR DESCRIPTION
see side bug of https://github.com/jolibrain/deepdetect/issues/1190