### PR TITLE
fix: torch model published config file

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -375,7 +375,6 @@ datatype           | string | true     | "fp32"      | datatype inside compiled 
 
 Parameter    | Type | Optional | Default | Description
 ---------    | ---- | -------- | ------- | -----------
-store_config | bool | yes      | false   | stores the creation call in a `config.json` file in the model directory
 measure      | array of string | yes | depending on problem type | measure to use at test time
 
 

--- a/src/backends/torch/torchlib.cc
+++ b/src/backends/torch/torchlib.cc
@@ -1199,7 +1199,10 @@ namespace dd
                   }
 
                 if (elapsed_it == iterations)
-                  out = meas_out;
+                  {
+                    out.add("measure", meas_out.getobj("measure"));
+                    out.add("measures", meas_out.getv("measures"));
+                  }
               }
 
             train_loss = 0;
@@ -1269,6 +1272,7 @@ namespace dd
 
     inputc.response_params(out);
     this->_logger->info("Training done.");
+
     return 0;
   }
 

--- a/src/backends/torch/torchmodel.h
+++ b/src/backends/torch/torchmodel.h
@@ -68,6 +68,10 @@ namespace dd
                        const std::string &target_repo,
                        const std::shared_ptr<spdlog::logger> &logger);
 
+    void update_config_json_parameters(
+        const std::string &target_repo,
+        const std::shared_ptr<spdlog::logger> &logger);
+
   public:
     std::string _traced;  /**< path of the traced part of the net. */
     std::string _weights; /**< path of the weights of the net. */

--- a/src/jsonapi.cc
+++ b/src/jsonapi.cc
@@ -464,8 +464,8 @@ namespace dd
 
     std::string mllib, input;
     std::string type, description;
-    bool store_config = false;
     APIData ad, ad_model;
+    bool store_config = true;
     try
       {
         // mandatory parameters.
@@ -484,11 +484,12 @@ namespace dd
         ad.fromRapidJson(d);
         ad_model = ad.getobj("model");
         APIData ad_param = ad.getobj("parameters");
-        if (ad_param.has("output"))
+
+        if (ad_param.has("mllib"))
           {
-            APIData ad_output = ad_param.getobj("output");
-            if (ad_output.has("store_config"))
-              store_config = ad_output.get("store_config").get<bool>();
+            APIData ad_mllib = ad_param.getobj("mllib");
+            if (ad_mllib.has("from_repository"))
+              store_config = false;
           }
       }
     catch (RapidjsonException &e)
@@ -552,16 +553,11 @@ namespace dd
                       ad);
                 else
                   return dd_input_connector_not_found_1004();
-                if (JsonAPI::store_json_blob(
-                        cmodel._repo, jstr)) // store successful call json blob
+                if (store_config
+                    && JsonAPI::store_json_config_blob(cmodel._repo, jstr))
                   _logger->error(
                       "couldn't write {} file in model repository {}",
-                      JsonAPI::_json_blob_fname, cmodel._repo);
-                if (store_config)
-                  if (JsonAPI::store_json_config_blob(cmodel._repo, jstr))
-                    _logger->error(
-                        "couldn't write {} file in model repository {}",
-                        JsonAPI::_json_config_blob_fname, cmodel._repo);
+                      JsonAPI::_json_config_blob_fname, cmodel._repo);
               }
             else if (type == "unsupervised")
               {
@@ -602,16 +598,11 @@ namespace dd
                       ad);
                 else
                   return dd_input_connector_not_found_1004();
-                if (JsonAPI::store_json_blob(
-                        cmodel._repo, jstr)) // store successful call json blob
+                if (store_config
+                    && JsonAPI::store_json_config_blob(cmodel._repo, jstr))
                   _logger->error(
                       "couldn't write {} file in model repository {}",
-                      JsonAPI::_json_blob_fname, cmodel._repo);
-                if (store_config)
-                  if (JsonAPI::store_json_config_blob(cmodel._repo, jstr))
-                    _logger->error(
-                        "couldn't write {} file in model repository {}",
-                        JsonAPI::_json_config_blob_fname, cmodel._repo);
+                      JsonAPI::_json_config_blob_fname, cmodel._repo);
               }
             else
               {
@@ -658,15 +649,6 @@ namespace dd
               }
             else
               return dd_service_bad_request_1006(); // unknown service type
