### PR TITLE
feat(trt): add return cv::Mat instead of vector for GAN output

### DIFF
--- a/src/chain.cc
+++ b/src/chain.cc
@@ -131,7 +131,12 @@ namespace dd
                   {
                     APIData vout;
                     APIData vals;
-                    vals.add("vals", p.get("vals").get<std::vector<double>>());
+                    if (p.get("vals").is<std::vector<cv::Mat>>())
+                      vals.add("vals",
+                               p.get("vals").get<std::vector<cv::Mat>>());
+                    else
+                      vals.add("vals",
+                               p.get("vals").get<std::vector<double>>());
                     if (p.has("nns"))
                       vals.add("nns", p.getv("nns"));
                     vout.add(model_name, vals);

--- a/src/dto/output_connector.hpp
+++ b/src/dto/output_connector.hpp
@@ -45,6 +45,13 @@ namespace dd
       DTO_FIELD(Int32, best);
       DTO_FIELD(Int32, best_bbox) = -1;
 
+      DTO_FIELD_INFO(image)
+      {
+        info->description = "wether to convert result to a cv::Mat (e.g. for "
+                            "GANs or segmentation)";
+      };
+      DTO_FIELD(Boolean, image) = false;
+
       /* ncnn */
       DTO_FIELD(Int32, blank_label) = -1;
       DTO_FIELD(Boolean, index) = false;


### PR DESCRIPTION
This feature is only available when linking with dede and does improve performances a lot especially with chains