### PR TITLE
feat(ml): data augmentation for object detection with torch backend

### DIFF
--- a/src/backends/torch/torchdataaug.h
+++ b/src/backends/torch/torchdataaug.h
@@ -23,32 +23,44 @@
 #define TORCHDATAAUG_H
 
 #include <opencv2/opencv.hpp>
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#include <torch/torch.h>
+#pragma GCC diagnostic pop
 #include <random>
 
 namespace dd
 {
-  class TorchImgRandAugCV
+  class ImgAugParams
   {
   public:
-    TorchImgRandAugCV()
+    ImgAugParams() : _img_width(224), _img_height(224)
     {
     }
 
-    TorchImgRandAugCV(
-        const int &img_width, const int &img_height, const bool &mirror,
-        const bool &rotate, const int &crop_size, const float &cutout,
-        const bool &geometry, const bool &geometry_persp_horizontal,
-        const bool &geometry_persp_vertical, const bool &geometry_zoom_out,
-        const bool &geometry_zoom_in, const int &geometry_pad_mode)
-        : _img_width(img_width), _img_height(img_height), _mirror(mirror),
-          _rotate(rotate), _crop_size(crop_size), _cutout(cutout),
-          _geometry(geometry),
-          _geometry_persp_horizontal(geometry_persp_horizontal),
-          _geometry_persp_vertical(geometry_persp_vertical),
-          _geometry_zoom_out(geometry_zoom_out),
-          _geometry_zoom_in(geometry_zoom_in),
-          _geometry_pad_mode(geometry_pad_mode), _uniform_real_1(0.0, 1.0),
-          _bernouilli(0.5), _uniform_int_rotate(0, 3)
+    ImgAugParams(const int &img_width, const int &img_height)
+        : _img_width(img_width), _img_height(img_height)
+    {
+    }
+
+    ~ImgAugParams()
+    {
+    }
+
+    int _img_width;
+    int _img_height;
+  };
+
+  class CropParams : public ImgAugParams
+  {
+  public:
+    CropParams() : ImgAugParams()
+    {
+    }
+
+    CropParams(const int &crop_size, const int &img_width,
+               const int &img_height)
+        : ImgAugParams(img_width, img_height), _crop_size(crop_size)
     {
       if (_crop_size > 0)
         {
@@ -57,49 +69,86 @@ namespace dd
           _uniform_int_crop_y = std::uniform_int_distribution<int>(
               0, _img_height - _crop_size);
         }
-      if (_cutout > 0.0)
-        {
-          _uniform_real_cutout_s
-              = std::uniform_real_distribution<float>(_cutout_sl, _cutout_sh);
-          _uniform_real_cutout_r
-              = std::uniform_real_distribution<float>(_cutout_rl, _cutout_rh);
-        }
     }
 
-    ~TorchImgRandAugCV()
+    ~CropParams()
     {
     }
 
-    void augment(cv::Mat &src);
-
-  protected:
-    void applyMirror(cv::Mat &src);
-    void applyRotate(cv::Mat &src);
-    void applyCrop(cv::Mat &src);
-    void applyCutout(cv::Mat &src);
-    void applyGeometry(cv::Mat &src);
-
-  private:
-    void getEnlargedImage(const cv::Mat &in_img, cv::Mat &in_img_enlarged);
-    void getQuads(const int &rows, const int &cols,
-                  cv::Point2f (&inputQuad)[4], cv::Point2f (&outputQuad)[4]);
-
-  private:
-    int _img_width = 224;
-    int _img_height = 224;
-
-    // augmentation options & parameter
-    bool _mirror = false;
-    bool _rotate = false;
+    // default params
     int _crop_size = -1;
-    float _cutout = 0.0;
+    std::uniform_int_distribution<int> _uniform_int_crop_x;
+    std::uniform_int_distribution<int> _uniform_int_crop_y;
+
+    // randomized params
+    int _crop_x = 0;
+    int _crop_y = 0;
+  };
+
+  class CutoutParams : public ImgAugParams
+  {
+  public:
+    CutoutParams() : ImgAugParams()
+    {
+    }
+
+    CutoutParams(const float &prob, const int &img_width,
+                 const int &img_height)
+        : ImgAugParams(img_width, img_height), _prob(prob)
+    {
+      _uniform_real_cutout_s
+          = std::uniform_real_distribution<float>(_cutout_sl, _cutout_sh);
+      _uniform_real_cutout_r
+          = std::uniform_real_distribution<float>(_cutout_rl, _cutout_rh);
+    }
+
+    ~CutoutParams()
+    {
+    }
+
+    // default params
+    float _prob = 0.0;
     float _cutout_sl = 0.02; /**< min proportion of erased area wrt image. */
     float _cutout_sh = 0.4;  /**< max proportion of erased area wrt image. */
     float _cutout_rl = 0.3;  /**< min aspect ratio of erased area. */
     float _cutout_rh = 3.0;  /**< max aspect ratio of erased area. */
     int _cutout_vl = 0;      /**< min erased area pixel value. */
     int _cutout_vh = 255;    /**< max erased area pixel value. */
-    float _geometry = 0.0;
+
+    // randomized params
+    int _rect_x = 0;
+    int _rect_y = 0;
+    int _w = 0;
+    int _h = 0;
+
+    std::uniform_real_distribution<float> _uniform_real_cutout_s;
+    std::uniform_real_distribution<float> _uniform_real_cutout_r;
+  };
+
+  class GeometryParams
+  {
+  public:
+    GeometryParams()
+    {
+    }
+
+    GeometryParams(const float &prob, const bool &geometry_persp_horizontal,
+                   const bool &geometry_persp_vertical,
+                   const bool &geometry_zoom_out, const bool &geometry_zoom_in,
+                   const int &geometry_pad_mode)
+        : _prob(prob), _geometry_persp_horizontal(geometry_persp_horizontal),
+          _geometry_persp_vertical(geometry_persp_vertical),
+          _geometry_zoom_out(geometry_zoom_out),
+          _geometry_zoom_in(geometry_zoom_in),
+          _geometry_pad_mode(geometry_pad_mode)
+    {
+    }
+
+    ~GeometryParams()
+    {
+    }
+
+    float _prob = 0.0;
     bool _geometry_persp_horizontal
         = true; /**< horizontal perspective change. */
     bool _geometry_persp_vertical = true; /**< vertical perspective change. */
@@ -113,6 +162,73 @@ namespace dd
                                       image corners  be in 1.25 or 0.75. */
     uint8_t _geometry_pad_mode = 1; /**< filling around images, 1: constant, 2:
                                        mirrored, 3: repeat nearest. */
+    float _geometry_bbox_intersect
+        = 0.75; /**< warped bboxes must at least have a 75% intersect with the
+                   original bbox, otherwise they are filtered out.*/
+    cv::Mat _lambda; /**< warp perspective matrix. */
+  };
+
+  class TorchImgRandAugCV
+  {
+  public:
+    TorchImgRandAugCV()
+    {
+    }
+
+    TorchImgRandAugCV(const bool &mirror, const bool &rotate,
+                      const CropParams &crop_params,
+                      const CutoutParams &cutout_params,
+                      const GeometryParams &geometry_params)
+        : _mirror(mirror), _rotate(rotate), _crop_params(crop_params),
+          _cutout_params(cutout_params), _geometry_params(geometry_params),
+          _uniform_real_1(0.0, 1.0), _bernouilli(0.5),
+          _uniform_int_rotate(0, 3)
+    {
+    }
+
+    ~TorchImgRandAugCV()
+    {
+    }
+
+    void augment(cv::Mat &src);
+    void augment_with_bbox(cv::Mat &src, std::vector<torch::Tensor> &targets);
+
+  protected:
+    bool applyMirror(cv::Mat &src);
+    void applyMirrorBBox(std::vector<std::vector<float>> &bboxes,
+                         const float &img_width);
+    int applyRotate(cv::Mat &src);
+    void applyRotateBBox(std::vector<std::vector<float>> &bboxes,
+                         const float &img_width, const float &img_height,
+                         const int &rot);
+    void applyCrop(cv::Mat &src, CropParams &cp,
+                   const bool &store_rparams = false);
+    void applyCutout(cv::Mat &src, CutoutParams &cp,
+                     const bool &store_rparams = false);
+    void applyGeometry(cv::Mat &src, GeometryParams &cp,
+                       const bool &store_rparams = false);
+    void applyGeometryBBox(std::vector<std::vector<float>> &bboxes,
+                           const GeometryParams &cp, const int &img_width,
+                           const int &img_height);
+
+  private:
+    void getEnlargedImage(const cv::Mat &in_img, const GeometryParams &cp,
+                          cv::Mat &in_img_enlarged);
+    void getQuads(const int &rows, const int &cols, const GeometryParams &cp,
+                  cv::Point2f (&inputQuad)[4], cv::Point2f (&outputQuad)[4]);
+    void warpBBoxes(std::vector<std::vector<float>> &bboxes, cv::Mat lambda);
+    void filterBBoxes(std::vector<std::vector<float>> &bboxes,
+                      const GeometryParams &cp, const int &img_width,
+                      const int &img_height);
+
+  private:
+    // augmentation options & parameter
+    bool _mirror = false;
+    bool _rotate = false;
+
+    CropParams _crop_params;
+    CutoutParams _cutout_params;
+    GeometryParams _geometry_params;
 
     // random generators
     std::default_random_engine _rnd_gen;
@@ -120,10 +236,6 @@ namespace dd
         _uniform_real_1; /**< random real uniform between 0 and 1. */
     std::bernoulli_distribution _bernouilli;
     std::uniform_int_distribution<int> _uniform_int_rotate;
-    std::uniform_int_distribution<int> _uniform_int_crop_x;
-    std::uniform_int_distribution<int> _uniform_int_crop_y;
-    std::uniform_real_distribution<float> _uniform_real_cutout_s;
-    std::uniform_real_distribution<float> _uniform_real_cutout_r;
   };
 }
 