-
-            // store successful call json blob
-            if (JsonAPI::store_json_blob(c2model._repo, jstr))
-              {
-                _logger->error("couldn't write {} file in model repository {}",
-                               JsonAPI::_json_blob_fname, c2model._repo);
-              }
-
-            // store model configuration json blob
             if (store_config
                 && JsonAPI::store_json_config_blob(c2model._repo, jstr))
               {
@@ -701,11 +683,6 @@ namespace dd
                       ad);
                 else
                   return dd_input_connector_not_found_1004();
-                if (JsonAPI::store_json_blob(ncnnmodel._repo, jstr))
-                  _logger->error(
-                      "couldn't write {} file in model repository {}",
-                      JsonAPI::_json_blob_fname, ncnnmodel._repo);
-                // store model configuration json blob
                 if (store_config
                     && JsonAPI::store_json_config_blob(ncnnmodel._repo, jstr))
                   {
@@ -752,11 +729,6 @@ namespace dd
                       ad);
                 else
                   return dd_input_connector_not_found_1004();
-                if (JsonAPI::store_json_blob(torchmodel._repo, jstr))
-                  _logger->error(
-                      "couldn't write {} file in model repository {}",
-                      JsonAPI::_json_blob_fname, torchmodel._repo);
-                // store model configuration json blob
                 if (store_config
                     && JsonAPI::store_json_config_blob(torchmodel._repo, jstr))
                   {
@@ -788,12 +760,6 @@ namespace dd
                               ad);
                 else
                   return dd_input_connector_not_found_1004();
-                if (JsonAPI::store_json_blob(
-                        tfmodel._repo,
-                        jstr)) // store successful call json blob
-                  _logger->error(
-                      "couldn't write {} file in model repository {}",
-                      JsonAPI::_json_blob_fname, tfmodel._repo);
               }
             else if (type == "unsupervised")
               {
@@ -805,23 +771,16 @@ namespace dd
                               ad);
                 else
                   return dd_input_connector_not_found_1004();
-                if (JsonAPI::store_json_blob(
-                        tfmodel._repo,
-                        jstr)) // store successful call json blob
-                  _logger->error(
-                      "couldn't write {} file in model repository {}",
-                      JsonAPI::_json_blob_fname, tfmodel._repo);
-                if (store_config)
-                  if (JsonAPI::store_json_config_blob(tfmodel._repo, jstr))
-                    _logger->error(
-                        "couldn't write {} file in model repository {}",
-                        JsonAPI::_json_config_blob_fname, tfmodel._repo);
               }
             else
               {
                 // unknown type
                 return dd_service_bad_request_1006();
               }
+            if (store_config
+                && JsonAPI::store_json_config_blob(tfmodel._repo, jstr))
+              _logger->error("couldn't write {} file in model repository {}",
+                             JsonAPI::_json_config_blob_fname, tfmodel._repo);
           }
 #endif
 #ifdef USE_DLIB
@@ -844,12 +803,6 @@ namespace dd
                   {
                     return dd_input_connector_not_found_1004();
                   }
-                if (JsonAPI::store_json_blob(dlibmodel._repo, jstr))
-                  { // store successful call json blob
-                    _logger->error(
-                        "couldn't write {} file in model repository {}",
-                        JsonAPI::_json_blob_fname, dlibmodel._repo);
-                  }
               }
             else if (type == "unsupervised")
               {
@@ -866,18 +819,16 @@ namespace dd
                   {
                     return dd_input_connector_not_found_1004();
                   }
-                if (JsonAPI::store_json_blob(dlibmodel._repo, jstr))
-                  { // store successful call json blob
-                    _logger->error(
-                        "couldn't write {} file in model repository {}",
-                        JsonAPI::_json_blob_fname, dlibmodel._repo);
-                  }
               }
             else
               {
                 // unknown type
                 return dd_service_bad_request_1006();
               }
