### PR TITLE
feat(chain): add action to draw bboxes as trailing action

### DIFF
--- a/demo/objdetect/README.md
+++ b/demo/objdetect/README.md
@@ -8,7 +8,7 @@ To run the code on your own image:
 
 - Install the pre-trained model:
 
-```
+```bash
 mkdir model
 cd model
 wget https://deepdetect.com/models/voc0712_dd.tar.gz
@@ -18,14 +18,20 @@ cd ..
 
 - Start a DeepDetect server:
 
-```
+```bash
 ./dede
 ```
 
 - Try object detection on an image
 
-```
+```bash
 python objdetect.py --image /path/to/yourimage.jpg --confidence-threshold 0.1
+```
+
+- Alternatively, try the chain version. It will draw the bounding boxes on the image and return it.
+
+```bash
+python chaindetect.py --image /path/to/yourimage.jpg --save-path image.png
 ```
 
 Notes:

--- a/demo/objdetect/chaindetect.py
+++ b/demo/objdetect/chaindetect.py
@@ -1,0 +1,64 @@
+import os, sys, argparse
+from dd_client import DD
+import cv2
+import numpy as np
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--image",help="path to image")
+parser.add_argument("--port", help="DeepDetect port", type=int, default=8080)
+parser.add_argument("--confidence-threshold",help="keep detections with confidence above threshold",type=float,default=0.1)
+parser.add_argument("--save-path", help="Where to save resulting image")
+args = parser.parse_args()
+
+host = 'localhost'
+sname = 'imgserv'
+description = 'image classification'
+mllib = 'caffe'
+mltype = 'supervised'
+nclasses = 21
+width = height = 300
+dd = DD(host, port=args.port)
+dd.set_return_format(dd.RETURN_PYTHON)
+
+# creating ML service
+model_repo = os.getcwd() + '/model'
+model = {'repository':model_repo}
+parameters_input = {'connector':'image','width':width,'height':height}
+parameters_mllib = {'nclasses':nclasses}
+parameters_output = {}
+dd.put_service(sname,model,description,mllib,
+               parameters_input,parameters_mllib,parameters_output,mltype)
+
+# chain call
+calls = []
+
+parameters_input = {"keep_orig":True}
+parameters_mllib = {'gpu':True}
+parameters_output = {'bbox':True, 'confidence_threshold': args.confidence_threshold}
+data = [args.image]
+calls.append(dd.make_call(sname, data, parameters_input, parameters_mllib, parameters_output))
+
+parameters_action = {"output_images":True, "write_prob": True}
+# parameters_action["save_path"] = os.getcwd()
+# parameters_action["save_img"] = True
+calls.append(dd.make_action("draw_bbox", parameters_action, "img_bbox"))
+
+detect = dd.post_chain("chain_ddetect",calls)
+# print(detect)
+if detect['status']['code'] != 200:
+    print('error',detect['status']['code'])
+    sys.exit()
+
+predictions = detect['body']['predictions']
+for p in predictions:
+    # get orig img dimensions
+    orig_img = cv2.imread(p['uri'])
+    width, height, _ = orig_img.shape
+
+    img = np.array(p["img_bbox"]["vals"])
+    img = img.reshape((width, height, 3))
+
+    if args.save_path:
+        cv2.imwrite(args.save_path, img)
+    cv2.imshow('img',img)
+    k = cv2.waitKey(0)

--- a/demo/objdetect/dd_client.py
+++ b/demo/objdetect/dd_client.py
@@ -1,1 +1,0 @@
-../../clients/python/dd_client.py

--- a/src/chain_actions.h
+++ b/src/chain_actions.h
@@ -129,6 +129,22 @@ namespace dd
     void apply(APIData &model_out, ChainData &cdata);
   };
 
+  class ImgsDrawBBoxAction : public ChainAction
+  {
+  public:
+    ImgsDrawBBoxAction(oatpp::Object<DTO::ChainCall> call_dto,
+                       const std::shared_ptr<spdlog::logger> chain_logger)
+        : ChainAction(call_dto, chain_logger)
+    {
+    }
+
+    ~ImgsDrawBBoxAction()
+    {
+    }
+
+    void apply(APIData &model_out, ChainData &cdata);
+  };
+
   class ClassFilter : public ChainAction
   {
   public:

--- a/src/dto/chain.hpp
+++ b/src/dto/chain.hpp
@@ -41,6 +41,13 @@ namespace dd
       DTO_INIT(ChainActionParams, DTO)
 
       // image
+      DTO_FIELD_INFO(output_images)
+      {
+        info->description = "If true, this action will add its result images "
+                            "to the response body of the chain call";
+      }
+      DTO_FIELD(Boolean, output_images) = false;
+
       DTO_FIELD_INFO(to_rgb)
       {
         info->description = "*Removed - use `parameters.input.rgb` instead*\n"
@@ -60,6 +67,13 @@ namespace dd
         info->description = "Path to save chain output, eg for debugging";
       }
       DTO_FIELD(String, save_path) = "";
+
+      DTO_FIELD_INFO(save_img)
+      {
+        info->description
+            = "whether to save image to `save_path` after action";
+      }
+      DTO_FIELD(Boolean, save_img) = false;
 
       // image - crop
       DTO_FIELD_INFO(fixed_width)
@@ -99,18 +113,32 @@ namespace dd
       }
       DTO_FIELD(String, orientation) = "relative";
 
