### PR TITLE
fix: exported yolox have the correct number of classes

### DIFF
--- a/src/backends/tensorrt/tensorrtlib.cc
+++ b/src/backends/tensorrt/tensorrtlib.cc
@@ -882,8 +882,8 @@ namespace dd
             if (_template == "yolox")
               {
                 yolo_out = yolo_utils::parse_yolo_output(
-                    _floatOut, num_processed, _results_height, _nclasses,
-                    inputc._width, inputc._height);
+                    _floatOut, num_processed, _results_height, _dims.d[2],
+                    _nclasses, inputc._width, inputc._height);
                 outr = yolo_out.data();
               };
 

--- a/tests/ut-tensorrtapi.cc
+++ b/tests/ut-tensorrtapi.cc
@@ -257,7 +257,7 @@ TEST(tensorrtapi, service_predict_bbox_onnx)
         + "\"},\"parameters\":{\"input\":{\"connector\":\"image\",\"height\":"
           "640,\"width\":640,\"rgb\":true},\"mllib\":{\"template\":\"yolox\","
           "\"maxBatchSize\":2,\"maxWorkspaceSize\":256,\"gpuid\":0,"
-          "\"nclasses\":80}}}";
+          "\"nclasses\":81}}}";
   std::string joutstr = japi.jrender(japi.service_create(sname, jstr));
   ASSERT_EQ(created_str, joutstr);
 
@@ -285,7 +285,7 @@ TEST(tensorrtapi, service_predict_bbox_onnx)
   auto &preds = jd["body"]["predictions"][cat_id]["classes"];
   ASSERT_EQ(preds.Size(), 1);
   std::string cl1 = preds[0]["cat"].GetString();
-  ASSERT_EQ(cl1, "15");
+  ASSERT_EQ(cl1, "16");
   ASSERT_TRUE(preds[0]["prob"].GetDouble() > 0.9);
   auto &bbox = preds[0]["bbox"];
   ASSERT_TRUE(bbox["xmin"].GetDouble() < 50 && bbox["xmax"].GetDouble() > 200
@@ -298,7 +298,7 @@ TEST(tensorrtapi, service_predict_bbox_onnx)
   auto &preds2 = jd["body"]["predictions"][dog_id]["classes"];
   ASSERT_EQ(preds2.Size(), 1);
   std::string cl2 = preds2[0]["cat"].GetString();
-  ASSERT_EQ(cl2, "16");
+  ASSERT_EQ(cl2, "17");
   ASSERT_TRUE(preds2[0]["prob"].GetDouble() > 0.8);
   auto &bbox2 = preds[0]["bbox"];
   ASSERT_TRUE(bbox2["xmin"].GetDouble() < 50 && bbox2["xmax"].GetDouble() > 200


### PR DESCRIPTION
YOLOX no longer have a useless class at index 0 (the "background" class)
- works with torch & trt models
- back compatibility with older models
- old torch models are convertible into trt with current script
- pretrained models need to be reexported