--- a/src/backends/torch/torchdataset.h
+++ b/src/backends/torch/torchdataset.h
@@ -83,6 +83,7 @@ namespace dd
 
     bool _image = false;                /**< whether an image dataset. */
     bool _bbox = false;                 /**< true if bbox detection dataset */
+    bool _test = false;                 /**< whether a test set */
     TorchImgRandAugCV _img_rand_aug_cv; /**< image data augmentation policy. */
 
     /**
@@ -103,7 +104,7 @@ namespace dd
           _indices(d._indices), _lfiles(d._lfiles), _batches(d._batches),
           _dbFullName(d._dbFullName), _inputc(d._inputc),
           _classification(d._classification), _image(d._image), _bbox(d._bbox),
-          _img_rand_aug_cv(d._img_rand_aug_cv)
+          _test(d._test), _img_rand_aug_cv(d._img_rand_aug_cv)
     {
     }
 
@@ -330,7 +331,8 @@ namespace dd
     void read_image_from_db(const std::string &datas,
                             const std::string &targets, cv::Mat &bgr,
                             std::vector<torch::Tensor> &targett,
-                            const bool &bw);
+                            const bool &bw, const int &width,
+                            const int &height);
   };
 
   /**
@@ -350,8 +352,8 @@ namespace dd
     TorchMultipleDataset(const TorchMultipleDataset &d)
         : _inputc(d._inputc), _image(d._image), _bbox(d._bbox),
           _classification(d._classification), _dbFullNames(d._dbFullNames),
-          _datasets_names(d._datasets_names), _db(d._db), _backend(d._backend),
-          _dbPrefix(d._dbPrefix), _logger(d._logger),
+          _datasets_names(d._datasets_names), _test(d._test), _db(d._db),
+          _backend(d._backend), _dbPrefix(d._dbPrefix), _logger(d._logger),
           _batches_per_transaction(d._batches_per_transaction),
           _datasets(d._datasets)
     {
@@ -508,6 +510,7 @@ namespace dd
       _datasets[id]._inputc = _inputc;
       _datasets[id]._image = _image;
       _datasets[id]._bbox = _bbox;
+      _datasets[id]._test = _test;
       _datasets[id]._classification = _classification;
       _datasets[id].set_db_params(_db, _backend,
                                   _dbPrefix + "_" + std::to_string(id));
@@ -523,6 +526,7 @@ namespace dd
     bool _classification = true; /**< whether a classification dataset. */
     std::vector<std::string> _dbFullNames;
     std::vector<std::string> _datasets_names;
