### PR TITLE
chore: provide a more accurate error message for model directory write/exists

### DIFF
--- a/src/mlmodel.h
+++ b/src/mlmodel.h
@@ -213,7 +213,7 @@ namespace dd
       if (!fileops::is_directory_writable(_repo))
         {
           std::string errmsg
-              = "destination model directory " + _repo + " is not writable";
+              = "destination model directory " + _repo + " is not writable or does not exist.";
           logger->error(errmsg);
           throw MLLibBadParamException(errmsg);
         }


### PR DESCRIPTION
Sometimes the directory may not exist, often I'm doing silly stuff like `chmod` and then I realise that it doesn't exist..