+            if (store_config
+                && JsonAPI::store_json_config_blob(tfmodel._repo, jstr))
+              _logger->error("couldn't write {} file in model repository {}",
+                             JsonAPI::_json_config_blob_fname, tfmodel._repo);
           }
 #endif
 #ifdef USE_XGBOOST
@@ -905,14 +856,10 @@ namespace dd
                           ad);
             else
               return dd_input_connector_not_found_1004();
-            if (JsonAPI::store_json_blob(
-                    xmodel._repo, jstr)) // store successful call json blob
+            if (store_config
+                && JsonAPI::store_json_config_blob(xmodel._repo, jstr))
               _logger->error("couldn't write {} file in model repository {}",
-                             JsonAPI::_json_blob_fname, xmodel._repo);
-            if (store_config)
-              if (JsonAPI::store_json_config_blob(xmodel._repo, jstr))
-                _logger->error("couldn't write {} file in model repository {}",
-                               JsonAPI::_json_config_blob_fname, xmodel._repo);
+                             JsonAPI::_json_config_blob_fname, xmodel._repo);
           }
 #endif
 #ifdef USE_TSNE
@@ -934,14 +881,10 @@ namespace dd
                           ad);
             else
               return dd_input_connector_not_found_1004();
-            if (JsonAPI::store_json_blob(
-                    tmodel._repo, jstr)) // store successful call json blob
+            if (store_config
+                && JsonAPI::store_json_config_blob(tmodel._repo, jstr))
               _logger->error("couldn't write {} file in model repository {}",
-                             JsonAPI::_json_blob_fname, tmodel._repo);
-            if (store_config)
-              if (JsonAPI::store_json_config_blob(tmodel._repo, jstr))
-                _logger->error("couldn't write {} file in model repository {}",
-                               JsonAPI::_json_config_blob_fname, tmodel._repo);
+                             JsonAPI::_json_config_blob_fname, tmodel._repo);
           }
 #endif
 #ifdef USE_TENSORRT
@@ -962,11 +905,6 @@ namespace dd
                       ad);
                 else
                   return dd_input_connector_not_found_1004();
-                if (JsonAPI::store_json_blob(tensorRTmodel._repo, jstr))
-                  _logger->error(
-                      "couldn't write {} file in model repository {}",
-                      JsonAPI::_json_blob_fname, tensorRTmodel._repo);
-                // store model configuration json blob
                 if (store_config
                     && JsonAPI::store_json_config_blob(tensorRTmodel._repo,
                                                        jstr))

--- a/src/mlservice.h
+++ b/src/mlservice.h
@@ -311,7 +311,6 @@ namespace dd
       APIData jmrepo;
       jmrepo.add("repository", this->_mlmodel._repo);
       out.add("model", jmrepo);