-      DTO_FIELD_INFO(save_img)
+      // image - draw bbox
+      DTO_FIELD_INFO(thickness)
+      {
+        info->description = "[draw_bbox] thickness of bbox rectangle";
+      }
+      DTO_FIELD(Int32, thickness) = 2;
+
+      DTO_FIELD_INFO(write_cat)
       {
         info->description
-            = "[rotate] whether to save image to `save_path` after rotation";
+            = "[draw_bbox] Write the found best class beside the bbox";
       }
-      DTO_FIELD(Boolean, save_img) = false;
+      DTO_FIELD(Boolean, write_cat) = true;
+
+      DTO_FIELD_INFO(write_prob)
+      {
+        info->description
+            = "[draw_bbox] Write the prediction score beside the bbox";
+      }
+      DTO_FIELD(Boolean, write_prob) = false;
 
       // filter
       DTO_FIELD_INFO(classes)
       {
-        info->description
-            = "[filter] classes NOT present in this list will be filtered out";
+        info->description = "[filter] classes NOT present in this list will "
+                            "be filtered out";
       }
       DTO_FIELD(Vector<String>, classes);
 

--- a/src/dto/ddtypes.cc
+++ b/src/dto/ddtypes.cc
@@ -33,6 +33,10 @@ namespace dd
       const oatpp::ClassId DTOVectorClass<double>::CLASS_ID("vector<double>");
 
       template <>
+      const oatpp::ClassId
+          DTOVectorClass<uint8_t>::CLASS_ID("vector<uint8_t>");
+
+      template <>
       const oatpp::ClassId DTOVectorClass<bool>::CLASS_ID("vector<bool>");
     }
   }

--- a/src/dto/ddtypes.hpp
+++ b/src/dto/ddtypes.hpp
@@ -144,6 +144,12 @@ namespace dd
       return caret.parseFloat64();
     }
 
+    template <>
+    inline uint8_t readVecElement<uint8_t>(oatpp::parser::Caret &caret)
+    {
+      return static_cast<uint8_t>(caret.parseUnsignedInt());
+    }
+
     template <> inline bool readVecElement<bool>(oatpp::parser::Caret &caret)
     {
       if (caret.isAtText("true"))

--- a/src/services.h
+++ b/src/services.h
@@ -994,22 +994,7 @@ namespace dd
             }
 
           // producing a nested output
-          if (npredicts > 1)
-            chain_dto = cdata.nested_chain_output();
-          else
-            {
-              // XXX(louis): fix this when chains will be entirely DTO (needs
-              // supervised output connector to DTO)
-              auto first_model_dto = cdata.get_model_data(cdata._first_id)
-                                         .createSharedDTO<DTO::PredictBody>();
-              chain_dto = DTO::ChainBody::createShared();
-
-              for (auto &pred : *first_model_dto->predictions)
-                {
-                  chain_dto->predictions->push_back(
-                      oatpp_utils::dtoToUFields(pred));
-                }
-            }
+          chain_dto = cdata.nested_chain_output();
 
           std::chrono::time_point<std::chrono::system_clock> tstop
               = std::chrono::system_clock::now();

--- a/src/utils/oatpp.cc
+++ b/src/utils/oatpp.cc
@@ -37,6 +37,8 @@ namespace dd
                                    DTO::gpuIdsDeserialize);
       deser->setDeserializerMethod(DTO::DTOVector<double>::Class::CLASS_ID,
                                    DTO::vectorDeserialize<double>);
+      deser->setDeserializerMethod(DTO::DTOVector<uint8_t>::Class::CLASS_ID,
+                                   DTO::vectorDeserialize<uint8_t>);
       deser->setDeserializerMethod(DTO::DTOVector<bool>::Class::CLASS_ID,
                                    DTO::vectorDeserialize<bool>);
       auto ser = object_mapper->getSerializer();
@@ -44,6 +46,8 @@ namespace dd
                                DTO::gpuIdsSerialize);
       ser->setSerializerMethod(DTO::DTOVector<double>::Class::CLASS_ID,
                                DTO::vectorSerialize<double>);
+      ser->setSerializerMethod(DTO::DTOVector<uint8_t>::Class::CLASS_ID,
+                               DTO::vectorSerialize<uint8_t>);
       ser->setSerializerMethod(DTO::DTOVector<bool>::Class::CLASS_ID,
                                DTO::vectorSerialize<bool>);
       return object_mapper;
