### PR TITLE
fix(nbeats): make seasonality block work

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1473,7 +1473,7 @@ Template parameters for native  templates (nbeats/ttransformer):
 
 Parameter       | Template  | Type            | Default                      | Description
 ---------       | --------- | ------          | ---------------------------- | -----------
-template_params.stackdef | nbeats    | array of string | ["t2","s8","g3","b3","h10" ] | default means: trend stack with theta = 2, seasonal stack with theta = 8 , generic stack with theta = 3, 3 blocks per stacks, hidden unit size of 10 everywhere
+template_params.stackdef | nbeats    | array of string | ["t2","s","g3","b3","h10" ] | default means: trend stack with theta = 2, seasonal stack with theta maxed , generic stack with theta = 3, 3 blocks per stacks, hidden unit size of 10 everywhere
 template_params.vit_flavor | vit | string | vit_base_patch16 | Vision transformer architecture, from smaller to larger: vit_tiny_patch16, vit_small_patch16, vit_base_patch32, vit_base_patch16, vit_large_patch16, vit_large_patch32, vit_huge_patch16, vit_huge_patch32
 template_params.realformer | vit | bool | false | Whether to use the 'realformer' residual among attention heads
 template_params.positional_encoding.type | ttransformer | string | "sincos" | Positional encoding "sincos for original frequential encoding, "naive" for simple enumeration

--- a/src/backends/torch/native/native_factory.cc
+++ b/src/backends/torch/native/native_factory.cc
@@ -48,8 +48,15 @@ namespace dd
   {
     if (tdef.find("nbeats") != std::string::npos)
       {
-        std::vector<std::string> p;
         double bc_loss_coef = NBEATS_DEFAULT_BACKCAST_LOSS_COEFF;
+        // t2 means 1 trend stack  with two functions in basis
+        // s means 1 seasonalitystack with max number of functions in basis
+        // g3 means 1 generic stack of 3 * datadim width after backbone
+        // b3 means 3 blocksr stack
+        // h10 means a width of 10* datadim for the backbone (common to all
+        // blocks)
+        std::vector<std::string> p{ "t2", "s", "g3", "b3", "h10" };
+
         if (template_params.has("stackdef"))
           {
             p = template_params.get("stackdef")

--- a/tests/ut-torchapi.cc
+++ b/tests/ut-torchapi.cc
@@ -1129,7 +1129,7 @@ TEST(torchapi, service_train_csvts_nbeats)
         + "\"},\"parameters\":{\"input\":{\"connector\":\"csvts\",\"ignore\":["
           "\"output\"],\"backcast_timesteps\":50,\"forecast_timesteps\":50},"
           "\"mllib\":{\"template\":\"nbeats\","
-          "\"template_params\":{\"stackdef\":[\"t2\",\"s4\",\"g3\",\"b3\"]},"
+          "\"template_params\":{\"stackdef\":[\"t2\",\"s\",\"g3\",\"b3\"]},"
           "\"loss\":\"L1\"}}}";
 
   std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
@@ -1262,7 +1262,7 @@ TEST(torchapi, service_train_csvts_nbeats_db)
           "\"ignore\":["
           "\"output\"],\"backcast_timesteps\":50,\"forecast_timesteps\":50},"
           "\"mllib\":{\"template\":\"nbeats\","
-          "\"template_params\":{\"stackdef\":[\"t2\",\"s4\",\"g3\",\"b3\"]},"
+          "\"template_params\":{\"stackdef\":[\"t2\",\"s\",\"g3\",\"b3\"]},"
           "\"loss\":\"L1\"}}}";
 
   std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
@@ -1390,7 +1390,7 @@ TEST(torchapi, service_train_csvts_nbeats_multiple_testsets)
         + "\"},\"parameters\":{\"input\":{\"connector\":\"csvts\",\"ignore\":["
           "\"output\"],\"backcast_timesteps\":50,\"forecast_timesteps\":50},"
           "\"mllib\":{\"template\":\"nbeats\","
-          "\"template_params\":[\"t2\",\"s4\",\"g3\",\"b3\"],"
+          "\"template_params\":[\"t2\",\"s\",\"g3\",\"b3\"],"
           "\"loss\":\"L1\"}}}";
 
   std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
@@ -1464,7 +1464,7 @@ TEST(torchapi, service_train_csvts_nbeats_resume_fail)
         + "\"},\"parameters\":{\"input\":{\"connector\":\"csvts\",\"ignore\":["
           "\"output\"],\"backcast_timesteps\":50,\"forecast_timesteps\":50},"
           "\"mllib\":{\"template\":\"nbeats\","
-          "\"template_params\":{\"stackdef\":[\"t2\",\"s4\",\"g3\",\"b3\"]},"
+          "\"template_params\":{\"stackdef\":[\"t2\",\"s\",\"g3\",\"b3\"]},"
           "\"loss\":\"L1\"}}}";
 
   std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
@@ -1528,7 +1528,7 @@ TEST(torchapi, service_train_csvts_nbeats_forecast)
           "\"mllib\":"
           "{\"template\":"
           "\"nbeats\","
-          "\"template_params\":{\"stackdef\":[\"t2\",\"s4\",\"g3\",\"b3\"]},"
+          "\"template_params\":{\"stackdef\":[\"t2\",\"s\",\"g3\",\"b3\"]},"
           "\"loss\":\"L1\"}}}";
 
   std::string joutstr = japi.jrender(japi.service_create(sname, jstr));


### PR DESCRIPTION
this PR fixes seasonality block thanks to @mathilde-schveitzer 's work
basically, the number of function in basis was not large enough, we now put a max value as a default
we also get back to simpler linspaces definitions (ie we also fix the conversion from timesteps to values to give to functions from this basis)
exemple : 
parameters.mllib.template = "nbeats"
parameters.mllib.template_params= {"stackdef" : ["s","g8","g8","b3","h8"] }

s for 1 seasonality stack
g8 for 1 generic stack of output width 8 * _datadim (number of signals)
b3 for 3 blocks per stack
h8 : internal width of 8 * _datadim everywhere (every block contains starts with a  3 layer MLP of width 8 * _datadim in this case)
 