-      // this->fillup_measures_history(ad);
       if (!ad.has("async") || (ad.has("async") && ad.get("async").get<bool>()))
         {
           std::lock_guard<std::mutex> lock(_tjobs_mutex);
@@ -342,8 +341,8 @@ namespace dd
       else
         {
           boost::unique_lock<boost::shared_mutex> lock(_train_mutex);
+          this->_has_predict = false;
           int status = this->train(ad, out);
-          // this->collect_measures(out);
           APIData ad_params_out = ad.getobj("parameters").getobj("output");
           if (ad_params_out.has("measure_hist")
               && ad_params_out.get("measure_hist").get<bool>())

--- a/tests/ut-caffeapi.cc
+++ b/tests/ut-caffeapi.cc
@@ -476,8 +476,8 @@ TEST(caffeapi, service_train_csv)
   ASSERT_EQ(created_str, joutstr);
 
   // assert json blob file
-  ASSERT_TRUE(
-      fileops::file_exists(forest_repo + "/" + JsonAPI::_json_blob_fname));
+  ASSERT_TRUE(fileops::file_exists(forest_repo + "/"
+                                   + JsonAPI::_json_config_blob_fname));
 
   // train
   std::string jtrainstr
@@ -626,8 +626,8 @@ TEST(caffeapi, service_train_csv_in_memory)
   ASSERT_EQ(created_str, joutstr);
 
   // assert json blob file
-  ASSERT_TRUE(
-      fileops::file_exists(forest_repo + "/" + JsonAPI::_json_blob_fname));
+  ASSERT_TRUE(fileops::file_exists(forest_repo + "/"
+                                   + JsonAPI::_json_config_blob_fname));
 
   // read CSV file
   std::string mem_data_str;
@@ -712,8 +712,8 @@ TEST(caffeapi, service_train_csv_resnet)
   ASSERT_EQ(created_str, joutstr);
 
   // assert json blob file
-  ASSERT_TRUE(
-      fileops::file_exists(forest_repo + "/" + JsonAPI::_json_blob_fname));
+  ASSERT_TRUE(fileops::file_exists(forest_repo + "/"
+                                   + JsonAPI::_json_config_blob_fname));
 
   // train
   std::string jtrainstr
@@ -864,8 +864,8 @@ TEST(caffeapi, service_train_svm)
   ASSERT_EQ(created_str, joutstr);
 
   // assert json blob file
-  ASSERT_TRUE(
-      fileops::file_exists(farm_repo_loc + "/" + JsonAPI::_json_blob_fname));
+  ASSERT_TRUE(fileops::file_exists(farm_repo_loc + "/"
+                                   + JsonAPI::_json_config_blob_fname));
 
   // train
   std::string jtrainstr
@@ -1032,8 +1032,8 @@ TEST(caffeapi, service_train_svm_resnet)
   ASSERT_EQ(created_str, joutstr);
 
   // assert json blob file
-  ASSERT_TRUE(
-      fileops::file_exists(farm_repo_loc + "/" + JsonAPI::_json_blob_fname));
+  ASSERT_TRUE(fileops::file_exists(farm_repo_loc + "/"
+                                   + JsonAPI::_json_config_blob_fname));
 
   // train
   std::string jtrainstr

--- a/tests/ut-torchapi.cc
+++ b/tests/ut-torchapi.cc
@@ -644,6 +644,9 @@ TEST(torchapi, service_train_images_split)
   ASSERT_TRUE(jd["body"]["measure"]["train_loss"].GetDouble() <= 3.0)
       << "loss";
 
+  ASSERT_TRUE(fileops::file_exists(resnet50_train_repo + "config.json"));
+  ASSERT_TRUE(fileops::file_exists(resnet50_train_repo + "model.json"));
+
   std::unordered_set<std::string> lfiles;
   fileops::list_directory(resnet50_train_repo, true, false, false, lfiles);
   for (std::string ff : lfiles)

--- a/tests/ut-xgbapi.cc
+++ b/tests/ut-xgbapi.cc
@@ -61,9 +61,10 @@ TEST(xgbapi, service_train_csv)
   ASSERT_EQ(created_str, joutstr);
 
   // assert json blob file
-  std::cerr << forest_repo + "/" + JsonAPI::_json_blob_fname << std::endl;
-  ASSERT_TRUE(
-      fileops::file_exists(forest_repo + "/" + JsonAPI::_json_blob_fname));
+  std::cerr << forest_repo + "/" + JsonAPI::_json_config_blob_fname
+            << std::endl;
+  ASSERT_TRUE(fileops::file_exists(forest_repo + "/"
+                                   + JsonAPI::_json_config_blob_fname));
 
   // train
   std::string jtrainstr


### PR DESCRIPTION
This PR fixes the publishing of models and their config files.

- bug: model.json file was overriden with config.json content
- fix: config.json was optional and there's no reason for it
- when publishing a model, config.json is not written down since it is instead copied from the source model repository
- async training jobs now correctly report as training
- When using random cropping, the model size is that of the crop size. Publishing a model requires the `config.json` file to be updated. This PR introduces a placeholder for these changes, starting with the crop fix and the db flag value, but it is generic to other, possibly forthcoming config update requirements.
- fileops in file replacement was buggy and the call has been removed.