### PR TITLE
Fix dto scale + fix ncnnapi deserialization error

### DIFF
--- a/src/apidata.cc
+++ b/src/apidata.cc
@@ -123,8 +123,7 @@ namespace dd
           {
             APIData ad;
             ad.fromRapidJson(jval[cit->name.GetString()]);
-            std::vector<APIData> vad = { ad };
-            add(cit->name.GetString(), vad);
+            add(cit->name.GetString(), ad);
           }
         else if (cit->value.IsArray()) // only supports array that bears a
                                        // single type, number, string or object

--- a/src/dto/input_connector.hpp
+++ b/src/dto/input_connector.hpp
@@ -52,7 +52,7 @@ namespace dd
       DTO_FIELD(Float64, test_split);
       DTO_FIELD(Vector<Float32>, mean);
       DTO_FIELD(Vector<Float32>, std);
-      DTO_FIELD(Float64, scale);
+      DTO_FIELD(Any, scale); // bool for csv/csvts , float for img
       DTO_FIELD(Boolean, scaled);
       DTO_FIELD(Int32, scale_min);
       DTO_FIELD(Int32, scale_max);

--- a/src/imginputfileconn.h
+++ b/src/imginputfileconn.h
@@ -515,7 +515,17 @@ namespace dd
       // Variable size
       _scaled |= params->scaled;
       if (params->scale)
-        _scale = params->scale;
+        try
+          {
+            _scale = params->scale.retrieve<oatpp::Float64>();
+          }
+        catch (const std::runtime_error &error)
+          {
+            std::string msg
+                = "could not read double value for scale input parameter";
+            _logger->error(msg);
+            throw InputConnectorBadParamException(msg);
+          }
       if (params->scale_min)
         {
           _scaled = true;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -287,15 +287,8 @@ if (USE_NCNN)
     "ocr"
     )
 
-
   if(USE_JSON_API)
-    # REGISTER_TEST(ut_ncnnapi ut-ncnnapi.cc)
-    # Temporary don't register the test, just compile it.
-    if (NOT TARGET $ut_ncnnapi)
-      add_executable(ut_ncnnapi ut-ncnnapi.cc)
-      add_dependencies(ut_ncnnapi protobuf)
-      target_link_libraries(ut_ncnnapi ${COMMON_LINK_LIBS} gtest gtest_main)
-    endif()
+    REGISTER_TEST(ut_ncnnapi ut-ncnnapi.cc)
   endif()
 endif()
 


### PR DESCRIPTION
this PR allows scale input param to be either bool for csv/csv or float for img;
this PR also includes https://github.com/jolibrain/deepdetect/pull/1277