### PR TITLE
fix: remove semantic commit check

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -7,7 +7,7 @@ defaults:
 queue_rules:
   - name: default
     conditions:
-      - "status-success=Semantic Pull Request"
+        # - "status-success=Semantic Pull Request"
       - "status-success=Jenkins - Unit tests GPU"
       - or:
         - "label!=ci:docker"
@@ -19,7 +19,7 @@ pull_request_rules:
       - "base=master"
       - "label!=process:manual-merge"
       - "#changes-requested-reviews-by=0"
-      - "status-success=Semantic Pull Request"
+        # - "status-success=Semantic Pull Request"
       - "status-success=Jenkins - Unit tests GPU"
       - or:
         - "label!=ci:docker"


### PR DESCRIPTION
Semantic PR service down since April 15th
https://github.com/zeke/semantic-pull-requests/issues/183

We can replace it by github actions or another service.