### PR TITLE
fix: simsearch ivf index craft after reload, disabling mmap

### DIFF
--- a/src/simsearch.cc
+++ b/src/simsearch.cc
@@ -281,8 +281,7 @@ namespace dd
     if (fileops::file_exists(index_filename))
       {
         if (_ondisk)
-          _findex
-              = faiss::read_index(index_filename.c_str(), faiss::IO_FLAG_MMAP);
+          _findex = faiss::read_index(index_filename.c_str());
         else
           _findex = faiss::read_index(index_filename.c_str());
         _index_size = _findex->ntotal;


### PR DESCRIPTION
This is a fix to #1368 that removes MMAP when reloading an existing faiss index. This potentially impacts working with very large indexes that do not fit in RAM, but none of the other potential fixes, including disabling faiss prefetching, did work.

Related issue: https://github.com/facebookresearch/faiss/issues/1540