### PR TITLE
fix: add missing headers in predict_out.hpp

### DIFF
--- a/src/dto/predict_out.hpp
+++ b/src/dto/predict_out.hpp
@@ -22,6 +22,9 @@
 #ifndef DTO_PREDICT_OUT_HPP
 #define DTO_PREDICT_OUT_HPP
 
+#include <opencv2/opencv.hpp>
+#include <opencv2/cudaimgproc.hpp>
+
 #include "oatpp/core/Types.hpp"
 #include "oatpp/core/macro/codegen.hpp"
 


### PR DESCRIPTION
Required when including "predict_out.hpp" alone in an external application