### PR TITLE
fix(torch): OCR predict with native model

### DIFF
--- a/clients/python/tox.ini
+++ b/clients/python/tox.ini
@@ -23,7 +23,7 @@ deps = flake8
        flake8-black
        flake8-blind-except
        flake8-builtins
-       flake8-logging-format
+       # flake8-logging-format
        isort
        # flake8-docstrings
        # flake8-rst-docstrings

--- a/src/backends/torch/torchinputconns.cc
+++ b/src/backends/torch/torchinputconns.cc
@@ -655,26 +655,24 @@ namespace dd
                   }
               }
           }
-        else // shouldLoad
-          {
-            if (_ctc)
-              {
-                int corresp_size = get_corresp_size();
-                if (corresp_size <= 0)
-                  {
-                    throw InputConnectorBadParamException(
-                        "found db but no valid corresp file, remove the db to "
-                        "rebuild it?");
-                  }
-                _alphabet_size = corresp_size;
-              }
-          }
 
         if (createDb)
           {
             _dataset.db_finalize();
             _test_datasets.db_finalize();
           }
+      }
+
+    if (_ctc && _alphabet_size <= 0)
+      {
+        int corresp_size = get_corresp_size();
+        if (corresp_size <= 0)
+          {
+            throw InputConnectorBadParamException(
+                "found db but no valid corresp file, remove the db to "
+                "rebuild it?");
+          }
+        _alphabet_size = corresp_size;
       }
   }
 

--- a/src/backends/torch/torchinputconns.h
+++ b/src/backends/torch/torchinputconns.h
@@ -73,8 +73,8 @@ namespace dd
     TorchInputInterface(const TorchInputInterface &i)
         : _lm_params(i._lm_params), _dataset(i._dataset),
           _test_datasets(i._test_datasets), _input_format(i._input_format),
-          _ctc(i._ctc), _ntargets(i._ntargets), _tilogger(i._tilogger),
-          _db(i._db)
+          _ctc(i._ctc), _ntargets(i._ntargets),
+          _alphabet_size(i._alphabet_size), _tilogger(i._tilogger), _db(i._db)
     {
     }
 

--- a/src/backends/torch/torchlib.cc
+++ b/src/backends/torch/torchlib.cc
@@ -1376,7 +1376,9 @@ namespace dd
     double confidence_threshold = output_params->confidence_threshold;
 
     int best_count = _nclasses;
-    if (output_params->best != nullptr)
+    if (ctc) // ctc = only one result
+      best_count = 1;
+    else if (output_params->best != nullptr)
       best_count = output_params->best;
 
     int best_bbox = output_params->best_bbox;
@@ -1655,8 +1657,6 @@ namespace dd
                     for (int j = 0; j < timestep; ++j)
                       {
                         int cur = indices_acc[j][i][0];
-                        std::cout << "char: " << cur << " ("
-                                  << probs_acc[j][i][0] << ")" << std::endl;
                         if (cur != prev && cur != output_params->blank_label)
                           pred_label_seq.push_back(cur);
                         prev = cur;
@@ -1675,7 +1675,6 @@ namespace dd
                                    std::vector<std::string>{ oss.str() });
                     results_ad.add("probs", std::vector<double>{ prob });
                     results_ad.add("nclasses", (int)_nclasses);
-                    std::cout << "predicted: " << oss.str() << std::endl;
                     results_ads.push_back(results_ad);
                   }
               }
@@ -1985,7 +1984,6 @@ namespace dd
         Tensor labels;
         if (_timeserie)
           {
-
             if (_module._native != nullptr)
               output = _module._native->cleanup_output(output);
             // iterate over data in batch


### PR DESCRIPTION
- Fix inference with OCR native model when recreating the service from a trained model repo.
- Fix a bug affecting all native models: buffers were not reloaded when recreating the service (mostly affecting models with batch norms)