### PR TITLE
chore: ignore faiss warnings

### DIFF
--- a/src/simsearch.cc
+++ b/src/simsearch.cc
@@ -23,7 +23,10 @@
 #include "utils/fileops.hpp"
 #include "utils/utils.hpp"
 #ifdef USE_FAISS
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 #include "faiss/IndexIVF.h"
+#pragma GCC diagnostic pop
 #include "faiss/invlists/OnDiskInvertedLists.h"
 #include "faiss/IndexPreTransform.h"
 #include "faiss/index_factory.h"


### PR DESCRIPTION
```
...
#26 1.876 [ 76%] Building CXX object src/CMakeFiles/ddetect.dir/commandlineapi.cc.o
#26 1.876 [ 76%] Building CXX object src/CMakeFiles/ddetect.dir/backends/xgb/xgblib.cc.o
#26 1.876 [ 77%] Building CXX object src/CMakeFiles/ddetect.dir/backends/xgb/xgbmodel.cc.o
#26 1.877 [ 78%] Building CXX object src/CMakeFiles/ddetect.dir/backends/xgb/xgbinputconns.cc.o
#26 1.878 [ 79%] Building CXX object src/CMakeFiles/ddetect.dir/backends/tsne/tsneinputconns.cc.o
#26 1.879 [ 79%] Building CXX object src/CMakeFiles/ddetect.dir/backends/tsne/tsnelib.cc.o
#26 1.879 [ 80%] Building CXX object src/CMakeFiles/ddetect.dir/simsearch.cc.o
#26 1.880 [ 81%] Building CXX object src/CMakeFiles/ddetect.dir/backends/torch/torchlib.cc.o
#26 1.881 In file included from /opt/deepdetect/build/faiss/src/faiss/faiss/IndexIVF.h:20,
#26 1.881                  from /opt/deepdetect/src/simsearch.cc:26:
#26 1.881 /opt/deepdetect/build/faiss/src/faiss/faiss/impl/IDSelector.h: In member function 'virtual bool faiss::IDSelectorAll::is_member(faiss::IDSelector::idx_t) const':
#26 1.881 /opt/deepdetect/build/faiss/src/faiss/faiss/impl/IDSelector.h:77:26: error: unused parameter 'id' [-Werror=unused-parameter]
#26 1.881    77 |     bool is_member(idx_t id) const override {
#26 1.881       |                    ~~~~~~^~
#26 1.881 cc1plus: all warnings being treated as errors
#26 1.881 make[2]: *** [src/CMakeFiles/ddetect.dir/build.make:566: src/CMakeFiles/ddetect.dir/simsearch.cc.o] Error 1
#26 1.881 make[2]: *** Waiting for unfinished jobs....
#26 1.896 make[1]: *** [CMakeFiles/Makefile2:519: src/CMakeFiles/ddetect.dir/all] Error 2
```