### PR TITLE
chore(torch): speedup dataset creation for bbox case

### DIFF
--- a/src/backends/torch/torchdataset.cc
+++ b/src/backends/torch/torchdataset.cc
@@ -152,6 +152,7 @@ namespace dd
     std::ostringstream tstream;
     torch::save(target, tstream);
 
+#pragma omp ordered
     write_image_to_db(dstream, tstream, bgr.rows, bgr.cols);
   }
 
@@ -257,6 +258,7 @@ namespace dd
       {
         // to tensor
         at::Tensor imgt = image_to_tensor(bgr, height, width);
+#pragma omp ordered
         add_batch({ imgt }, targett);
       }
     else

--- a/src/backends/torch/torchinputconns.cc
+++ b/src/backends/torch/torchinputconns.cc
@@ -444,6 +444,7 @@ namespace dd
                     split_dataset<std::string>(lfiles, tests_lfiles[0]);
                   }
 
+#pragma omp parallel for ordered schedule(static, 1)
                 for (const std::pair<std::string, std::string> &lfile : lfiles)
                   {
                     _dataset.add_image_bbox_file(lfile.first, lfile.second,
@@ -458,6 +459,7 @@ namespace dd
                   }
 
                 for (size_t i = 0; i < tests_lfiles.size(); ++i)
+#pragma omp parallel for ordered schedule(static, 1)
                   for (const std::pair<std::string, std::string> &lfile :
                        tests_lfiles[i])
                     _test_datasets[i].add_image_bbox_file(


### PR DESCRIPTION
process entries in parallel and reorder just before insertion into vector or db