### PR TITLE
feat(torch): image data augmentation with random geometric perspectives

### DIFF
--- a/src/backends/torch/torchdataaug.h
+++ b/src/backends/torch/torchdataaug.h
@@ -34,13 +34,21 @@ namespace dd
     {
     }
 
-    TorchImgRandAugCV(const int &img_width, const int &img_height,
-                      const bool &mirror, const bool &rotate,
-                      const int &crop_size, const bool &cutout)
+    TorchImgRandAugCV(
+        const int &img_width, const int &img_height, const bool &mirror,
+        const bool &rotate, const int &crop_size, const float &cutout,
+        const bool &geometry, const bool &geometry_persp_horizontal,
+        const bool &geometry_persp_vertical, const bool &geometry_zoom_out,
+        const bool &geometry_zoom_in, const int &geometry_pad_mode)
         : _img_width(img_width), _img_height(img_height), _mirror(mirror),
           _rotate(rotate), _crop_size(crop_size), _cutout(cutout),
-          _uniform_real_1(0.0, 1.0), _bernouilli(0.5),
-          _uniform_int_rotate(0, 3)
+          _geometry(geometry),
+          _geometry_persp_horizontal(geometry_persp_horizontal),
+          _geometry_persp_vertical(geometry_persp_vertical),
+          _geometry_zoom_out(geometry_zoom_out),
+          _geometry_zoom_in(geometry_zoom_in),
+          _geometry_pad_mode(geometry_pad_mode), _uniform_real_1(0.0, 1.0),
+          _bernouilli(0.5), _uniform_int_rotate(0, 3)
     {
       if (_crop_size > 0)
         {
@@ -69,6 +77,12 @@ namespace dd
     void applyRotate(cv::Mat &src);
     void applyCrop(cv::Mat &src);
     void applyCutout(cv::Mat &src);
+    void applyGeometry(cv::Mat &src);
+
+  private:
+    void getEnlargedImage(const cv::Mat &in_img, cv::Mat &in_img_enlarged);
+    void getQuads(const int &rows, const int &cols,
+                  cv::Point2f (&inputQuad)[4], cv::Point2f (&outputQuad)[4]);
 
   private:
     int _img_width = 224;
@@ -85,6 +99,20 @@ namespace dd
     float _cutout_rh = 3.0;  /**< max aspect ratio of erased area. */
     int _cutout_vl = 0;      /**< min erased area pixel value. */
     int _cutout_vh = 255;    /**< max erased area pixel value. */
+    float _geometry = 0.0;
+    bool _geometry_persp_horizontal
+        = true; /**< horizontal perspective change. */
+    bool _geometry_persp_vertical = true; /**< vertical perspective change. */
+    bool _geometry_zoom_out
+        = true; /**< distance change: look from further away. */
+    bool _geometry_zoom_in = true;      /**< distance change: look closer. */
+    float _geometry_zoom_factor = 0.25; /**< zoom factor: 0.25 means that image
+                                           can be *1.25 or /1.25. */
+    float _geometry_persp_factor
+        = 0.25;                     /**< persp factor: 0.25 means that new
+                                      image corners  be in 1.25 or 0.75. */
+    uint8_t _geometry_pad_mode = 1; /**< filling around images, 1: constant, 2:
+                                       mirrored, 3: repeat nearest. */
 
     // random generators
     std::default_random_engine _rnd_gen;

--- a/src/backends/torch/torchlib.cc
+++ b/src/backends/torch/torchlib.cc
@@ -604,9 +604,35 @@ namespace dd
             cutout = ad_mllib.get("cutout").get<double>();
             this->_logger->info("cutout: {}", cutout);
           }
-        inputc._dataset._img_rand_aug_cv
-            = TorchImgRandAugCV(inputc.width(), inputc.height(), has_mirror,
-                                has_rotate, crop_size, cutout);
+        float geometry = 0.0;
+        bool geometry_persp_vertical = false;
+        bool geometry_persp_horizontal = false;
+        bool geometry_zoom_out = false;
+        bool geometry_zoom_in = false;
+        int geometry_pad_mode = 1;
+        APIData ad_geometry = ad_mllib.getobj("geometry");
+        if (!ad_geometry.empty())
+          {
+            geometry = ad_geometry.get("prob").get<double>();
+            this->_logger->info("geometry: {}", geometry);
+            if (ad_geometry.has("persp_vertical"))
+              geometry_persp_vertical
+                  = ad_geometry.get("persp_vertical").get<bool>();
+            if (ad_geometry.has("persp_horizontal"))
+              geometry_persp_horizontal
+                  = ad_geometry.get("persp_horizontal").get<bool>();
+            if (ad_geometry.has("zoom_out"))
+              geometry_zoom_out = ad_geometry.get("zoom_out").get<bool>();
+            if (ad_geometry.has("zoom_in"))
+              geometry_zoom_in = ad_geometry.get("zoom_in").get<bool>();
+            if (ad_geometry.has("pad_mode"))
+              geometry_pad_mode = ad_geometry.get("pad_mode").get<int>();
+          }
+        inputc._dataset._img_rand_aug_cv = TorchImgRandAugCV(
+            inputc.width(), inputc.height(), has_mirror, has_rotate, crop_size,
+            cutout, geometry, geometry_persp_horizontal,
+            geometry_persp_vertical, geometry_zoom_out, geometry_zoom_in,
+            geometry_pad_mode);
       }
 
     // solver params

--- a/tests/ut-torchapi.cc
+++ b/tests/ut-torchapi.cc
@@ -554,8 +554,9 @@ TEST(torchapi, service_train_images)
         + ",\"iter_size\":4,\"solver_type\":\"ADAM\",\"test_"
           "interval\":200},\"net\":{\"batch_size\":4},"
           "\"resume\":false,\"mirror\":true,\"rotate\":true,\"crop_size\":224,"
-          "\"cutout\":0.5}"
-          ","
+          "\"cutout\":0.5,\"geometry\":{\"prob\":0.1,\"persp_horizontal\":"
+          "true,\"persp_vertical\":true,\"zoom_in\":true,\"zoom_out\":true,"
+          "\"pad_mode\":1}},"
           "\"input\":{\"seed\":12345,\"db\":true,\"shuffle\":true},"
           "\"output\":{\"measure\":[\"f1\",\"acc\"]}},\"data\":[\""
         + resnet50_train_data + "\",\"" + resnet50_test_data + "\"]}";


### PR DESCRIPTION
![tmp_1](https://user-images.githubusercontent.com/3530657/116393435-e7b94d00-a821-11eb-8981-8d2a86be0266.png)
![tmp_5](https://user-images.githubusercontent.com/3530657/116393439-e9831080-a821-11eb-98a7-14adfb2fc52e.png)
![tmp_12](https://user-images.githubusercontent.com/3530657/116393443-eb4cd400-a821-11eb-877b-d2f2d0f58d16.png)
![tmp_1](https://user-images.githubusercontent.com/3530657/116394431-30253a80-a823-11eb-9d4a-2e34e8ccaf51.png)

API remains unchanged wrt. caffe backend.

This also fixes:
- cutout with BW images
- cutout probability setup via API