+    bool _test = false; /**< wheater a test set */
 
   protected:
     bool _db = false;

--- a/src/backends/torch/torchinputconns.h
+++ b/src/backends/torch/torchinputconns.h
@@ -258,6 +258,7 @@ namespace dd
         _bbox = ad.get("bbox").get<bool>();
       _dataset._bbox = _bbox;
       _test_datasets._bbox = _bbox;
+      _test_datasets._test = true;
     }
 
     void fillup_parameters(const APIData &ad_input)

--- a/src/backends/torch/torchlib.cc
+++ b/src/backends/torch/torchlib.cc
@@ -605,47 +605,47 @@ namespace dd
         bool has_rotate
             = ad_mllib.has("rotate") && ad_mllib.get("rotate").get<bool>();
         this->_logger->info("rotate: {}", has_rotate);
-        int crop_size = -1;
+        CropParams crop_params;
         if (ad_mllib.has("crop_size"))
           {
-            crop_size = ad_mllib.get("crop_size").get<int>();
+            int crop_size = ad_mllib.get("crop_size").get<int>();
+            crop_params
+                = CropParams(crop_size, inputc.width(), inputc.height());
             this->_logger->info("crop_size : {}", crop_size);
           }
-        float cutout = 0.0;
+        CutoutParams cutout_params;
         if (ad_mllib.has("cutout"))
           {
-            cutout = ad_mllib.get("cutout").get<double>();
+            float cutout = ad_mllib.get("cutout").get<double>();
+            cutout_params
+                = CutoutParams(cutout, inputc.width(), inputc.height());
             this->_logger->info("cutout: {}", cutout);
           }
