### PR TITLE
feat(ml): Visformer architecture with torch backend

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -747,7 +747,7 @@ self_supervised | string | yes      | ""      | self-supervised mode: "mask" for
 embedding_size  | int    | yes      | 768     | embedding size for NLP models
 freeze_traced   | bool   | yes      | false   | Freeze the traced part of the net during finetuning (e.g. for classification)
 retain_graph	| bool	 | yes	    | false   | Whether to use `retain_graph` with torch autograd
-template        | string | yes      | ""      | e.g. "bert", "gpt2", "recurrent", "nbeats", "vit", "ttransformer", "resnet50", ... All templates are listed in the [Model Templates](#model-templates) section.
+template        | string | yes      | ""      | e.g. "bert", "gpt2", "recurrent", "nbeats", "vit", "visformer", "ttransformer", "resnet50", ... All templates are listed in the [Model Templates](#model-templates) section.
 template_params | dict   | yes      | template dependent | Model parameter for templates. All parameters are listed in the [Model Templates](#model-templates) section.
 regression | bool            | yes                      | false   | Whether the model is a regressor
 timesteps     | int            | yes      | N/A            | Number of timesteps for time models (LSTM/NBEATS...) : this sets the length of sequences that will be given for learning, every timestep contains inputs and outputs as defined by the csv/csvts connector
@@ -1401,7 +1401,7 @@ vgg_16 | deep neural net	       | Images   		| Convolutional network for image c
 
 - LSTM-like models (including autoencoder): `recurrent`
 - NBEATS model: `nbeats`
-- Vision transformer: `vit`
+- Vision transformer: `vit` and `visformer`
 - Transformer-based timeseries models: `ttransformer`
 - [TorchVision image classification models](https://pytorch.org/vision/0.8/models.html):
 	- `resnet18`
@@ -1480,6 +1480,7 @@ Parameter       | Template  | Type            | Default                      | D
 ---------       | --------- | ------          | ---------------------------- | -----------
 template_params.stackdef | nbeats    | array of string | ["t2","s","g3","b3","h10" ] | default means: trend stack with theta = 2, seasonal stack with theta maxed , generic stack with theta = 3, 3 blocks per stacks, hidden unit size of 10 everywhere
 template_params.vit_flavor | vit | string | vit_base_patch16 | Vision transformer architecture, from smaller to larger: vit_tiny_patch16, vit_small_patch16, vit_base_patch32, vit_base_patch16, vit_large_patch16, vit_large_patch32, vit_huge_patch16, vit_huge_patch32
+template_params.visformer_flavor | visformer | visformer_tiny | Visformer architecture, from visformer_tiny or visformer_small
 template_params.realformer | vit | bool | false | Whether to use the 'realformer' residual among attention heads
 template_params.positional_encoding.type | ttransformer | string | "sincos" | Positional encoding "sincos for original frequential encoding, "naive" for simple enumeration
 template_params.positional_encoding.learn | ttransformer | bool | false | learn or not positional encoding (starting from above value)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -92,6 +92,7 @@ if (USE_TORCH)
     backends/torch/db_lmdb.cpp
     backends/torch/native/templates/nbeats.cc
     backends/torch/native/templates/vit.cc
+    backends/torch/native/templates/visformer.cc
     backends/torch/native/templates/ttransformer.cc
     backends/torch/native/templates/ttransformer/tembedder.cc
     backends/torch/native/templates/ttransformer/positionalenc.cc

--- a/src/backends/torch/native/native_factory.cc
+++ b/src/backends/torch/native/native_factory.cc
@@ -20,7 +20,6 @@
  */
 
 #include "native_factory.h"
-
 #include "native_wrapper.h"
 
 namespace dd
@@ -88,6 +87,10 @@ namespace dd
       {
 
         return new ViT(inputc, template_params);
+      }
+    else if (tdef.find("visformer") != std::string::npos)
+      {
+        return new Visformer(inputc, template_params);
       }
     else if (VisionModelsFactory::is_vision_template(tdef))
       {

--- a/src/backends/torch/native/native_factory.h
+++ b/src/backends/torch/native/native_factory.h
@@ -25,6 +25,7 @@
 #include "native_net.h"
 #include "./templates/nbeats.h"
 #include "./templates/vit.h"
+#include "./templates/visformer.h"
 #include "./templates/ttransformer.h"
 #include "../torchinputconns.h"
 #include "apidata.h"
@@ -45,6 +46,7 @@ namespace dd
     {
       if (tdef.find("nbeats") != std::string::npos
           || tdef.find("vit") != std::string::npos
+          || tdef.find("visformer") != std::string::npos
           || tdef.find("ttransformer") != std::string::npos)
         return true;
       else if (VisionModelsFactory::is_vision_template(tdef))

--- a/src/backends/torch/native/templates/visformer.cc
+++ b/src/backends/torch/native/templates/visformer.cc
@@ -1,0 +1,368 @@
+/**
+ * DeepDetect
+ * Copyright (c) 2021 Jolibrain
+ * Author:  Emmanuel Benazera <emmanuel.benazera@jolibrain.com>
+ *
+ * This file is part of deepdetect.
+ *
+ * deepdetect is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * deepdetect is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with deepdetect.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "visformer.h"
+#include <iostream>
+
+namespace dd
+{
+
+  /*-- MLPImpl --*/
+  void Visformer::MLPImpl::init_block()
+  {
+    if (!_output_dim)
+      _output_dim = _input_dim;
+    if (!_hidden_dim)
+      _hidden_dim = _input_dim;
+
+    if (_spatial_conv)
+      {
+        if (_group < 2)
+          _hidden_dim = std::floor(_input_dim * 5 / 6);
+        else
+          _hidden_dim = _input_dim * 2;
+      }
+
+    _convc1 = register_module(
+        "convc1",
+        torch::nn::Conv2d(torch::nn::Conv2dOptions(_input_dim, _hidden_dim, 1)
+                              .stride(1)
+                              .padding(0)
+                              .bias(false)));
+    if (_spatial_conv)
+      _convc2 = register_module(
+          "convc2", torch::nn::Conv2d(
+                        torch::nn::Conv2dOptions(_hidden_dim, _hidden_dim, 3)
+                            .stride(1)
+                            .padding(1)
+                            .groups(_group)
+                            .bias(false)));
+    _convc3 = register_module(
+        "convc3",
+        torch::nn::Conv2d(torch::nn::Conv2dOptions(_hidden_dim, _output_dim, 1)
+                              .stride(1)
+                              .padding(0)
+                              .bias(false)));
+    _drop1 = register_module(
+        "drop", torch::nn::Dropout(torch::nn::DropoutOptions(_drop)));
+  }
+
+  torch::Tensor Visformer::MLPImpl::forward(torch::Tensor x)
+  {
+    x = _convc1(x);
+    x = torch::gelu(x);
+    x = _drop1(x);
+    if (_spatial_conv)
+      {
+        x = _convc2(x);
+        x = torch::gelu(x);
+      }
+    x = _convc3(x);
+    x = _drop1(x);
+    return x;
+  }
+
+  /*-- AttentionImpl --*/
+  void Visformer::AttentionImpl::init_block()
+  {
+    _head_dim = std::floor(_dim / _num_heads);
+    if (_qk_scale > 0.0)
+      _scale = _qk_scale;
+    else
+      _scale = std::pow(_head_dim, -0.5);
+
+    _qkv = register_module(
+        "qkv", torch::nn::Conv2d(torch::nn::Conv2dOptions(
+                                     _dim, _head_dim * _num_heads * 3, 1)
+                                     .stride(1)
+                                     .padding(0)
+                                     .bias(_qkv_bias)));
+    _attn_drop = register_module(
+        "attn_drop",
+        torch::nn::Dropout(torch::nn::DropoutOptions(_attn_drop_val)));
+    _proj = register_module(
+        "proj", torch::nn::Conv2d(
+                    torch::nn::Conv2dOptions(_head_dim * _num_heads, _dim, 1)
+                        .stride(1)
+                        .padding(0)
+                        .bias(false)));
+    _proj_drop = register_module(
+        "proj_drop",
+        torch::nn::Dropout(torch::nn::DropoutOptions(_proj_drop_val)));
+  }
+
+  torch::Tensor Visformer::AttentionImpl::forward(torch::Tensor x)
+  {
+    long int B = x.size(0);
+    long int C = x.size(2);
+    long int W = x.size(3);
+    auto qkv = _qkv(x);
+    qkv = qkv.reshape({ B, 3, _num_heads, _head_dim, C * W })
+              .permute({ 1, 0, 2, 4, 3 });
+    auto q = qkv[0];
+    auto k = qkv[1];
+    auto v = qkv[2];
+
+    auto attn = q.matmul(k.transpose(-2, -1)) * _scale;
+
+    attn = torch::softmax(attn, -1);
+    attn = _attn_drop(attn);
+
+    x = attn.matmul(v);
+    x = x.permute({ 0, 1, 2, 3 }).reshape({ B, _num_heads * _head_dim, C, W });
+    x = _proj(x);
+    x = _proj_drop(x);
+
+    return x;
+  }
+
+  /*-- BlockImpl --*/
+  void Visformer::BlockImpl::init_block()
+  {
+    if (!_attn_disabled)
+      {
+        _norm1 = register_module(
+            "norm1",
+            torch::nn::BatchNorm2d(torch::nn::BatchNorm2dOptions({ _dim })));
+        _attn = register_module(
+            "attn", Attention(_dim, _num_heads, _head_dim_ratio, _qkv_bias,
+                              _qk_scale, _attn_drop_val, _drop_val));
+      }
+    _norm2 = register_module(
+        "norm2",
+        torch::nn::BatchNorm2d(torch::nn::BatchNorm2dOptions({ _dim })));
+
+    unsigned int mlp_hidden_dim = static_cast<int>(_dim * _mlp_ratio);
+    _mlp = register_module(
+        "mlp", MLP(_dim, mlp_hidden_dim, 0, _drop_val, _group, _spatial_conv));
+  }
+
+  torch::Tensor Visformer::BlockImpl::forward(torch::Tensor x)
+  {
+    if (!_attn_disabled)
+      x = x + _attn(_norm1(x));
+    x = x + _mlp(_norm2(x));
+    return x;
+  }
+
+  /*-- PatchEmbedImpl --*/
+  void Visformer::PatchEmbedImpl::init_block(const int &img_size,
+                                             const int &patch_size)
+  {
+    _img_size = std::make_pair<unsigned int, unsigned int>(img_size, img_size);
+    _patch_size
+        = std::make_pair<unsigned int, unsigned int>(patch_size, patch_size);
+    _num_patches = std::floor(_img_size.second / _patch_size.second)
+                   * std::floor(_img_size.first / _patch_size.first);
+
+    _proj = register_module(
+        "proj", torch::nn::Conv2d(
+                    torch::nn::Conv2dOptions(_in_chans, _embed_dim, patch_size)
+                        .stride(patch_size)));
+    _norm_embed
+        = register_module("norm_embed", torch::nn::BatchNorm2d(_embed_dim));
+  }
+
+  torch::Tensor Visformer::PatchEmbedImpl::forward(torch::Tensor x)
+  {
+    x = _proj(x);
+    x = _norm_embed(x);
+    return x;
+  }
+
+  /*-- Visformer --*/
+  void Visformer::init_block()
+  {
+    const unsigned int stage_num1 = 7;
+    const unsigned int stage_num2 = 4;
+    const unsigned int stage_num3 = 4;
+    _depth = stage_num1 + stage_num2 + stage_num3;
+
+    // stage 1
+    _stem = register_module(
+        "stem", torch::nn::Sequential(
+                    torch::nn::Conv2d(torch::nn::Conv2dOptions(3, _in_chans, 7)
+                                          .stride(2)
+                                          .padding(3)
+                                          .bias(false)),
+                    torch::nn::BatchNorm2d(_in_chans), torch::nn::ReLU(true)));
+
+    int n_img_size = std::floor(_img_size / 2);
+
+    int p1_out_dim = std::floor(_embed_dim / 2);
+    _patch_embed1 = register_module(
+        "patch_embed1", PatchEmbed(n_img_size, 4, _in_chans, p1_out_dim));
+    n_img_size = std::floor(n_img_size / 4);
+
+    int half_embed_dim = std::floor(_embed_dim / 2);
+    _pos_embed1 = register_parameter(
+        "pos_embed1",
+        torch::randn({ 1, half_embed_dim, n_img_size, n_img_size }));
+    _pos_drop = register_module(
+        "pos_drop", torch::nn::Dropout(torch::nn::DropoutOptions(_drop_rate)));
+
+    for (unsigned int d = 0; d < stage_num1; ++d)
+      {
+        _stage1_blocks->push_back(Block(
+            std::floor(_embed_dim / 2), _num_heads, 0.5 /* head_dim_ratio */,
+            _mlp_ratio, _qkv_bias, _qk_scale, _drop_rate, _attn_drop_rate,
+            _group, _attn_stage[0] == '0' /* attn_disabled */,
+            _spatial_conv[0] == '1' /* spatial_conv */));
+      }
+    register_module("blocks1", _stage1_blocks);
+
+    // stage 2
+    _patch_embed2 = register_module(
+        "patch_embed2",
+        PatchEmbed(n_img_size, 2, std::floor(_embed_dim / 2), _embed_dim));
+    n_img_size = std::floor(n_img_size / 2);
+    _pos_embed2 = register_parameter(
+        "pos_embed2", torch::randn({ 1, _embed_dim, n_img_size, n_img_size }));
+    for (unsigned int d = stage_num1; d < stage_num1 + stage_num2; ++d)
+      {
+        _stage2_blocks->push_back(
+            Block(_embed_dim, _num_heads, 1.0 /* head_dim_ratio */, _mlp_ratio,
+                  _qkv_bias, _qk_scale, _drop_rate, _attn_drop_rate, _group,
+                  _attn_stage[1] == '0', _spatial_conv[1] == '1'));
+      }
+    register_module("blocks2", _stage2_blocks);
+
+    // stage 3
+    int p3_out_dim = _embed_dim * 2;
+    _patch_embed3 = register_module(
+        "patch_embed3", PatchEmbed(n_img_size, 2, _embed_dim, p3_out_dim));
+    n_img_size = std::floor(n_img_size / 2);
+    _pos_embed3 = register_parameter(
+        "pos_embed3", torch::randn({ 1, p3_out_dim, n_img_size, n_img_size }));
+    for (unsigned int d = stage_num2; d < _depth; ++d)
+      {
+        _stage3_blocks->push_back(
+            Block(p3_out_dim, _num_heads, 1.0 /* head_dim_ratio */, _mlp_ratio,
+                  _qkv_bias, _qk_scale, _drop_rate, _attn_drop_rate, _group,
+                  _attn_stage[2] == '0', _spatial_conv[2] == '1'));
+      }
+    register_module("blocks3", _stage3_blocks);
+
+    // head
+    _global_pooling = torch::nn::AdaptiveAvgPool2d(1);
+    _norm = register_module(
+        "norm", torch::nn::BatchNorm2d(
+                    torch::nn::BatchNorm2dOptions({ _embed_dim * 2 })));
+    _head
+        = register_module("head", torch::nn::Linear(p3_out_dim, _num_classes));
+  }
+
+  torch::Tensor Visformer::forward(torch::Tensor x)
+  {
+    x = _stem->forward(x);
+
+    // stage 1
+    x = _patch_embed1(x);
+    x = x + _pos_embed1;
+    x = _pos_drop(x);
+
+    for (const auto &blk : *_stage1_blocks)
+      {
+        x = blk->as<Block>()->forward(x);
+      }
+
+    // stage 2
+    x = _patch_embed2(x);
+    x = x + _pos_embed2;
+    x = _pos_drop(x);
+    for (const auto &blk : *_stage2_blocks)
+      {
+        x = blk->as<Block>()->forward(x);
+      }
+
+    // stage 3
+    x = _patch_embed3(x);
+    x = x + _pos_embed3;
+    x = _pos_drop(x);
+    for (const auto &blk : *_stage3_blocks)
+      {
+        x = blk->as<Block>()->forward(x);
+      }
+
+    // head
+    x = _norm(x);
+    x = _global_pooling(x);
+    int view_size = x.size(0);
+    x = _head(x.view({ view_size, -1 }));
+
+    return x;
+  }
+
+  void
+  Visformer::get_params_and_init_block(const ImgTorchInputFileConn &inputc,
+                                       const APIData &ad_params)
+  {
+    _img_size = inputc.width();
+    _patch_size = 16;
+    _in_chans = 32;
+    _embed_dim = 192;
+    _num_heads = 12;
+    _mlp_ratio = 4.0;
+    _qkv_bias = false;
+    _qk_scale = -1.0;
+    _drop_rate = 0.0;
+    _attn_drop_rate = 0.0;
+
+    _num_classes = 2;
+    if (ad_params.has("nclasses"))
+      _num_classes = ad_params.get("nclasses").get<int>();
+
+    if (ad_params.has("dropout"))
+      _drop_rate = _attn_drop_rate = ad_params.get("dropout").get<double>();
+
+    std::string visformer_flavor = "visformer_tiny";
+    if (ad_params.has("visformer_tiny"))
+      visformer_flavor = ad_params.get("visformer_tiny").get<std::string>();
+
+    if (visformer_flavor == "visformer_tiny")
+      {
+        _embed_dim = 192;
+        _in_chans = 16;
+        //_depth = 16; // XXX: unused, 7, 4, 4 aka the three stages
+        _num_heads = 3;
+        _mlp_ratio = 4.0;
+        _group = 8;
+        _attn_stage = "011";
+        _spatial_conv = "100";
+      }
+    else if (visformer_flavor == "visformer_small")
+      {
+        _embed_dim = 384;
+        _num_heads = 6;
+        _mlp_ratio = 4.0;
+        _group = 8;
+        _attn_stage = "011";
+        _spatial_conv = "100";
+      }
+    else
+      {
+        throw MLLibBadParamException("unknown Visformer flavor "
+                                     + visformer_flavor);
+      }
+
+    init_block();
+  }
+}

--- a/src/backends/torch/native/templates/visformer.h
+++ b/src/backends/torch/native/templates/visformer.h
@@ -1,0 +1,402 @@
+/**
+ * DeepDetect
+ * Copyright (c) 2020 Jolibrain
+ * Author:  Emmanuel Benazera <emmanuel.benazera@jolibrain.com>
+ *
+ * This file is part of deepdetect.
+ *
+ * deepdetect is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * deepdetect is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with deepdetect.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef VISFORMER_H
+#define VISFORMER_H
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#include "torch/torch.h"
+#pragma GCC diagnostic pop
+#include "../../torchinputconns.h"
+#include "mllibstrategy.h"
+#include "../native_net.h"
+
+namespace dd
+{
+
+  class Visformer : public NativeModuleImpl<Visformer>
+  {
+
+    class MLPImpl : public torch::nn::Cloneable<MLPImpl>
+    {
+    public:
+      MLPImpl(const int &input_dim, const int &hidden_dim,
+              const int &output_dim, const double &drop = 0.0,
+              const int &group = 8, const bool &spatial_conv = false)
+          : _input_dim(input_dim), _hidden_dim(hidden_dim),
+            _output_dim(output_dim), _drop(drop), _group(group),
+            _spatial_conv(spatial_conv)
+      {
+        init_block();
+      }
+
+      MLPImpl(const MLPImpl &m)
+          : torch::nn::Module(m), _input_dim(m._input_dim),
+            _hidden_dim(m._hidden_dim), _output_dim(m._output_dim),
+            _drop(m._drop), _group(m._group), _spatial_conv(m._spatial_conv)
+      {
+      }
+
+      MLPImpl &operator=(const MLPImpl &m)
+      {
+        torch::nn::Module::operator=(m);
+        _input_dim = m._input_dim;
+        _hidden_dim = m._hidden_dim;
+        _output_dim = m._output_dim;
+        _drop = m._drop;
+
+        _convc1 = m._convc1;
+        _convc2 = m._convc2;
+        _convc3 = m._convc3;
+        _drop1 = m._drop1;
+        return *this;
+      }
+
+      void reset()
+      {
+        init_block();
+      }
+
+      torch::Tensor forward(torch::Tensor x);
+
+    protected:
+      void init_block();
+
+      unsigned int _input_dim = 0;
+      unsigned int _hidden_dim = 0;
+      unsigned int _output_dim = 0;
+      std::string _act = "gelu";
+      double _drop = 0.0;
+      int _group = 8;
+      bool _spatial_conv = false;
+
+      torch::nn::Conv2d _convc1{ nullptr };
+      torch::nn::Conv2d _convc2{ nullptr };
+      torch::nn::Conv2d _convc3{ nullptr };
+      torch::nn::Dropout _drop1{ nullptr };
+    };
+
+    typedef torch::nn::ModuleHolder<MLPImpl> MLP;
+
+    class AttentionImpl : public torch::nn::Cloneable<AttentionImpl>
+    {
+    public:
+      AttentionImpl(const int &dim, const int &num_heads = 8,
+                    const double &head_dim_ratio = 1.0,
+                    const bool &qkv_bias = false,
+                    const double &qk_scale = -1.0,
+                    const double &attn_drop_val = 0.0,
+                    const double &proj_drop_val = 0.0)
+          : _dim(dim), _num_heads(num_heads), _head_dim_ratio(head_dim_ratio),
+            _qkv_bias(qkv_bias), _qk_scale(qk_scale),
+            _attn_drop_val(attn_drop_val), _proj_drop_val(proj_drop_val)
+      {
+        init_block();
+      }
+
+      AttentionImpl(const AttentionImpl &a)
+          : torch::nn::Module(a), _dim(a._dim), _num_heads(a._num_heads),
+            _head_dim_ratio(a._head_dim_ratio), _qkv_bias(a._qkv_bias),
+            _qk_scale(a._qk_scale), _attn_drop_val(a._attn_drop_val),
+            _proj_drop_val(a._proj_drop_val)
+      {
+      }
+
+      AttentionImpl &operator=(const AttentionImpl &a)
+      {
+        torch::nn::Module::operator=(a);
+        _dim = a._dim;
+        _num_heads = a._num_heads;
+        _head_dim_ratio = a._head_dim_ratio;
+        _qkv_bias = a._qkv_bias;
+        _qk_scale = a._qk_scale;
+        _attn_drop_val = a._attn_drop_val;
+        _proj_drop_val = a._proj_drop_val;
+
+        _scale = a._scale;
+        _head_dim = a._head_dim;
+        _qkv = a._qkv;
+        _attn_drop = a._attn_drop;
+        _proj = a._proj;
+        _proj_drop = a._proj_drop;
+        return *this;
+      }
+
+      void reset()
+      {
+        init_block();
+      }
+
+      torch::Tensor forward(torch::Tensor x);
+
+    protected:
+      void init_block();
+
+      unsigned int _dim;
+      unsigned int _num_heads = 8;
+      double _head_dim_ratio = 1.0;
+      bool _qkv_bias = false;
+      double _qk_scale = -1.0;
+      double _attn_drop_val = 0.0;
+      double _proj_drop_val = 0.0;
+
+      double _scale = 1.0;
+      unsigned int _head_dim = 0;
+
+      torch::nn::Conv2d _qkv{ nullptr };
+      torch::nn::Dropout _attn_drop{ nullptr };
+      torch::nn::Conv2d _proj{ nullptr };
+      torch::nn::Dropout _proj_drop{ nullptr };
+    };
+
+    typedef torch::nn::ModuleHolder<AttentionImpl> Attention;
+
+    class BlockImpl : public torch::nn::Cloneable<BlockImpl>
+    {
+    public:
+      BlockImpl(const int &dim, const int &num_heads,
+                const int &head_dim_ratio = 1.0, const double &mlp_ratio = 4.0,
+                const bool &qkv_bias = false, const double &qk_scale = -1.0,
+                const double &drop_val = 0.0,
+                const double &attn_drop_val = 0.0, const int &group = 8,
+                const bool &attn_disabled = false,
+                const bool &spatial_conv = false)
+          : _dim(dim), _num_heads(num_heads), _head_dim_ratio(head_dim_ratio),
+            _mlp_ratio(mlp_ratio), _qkv_bias(qkv_bias), _qk_scale(qk_scale),
+            _drop_val(drop_val), _attn_drop_val(attn_drop_val), _group(group),
+            _attn_disabled(attn_disabled), _spatial_conv(spatial_conv)
+      {
+        init_block();
+      }
+
+      BlockImpl(const BlockImpl &b)
+          : torch::nn::Module(b), _dim(b._dim), _num_heads(b._num_heads),
+            _head_dim_ratio(b._head_dim_ratio), _mlp_ratio(b._mlp_ratio),
+            _qkv_bias(b._qkv_bias), _qk_scale(b._qk_scale),
+            _drop_val(b._drop_val), _attn_drop_val(b._attn_drop_val),
+            _group(b._group), _attn_disabled(b._attn_disabled),
+            _spatial_conv(b._spatial_conv)
+      {
+      }
+
+      BlockImpl &operator=(const BlockImpl &b)
+      {
+        torch::nn::Module::operator=(b);
+        _dim = b._dim;
+        _num_heads = b._num_heads;
+        _head_dim_ratio = b._head_dim_ratio;
+        _mlp_ratio = b._mlp_ratio;
+        _qkv_bias = b._qkv_bias;
+        _qk_scale = b._qk_scale;
+        _drop_val = b._drop_val;
+        _attn_drop_val = b._attn_drop_val;
+        _group = b._group;
+        _attn_disabled = b._attn_disabled;
+        _spatial_conv = b._spatial_conv;
+
+        _norm1 = b._norm1;
+        _attn = b._attn;
+        _norm2 = b._norm2;
+        _mlp = b._mlp;
+        return *this;
+      }
+
+      void reset()
+      {
+        init_block();
+      }
+
+      torch::Tensor forward(torch::Tensor x);
+
+    protected:
+      void init_block();
+
+      unsigned int _dim = 0;
+      unsigned int _num_heads = 0;
+      double _head_dim_ratio = 1.0;
+
+      double _mlp_ratio;
+      double _qkv_bias;
+      double _qk_scale;
+      double _drop_val;
+      double _attn_drop_val;
+      int _group;
+      bool _attn_disabled;
+      bool _spatial_conv;
+
+      torch::nn::BatchNorm2d _norm1{ nullptr };
+
+    public:
+      Attention _attn{ nullptr };
+
+    protected:
+      torch::nn::BatchNorm2d _norm2{ nullptr };
+      MLP _mlp{ nullptr };
+    };
+
+    typedef torch::nn::ModuleHolder<BlockImpl> Block;
+
+    class PatchEmbedImpl : public torch::nn::Cloneable<PatchEmbedImpl>
+    {
+    public:
+      PatchEmbedImpl(const int &img_size = 224, const int &patch_size = 16,
+                     const int &in_chans = 3, const int &embed_dim = 768)
+          : _in_chans(in_chans), _embed_dim(embed_dim)
+      {
+        init_block(img_size, patch_size);
+      }
+
+      PatchEmbedImpl(const PatchEmbedImpl &p)
+          : torch::nn::Module(p), _img_size(p._img_size),
+            _patch_size(p._patch_size), _in_chans(p._in_chans),
+            _embed_dim(p._embed_dim)
+      {
+      }
+
+      PatchEmbedImpl &operator=(const PatchEmbedImpl &p)
+      {
+        torch::nn::Module::operator=(p);
+        _img_size = p._img_size;
+        _patch_size = p._patch_size;
+        _in_chans = p._in_chans;
+        _embed_dim = p._embed_dim;
+
+        _proj = p._proj;
+        return *this;
+      }
+
+      void reset()
+      {
+        init_block(_img_size.first, _patch_size.first);
+      }
+
+      torch::Tensor forward(torch::Tensor x);
+
+      unsigned int _num_patches = 0;
+
+    protected:
+      void init_block(const int &img_size, const int &patch_size);
+
+      std::pair<unsigned int, unsigned int> _img_size;
+      std::pair<unsigned int, unsigned int> _patch_size;
+      unsigned int _in_chans = 3;
+      unsigned int _embed_dim = 768;
+
+      torch::nn::Conv2d _proj{ nullptr };
+      torch::nn::BatchNorm2d _norm_embed{ nullptr };
+    };
+
+    typedef torch::nn::ModuleHolder<PatchEmbedImpl> PatchEmbed;
+
+  public:
+    Visformer(const ImgTorchInputFileConn &inputc, const APIData &ad_params)
+    {
+      get_params_and_init_block(inputc, ad_params);
+    }
+
+    // TODO: copy constructors
+
+    virtual ~Visformer() = default;
+
+    void reset() override
+    {
+      init_block();
+    }
+
+    void get_params_and_init_block(const ImgTorchInputFileConn &inputc,
+                                   const APIData &ad_params);
+
+    torch::Tensor forward(torch::Tensor x);
+
+    torch::Tensor extract(torch::Tensor x, std::string extract_layer) override
+    {
+      (void)x;
+      (void)extract_layer;
+      return torch::Tensor();
+    }
+
+    bool extractable(std::string extract_layer) const override
+    {
+      (void)extract_layer;
+      return false;
+    }
+
+    std::vector<std::string> extractable_layers() const override
+    {
+      return std::vector<std::string>();
+    }
+
+    torch::Tensor cleanup_output(torch::Tensor output) override
+    {
+      return output;
+    }
+
+    torch::Tensor loss(std::string loss, torch::Tensor input,
+                       torch::Tensor output, torch::Tensor target) override
+    {
+      (void)loss;
+      (void)input;
+      (void)output;
+      (void)target;
+      throw MLLibInternalException("Visformer::loss not implemented");
+    }
+
+  protected:
+    void init_block();
+
+    unsigned int _img_size = 224;
+    unsigned int _patch_size = 16;
+    unsigned int _in_chans = 3;
+    unsigned int _num_classes;
+    unsigned int _embed_dim;
+    unsigned int _depth = 12;
+    unsigned int _num_heads;
+    double _mlp_ratio;
+    double _qkv_bias;
+    double _qk_scale;
+    double _drop_rate;
+    double _attn_drop_rate;
+    unsigned int _num_features;
+    int _group;
+    std::string _attn_stage;
+    std::string _spatial_conv;
+
+    torch::nn::Sequential _stem{ nullptr };
+    PatchEmbed _patch_embed1{ nullptr };
+    PatchEmbed _patch_embed2{ nullptr };
+    PatchEmbed _patch_embed3{ nullptr };
+    torch::Tensor _cls_token;
+    torch::Tensor _pos_embed1;
+    torch::Tensor _pos_embed2;
+    torch::Tensor _pos_embed3;
+    torch::nn::Dropout _pos_drop{ nullptr };
+    torch::nn::ModuleList _stage1_blocks;
+    torch::nn::ModuleList _stage2_blocks;
+    torch::nn::ModuleList _stage3_blocks;
+    torch::nn::BatchNorm2d _norm{ nullptr };
+    torch::nn::AdaptiveAvgPool2d _global_pooling{ nullptr };
+    torch::nn::Linear _head{ nullptr };
+  };
+
+}
+
+#endif

--- a/tests/ut-torchapi.cc
+++ b/tests/ut-torchapi.cc
@@ -2908,4 +2908,93 @@ TEST(torchapi, service_train_vit_images_multigpu)
   fileops::remove_dir(vit_train_repo + "test_0.lmdb");
 }
 
+TEST(torchapi, service_train_visformer_images_gpu)
+{
+  setenv("CUBLAS_WORKSPACE_CONFIG", ":4096:8", true);
+  torch::manual_seed(torch_seed);
+  at::globalContext().setDeterministicCuDNN(true);
+  // torch::autograd::AnomalyMode::set_enabled(true);
+
+  mkdir(vit_train_repo.c_str(), 0777);
+
+  // Create service
+  JsonAPI japi;
+  std::string sname = "imgserv";
+  std::string jstr
+      = "{\"mllib\":\"torch\",\"description\":\"image\",\"type\":"
+        "\"supervised\",\"model\":{\"repository\":\""
+
+        + vit_train_repo
+        + "\"},\"parameters\":{\"input\":{\"connector\":\"image\","
+          "\"width\":224,\"height\":224,\"db\":true},\"mllib\":{\"nclasses\":"
+          "2,\"template\":\"visformer\",\"gpu\":true,\"template_params\":{"
+          "\"visformer_"
+          "flavor\":\"visformer_tiny\"}}}}";
+  std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
+
+  // Train
+  std::string jtrainstr
+      = "{\"service\":\"imgserv\",\"async\":false,\"parameters\":{"
+        "\"mllib\":{\"solver\":{\"iterations\":"
+        + iterations_vit + ",\"base_lr\":" + torch_lr
+        + ",\"iter_size\":4,\"solver_type\":\"RANGER\","
+          "\"lookahead\":true,\"rectified\":false,\"adabelief\":true,"
+          "\"gradient_centralization\":true,\"test_interval\":"
+        + iterations_vit
+        + "},\"net\":{\"batch_size\":4},\"nclasses\":2,\"resume\":false},"
+          "\"input\":{\"seed\":12345,\"db\":true,\"shuffle\":true},"
+          "\"output\":{\"measure\":[\"f1\",\"acc\"]}},\"data\":[\""
+        + resnet50_train_data + "\",\"" + resnet50_test_data + "\"]}";
+  joutstr = japi.jrender(japi.service_train(jtrainstr));
+  JDoc jd;
+  std::cout << "joutstr=" << joutstr << std::endl;
+  jd.Parse<rapidjson::kParseNanAndInfFlag>(joutstr.c_str());
+  ASSERT_TRUE(!jd.HasParseError());
+  ASSERT_EQ(201, jd["status"]["code"]);
+
+  ASSERT_TRUE(jd["body"]["measure"]["acc"].GetDouble() <= 1) << "accuracy";
+  ASSERT_TRUE(jd["body"]["measure"]["acc"].GetDouble() >= 0.45)
+      << "accuracy good";
+  ASSERT_TRUE(jd["body"]["measure"]["f1"].GetDouble() <= 1) << "f1";
+
+  // Predict
+  std::string jpredictstr
+      = "{\"service\":\"imgserv\",\"parameters\":{\"output\":{\"best\":1}},"
+        "\"data\":[\""
+        + resnet50_test_image + "\"]}";
+
+  joutstr = japi.jrender(japi.service_predict(jpredictstr));
+  jd = JDoc();
+  std::cout << "joutstr=" << joutstr << std::endl;
+  jd.Parse<rapidjson::kParseNanAndInfFlag>(joutstr.c_str());
+  ASSERT_TRUE(!jd.HasParseError());
+  ASSERT_EQ(200, jd["status"]["code"]);
+  ASSERT_TRUE(jd["body"]["predictions"].IsArray());
+  std::string cl1
+      = jd["body"]["predictions"][0]["classes"][0]["cat"].GetString();
+  // Not training for long enough to be 100% sure a cat will be detected
+  // ASSERT_TRUE(cl1 == "cats");
+  ASSERT_TRUE(jd["body"]["predictions"][0]["classes"][0]["prob"].GetDouble()
+              > 0.0);
+
+  std::unordered_set<std::string> lfiles;
+  fileops::list_directory(vit_train_repo, true, false, false, lfiles);
+  for (std::string ff : lfiles)
+    {
+      if (ff.find("checkpoint") != std::string::npos
+          || ff.find("solver") != std::string::npos)
+        remove(ff.c_str());
+    }
+  ASSERT_TRUE(!fileops::file_exists(vit_train_repo + "checkpoint-"
+                                    + iterations_vit + ".ptw"));
+  ASSERT_TRUE(!fileops::file_exists(vit_train_repo + "checkpoint-"
+                                    + iterations_vit + ".pt"));
+
+  fileops::clear_directory(vit_train_repo + "train.lmdb");
+  fileops::clear_directory(vit_train_repo + "test_0.lmdb");
+  fileops::remove_dir(vit_train_repo + "train.lmdb");
+  fileops::remove_dir(vit_train_repo + "test_0.lmdb");
+}
+
 #endif


### PR DESCRIPTION
This an implementation of https://arxiv.org/pdf/2104.12533.pdf with Visformer-tiny and Visformer-S, available respectively via API:

```
"mllib":{
  "template":"visformer",
  "template_params": 
   {
     "visformer_flavor":"visformer_tiny",
     "dropout": 0.1
   }
}
```

Quick training results on cats/dogs yield much easier and natural convergence than with ViT, probably thanks to the removal of the lowest attention layer, staging and batch norm, as elegantly detailed in the paper.

![image](https://user-images.githubusercontent.com/3530657/116791772-cc1da300-aabc-11eb-88f1-72d59e97df39.png)
