### PR TITLE
docs: fix pip install command from git repository

### DIFF
--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -24,7 +24,7 @@ pip install .
 or directly with:
 
 ```
-pip install git+https://github.com/deepdetect.git#egg=dd_client&subdirectory=dd_client
+pip install 'git+https://github.com/jolibrain/deepdetect.git#egg=dd_client&subdirectory=clients/python'
 ```
 
 The DD client may post images through they base64 representation if those are


### PR DESCRIPTION
Current command returns the following error when trying to install `dd_client` python client from git repository:

```
ERROR: File "setup.py" not found for legacy project dd_client from git+https://github.com/jolibrain/deepdetect.git#egg=dd_client&subdirectory=dd_client.
```

This commit contains the correct command to install  `dd_client` python client from git repository.