@@ -138,6 +142,16 @@ namespace dd
       else if (polymorph.valueType == DTO::DTOVector<double>::Class::getType())
         {
           auto vec = polymorph.staticCast<DTO::DTOVector<double>>();
+          jval = JVal(rapidjson::kArrayType);
+          for (size_t i = 0; i < vec->size(); ++i)
+            {
+              jval.PushBack(vec->at(i), jdoc.GetAllocator());
+            }
+        }
+      else if (polymorph.valueType
+               == DTO::DTOVector<uint8_t>::Class::getType())
+        {
+          auto vec = polymorph.staticCast<DTO::DTOVector<uint8_t>>();
           jval = JVal(rapidjson::kArrayType);
           for (size_t i = 0; i < vec->size(); ++i)
             {

--- a/tests/ut-chain.cc
+++ b/tests/ut-chain.cc
@@ -309,6 +309,53 @@ TEST(chain, chain_caffe_faces_classification)
   ASSERT_EQ(pred1["classes"][0]["age"]["classes"][0]["cat"].GetString(),
             std::string("48"));
 }
+
+TEST(chain, chain_caffe_detect_draw_bboxes)
+{
+  JsonAPI japi;
+  std::string detect_sname = "detect";
+  std::string jstr
+      = "{\"mllib\":\"caffe\",\"description\":\"face detection "
+        "model\",\"type\":\"supervised\",\"model\":{\"repository\":\""
+        + caffe_faces_detect_repo
+        + "\"},\"parameters\":{\"input\":{\"connector\":\"image\",\"width\":"
+          "512,\"height\":512},\"mllib\":{\"nclasses\":1,\"best\":-1,"
+          "\"gpu\":true,\"gpuid\":0,\"net\":{\"test_batch_size\":1}}}}";
+  std::string joutstr = japi.jrender(japi.service_create(detect_sname, jstr));
+  ASSERT_EQ(created_str, joutstr);
+
+  // TODO prendre l'image de gens qqpart dans le repo test
+  std::string uri1 = "https://icour.fr/ELeveSeconde/ajout/yann_lecum_vidal/"
+                     "images/yann_LeCun.jpg";
+
+  std::string jchainstr
+      = "{\"chain\": {\"calls\": [{\"parameters\": {\"input\": "
+        "{\"keep_orig\": true,\"connector\": \"image\"},\"output\": "
+        "{\"confidence_threshold\": 0.5,\"bbox\": true},\"mllib\": {\"net\": "
+        "{\"test_batch_size\": 2}}},\"service\":\""
+        + detect_sname + "\",\"data\":[\"" + uri1
+        + "\"]},{\"id\":\"face_detection_bbox\",\"action\":{\"parameters\": "
+          "{\"padding_ratio\":0.0,\"output_images\":true,\"write_prob\":true}"
+          ",\"type\":\"draw_bbox\"}}]}}";
+  joutstr = japi.jrender(japi.service_chain("chain", jchainstr));
+  JDoc jd;
+  // very long outstr is truncated
+  std::cout << "joutstr=" << joutstr.substr(0, 500)
+            << (joutstr.size() > 500
+                    ? " ... " + joutstr.substr(joutstr.size() - 500)
+                    : "")
+            << std::endl;
+  jd.Parse<rapidjson::kParseNanAndInfFlag>(joutstr.c_str());
+  ASSERT_TRUE(!jd.HasParseError());
+  ASSERT_EQ(200, jd["status"]["code"]);
+
+  ASSERT_TRUE(jd["body"]["predictions"].IsArray());
+  ASSERT_TRUE(jd["body"]["predictions"][0]["classes"].IsArray());
+  ASSERT_TRUE(jd["body"]["predictions"][0]["classes"].Size() == 1);
+  auto &bbox_images = jd["body"]["predictions"][0]["face_detection_bbox"];
+  ASSERT_TRUE(bbox_images["vals"].IsArray());
+  ASSERT_EQ(bbox_images["vals"].Size(), 3 * 1000 * 562);
+}
 #endif
 
 #ifdef USE_TENSORRT


### PR DESCRIPTION
This PR opens the possibility for chains to have trailing actions.

- [x] add a demo script

Example chain call:
```json
{
   "chain":{
      "calls":[
         {
            "parameters":{
               "input":{
                  "keep_orig":true,
                  "connector":"image"
               },
               "output":{
                  "confidence_threshold":0.5,
                  "bbox":true
               },
               "mllib":{
                  "net":{
                     "test_batch_size":2
                  }
               }
            },
            "service":"detect",
            "data":[
               "/opt/platform/data/image.jpg"
            ]
         },
         {
            "id":"face_detection_bbox",
            "action":{
               "parameters":{
                  "output_images":true,
                  "write_prob":true
               },
               "type":"draw_bbox"
            }
         }
      ]
   }
}
```
![image](https://user-images.githubusercontent.com/15674552/149920203-6ac95526-e406-4579-bf56-f98c419a6073.png)