-        float geometry = 0.0;
-        bool geometry_persp_vertical = false;
-        bool geometry_persp_horizontal = false;
-        bool geometry_zoom_out = false;
-        bool geometry_zoom_in = false;
-        int geometry_pad_mode = 1;
+        GeometryParams geometry_params;
         APIData ad_geometry = ad_mllib.getobj("geometry");
         if (!ad_geometry.empty())
           {
-            geometry = ad_geometry.get("prob").get<double>();
-            this->_logger->info("geometry: {}", geometry);
+            geometry_params._prob = ad_geometry.get("prob").get<double>();
+            this->_logger->info("geometry: {}", geometry_params._prob);
             if (ad_geometry.has("persp_vertical"))
-              geometry_persp_vertical
+              geometry_params._geometry_persp_vertical
                   = ad_geometry.get("persp_vertical").get<bool>();
             if (ad_geometry.has("persp_horizontal"))
-              geometry_persp_horizontal
+              geometry_params._geometry_persp_horizontal
                   = ad_geometry.get("persp_horizontal").get<bool>();
             if (ad_geometry.has("zoom_out"))
-              geometry_zoom_out = ad_geometry.get("zoom_out").get<bool>();
+              geometry_params._geometry_zoom_out
+                  = ad_geometry.get("zoom_out").get<bool>();
             if (ad_geometry.has("zoom_in"))
-              geometry_zoom_in = ad_geometry.get("zoom_in").get<bool>();
+              geometry_params._geometry_zoom_in
+                  = ad_geometry.get("zoom_in").get<bool>();
             if (ad_geometry.has("pad_mode"))
-              geometry_pad_mode = ad_geometry.get("pad_mode").get<int>();
+              geometry_params._geometry_pad_mode
+                  = ad_geometry.get("pad_mode").get<int>();
           }
-        inputc._dataset._img_rand_aug_cv = TorchImgRandAugCV(
-            inputc.width(), inputc.height(), has_mirror, has_rotate, crop_size,
-            cutout, geometry, geometry_persp_horizontal,
-            geometry_persp_vertical, geometry_zoom_out, geometry_zoom_in,
-            geometry_pad_mode);
+        inputc._dataset._img_rand_aug_cv
+            = TorchImgRandAugCV(has_mirror, has_rotate, crop_params,
+                                cutout_params, geometry_params);
       }
 
     // solver params


### PR DESCRIPTION
This PR adds data augmentation on both images and bounding boxes for training robus object detectors with the torch backend.
There's support for mirroring, rotations and random affine transforms. Cutout is not supported at this stage, it is easy to add it. Multiple transforms can be applied sequentially.

Example augmented inputs:

![test_aug_36](https://user-images.githubusercontent.com/3530657/117078293-e4e6bc80-ad39-11eb-9383-4fc6e4770ed6.png)
![test_aug_9](https://user-images.githubusercontent.com/3530657/117078295-e57f5300-ad39-11eb-8f52-4a77b4f0e986.png)
![test_aug_0](https://user-images.githubusercontent.com/3530657/117078300-e7e1ad00-ad39-11eb-8a81-fc8450cadbb9.png)


It also adds the additional fix/features below:- 
- fixes a bug that had test db reader apply data augmentation at test time
- allow on-the-fly training image resizing when reading from a db created with a different image size
- fix rotation 90 vs 270 degrees, 