### PR TITLE
fix: missing path to cub headers in tensorrt-oss build for jetson nano

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -980,6 +980,7 @@ if (USE_TENSORRT)
       ${TRT_PATCHES_PATH}/0003-c++14.patch
       ${TRT_PATCHES_PATH}/0009-fix_compil_order.patch
       ${TRT_PATCHES_PATH}/0010-fix_plugin_detect.patch
+      ${TRT_PATCHES_PATH}/0011-fix_plugin_makefile_cub.patch
       )
 
     # Tensorrt uses its own protobuf version (3.0.0) and this cannot be overrided

--- a/patches/trt/0011-fix_plugin_makefile_cub.patch
+++ b/patches/trt/0011-fix_plugin_makefile_cub.patch
@@ -1,0 +1,13 @@
+diff --git a/plugin/CMakeLists.txt b/plugin/CMakeLists.txt
+index 562681f..656cf9e 100644
+--- a/plugin/CMakeLists.txt
++++ b/plugin/CMakeLists.txt
+@@ -77,7 +77,7 @@ if(BERT_GENCODES)
+     include_directories(bertQKVToContextPlugin/fused_multihead_attention/include bertQKVToContextPlugin/fused_multihead_attention_v2/include)
+ endif()
+ 
+-include_directories(common common/kernels ${CMAKE_SOURCE_DIR}/third_party)
++include_directories(common common/kernels ${CMAKE_SOURCE_DIR}/third_party ${CMAKE_SOURCE_DIR}/third_party/cub)
+ 
+ foreach(PLUGIN_ITER ${PLUGIN_LISTS})
+     include_directories(${PLUGIN_ITER})


### PR DESCRIPTION
Note: tests are off atm for nano, so here we make sure it still works for regular trt builds.