### PR TITLE
feat: update default cuda compute list

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,7 @@ deepdetect_gpu_build_profiles=(default torch tf caffe2 tensorrt)
 # NOTE(sileht): list of all supported card by CUDA 10.2
 # https://arnon.dk/matching-sm-architectures-arch-and-gencode-for-various-nvidia-cards/
 if [ ! "$DEEPDETECT_CUDA_ARCH" ]; then
-    for card in 50 52 60 61 62 70 72 75; do
+    for card in 60 61 62 70 72 75 80 86; do
         DEEPDETECT_CUDA_ARCH="$DEEPDETECT_CUDA_ARCH -gencode arch=compute_${card},code=sm_${card}"
     done
     # trim spaces


### PR DESCRIPTION
This removes cuda 11 deprecated cuda architectures:

SM50 or SM_50, compute_50 – Tesla/Quadro M series.
SM52 or SM_52, compute_52 – Quadro M6000 , GeForce 900, GTX-970, GTX-980, GTX Titan X.
SM53 or SM_53, compute_53 – Tegra (Jetson) TX1 / Tegra X1, Drive CX, Drive PX, Jetson Nano.

And new cuda 11 architectures

SM80 or SM_80, compute_80 – NVIDIA A100 (the name “Tesla” has been dropped – GA100), NVIDIA DGX-A100
SM86 or SM_86, compute_86 – Tesla GA10x cards, RTX Ampere – RTX 3080, GA102 – RTX 3090, RTX A6000, RTX A40, GA106 – RTX 3060, GA104 – RTX 3070, GA107 – RTX 3050