### PR TITLE
fix: services names were not always case insensitive

### DIFF
--- a/src/jsonapi.cc
+++ b/src/jsonapi.cc
@@ -222,10 +222,11 @@ namespace dd
     return jd;
   }
 
-  JDoc JsonAPI::dd_service_not_found_1002() const
+  JDoc JsonAPI::dd_service_not_found_1002(std::string sname) const
   {
     JDoc jd;
     jd.SetObject();
+    _logger->error("service not found: \"{}\"", sname);
     render_status(jd, 404, "NotFound", 1002, "Service Not Found");
     return jd;
   }
@@ -435,9 +436,12 @@ namespace dd
     return jinfo;
   }
 
-  JDoc JsonAPI::service_create(const std::string &sname,
+  JDoc JsonAPI::service_create(const std::string &snamein,
                                const std::string &jstr)
   {
+    std::string sname(snamein);
+    std::transform(snamein.begin(), snamein.end(), sname.begin(), ::tolower);
+
     if (sname.empty())
       {
         _logger->error("missing service resource name: {}", sname);
@@ -1012,12 +1016,15 @@ namespace dd
     return jsc;
   }
 
-  JDoc JsonAPI::service_status(const std::string &sname)
+  JDoc JsonAPI::service_status(const std::string &snamein)
   {
+    std::string sname(snamein);
+    std::transform(snamein.begin(), snamein.end(), sname.begin(), ::tolower);
+
     if (sname.empty())
-      return dd_service_not_found_1002();
+      return dd_service_not_found_1002(sname);
     if (!this->service_exists(sname))
-      return dd_service_not_found_1002();
+      return dd_service_not_found_1002(sname);
     auto hit = this->get_service_it(sname);
     APIData ad = mapbox::util::apply_visitor(visitor_status(), (*hit).second);
     JDoc jst = dd_ok_200();
@@ -1027,11 +1034,15 @@ namespace dd
     return jst;
   }
 
-  JDoc JsonAPI::service_delete(const std::string &sname,
+  JDoc JsonAPI::service_delete(const std::string &snamein,
                                const std::string &jstr)
   {
+
+    std::string sname(snamein);
+    std::transform(snamein.begin(), snamein.end(), sname.begin(), ::tolower);
+
     if (sname.empty())
-      return dd_service_not_found_1002();
+      return dd_service_not_found_1002(sname);
 
     rapidjson::Document d;
     if (!jstr.empty())
@@ -1093,7 +1104,7 @@ namespace dd
         sname = d["service"].GetString();
         std::transform(sname.begin(), sname.end(), sname.begin(), ::tolower);
         if (!this->service_exists(sname))
-          return dd_service_not_found_1002();
+          return dd_service_not_found_1002(sname);
       }
     catch (...)
       {
@@ -1226,7 +1237,7 @@ namespace dd
         sname = d["service"].GetString();
         std::transform(sname.begin(), sname.end(), sname.begin(), ::tolower);
         if (!this->service_exists(sname))
-          return dd_service_not_found_1002();
+          return dd_service_not_found_1002(sname);
       }
     catch (...)
       {
@@ -1329,7 +1340,7 @@ namespace dd
         sname = d["service"].GetString();
         std::transform(sname.begin(), sname.end(), sname.begin(), ::tolower);
         if (!this->service_exists(sname))
-          return dd_service_not_found_1002();
+          return dd_service_not_found_1002(sname);
       }
     catch (...)
       {
@@ -1461,7 +1472,7 @@ namespace dd
         sname = d["service"].GetString();
         std::transform(sname.begin(), sname.end(), sname.begin(), ::tolower);
         if (!this->service_exists(sname))
-          return dd_service_not_found_1002();
+          return dd_service_not_found_1002(sname);
       }
     catch (...)
       {
@@ -1508,9 +1519,12 @@ namespace dd
     return jd;
   }
 
-  JDoc JsonAPI::service_chain(const std::string &cname,
+  JDoc JsonAPI::service_chain(const std::string &cnamein,
                               const std::string &jstr)
   {
+    std::string cname(cnamein);
+    std::transform(cnamein.begin(), cnamein.end(), cname.begin(), ::tolower);
+
     rapidjson::Document d;
     d.Parse<rapidjson::kParseNanAndInfFlag>(jstr.c_str());
     if (d.HasParseError())

--- a/src/jsonapi.h
+++ b/src/jsonapi.h
@@ -71,7 +71,7 @@ namespace dd
     // specific errors
     JDoc dd_unknown_library_1000() const;
     JDoc dd_no_data_1001() const;
-    JDoc dd_service_not_found_1002() const;
+    JDoc dd_service_not_found_1002(std::string sname) const;
     JDoc dd_job_not_found_1003() const;
     JDoc dd_input_connector_not_found_1004() const;
     JDoc dd_service_input_bad_request_1005(const std::string &what = "") const;

--- a/tests/ut-oatpp.cc
+++ b/tests/ut-oatpp.cc
@@ -26,7 +26,10 @@
 
 #include "ut-oatpp.h"
 
-const std::string serv = "very_long_label_service_name_with_😀_inside";
+const std::string serv
+    = "very_long_label_service_name_with_😀_inside_and_some_MAJ";
+const std::string serv_lower
+    = "very_long_label_service_name_with_😀_inside_and_some_maj";
 const std::string serv2 = "myserv2";
 #if defined(CPU_ONLY) || defined(USE_CAFFE_CPU_ONLY)
 static std::string iterations_mnist = "10";
@@ -83,7 +86,7 @@ void test_services(std::shared_ptr<DedeApiTestClient> client)
   ASSERT_TRUE(d.HasMember("status"));
   ASSERT_TRUE(d.HasMember("body"));
   ASSERT_EQ("caffe", d["body"]["mllib"]);
-  ASSERT_EQ(serv.c_str(), d["body"]["name"]);
+  ASSERT_EQ(serv_lower.c_str(), d["body"]["name"]);
   ASSERT_TRUE(d["body"].HasMember("jobs"));
 
   // info call
@@ -206,7 +209,7 @@ void test_train(std::shared_ptr<DedeApiTestClient> client)
   ASSERT_TRUE(d.HasMember("status"));
   ASSERT_TRUE(d.HasMember("body"));
   ASSERT_EQ("caffe", d["body"]["mllib"]);
-  ASSERT_EQ(serv.c_str(), d["body"]["name"]);
+  ASSERT_EQ(serv_lower.c_str(), d["body"]["name"]);
   ASSERT_TRUE(d["body"].HasMember("jobs"));
   ASSERT_EQ("running", d["body"]["jobs"][0]["status"]);
 
@@ -298,7 +301,7 @@ void test_multiservices(std::shared_ptr<DedeApiTestClient> client)
   ASSERT_TRUE(d["head"].HasMember("services"));
   ASSERT_EQ(2, d["head"]["services"].Size());
   ASSERT_EQ(serv2, d["head"]["services"][0]["name"].GetString());
-  ASSERT_EQ(serv, d["head"]["services"][1]["name"].GetString());
+  ASSERT_EQ(serv_lower, d["head"]["services"][1]["name"].GetString());
 
   // remove services and trained model files
   response = client->delete_services(serv.c_str(), "lib");
@@ -367,7 +370,7 @@ void test_concurrency(std::shared_ptr<DedeApiTestClient> client)
   ASSERT_TRUE(d["head"].HasMember("services"));
   ASSERT_EQ(2, d["head"]["services"].Size());
   ASSERT_EQ(serv2, d["head"]["services"][0]["name"].GetString());
-  ASSERT_EQ(serv, d["head"]["services"][1]["name"].GetString());
+  ASSERT_EQ(serv_lower, d["head"]["services"][1]["name"].GetString());
 
   // train async second job
   train_post = "{\"service\":\"" + serv2
@@ -537,7 +540,7 @@ void test_predict(std::shared_ptr<DedeApiTestClient> client)
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_EQ(200, jd["status"]["code"]);
   ASSERT_TRUE(jd.HasMember("head"));
-  ASSERT_EQ(serv.c_str(), jd["head"]["service"]);
+  ASSERT_EQ(serv_lower.c_str(), jd["head"]["service"]);
   ASSERT_EQ("/predict", jd["head"]["method"]);
   ASSERT_TRUE(jd["body"]["predictions"][0]["classes"][0]["prob"].GetDouble()
               > 0);


### PR DESCRIPTION
in jsonapi, service names were forced to lower when read from json, but were not forced lower case when directly read for url (since switch to  oatppjsonapi from httpjsonapi). We now always force lower case (and thus case insentitivity) 
now with updated ut