### PR TITLE
feat: data augmentation for training segmentation models with torch backend

### DIFF
--- a/src/backends/torch/torchdataaug.h
+++ b/src/backends/torch/torchdataaug.h
@@ -161,7 +161,7 @@ namespace dd
         = 0.25;                     /**< persp factor: 0.25 means that new
                                       image corners  be in 1.25 or 0.75. */
     uint8_t _geometry_pad_mode = 1; /**< filling around images, 1: constant, 2:
-                                       mirrored, 3: repeat nearest. */
+                                       repeat nearest (replicate). */
     float _geometry_bbox_intersect
         = 0.75; /**< warped bboxes must at least have a 75% intersect with the
                    original bbox, otherwise they are filtered out.*/
@@ -192,12 +192,13 @@ namespace dd
 
     void augment(cv::Mat &src);
     void augment_with_bbox(cv::Mat &src, std::vector<torch::Tensor> &targets);
+    void augment_with_segmap(cv::Mat &src, cv::Mat &tgt);
 
   protected:
-    bool applyMirror(cv::Mat &src);
+    bool applyMirror(cv::Mat &src, const bool &sample = true);
     void applyMirrorBBox(std::vector<std::vector<float>> &bboxes,
                          const float &img_width);
-    int applyRotate(cv::Mat &src);
+    int applyRotate(cv::Mat &src, const bool &sample = true, int rot = 0);
     void applyRotateBBox(std::vector<std::vector<float>> &bboxes,
                          const float &img_width, const float &img_height,
                          const int &rot);
@@ -206,7 +207,8 @@ namespace dd
     void applyCutout(cv::Mat &src, CutoutParams &cp,
                      const bool &store_rparams = false);
     void applyGeometry(cv::Mat &src, GeometryParams &cp,
-                       const bool &store_rparams = false);
+                       const bool &store_rparams = false,
+                       const bool &sample = true);
     void applyGeometryBBox(std::vector<std::vector<float>> &bboxes,
                            const GeometryParams &cp, const int &img_width,
                            const int &img_height);

--- a/src/backends/torch/torchdataset.h
+++ b/src/backends/torch/torchdataset.h
@@ -350,8 +350,8 @@ namespace dd
     /**
      * \brief converts and image to a serialized string
      */
-    void image_to_stringstream(const cv::Mat &img,
-                               std::ostringstream &dstream);
+    void image_to_stringstream(const cv::Mat &img, std::ostringstream &dstream,
+                               const bool &lossless = true);
 
     /**
      * \brief writes encoded image to db with a tensor target
@@ -378,8 +378,8 @@ namespace dd
     void read_image_from_db(const std::string &datas,
                             const std::string &targets, cv::Mat &bgr,
                             std::vector<torch::Tensor> &targett,
-                            const bool &bw, const int &width,
-                            const int &height);
+                            cv::Mat &bw_target, const bool &bw,
+                            const int &width, const int &height);
   };
 
   /**

--- a/tests/ut-torchapi.cc
+++ b/tests/ut-torchapi.cc
@@ -768,7 +768,10 @@ TEST(torchapi, service_train_image_segmentation)
         + iterations_deeplabv3 + ",\"base_lr\":" + torch_lr
         + ",\"iter_size\":1,\"solver_type\":\"ADAM\",\"test_"
           "interval\":100},\"net\":{\"batch_size\":4},"
-          "\"resume\":false},"
+          "\"resume\":false,\"mirror\":true,\"rotate\":true,\"crop_size\":224,"
+          "\"cutout\":0.5,\"geometry\":{\"prob\":0.1,\"persp_horizontal\":"
+          "true,\"persp_vertical\":true,\"zoom_in\":true,\"zoom_out\":true,"
+          "\"pad_mode\":1}},"
           "\"input\":{\"seed\":12345,\"db\":true,\"shuffle\":true,"
           "\"segmentation\":true,\"scale\":0.0039,\"mean\":[0.485,0.456,0.406]"
           ",\"std\":[0.229,0.224,0.225]},"
@@ -782,7 +785,7 @@ TEST(torchapi, service_train_image_segmentation)
   ASSERT_EQ(201, jd["status"]["code"]);
 
   ASSERT_TRUE(jd["body"]["measure"]["meanacc"].GetDouble() <= 1) << "accuracy";
-  ASSERT_TRUE(jd["body"]["measure"]["meanacc"].GetDouble() >= 0.01)
+  ASSERT_TRUE(jd["body"]["measure"]["meanacc"].GetDouble() >= 0.007)
       << "accuracy good";
   ASSERT_TRUE(jd["body"]["measure"]["meaniou"].GetDouble() <= 1) << "meaniou";
 


### PR DESCRIPTION
This PR brings:
- basic data augmentation (rotation, cutout, perspectives) to segmentation with torch
- swapped jpg compression (quality 100) to png with compression 0, as jpg was corrupting the segmentation masks (even with quality set to 100...)

![seg_aug_geom1_src](https://user-images.githubusercontent.com/3530657/143754245-586a7b66-0d0c-4dab-bfd4-be91352f9b54.png)
![seg_aug_geom1](https://user-images.githubusercontent.com/3530657/143754221-724b4b81-0aa6-4e41-8955-7b0b6f9f7115.png)

