### PR TITLE
fix: torch train shuffles image dataset by default

### DIFF
--- a/src/backends/torch/torchdataset.h
+++ b/src/backends/torch/torchdataset.h
@@ -69,7 +69,7 @@ namespace dd
     std::mutex _mutex; /**< lock to keep the dataset synchronized */
 
   public:
-    bool _shuffle = false;           /**< shuffle dataset upon reset() */
+    bool _shuffle = true;            /**< shuffle dataset upon reset() */
     std::shared_ptr<db::DB> _dbData; /**< db data */
     db::Cursor *_dbCursor = nullptr; /**< db cursor */
     std::vector<int64_t> _indices;   /**< id/key  of data points */


### PR DESCRIPTION
Default is now to shuffle image datasets when training with torch. 

In this configuration it's not possible to undo it via API. I don't believe it's an issue though?

Note that there are two shuffling phases: one a dataset creation, the other at every epoch, but they are governed by the same boolean in `TorchDataset`. That is fine I believe.