### PR TITLE
feat(torch): torch detection training

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -804,6 +804,12 @@ if (USE_TORCH)
   #set(PYTORCH_VISION_COMMIT "v0.7.0") # 0.7 & torch 1.6
   #set(PYTORCH_VISION_COMMIT "v0.8.2") # 0.8.2 & torch 1.7.1
   set(PYTORCH_VISION_COMMIT "v0.9.0") # 0.9.0 & torch 1.8
+  set(PYTORCH_VISION_PATCHES_PATH ${CMAKE_BINARY_DIR}/patches/pytorch/vision)
+  set(PYTORCH_VISION_PATCHES
+      ${PYTORCH_VISION_PATCHES_PATH}/pytorch_vision_09_fasterrcnn.patch
+  )
+
+  set(PYTORCH_VISION_COMPLETE ${CMAKE_BINARY_DIR}/CMakeFiles/pytorch_vision-complete)
   set(TORCHVISION_LOCATION "${CMAKE_BINARY_DIR}/pytorch_vision/src/pytorch_vision-install")
   ExternalProject_Add(
     pytorch_vision
@@ -812,6 +818,7 @@ if (USE_TORCH)
     GIT_REPOSITORY https://github.com/pytorch/vision.git
     GIT_TAG ${PYTORCH_VISION_COMMIT}
     GIT_CONFIG advice.detachedHead=false
+    PATCH_COMMAND test -f ${PYTORCH_VISION_COMPLETE} && echo Skipping || git apply ${PYTORCH_VISION_PATCHES} && echo Applying ${PYTORCH_VISION_PATCHES}
     CMAKE_ARGS -DWITH_CUDA=${PYTORCH_USE_CUDA} -DCMAKE_PREFIX_PATH=${TORCH_LOCATION} -DCMAKE_INSTALL_PREFIX=${TORCHVISION_LOCATION}
       -DCMAKE_INCLUDE_PATH=${PROTOBUF_INCLUDE_DIR} -DCMAKE_LIBRARY_PATH=${PROTOBUF_LIB_DIR}
       "-DCMAKE_CXX_FLAGS=-isystem ${CMAKE_BINARY_DIR}/pytorch/src/pytorch/ -isystem ${SPDLOG_INCLUDE_DIR} -isystem ${PROTOBUF_INCLUDE_DIR}"

--- a/docs/api.md
+++ b/docs/api.md
@@ -1444,6 +1444,9 @@ These templates require an external traced model to work:
 - Language models:
 	- `bert`
 	- `gpt2`
+- Detection models:
+	- `fasterrcnn`
+	- `retinanet`
 
 ## Parameters
 

--- a/patches/pytorch/vision/pytorch_vision_09_fasterrcnn.patch
+++ b/patches/pytorch/vision/pytorch_vision_09_fasterrcnn.patch
@@ -1,0 +1,30 @@
+diff --git a/torchvision/extension.py b/torchvision/extension.py
+index 265c989a..83e18345 100644
+--- a/torchvision/extension.py
++++ b/torchvision/extension.py
+@@ -1,8 +1,8 @@
+-_HAS_OPS = False
++_HAS_OPS = True
+ 
+ 
+ def _has_ops():
+-    return False
++    return True
+ 
+ 
+ def _register_extensions():
+diff --git a/torchvision/models/detection/_utils.py b/torchvision/models/detection/_utils.py
+index db971176..35a50758 100644
+--- a/torchvision/models/detection/_utils.py
++++ b/torchvision/models/detection/_utils.py
+@@ -53,8 +53,8 @@ class BalancedPositiveNegativeSampler(object):
+             num_neg = min(negative.numel(), num_neg)
+ 
+             # randomly select positive and negative examples
+-            perm1 = torch.randperm(positive.numel(), device=positive.device)[:num_pos]
+-            perm2 = torch.randperm(negative.numel(), device=negative.device)[:num_neg]
++            perm1 = torch.randperm(positive.numel(), device=positive.device, dtype=torch.int64)[:num_pos]
++            perm2 = torch.randperm(negative.numel(), device=negative.device, dtype=torch.int64)[:num_neg]
+ 
+             pos_idx_per_image = positive[perm1]
+             neg_idx_per_image = negative[perm2]

--- a/src/backends/torch/torchdataset.h
+++ b/src/backends/torch/torchdataset.h
@@ -270,16 +270,29 @@ namespace dd
 
     /**
      * \brief adds image from image filename, with an int target
+     * \param width of preprocessed image
+     * \param height of preprocessed image
      */
     int add_image_file(const std::string &fname, const int &target,
                        const int &height, const int &width);
 
     /**
      * \brief adds image from image filename, with a set of regression targets
+     * \param width of preprocessed image
+     * \param height of preprocessed image
      */
     int add_image_file(const std::string &fname,
                        const std::vector<double> &target, const int &height,
                        const int &width);
+
+    /**
+     * \brief adds image to batch, with a bbox list file as target.
+     * \param width of preprocessed image
+     * \param height of preprocessed image
+     */
+    int add_image_bbox_file(const std::string &fname,
+                            const std::string &bboxfname, const int &height,
+                            const int &width);
 
     /**
      * \brief turns an image into a torch::Tensor

--- a/src/backends/torch/torchinputconns.h
+++ b/src/backends/torch/torchinputconns.h
@@ -93,6 +93,9 @@ namespace dd
         }
     }
 
+    void set_test_names(size_t test_count,
+                        const std::vector<std::string> &uris);
+
     /**
      * \brief init  generic parts of input connector
      */
@@ -222,7 +225,7 @@ namespace dd
      * \brief copy constructor
      */
     ImgTorchInputFileConn(const ImgTorchInputFileConn &i)
-        : ImgInputFileConn(i), TorchInputInterface(i)
+        : ImgInputFileConn(i), TorchInputInterface(i), _bbox(i._bbox)
     {
       _dataset._inputc = this;
       _dataset._image = true;
@@ -258,6 +261,8 @@ namespace dd
     {
       TorchInputInterface::init(ad, _model_repo, _logger);
       ImgInputFileConn::init(ad);
+      if (ad.has("bbox"))
+        _bbox = ad.get("bbox").get<bool>();
     }
 
     void fillup_parameters(const APIData &ad_input)
@@ -282,6 +287,13 @@ namespace dd
     void read_image_list(
         std::vector<std::pair<std::string, std::vector<double>>> &lfiles,
         const std::string &listfilePath);
+
+    /**
+     * \brief read images from txt list. Targets are bbox files.
+     */
+    void
+    read_image_bbox(std::vector<std::pair<std::string, std::string>> &lfiles,
+                    const std::string &listfilePath);
 
     /**
      * \brief shuffle dataset

--- a/src/backends/torch/torchlib.cc
+++ b/src/backends/torch/torchlib.cc
@@ -40,6 +40,8 @@
 #include "torchloss.h"
 #include "torchutils.h"
 
+#include "utils/bbox.hpp"
+
 using namespace torch;
 
 namespace dd
@@ -369,7 +371,8 @@ namespace dd
     // TorchVision detection models
     else if (_template == "fasterrcnn" || _template == "retinanet")
       {
-        // fasterrcnn output is a tuple (Loss, Predictions)
+        // torchvision models output is a tuple (Loss, Predictions)
+        _module._loss_id = 0;
         _module._linear_in = 1;
       }
     else if (!_template.empty())
@@ -602,8 +605,8 @@ namespace dd
     int64_t test_batch_size = 1;
     int64_t test_interval = 1;
     int64_t save_period = 0;
-    TorchLoss tloss(_loss, _seq_training, _timeserie, _regression,
-                    _classification, _module, this->_logger);
+    TorchLoss tloss(_loss, _module.has_model_loss(), _seq_training, _timeserie,
+                    _regression, _classification, _module, this->_logger);
     TorchSolver tsolver(_module, tloss, _devices, this->_logger);
     Tensor class_weights = {};
 
@@ -728,6 +731,12 @@ namespace dd
               {
                 in_vals.push_back(tensor.to(_main_device));
               }
+            if (_module.has_model_loss())
+              {
+                // if the model computes the loss then we pass target as input
+                for (Tensor tensor : batch.target)
+                  in_vals.push_back(tensor.to(_main_device));
+              }
 
             if (batch.target.size() == 0)
               {
@@ -735,7 +744,6 @@ namespace dd
                     "Batch " + std::to_string(batch_id) + ": no target");
               }
             Tensor y = batch.target.at(0).to(_main_device);
-
             Tensor y_pred;
             try
               {
@@ -1203,7 +1211,7 @@ namespace dd
 
             if (bbox)
               {
-                // Supporting only Faster RCNN format at the moment.
+                // Supporting only torchvision output format at the moment.
                 auto out_dicts = out_ivalue.toList();
 
                 for (size_t i = 0; i < out_dicts.size(); ++i)
@@ -1231,11 +1239,14 @@ namespace dd
 
                     auto out_dict = out_dicts.get(i).toGenericDict();
                     Tensor bboxes_tensor
-                        = torch_utils::to_tensor_safe(out_dict.at("boxes"));
+                        = torch_utils::to_tensor_safe(out_dict.at("boxes"))
+                              .to(cpu);
                     Tensor labels_tensor
-                        = torch_utils::to_tensor_safe(out_dict.at("labels"));
+                        = torch_utils::to_tensor_safe(out_dict.at("labels"))
+                              .to(cpu);
                     Tensor score_tensor
-                        = torch_utils::to_tensor_safe(out_dict.at("scores"));
+                        = torch_utils::to_tensor_safe(out_dict.at("scores"))
+                              .to(cpu);
 
                     auto bboxes_acc = bboxes_tensor.accessor<float, 2>();
                     auto labels_acc = labels_tensor.accessor<int64_t, 1>();
@@ -1432,6 +1443,7 @@ namespace dd
                                const std::string &test_name)
   {
     APIData ad_res;
+    APIData ad_bbox;
     APIData ad_out = ad.getobj("parameters").getobj("output");
     int nclasses = _masked_lm ? inputc.vocab_size() : _nclasses;
 
@@ -1464,9 +1476,14 @@ namespace dd
           in_vals.push_back(tensor.to(_main_device));
 
         Tensor output;
+        c10::IValue out_ivalue;
         try
           {
-            output = torch_utils::to_tensor_safe(_module.forward(in_vals));
+            out_ivalue = _module.forward(in_vals);
+            if (!_bbox)
+              {
+                output = torch_utils::to_tensor_safe(out_ivalue);
+              }
           }
         catch (std::exception &e)
           {
@@ -1512,6 +1529,33 @@ namespace dd
                 bad.add("target_unscaled", targets_unscaled);
                 bad.add("pred_unscaled", predictions_unscaled);
                 ad_res.add(std::to_string(entry_id), bad);
+                ++entry_id;
+              }
+          }
+        else if (_bbox)
+          {
+            // Supporting only Faster RCNN format at the moment.
+            auto out_dicts = out_ivalue.toList();
+            Tensor targ_bboxes = batch.target.at(0);
+            Tensor targ_labels = batch.target.at(1);
+
+            for (size_t i = 0; i < out_dicts.size(); ++i)
+              {
+                auto out_dict = out_dicts.get(i).toGenericDict();
+                Tensor bboxes_tensor
+                    = torch_utils::to_tensor_safe(out_dict.at("boxes"))
+                          .to(cpu);
+                Tensor labels_tensor
+                    = torch_utils::to_tensor_safe(out_dict.at("labels"))
+                          .to(cpu);
+                Tensor score_tensor
+                    = torch_utils::to_tensor_safe(out_dict.at("scores"))
+                          .to(cpu);
+
+                auto vbad = get_bbox_stats(targ_bboxes[i], targ_labels[i],
+                                           bboxes_tensor, labels_tensor,
+                                           score_tensor);
+                ad_bbox.add(std::to_string(entry_id), vbad);
                 ++entry_id;
               }
           }
@@ -1586,11 +1630,131 @@ namespace dd
         ad_res.add("clnames", clnames);
         ad_res.add("nclasses", nclasses);
       }
+    if (_bbox)
+      {
+        ad_res.add("bbox", true);
+        ad_res.add("pos_count", entry_id);
+        ad_res.add("0", ad_bbox);
+      }
     ad_res.add("batch_size",
                entry_id); // here batch_size = tested entries count
     SupervisedOutput::measure(ad_res, ad_out, out, test_id, test_name);
     _module.train();
     return 0;
+  }
+
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy,
+            class TMLModel>
+  std::vector<APIData>
+  TorchLib<TInputConnectorStrategy, TOutputConnectorStrategy,
+           TMLModel>::get_bbox_stats(const at::Tensor &targ_bboxes,
+                                     const at::Tensor &targ_labels,
+                                     const at::Tensor &bboxes_tensor,
+                                     const at::Tensor &labels_tensor,
+                                     const at::Tensor &score_tensor)
+  {
+    auto targ_bboxes_acc = targ_bboxes.accessor<float, 2>();
+    auto targ_labels_acc = targ_labels.accessor<int64_t, 1>();
+    auto bboxes_acc = bboxes_tensor.accessor<float, 2>();
+    auto labels_acc = labels_tensor.accessor<int64_t, 1>();
+    auto score_acc = score_tensor.accessor<float, 1>();
+
+    APIData bad; // see caffe
+    const int targ_bbox_count = targ_labels.size(0);
+    const int pred_bbox_count = labels_tensor.size(0);
+    std::vector<bool> match_used(targ_bbox_count, false);
+
+    struct eval_info
+    {
+      // every positive score
+      std::vector<double> tp_d;
+      // 1 if true pos, 0 otherwise
+      std::vector<int> tp_i;
+      // every positive score
+      std::vector<double> fp_d;
+      // 1 if false pos, 0 otherwise
+      std::vector<int> fp_i;
+      int num_pos;
+      // XXX: fp variables are useless since tp_d == fp_d & tp_i == !fp_i
+      // This could be refactored along with supervised output
+      // connector
+    };
+
+    std::vector<eval_info> eval_infos(_nclasses);
+
+    for (int j = 0; j < pred_bbox_count; ++j)
+      {
+        double score = score_acc[j];
+        int cls = labels_acc[j];
+
+        if (cls >= static_cast<int>(_nclasses))
+          {
+            throw MLLibInternalException(
+                "Model output class: " + std::to_string(cls)
+                + " is invalid for nclasses = " + std::to_string(_nclasses));
+          }
+
+        std::vector<double> bbox{
+          bboxes_acc[j][0],
+          bboxes_acc[j][1],
+          bboxes_acc[j][2],
+          bboxes_acc[j][3],
+        };
+
+        bool found = false;
+
+        for (int k = 0; k < targ_bbox_count; ++k)
+          {
+            if (!match_used[k])
+              {
+                std::vector<double> targ_bbox{
+                  targ_bboxes_acc[k][0],
+                  targ_bboxes_acc[k][1],
+                  targ_bboxes_acc[k][2],
+                  targ_bboxes_acc[k][3],
+                };
+
+                if (bbox_utils::iou(bbox, targ_bbox) > 0.5
+                    && targ_labels_acc[k] == cls)
+                  {
+                    match_used[k] = true;
+                    found = true;
+
+                    eval_infos[cls].tp_d.push_back(score);
+                    eval_infos[cls].tp_i.push_back(1);
+                    eval_infos[cls].fp_d.push_back(score);
+                    eval_infos[cls].fp_i.push_back(0);
+                    break;
+                  }
+              }
+          }
+
+        if (!found)
+          {
+            eval_infos[cls].tp_d.push_back(score);
+            eval_infos[cls].tp_i.push_back(0);
+            eval_infos[cls].fp_d.push_back(score);
+            eval_infos[cls].fp_i.push_back(1);
+          }
+      }
+
+    for (int k = 0; k < targ_bbox_count; ++k)
+      {
+        eval_infos[targ_labels_acc[k]].num_pos++;
+      }
+    std::vector<APIData> vbad;
+    for (size_t label = 1; label < _nclasses; ++label)
+      {
+        APIData lbad;
+        lbad.add("tp_d", eval_infos[label].tp_d);
+        lbad.add("tp_i", eval_infos[label].tp_i);
+        lbad.add("fp_d", eval_infos[label].fp_d);
+        lbad.add("fp_i", eval_infos[label].fp_i);
+        lbad.add("num_pos", eval_infos[label].num_pos);
+        lbad.add("label", static_cast<int>(label));
+        vbad.push_back(lbad);
+      }
+    return vbad;
   }
 
   template class TorchLib<ImgTorchInputFileConn, SupervisedOutput, TorchModel>;

--- a/src/backends/torch/torchlib.h
+++ b/src/backends/torch/torchlib.h
@@ -85,6 +85,12 @@ namespace dd
              TorchDataset &dataset, int batch_size, APIData &out,
              size_t test_id = 0, const std::string &test_name = "");
 
+    std::vector<APIData> get_bbox_stats(const at::Tensor &targ_bboxes,
+                                        const at::Tensor &targ_labels,
+                                        const at::Tensor &bboxes_tensor,
+                                        const at::Tensor &labels_tensor,
+                                        const at::Tensor &score_tensor);
+
   public:
     unsigned int _nclasses = 0; /**< number of classes*/
     std::string _template; /**< template identifier (recurrent/bert/gpt2...)*/

--- a/src/backends/torch/torchloss.cc
+++ b/src/backends/torch/torchloss.cc
@@ -38,10 +38,12 @@ namespace dd
     torch::Tensor x = ivx[0].toTensor();
 
     torch::Tensor loss;
-    // As CrossEntropy is not available (Libtorch 1.1) we use
-    // nllloss
-    // + log_softmax
-    if (_seq_training)
+
+    if (_model_loss)
+      {
+        loss = y_pred;
+      }
+    else if (_seq_training)
       {
         // Convert [n_batch, sequence_length, vocab_size] to
         // [n_batch
@@ -78,6 +80,9 @@ namespace dd
       }
     else if (_classification)
       {
+        // As CrossEntropy is not available (Libtorch 1.1) we use
+        // nllloss
+        // + log_softmax
         loss = torch::nll_loss(torch::log_softmax(y_pred, 1),
                                y.view(torch::IntList{ -1 }), _class_weights);
       }

--- a/src/backends/torch/torchloss.h
+++ b/src/backends/torch/torchloss.h
@@ -43,12 +43,12 @@ namespace dd
     /**
      * \brief simple constructor
      */
-    TorchLoss(std::string loss, bool seq_training, bool timeserie,
-              bool regression, bool classification, TorchModule &module,
-              std::shared_ptr<spdlog::logger> logger)
-        : _loss(loss), _seq_training(seq_training), _timeserie(timeserie),
-          _regression(regression), _classification(classification),
-          _logger(logger)
+    TorchLoss(std::string loss, bool model_loss, bool seq_training,
+              bool timeserie, bool regression, bool classification,
+              TorchModule &module, std::shared_ptr<spdlog::logger> logger)
+        : _loss(loss), _model_loss(model_loss), _seq_training(seq_training),
+          _timeserie(timeserie), _regression(regression),
+          _classification(classification), _logger(logger)
     {
       _native = module._native;
     }
@@ -69,6 +69,7 @@ namespace dd
 
   protected:
     std::string _loss;
+    bool _model_loss; /** < wether loss is provided by the model */
     bool _seq_training;
     bool _timeserie;
     bool _regression;

--- a/src/backends/torch/torchmodule.cc
+++ b/src/backends/torch/torchmodule.cc
@@ -296,7 +296,16 @@ namespace dd
             source = torch_utils::unwrap_c10_vector(output);
           }
       }
