### PR TITLE
chore: source doc requirements update

### DIFF
--- a/docs/source.md
+++ b/docs/source.md
@@ -4,7 +4,7 @@ Below are instructions for 20.04 LTS. For other Linux and Unix systems, steps ma
 
 Beware of [dependencies](https://github.com/jolibrain/deepdetect/tree/master/docs/dependencies.md), typically on Debian/Ubuntu Linux, do:
 ```
-sudo apt-get install build-essential libgoogle-glog-dev libgflags-dev libeigen3-dev libopencv-dev libboost-all-dev libboost-iostreams-dev libcurlpp-dev libcurl4-openssl-dev libopenblas-dev libhdf5-dev libprotobuf-dev libleveldb-dev libsnappy-dev liblmdb-dev libutfcpp-dev cmake libgoogle-perftools-dev unzip python-setuptools python-dev libspdlog-dev python-six python-enum34 libarchive-dev rapidjson-dev libmapbox-variant-dev wget libboost-test-dev libboost-stacktrace-dev
+sudo apt-get install build-essential libgoogle-glog-dev libgflags-dev libeigen3-dev libopencv-dev libboost-all-dev libboost-iostreams-dev libcurlpp-dev libcurl4-openssl-dev libopenblas-dev libhdf5-dev libprotobuf-dev libleveldb-dev libsnappy-dev liblmdb-dev libutfcpp-dev cmake libgoogle-perftools-dev unzip python-setuptools python-dev python-six python-enum34 libarchive-dev rapidjson-dev libmapbox-variant-dev wget libboost-test-dev libboost-stacktrace-dev python-typing-extensions python-numpy
 ```
 
 With CUDA 11+, a more recent version of cmake than that of Ubuntu 20.04 is required, and needs to be installed beforehand:


### PR DESCRIPTION
- `libspdlog-dev` is not required and fails the torch+cuda builds on 20.04, it's built by default by the DD build, we can remove it
- missing dependencies on tests and standard torch build.