### PR TITLE
ci: increase time of dd bootup

### DIFF
--- a/ci/build-docker-images.sh
+++ b/ci/build-docker-images.sh
@@ -76,7 +76,7 @@ for name in $NAMES; do
 
     timeout 60 sh -c "until nc -z localhost $PORT; do sleep 1; done"
 
-    sleep 5  # Wait dd start
+    sleep 10  # Wait dd start
 
     curl -s --head --request GET http://localhost:$PORT/info | head -1 | grep 'HTTP/1.1 200'
     trap - EXIT


### PR DESCRIPTION
tensorrt image is a bit longer to start, so increase the waiting time