+
+    if (_training && _loss_id >= 0)
+      {
+        // if we are in training mode and model does output the loss (eg traced
+        // detection models), then we return the loss.
+        return source.at(_loss_id);
+      }
+
     c10::IValue out_val = source.at(_linear_in);
+
     if (_hidden_states)
       {
         // out_val is a tuple containing tensors of dimension n_batch *
@@ -398,6 +407,11 @@ namespace dd
     if (_traced)
       return extract_layer == "final";
     return false;
+  }
+
+  bool TorchModule::has_model_loss() const
+  {
+    return _loss_id >= 0;
   }
 
   std::vector<std::string> TorchModule::extractable_layers() const
@@ -512,6 +526,8 @@ namespace dd
       _linear->eval();
     if (_native)
       _native->eval();
+
+    _training = false;
   }
 
   void TorchModule::train()
@@ -524,6 +540,8 @@ namespace dd
       _linear->train();
     if (_native)
       _native->train();
+
+    _training = true;
   }
 
   void TorchModule::free()

--- a/src/backends/torch/torchmodule.h
+++ b/src/backends/torch/torchmodule.h
@@ -83,6 +83,11 @@ namespace dd
     std::vector<std::string> extractable_layers() const;
 
     /**
+     * \brief return true if this model output its loss during training.
+     */
+    bool has_model_loss() const;
+
+    /**
      * \brief freeze traced net so that it is not updated during learning
      */
     void freeze_traced(bool freeze);
