### PR TITLE
chore(tensorrt): update to c++ 14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -967,7 +967,10 @@ if (USE_TENSORRT)
     endif()
 
 	set(TRT_PATCHES_PATH ${CMAKE_BINARY_DIR}/patches/trt)
-	set(TRT_PATCHES ${TRT_PATCHES_PATH}/0001-support-for-refinedet.patch)
+	set(TRT_PATCHES
+      ${TRT_PATCHES_PATH}/0001-support-for-refinedet.patch
+      ${TRT_PATCHES_PATH}/0003-c++14.patch
+      )
 
     # Tensorrt uses its own protobuf version (3.0.0) and this cannot be overrided
     # At best we can set the version it will internally build

--- a/patches/trt/0003-c++14.patch
+++ b/patches/trt/0003-c++14.patch
@@ -1,0 +1,92 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4b5e148..071e2eb 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -57,7 +57,7 @@ option(BUILD_PLUGINS "Build TensorRT plugin" ON)
+ option(BUILD_PARSERS "Build TensorRT parsers" ON)
+ option(BUILD_SAMPLES "Build TensorRT samples" ON)
+ 
+-set(CMAKE_CXX_STANDARD 11)
++set(CMAKE_CXX_STANDARD 14)
+ set(CMAKE_CXX_STANDARD_REQUIRED ON)
+ set(CMAKE_CXX_EXTENSIONS OFF)
+ set(CMAKE_CXX_FLAGS "-Wno-deprecated-declarations ${CMAKE_CXX_FLAGS} -DBUILD_SYSTEM=cmake_oss")
+@@ -173,7 +173,7 @@ set(GENCODES "${GENCODES} -gencode arch=compute_${LATEST_SM},code=compute_${LATE
+ if (${LATEST_SM} GREATER_EQUAL 70)
+     set(BERT_GENCODES "${BERT_GENCODES} -gencode arch=compute_${LATEST_SM},code=compute_${LATEST_SM}")
+ endif()
+-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler -Wno-deprecated-declarations")
++set(CMAKE_CUDA_FLAGS "-std=c++14 ${CMAKE_CUDA_FLAGS} -Xcompiler -Wno-deprecated-declarations")
+ 
+ ############################################################################################
+ # TensorRT
+diff --git a/parsers/caffe/CMakeLists.txt b/parsers/caffe/CMakeLists.txt
+index 285da1b..caed6ff 100644
+--- a/parsers/caffe/CMakeLists.txt
++++ b/parsers/caffe/CMakeLists.txt
+@@ -52,7 +52,7 @@ target_include_directories(${SHARED_TARGET}
+ 
+ set_target_properties(${SHARED_TARGET} 
+     PROPERTIES
+-    CXX_STANDARD 11
++    CXX_STANDARD 14
+     CXX_STANDARD_REQUIRED YES
+     CXX_EXTENSIONS NO
+     ARCHIVE_OUTPUT_DIRECTORY "${TRT_OUT_DIR}"
+@@ -102,7 +102,7 @@ target_include_directories(${STATIC_TARGET}
+ 
+ set_target_properties(${STATIC_TARGET} 
+     PROPERTIES
+-    CXX_STANDARD 11
++    CXX_STANDARD 14
+     CXX_STANDARD_REQUIRED YES
+     CXX_EXTENSIONS NO
+     ARCHIVE_OUTPUT_DIRECTORY "${TRT_OUT_DIR}"
+diff --git a/plugin/CMakeLists.txt b/plugin/CMakeLists.txt
+index 940392a..70abeb1 100644
+--- a/plugin/CMakeLists.txt
++++ b/plugin/CMakeLists.txt
+@@ -105,9 +105,9 @@ target_include_directories(${SHARED_TARGET}
+ )
+ 
+ set_target_properties(${SHARED_TARGET} PROPERTIES
+-    CXX_STANDARD "11"
+-    CXX_STANDARD_REQUIRED "YES"
+-    CXX_EXTENSIONS "NO"
++    CXX_STANDARD 14
++    CXX_STANDARD_REQUIRED YES
++    CXX_EXTENSIONS NO
+     ARCHIVE_OUTPUT_DIRECTORY "${TRT_OUT_DIR}"
+     LIBRARY_OUTPUT_DIRECTORY "${TRT_OUT_DIR}"
+     RUNTIME_OUTPUT_DIRECTORY "${TRT_OUT_DIR}"
+@@ -119,7 +119,7 @@ set_target_properties(${SHARED_TARGET} PROPERTIES DEBUG_POSTFIX ${TRT_DEBUG_POST
+ 
+ set_target_properties(${SHARED_TARGET} PROPERTIES VERSION ${TRT_VERSION} SOVERSION ${TRT_SOVERSION} )
+ 
+-set_property(TARGET ${SHARED_TARGET} PROPERTY CUDA_STANDARD 11)
++set_property(TARGET ${SHARED_TARGET} PROPERTY CUDA_STANDARD 14)
+ 
+ target_link_libraries(${SHARED_TARGET}
+     ${CUBLAS_LIB}
+@@ -145,9 +145,9 @@ target_include_directories(${STATIC_TARGET}
+ )
+ 
+ set_target_properties(${STATIC_TARGET} PROPERTIES
+-    CXX_STANDARD "11"
+-    CXX_STANDARD_REQUIRED "YES"
+-    CXX_EXTENSIONS "NO"
++    CXX_STANDARD 14
++    CXX_STANDARD_REQUIRED YES
++    CXX_EXTENSIONS NO
+     ARCHIVE_OUTPUT_DIRECTORY "${TRT_OUT_DIR}"
+     LIBRARY_OUTPUT_DIRECTORY "${TRT_OUT_DIR}"
+     RUNTIME_OUTPUT_DIRECTORY "${TRT_OUT_DIR}"
+@@ -159,7 +159,7 @@ set_target_properties(${STATIC_TARGET} PROPERTIES DEBUG_POSTFIX ${TRT_DEBUG_POST
+ 
+ set_target_properties(${STATIC_TARGET} PROPERTIES VERSION ${TRT_VERSION} SOVERSION ${TRT_SOVERSION} )
+ 
+-set_property(TARGET ${STATIC_TARGET} PROPERTY CUDA_STANDARD 11)
++set_property(TARGET ${STATIC_TARGET} PROPERTY CUDA_STANDARD 14)
+ 
+ #########################################################################################
+ 


### PR DESCRIPTION
this PR forces trt to compile with -std=c++14 everywhere, removes _a lot_ of deprecation warning