### PR TITLE
feat(torch): allow FP16 inference on GPU

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -754,6 +754,7 @@ timesteps     | int            | yes      | N/A            | Number of timesteps
 offset        | int            | yes      | N/A            | Offset beween start point of sequences with connector `cvsts`, defining the overlap of input series
 forecast_timesteps      | int            | yes      | N/A       | for nbeats model, this gives the length of the forecast
 backcast_timesteps      | int            | yes      | N/A       | for nbeats model, this gives the length of the backcast
+datatype      | string | yes       | fp32 | Datatype used at prediction time, possible values are "fp16" (only if inference is done on GPU) , "fp32" and "fp64" (double)
 
 Solver:
 

--- a/src/backends/torch/torchlib.h
+++ b/src/backends/torch/torchlib.h
@@ -113,6 +113,8 @@ namespace dd
         _best_metrics; /**< metric to use for saving best model */
     std::vector<double> _best_metric_values; /**< best metric values  */
 
+    torch::Dtype _dtype = torch::kFloat32;
+
   private:
     /**
      * \brief checks wether v1 is better than v2

--- a/src/backends/torch/torchmodule.cc
+++ b/src/backends/torch/torchmodule.cc
@@ -48,6 +48,7 @@ namespace dd
 
   void TorchModule::to(torch::Dtype dtype)
   {
+    _dtype = dtype;
     if (_graph)
       _graph->to(dtype);
     if (_native)
@@ -61,6 +62,7 @@ namespace dd
   void TorchModule::to(torch::Device device, torch::Dtype dtype)
   {
     _device = device;
+    _dtype = dtype;
     if (_graph)
       _graph->to(device, dtype);
     if (_native)

--- a/src/backends/torch/torchmodule.h
+++ b/src/backends/torch/torchmodule.h
@@ -195,6 +195,7 @@ namespace dd
     torch::nn::Linear _linear = nullptr;
 
     torch::Device _device;
+    torch::Dtype _dtype;
     int _linear_in = 0; /**<id of the input of the final linear layer */
     bool _hidden_states = false; /**< Take BERT hidden states as input. */
 

--- a/src/backends/torch/torchutils.cc
+++ b/src/backends/torch/torchutils.cc
@@ -57,7 +57,12 @@ namespace dd
       if (!value.isTensor())
         throw MLLibInternalException("Expected Tensor, found "
                                      + value.tagKind());
-      return value.toTensor();
+      torch::Tensor t = value.toTensor();
+      if (t.scalar_type() == torch::kFloat16
+          || t.scalar_type() == torch::kFloat64)
+        return t.to(torch::kFloat32);
+      else
+        return t;
     }
 
     void fill_one_hot(torch::Tensor &one_hot, torch::Tensor ids,


### PR DESCRIPTION
at predict time, allow to change internal data representation
simply add: 
`parameters.mllib.datatype : "fp16"`
(default is fp32)
also supports fp64 (double) on cpu and gpu