@@ -196,7 +201,10 @@ namespace dd
 
     torch::Device _device;
     torch::Dtype _dtype;
-    int _linear_in = 0; /**<id of the input of the final linear layer */
+    bool _training = false; /**<true if model is in training mode */
+    int _linear_in = 0;     /**<id of the input of the final linear layer */
+    int _loss_id = -1; /**<id of the loss output. If >= 0, forward returns this
+                          output only during training */
     bool _hidden_states = false; /**< Take BERT hidden states as input. */
 
     bool _require_linear_layer = false;

--- a/src/utils/bbox.hpp
+++ b/src/utils/bbox.hpp
@@ -1,0 +1,66 @@
+/**
+ * DeepDetect
+ * Copyright (c) 2021 Jolibrain
+ * Author: Louis Jean <louis.jean@jolibrain.com>
+ *
+ * This file is part of deepdetect.
+ *
+ * deepdetect is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * deepdetect is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with deepdetect.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef DD_UTILS_BBOX_HPP
+#define DD_UTILS_BBOX_HPP
+
+#include <vector>
+
+namespace dd
+{
+  namespace bbox_utils
+  {
+    double area(const std::vector<double> &bbox)
+    {
+      return (bbox[2] - bbox[0]) * (bbox[3] - bbox[1]);
+    }
+
+    std::vector<double> intersect(const std::vector<double> &bbox1,
+                                  const std::vector<double> &bbox2)
+    {
+      std::vector<double> inter{
+        std::max(bbox1[0], bbox2[0]),
+        std::max(bbox1[1], bbox2[1]),
+        std::min(bbox1[2], bbox2[2]),
+        std::min(bbox1[3], bbox2[3]),
+      };
+      // if xmin > xmax or ymin > ymax, intersection is empty
+      if (inter[0] >= inter[2] || inter[1] >= inter[3])
+        {
+          return { 0., 0., 0., 0. };
+        }
+      else
+        return inter;
+    }
+
+    double iou(const std::vector<double> &bbox1,
+               const std::vector<double> &bbox2)
+    {
+      double a1 = area(bbox1);
+      double a2 = area(bbox2);
+      auto inter = intersect(bbox1, bbox2);
+      double ainter = area(inter);
+      return ainter / (a1 + a2 - ainter);
+    }
+  }
+}
+
+#endif // DD_UTILS_BBOX_HPP

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -364,6 +364,13 @@ if (USE_TORCH)
     "fasterrcnn_torch"
     )
   DOWNLOAD_DATASET(
+    "Torchvision training Faster RCNN model & cars dataset"
+    "https://www.deepdetect.com/dd/examples/torch/fasterrcnn_train_torch.tar.gz"
+    "examples/torch"
+    "fasterrcnn_train_torch.tar.gz"
+    "fasterrcnn_train_torch"
+    )
+  DOWNLOAD_DATASET(
     "Torch BERT classification test model"
     "https://www.deepdetect.com/dd/examples/torch/bert_inference_torch.tar.gz"
     "examples/torch"

--- a/tests/ut-torchapi.cc
+++ b/tests/ut-torchapi.cc
@@ -25,6 +25,7 @@
 #include <gtest/gtest.h>
 #include <stdio.h>
 #include <iostream>
+#include <numeric>
 #include "backends/torch/native/templates/nbeats.h"
 #include <torch/torch.h>
 
@@ -40,6 +41,8 @@ static std::string not_found_str
 
 static std::string incept_repo = "../examples/torch/resnet50_torch/";
 static std::string detect_repo = "../examples/torch/fasterrcnn_torch/";
+static std::string detect_train_repo
+    = "../examples/torch/fasterrcnn_train_torch";
 static std::string resnet50_train_repo
     = "../examples/torch/resnet50_training_torch_small/";
 static std::string resnet50_train_data
@@ -70,6 +73,11 @@ static std::string bert_train_repo
 static std::string bert_train_data
     = "../examples/torch/bert_training_torch_140_transformers_251/data/";
 
+static std::string fasterrcnn_train_data
+    = "../examples/torch/fasterrcnn_train_torch/train.txt";
+static std::string fasterrcnn_test_data
+    = "../examples/torch/fasterrcnn_train_torch/test.txt";
+
 static std::string sinus = "../examples/all/sinus/";
 
 static std::string iterations_nbeats_cpu = "100";
@@ -79,6 +87,7 @@ static std::string iterations_ttransformer_gpu = "1000";
 
 static std::string iterations_resnet50 = "200";
 static std::string iterations_vit = "200";
+static std::string iterations_detection = "200";
 
 static int torch_seed = 1235;
 static std::string torch_lr = "1e-5";
@@ -373,6 +382,83 @@ TEST(torchapi, load_weights_native_model)
   ASSERT_TRUE(torch::allclose(before_val, after_val));
 
   fileops::remove_file(".", mlmodel._native);
+}
+
+TEST(torchapi, compute_bbox_stats)
+{
+  TorchModel torchmodel;
+  TorchLib<ImgTorchInputFileConn, SupervisedOutput, TorchModel> torchlib(
+      torchmodel);
+  torchlib._nclasses = 2;
+  // img dims are e.g. 1000, 1000
+  float targ_bboxes_data[] = {
+    10,  10,  100, 100, // matching
+    500, 500, 600, 600, // 2 preds for 1 targets
+    10,  500, 100, 600, // not matching
+    900, 900, 950, 950, // overlapping but iou < 0.5
+  };
+  at::Tensor targ_bboxes = torch::from_blob(targ_bboxes_data, { 4, 4 });
+
+  // TODO test with multiple labels
+  int64_t targ_labels_data[] = { 1, 1, 1, 1 };
+  at::Tensor targ_labels = torch::from_blob(targ_labels_data, 4, torch::kLong);
+
+  float bboxes_data[] = {
+    11,  11,  101, 101, // matching
+    900, 10,  950, 100, // false positive
+    510, 510, 610, 610, // 2 preds for 1 targets
+    490, 490, 590, 590, // --
+    940, 940, 990, 990, // overlapping but iou < 0.5 -> false positive
+  };
+  at::Tensor bboxes_tensor = torch::from_blob(bboxes_data, { 5, 4 });
+
+  int64_t labels_data[] = { 1, 1, 1, 1, 1 };
+  at::Tensor labels_tensor = torch::from_blob(labels_data, 5, torch::kLong);
+
+  float score_data[] = { 0.9, 0.8, 0.7, 0.6, 0.5 };
+  at::Tensor score_tensor = torch::from_blob(score_data, 5);
+
+  auto vbad = torchlib.get_bbox_stats(targ_bboxes, targ_labels, bboxes_tensor,
+                                      labels_tensor, score_tensor);
+
+  auto lbad = vbad.at(0);
+  auto tp_i = lbad.get("tp_i").get<std::vector<int>>();
+  auto tp_d = lbad.get("tp_d").get<std::vector<double>>();
+  auto fp_i = lbad.get("fp_i").get<std::vector<int>>();
+  auto fp_d = lbad.get("fp_d").get<std::vector<double>>();
+  ASSERT_EQ(std::accumulate(tp_i.begin(), tp_i.end(), 0), 2);
+  ASSERT_EQ(std::accumulate(fp_i.begin(), fp_i.end(), 0), 3);
+  ASSERT_TRUE(tp_i[2]);
+  ASSERT_FALSE(tp_i[3]);
+  for (int i = 0; i < 5; ++i)
+    {
+      ASSERT_TRUE(tp_i[i] != fp_i[i]) << std::to_string(i);
+      ASSERT_NEAR(tp_d[i], score_data[i],
+                  std::numeric_limits<float>::epsilon())
+          << std::to_string(i);
+      ASSERT_NEAR(fp_d[i], score_data[i],
+                  std::numeric_limits<float>::epsilon())
+          << std::to_string(i);
+    }
+  ASSERT_EQ(lbad.get("num_pos").get<int>(), 4);
+  ASSERT_EQ(lbad.get("label").get<int>(), 1);
+
+  // Get MAP
+  APIData ad_res;
+  ad_res.add("clnames", std::vector<std::string>{ "0", "1" });
+  ad_res.add("nclasses", static_cast<int>(torchlib._nclasses));
+  ad_res.add("bbox", true);
+  ad_res.add("pos_count", 1);
+  APIData ad_bbox;
+  ad_bbox.add("0", vbad);
+  ad_res.add("0", ad_bbox);
+  ad_res.add("batch_size", 1);
+  APIData ad_out;
+  ad_out.add("measure", std::vector<std::string>{ "map" });
+  APIData out;
+  SupervisedOutput::measure(ad_res, ad_out, out, 0, "test");
+  ASSERT_NEAR(out.getobj("measure").get("map").get<double>(), 5. / 12.,
+              std::numeric_limits<float>::epsilon());
 }
 
 // Training tests
@@ -1052,6 +1138,68 @@ TEST(torchapi, service_train_images_split_regression_db_false)
   fileops::clear_directory(resnet50_train_repo + "test_0.lmdb");
   fileops::remove_dir(resnet50_train_repo + "train.lmdb");
   fileops::remove_dir(resnet50_train_repo + "test_0.lmdb");
+}
+
+TEST(torchapi, service_train_object_detection)
+{
+  setenv("CUBLAS_WORKSPACE_CONFIG", ":4096:8", true);
+  torch::manual_seed(torch_seed);
+  at::globalContext().setDeterministicCuDNN(true);
+
+  JsonAPI japi;
+  std::string sname = "detectserv";
+  std::string jstr
+      = "{\"mllib\":\"torch\",\"description\":\"fasterrcnn\",\"type\":"
+        "\"supervised\",\"model\":{\"repository\":\""
+        + detect_train_repo
+        + "\"},\"parameters\":{\"input\":{\"connector\":\"image\",\"height\":"
+          "224,\"width\":224,\"rgb\":true,\"scale\":0.0039,\"bbox\":true},"
+          "\"mllib\":{\"template\":\"fasterrcnn\",\"gpu\":true,\"nclasses\":"
+          "2}}}";
+
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
+
+  // Train
+  std::string jtrainstr
+      = "{\"service\":\"detectserv\",\"async\":false,\"parameters\":{"
+        "\"mllib\":{\"solver\":{\"iterations\":"
+        + iterations_detection + ",\"base_lr\":" + torch_lr
+        + ",\"iter_size\":4,\"solver_"
+          "type\":\"ADAM\",\"test_interval\":200},\"net\":{\"batch_size\":1},"
+          "\"resume\":false},"
+          "\"input\":{\"seed\":12347,\"db\":true,\"shuffle\":true},"
+          "\"output\":{\"measure\":[\"map\"]}},\"data\":[\""
+        + fasterrcnn_train_data + "\",\"" + fasterrcnn_test_data + "\"]}";
+
+  joutstr = japi.jrender(japi.service_train(jtrainstr));
+  JDoc jd;
+  std::cout << "joutstr=" << joutstr << std::endl;
+  jd.Parse<rapidjson::kParseNanAndInfFlag>(joutstr.c_str());
+  ASSERT_TRUE(!jd.HasParseError());
+  ASSERT_EQ(201, jd["status"]["code"]);
+
+  ASSERT_TRUE(jd["body"]["measure"]["iteration"] == 200) << "iterations";
+  ASSERT_TRUE(jd["body"]["measure"]["map"].GetDouble() <= 1.0) << "map";
+  ASSERT_TRUE(jd["body"]["measure"]["map"].GetDouble() > 0.0) << "map";
+
+  std::unordered_set<std::string> lfiles;
+  fileops::list_directory(detect_train_repo, true, false, false, lfiles);
+  for (std::string ff : lfiles)
+    {
+      if (ff.find("checkpoint") != std::string::npos
+          || ff.find("solver") != std::string::npos)
+        remove(ff.c_str());
+    }
+  ASSERT_TRUE(!fileops::file_exists(detect_train_repo + "checkpoint-"
+                                    + iterations_resnet50 + ".ptw"));
+  ASSERT_TRUE(!fileops::file_exists(detect_train_repo + "checkpoint-"
+                                    + iterations_resnet50 + ".pt"));
+
+  fileops::clear_directory(detect_train_repo + "train.lmdb");
+  fileops::clear_directory(detect_train_repo + "test_0.lmdb");
+  fileops::remove_dir(detect_train_repo + "train.lmdb");
+  fileops::remove_dir(detect_train_repo + "test_0.lmdb");
 }
 
 TEST(torchapi, service_train_images_native)


### PR DESCRIPTION
Support of Faster RCNN & RetinaNet training on CPU at batch size 1
only.

Training on GPU leads to a segfault: https://github.com/pytorch/vision/issues/3525
EDIT: Fixed by upgrading pytorch to 1.8, see #1222

Models must be traced with a modified torchvision until this bug is resolved: 
https://github.com/pytorch/vision/issues/3469
`trace_torchvision` script uses the same torchvision used to build dede, which has the necessary modification.

TODO
- [x] working Faster RCNN training
- [ ] working RetinaNet training
- [x] Check that the MAP returned by dede is correct

```bash
# trace model with 2 classes
python3 tools/torch/trace_torchvision.py -v fasterrcnn_resnet50_fpn -o "/opt/platform/models/training/fasterrcnn_test_coco/" --num_classes 2

# service creation call
curl -X PUT 'http://localhost:8080/services/fasterrcnn_train' -d '{
    "description": "Torch traced fasterrcnn on cars",
    "mllib": "torch",
    "model": {
        "repository": "/opt/platform/models/training/fasterrcnn_train_cars/"
    },
    "parameters": {
        "input": {
            "connector": "image",
            "width":224,
            "height":224,
            "rgb":true,
            "scale":0.0039,
            "bbox":true
        },
        "mllib":{
            "template":"fasterrcnn",
            "nclasses":2,
            "gpu":true,
            "gpuid":0
        },
        "output": {
            "bbox": true,
            "store_config": true
        }
    },
    "mltype": "detection",
    "type": "supervised"
}'

# train call
curl -X POST 'http://localhost:8080/train' -d '{
   "service":"fasterrcnn_train",
   "parameters":{
      "input":{
         "db":true
      },
      "output":{
         "measure":[
            "map"
         ]
      },
      "mllib":{
         "solver":{
            "iterations":5000,
            "base_lr":1e-5,
            "finetune":true,
            "iter_size":16,
            "solver_type":"ADAM",
            "test_interval":250
         },
         "net":{
            "batch_size":1
         },
         "nclasses":1,
         "resume":false
      }
   },
   "data":[
      "/opt/platform/examples/cars/train.txt",
      "/opt/platform/examples/cars/test.txt"
   ]
}'
```