### PR TITLE
Add the list of labels for a model service to the output of /services/<name>

### DIFF
--- a/src/mlservice.h
+++ b/src/mlservice.h
@@ -247,6 +247,15 @@ namespace dd
               ad.add("width", this->_inputc.width());
               ad.add("height", this->_inputc.height());
             }
+          if (!this->_mlmodel._hcorresp.empty())
+            {
+              std::vector<std::string> labels(this->_mlmodel._hcorresp.size());
+              for (const auto &kv : this->_mlmodel._hcorresp)
+                {
+                  labels.push_back(kv.second);
+                }
+              ad.add("labels", labels);
+            }
         }
       this->_stats.to(ad);
       return ad;

--- a/src/mlservice.h
+++ b/src/mlservice.h
@@ -247,15 +247,6 @@ namespace dd
               ad.add("width", this->_inputc.width());
               ad.add("height", this->_inputc.height());
             }
-          if (!this->_mlmodel._hcorresp.empty())
-            {
-              std::vector<std::string> labels(this->_mlmodel._hcorresp.size());
-              for (const auto &kv : this->_mlmodel._hcorresp)
-                {
-                  labels.push_back(kv.second);
-                }
-              ad.add("labels", labels);
-            }
         }
       this->_stats.to(ad);
       return ad;
@@ -304,6 +295,16 @@ namespace dd
         ad.add("type", std::string("unsupervised"));
       else
         ad.add("type", std::string("supervised"));
+      if (!this->_mlmodel._hcorresp.empty())
+        {
+          std::vector<std::string> labels;
+          labels.reserve(this->_mlmodel._hcorresp.size());
+          for (const auto &kv : this->_mlmodel._hcorresp)
+            {
+              labels.push_back(kv.second);
+            }
+          ad.add("labels", labels);
+        }
       this->_stats.to(ad);
       return ad;
     }


### PR DESCRIPTION
This adds the full list of labels from the corresp.txt file (if present) for the service model when the `/services/<name>` endpoint is hit. E.g.

```
curl -X GET http://localhost:8080/services/placeshybrid | jq
```
produces the following with this change:
```
{
  "status": {
    "code": 200,
    "msg": "OK"
  },
  "body": {
    "mltype": "classification",
    "jobs": [],
    "stats": {
      "data_mem_test": 1152129720,
      "data_mem_train": 0,
      "params": 139839168,
      "flops": 15471759360
    },
    "service_stats": {
      "avg_transform_duration": 0.03255472,
      "avg_predict_duration": 0.837866442,
      "avg_transform_duration_s": 0.03255472,
      "avg_predict_duration_s": 0.837866442,
      "avg_transform_duration_ms": 32.55472,
      "avg_predict_duration_ms": 837.866442,
      "avg_batch_size": 1,
      "total_transform_duration_ms": 32.55472,
      "predict_failure": 0,
      "total_predict_duration_ms": 837.866442,
      "predict_count": 1,
      "predict_success": 1,
      "inference_count": 1
    },
    "labels": [
      "zen garden",
      "youth hostel",
      "yard",
      "windmill",
      "wind farm",
      "wheat field",
      "wet bar",
      "wave",
      "watering hole",
      "waterfall",
      "water tower",
      "water park",
      "waiting room",
      "volleyball court outdoor",
      "volcano",
      "vineyard",
      "village",
      "viaduct",
      "veterinarians office",
      "vegetable garden",
      "valley",
      "utility room",
      "underwater ocean deep",
      "tundra",
      "trench",
      "tree house",
      "tree farm",
      "train station platform",
      "train interior",
      "toyshop",
      "tower",
      "topiary garden",
      "ticket booth",
      "throne room",
      "temple asia",
      "television studio",
      "television room",
      "synagogue outdoor",
      "swimming pool outdoor",
      "swimming pool indoor",
      "swimming hole",
      "swamp",
      "sushi bar",
      "supermarket",
      "subway station platform",
      "street",
      "storage room",
      "staircase",
      "stage outdoor",
      "stage indoor",
      "stadium soccer",
      "stadium football",
      "stadium baseball",
      "stable",
      "soccer field",
      "snowfield",
      "slum",
      "skyscraper",
      "sky",
      "ski slope",
      "ski resort",
      "shower",
      "shopping mall indoor",
      "shopfront",
      "shoe shop",
      "shed",
      "server room",
      "science museum",
      "schoolhouse",
      "sauna",
      "sandbox",
      "runway",
      "ruin",
      "rope bridge",
      "roof garden",
      "rock arch",
      "river",
      "rice paddy",
      "restaurant patio",
      "restaurant kitchen",
      "restaurant",
      "residential neighborhood",
      "repair shop",
      "recreation room",
      "reception",
      "rainforest",
      "railroad track",
      "raft",
      "raceway",
      "racecourse",
      "pub indoor",
      "promenade",
      "porch",
      "pond",
      "plaza",
      "playroom",
      "playground",
      "pizzeria",
      "pier",
      "picnic area",
      "physics laboratory",
      "phone booth",
      "pharmacy",
      "pet shop",
      "pavilion",
      "patio",
      "pasture",
      "parking lot",
      "parking garage outdoor",
      "parking garage indoor",
      "park",
      "pantry",
      "palace",
      "pagoda",
      "orchestra pit",
      "orchard",
      "operating room",
      "oilrig",
      "office cubicles",
      "office building",
      "office",
      "ocean",
      "oast house",
      "nursing home",
      "nursery",
      "natural history museum",
      "music studio",
      "museum outdoor",
      "museum indoor",
      "movie theater indoor",
      "mountain snowy",
      "mountain path",
      "mountain",
      "motel",
      "mosque outdoor",
      "moat water",
      "mezzanine",
      "medina",
      "mausoleum",
      "martial arts gym",
      "marsh",
      "market outdoor",
      "market indoor",
      "manufactured home",
      "mansion",
      "locker room",
      "lock chamber",
      "lobby",
      "loading dock",
      "living room",
      "lighthouse",
      "library outdoor",
      "library indoor",
      "legislative chamber",
      "lecture room",
      "lawn",
      "laundromat",
      "landing deck",
      "landfill",
      "lake natural",
      "lagoon",
      "kitchen",
      "kindergarden classroom",
      "kennel outdoor",
      "kasbah",
      "junkyard",
      "jewelry shop",
      "japanese garden",
      "jail cell",
      "jacuzzi indoor",
      "islet",
      "inn outdoor",
      "industrial area",
      "igloo",
      "iceberg",
      "ice skating rink outdoor",
      "ice skating rink indoor",
      "ice shelf",
      "ice floe",
      "ice cream parlor",
      "hunting lodge outdoor",
      "house",
      "hotel room",
      "hotel outdoor",
      "hot spring",
      "hospital room",
      "hospital",
      "home theater",
      "home office",
      "highway",
      "heliport",
      "hayfield",
      "hardware store",
      "harbor",
      "hangar outdoor",
      "hangar indoor",
      "gymnasium indoor",
      "grotto",
      "greenhouse outdoor",
      "greenhouse indoor",
      "golf course",
      "glacier",
      "gift shop",
      "general store outdoor",
      "general store indoor",
      "gazebo exterior",
      "gas station",
      "garage outdoor",
      "garage indoor",
      "galley",
      "fountain",
      "formal garden",
      "forest road",
      "forest path",
      "forest broadleaf",
      "football field",
      "food court",
      "florist shop indoor",
      "flea market indoor",
      "fishpond",
      "fire station",
      "fire escape",
      "field road",
      "field wild",
      "field cultivated",
      "fastfood restaurant",
      "farm",
      "fabric store",
      "excavation",
      "escalator indoor",
      "entrance hall",
      "engine room",
      "embassy",
      "elevator shaft",
      "elevator lobby",
      "elevator door",
      "drugstore",
      "driveway",
      "dressing room",
      "downtown",
      "dorm room",
      "doorway outdoor",
      "discotheque",
      "dining room",
      "dining hall",
      "diner outdoor",
      "desert road",
      "desert vegetation",
      "desert sand",
      "department store",
      "delicatessen",
      "dam",
      "crosswalk",
      "crevasse",
      "creek",
      "courtyard",
      "drilling platform, offshore rig",
      "doormat, welcome mat",
      "dome",
      "dogsled, dog sled, dog sleigh",
      "dock, dockage, docking facility",
      "disk brake, disc brake",
      "dishwasher, dish washer, dishwashing machine",
      "dishrag, dishcloth",
      "dining table, board",
      "digital watch",
      "digital clock",
      "diaper, nappy, napkin",
      "dial telephone, dial phone",
      "desktop computer",
      "desk",
      "dam, dike, dyke",
      "cuirass",
      "crutch",
      "croquet ball",
      "Crock Pot",
      "crib, cot",
      "crate",
      "crash helmet",
      "crane",
      "cradle",
      "cowboy hat, ten-gallon hat",
      "cowboy boot",
      "cornet, horn, trumpet, trump",
      "corkscrew, bottle screw",
      "convertible",
      "container ship, containership, container vessel",
      "confectionery, confectionary, candy store",
      "computer keyboard, keypad",
      "combination lock",
      "coil, spiral, volute, whorl, helix",
      "coffeepot",
      "coffee mug",
      "cocktail shaker",
      "clog, geta, patten, sabot",
      "cloak",
      "cliff dwelling",
      "cleaver, meat cleaver, chopper",
      "cinema, movie theater, movie theatre, movie house, picture palace",
      "church, church building",
      "Christmas stocking",
      "china cabinet, china closet",
      "chime, bell, gong",
      "chiffonier, commode",
      "chest",
      "chain saw, chainsaw",
      "chain mail, ring mail, mail, chain armor, chain armour, ring armor, ring armour",
      "chainlink fence",
      "chain",
      "cellular telephone, cellular phone, cellphone, cell, mobile phone",
      "cello, violoncello",
      "CD player",
      "catamaran",
      "castle",
      "cassette player",
      "cassette",
      "cash machine, cash dispenser, automated teller machine, automatic teller machine, automated teller, automatic teller, ATM",
      "car wheel",
      "carton",
      "carpenter's kit, tool kit",
      "carousel, carrousel, merry-go-round, roundabout, whirligig",
      "car mirror",
      "cardigan",
      "can opener, tin opener",
      "canoe",
      "cannon",
      "candle, taper, wax light",
      "caldron, cauldron",
      "cab, hack, taxi, taxicab",
      "butcher shop, meat market",
      "bullet train, bullet",
      "bulletproof vest",
      "buckle",
      "bucket, pail",
      "broom",
      "breastplate, aegis, egis",
      "breakwater, groin, groyne, mole, bulwark, seawall, jetty",
      "brassiere, bra, bandeau",
      "brass, memorial tablet, plaque",
      "bow tie, bow-tie, bowtie",
      "bow",
      "bottlecap",
      "bookshop, bookstore, bookstall",
      "bookcase",
      "bonnet, poke bonnet",
      "bolo tie, bolo, bola tie, bola",
      "bobsled, bobsleigh, bob",
      "boathouse",
      "birdhouse",
      "binoculars, field glasses, opera glasses",
      "binder, ring-binder",
      "bikini, two-piece",
      "bicycle-built-for-two, tandem bicycle, tandem",
      "bib",
      "bell cote, bell cot",
      "beer glass",
      "beer bottle",
      "bearskin, busby, shako",
      "beaker",
      "beacon, lighthouse, beacon light, pharos",
      "beach wagon, station wagon, wagon, estate car, beach waggon, station waggon, waggon",
      "bathtub, bathing tub, bath, tub",
      "bath towel",
      "bathing cap, swimming cap",
      "bassoon",
      "bassinet",
      "basketball",
      "baseball",
      "barrow, garden cart, lawn cart, wheelbarrow",
      "barrel, cask",
      "barometer",
      "barn",
      "barbershop",
      "barber chair",
      "barbell",
      "bannister, banister, balustrade, balusters, handrail",
      "banjo",
      "Band Aid",
      "ballpoint, ballpoint pen, ballpen, Biro",
      "balloon",
      "balance beam, beam",
      "bakery, bakeshop, bakehouse",
      "backpack, back pack, knapsack, packsack, rucksack, haversack",
      "assault rifle, assault gun",
      "ashcan, trash can, garbage can, wastebin, ash bin, ash-bin, ashbin, dustbin, trash barrel, trash bin",
      "apron",
      "apiary, bee house",
      "analog clock",
      "amphibian, amphibious vehicle",
      "ambulance",
      "altar",
      "airship, dirigible",
      "airliner",
      "aircraft carrier, carrier, flattop, attack aircraft carrier",
      "acoustic guitar",
      "accordion, piano accordion, squeeze box",
      "academic gown, academic robe, judge's robe",
      "abaya",
      "abacus",
      "puffer, pufferfish, blowfish, globefish",
      "lionfish",
      "gar, garfish, garpike, billfish, Lepisosteus osseus",
      "sturgeon",
      "anemone fish",
      "rock beauty, Holocanthus tricolor",
      "coho, cohoe, coho salmon, blue jack, silver salmon, Oncorhynchus kisutch",
      "eel",
      "barracouta, snoek",
      "giant panda, panda, panda bear, coon bear, Ailuropoda melanoleuca",
      "lesser panda, red panda, panda, bear cat, cat bear, Ailurus fulgens",
      "African elephant, Loxodonta africana",
      "Indian elephant, Elephas maximus",
      "indri, indris, Indri indri, Indri brevicaudatus",
      "Madagascar cat, ring-tailed lemur, Lemur catta",
      "squirrel monkey, Saimiri sciureus",
      "spider monkey, Ateles geoffroyi",
      "titi, titi monkey",
      "howler monkey, howler",
      "capuchin, ringtail, Cebus capucinus",
      "marmoset",
      "proboscis monkey, Nasalis larvatus",
      "colobus, colobus monkey",
      "langur",
      "macaque",
      "baboon",
      "patas, hussar monkey, Erythrocebus patas",
      "guenon, guenon monkey",
      "siamang, Hylobates syndactylus, Symphalangus syndactylus",
      "gibbon, Hylobates lar",
      "chimpanzee, chimp, Pan troglodytes",
      "gorilla, Gorilla gorilla",
      "orangutan, orang, orangutang, Pongo pygmaeus",
      "three-toed sloth, ai, Bradypus tridactylus",
      "armadillo",
      "badger",
      "skunk, polecat, wood pussy",
      "otter",
      "black-footed ferret, ferret, Mustela nigripes",
      "polecat, fitch, foulmart, foumart, Mustela putorius",
      "mink",
      "weasel",
      "llama",
      "Arabian camel, dromedary, Camelus dromedarius",
      "gazelle",
      "impala, Aepyceros melampus",
      "hartebeest",
      "ibex, Capra ibex",
      "bighorn, bighorn sheep, cimarron, Rocky Mountain bighorn, Rocky Mountain sheep, Ovis canadensis",
      "ram, tup",
      "bison",
      "water buffalo, water ox, Asiatic buffalo, Bubalus bubalis",
      "ox",
      "hippopotamus, hippo, river horse, Hippopotamus amphibius",
      "warthog",
      "wild boar, boar, Sus scrofa",
      "hog, pig, grunter, squealer, Sus scrofa",
      "zebra",
      "sorrel",
      "guinea pig, Cavia cobaya",
      "beaver",
      "marmot",
      "fox squirrel, eastern fox squirrel, Sciurus niger",
      "porcupine, hedgehog",
      "hamster",
      "Angora, Angora rabbit",
      "hare",
      "wood rabbit, cottontail, cottontail rabbit",
      "sea cucumber, holothurian",
      "sea urchin",
      "starfish, sea star",
      "lycaenid, lycaenid butterfly",
      "sulphur butterfly, sulfur butterfly",
      "cabbage butterfly",
      "monarch, monarch butterfly, milkweed butterfly, Danaus plexippus",
      "ringlet, ringlet butterfly",
      "admiral",
      "damselfly",
      "dragonfly, darning needle, devil's darning needle, sewing needle, snake feeder, snake doctor, mosquito hawk, skeeter hawk",
      "lacewing, lacewing fly",
      "leafhopper",
      "cicada, cicala",
      "mantis, mantid",
      "cockroach, roach",
      "walking stick, walkingstick, stick insect",
      "cricket",
      "grasshopper, hopper",
      "ant, emmet, pismire",
      "bee",
      "fly",
      "weevil",
      "rhinoceros beetle",
      "dung beetle",
      "leaf beetle, chrysomelid",
      "long-horned beetle, longicorn, longicorn beetle",
      "ground beetle, carabid beetle",
      "ladybug, ladybeetle, lady beetle, ladybird, ladybird beetle",
      "tiger beetle",
      "meerkat, mierkat",
      "mongoose",
      "sloth bear, Melursus ursinus, Ursus ursinus",
      "ice bear, polar bear, Ursus Maritimus, Thalarctos maritimus",
      "American black bear, black bear, Ursus americanus, Euarctos americanus",
      "brown bear, bruin, Ursus arctos",
      "cheetah, chetah, Acinonyx jubatus",
      "tiger, Panthera tigris",
      "lion, king of beasts, Panthera leo",
      "jaguar, panther, Panthera onca, Felis onca",
      "snow leopard, ounce, Panthera uncia",
      "leopard, Panthera pardus",
      "lynx, catamount",
      "cougar, puma, catamount, mountain lion, painter, panther, Felis concolor",
      "Egyptian cat",
      "Siamese cat, Siamese",
      "Persian cat",
      "tiger cat",
      "tabby, tabby cat",
      "grey fox, gray fox, Urocyon cinereoargenteus",
      "Arctic fox, white fox, Alopex lagopus",
      "kit fox, Vulpes macrotis",
      "red fox, Vulpes vulpes",
      "hyena, hyaena",
      "African hunting dog, hyena dog, Cape hunting dog, Lycaon pictus",
      "dhole, Cuon alpinus",
      "dingo, warrigal, warragal, Canis dingo",
      "coyote, prairie wolf, brush wolf, Canis latrans",
      "red wolf, maned wolf, Canis rufus, Canis niger",
      "white wolf, Arctic wolf, Canis lupus tundrarum",
      "timber wolf, grey wolf, gray wolf, Canis lupus",
      "Mexican hairless",
      "standard poodle",
      "miniature poodle",
      "toy poodle",
      "Cardigan, Cardigan Welsh corgi",
      "Pembroke, Pembroke Welsh corgi",
      "Brabancon griffon",
      "keeshond",
      "chow, chow chow",
      "Pomeranian",
      "Samoyed, Samoyede",
      "Great Pyrenees",
      "isopod",
      "hermit crab",
      "crayfish, crawfish, crawdad, crawdaddy",
      "spiny lobster, langouste, rock lobster, crawfish, crayfish, sea crawfish",
      "American lobster, Northern lobster, Maine lobster, Homarus americanus",
      "king crab, Alaska crab, Alaskan king crab, Alaska king crab, Paralithodes camtschatica",
      "fiddler crab",
      "rock crab, Cancer irroratus",
      "Dungeness crab, Cancer magister",
      "chambered nautilus, pearly nautilus, nautilus",
      "chiton, coat-of-mail shell, sea cradle, polyplacophore",
      "sea slug, nudibranch",
      "slug",
      "snail",
      "conch",
      "nematode, nematode worm, roundworm",
      "flatworm, platyhelminth",
      "brain coral",
      "sea anemone, anemone",
      "jellyfish",
      "wombat",
      "koala, koala bear, kangaroo bear, native bear, Phascolarctos cinereus",
      "wallaby, brush kangaroo",
      "platypus, duckbill, duckbilled platypus, duck-billed platypus, Ornithorhynchus anatinus",
      "echidna, spiny anteater, anteater",
      "tusker",
      "black swan, Cygnus atratus",
      "goose",
      "red-breasted merganser, Mergus serrator",
      "drake",
      "toucan",
      "jacamar",
      "hummingbird",
      "hornbill",
      "bee eater",
      "coucal",
      "lorikeet",
      "sulphur-crested cockatoo, Kakatoe galerita, Cacatua galerita",
      "macaw",
      "African grey, African gray, Psittacus erithacus",
      "partridge",
      "quail",
      "peacock",
      "prairie chicken, prairie grouse, prairie fowl",
      "ruffed grouse, partridge, Bonasa umbellus",
      "ptarmigan",
      "black grouse",
      "centipede",
      "tick",
      "wolf spider, hunting spider",
      "tarantula",
      "black widow, Latrodectus mactans",
      "garden spider, Aranea diademata",
      "barn spider, Araneus cavaticus",
      "black and gold garden spider, Argiope aurantia",
      "scorpion",
      "harvestman, daddy longlegs, Phalangium opilio",
      "trilobite",
      "sidewinder, horned rattlesnake, Crotalus cerastes",
      "diamondback, diamondback rattlesnake, Crotalus adamanteus",
      "horned viper, cerastes, sand viper, horned asp, Cerastes cornutus",
      "sea snake",
      "green mamba",
      "Indian cobra, Naja naja",
      "rock python, rock snake, Python sebae",
      "boa constrictor, Constrictor constrictor",
      "night snake, Hypsiglena torquata",
      "vine snake",
      "spotted salamander, Ambystoma maculatum",
      "eft",
      "common newt, Triturus vulgaris",
      "European fire salamander, Salamandra salamandra",
      "great grey owl, great gray owl, Strix nebulosa",
      "vulture",
      "bald eagle, American eagle, Haliaeetus leucocephalus",
      "kite",
      "water ouzel, dipper",
      "chickadee",
      "magpie",
      "jay",
      "bulbul",
      "robin, American robin, Turdus migratorius",
      "indigo bunting, indigo finch, indigo bird, Passerina cyanea",
      "junco, snowbird",
      "tench, Tinca tinca",
      "goldfish, Carassius auratus",
      "great white shark, white shark, man-eater, man-eating shark, Carcharodon carcharias",
      "tiger shark, Galeocerdo cuvieri",
      "hammerhead, hammerhead shark",
      "electric ray, crampfish, numbfish, torpedo",
      "stingray",
      "cock",
      "hen",
      "ostrich, Struthio camelus",
      "brambling, Fringilla montifringilla",
      "goldfinch, Carduelis carduelis",
      "house finch, linnet, Carpodacus mexicanus",
      "axolotl, mud puppy, Ambystoma mexicanum",
      "bullfrog, Rana catesbeiana",
      "tree frog, tree-frog",
      "tailed frog, bell toad, ribbed toad, tailed toad, Ascaphus trui",
      "loggerhead, loggerhead turtle, Caretta caretta",
      "leatherback turtle, leatherback, leathery turtle, Dermochelys coriacea",
      "mud turtle",
      "terrapin",
      "box turtle, box tortoise",
      "banded gecko",
      "common iguana, iguana, Iguana iguana",
      "American chameleon, anole, Anolis carolinensis",
      "whiptail, whiptail lizard",
      "agama",
      "frilled lizard, Chlamydosaurus kingi",
      "alligator lizard",
      "Gila monster, Heloderma suspectum",
      "green lizard, Lacerta viridis",
      "African chameleon, Chamaeleo chamaeleon",
      "Komodo dragon, Komodo lizard, dragon lizard, giant lizard, Varanus komodoensis",
      "African crocodile, Nile crocodile, Crocodylus niloticus",
      "American alligator, Alligator mississipiensis",
      "triceratops",
      "thunder snake, worm snake, Carphophis amoenus",
      "ringneck snake, ring-necked snake, ring snake",
      "hognose snake, puff adder, sand viper",
      "green snake, grass snake",
      "king snake, kingsnake",
      "garter snake, grass snake",
      "water snake",
      "white stork, Ciconia ciconia",
      "black stork, Ciconia nigra",
      "spoonbill",
      "flamingo",
      "little blue heron, Egretta caerulea",
      "American egret, great white heron, Egretta albus",
      "bittern",
      "crane",
      "limpkin, Aramus pictus",
      "European gallinule, Porphyrio porphyrio",
      "American coot, marsh hen, mud hen, water hen, Fulica americana",
      "bustard",
      "ruddy turnstone, Arenaria interpres",
      "red-backed sandpiper, dunlin, Erolia alpina",
      "redshank, Tringa totanus",
      "dowitcher",
      "oystercatcher, oyster catcher",
      "pelican",
      "king penguin, Aptenodytes patagonica",
      "albatross, mollymawk",
      "grey whale, gray whale, devilfish, Eschrichtius gibbosus, Eschrichtius robustus",
      "killer whale, killer, orca, grampus, sea wolf, Orcinus orca",
      "dugong, Dugong dugon",
      "sea lion",
      "Chihuahua",
      "Japanese spaniel",
      "Maltese dog, Maltese terrier, Maltese",
      "Pekinese, Pekingese, Peke",
      "Shih-Tzu",
      "Blenheim spaniel",
      "papillon",
      "toy terrier",
      "Rhodesian ridgeback",
      "Afghan hound, Afghan",
      "basset, basset hound",
      "beagle",
      "bloodhound, sleuthhound",
      "bluetick",
      "black-and-tan coonhound",
      "Walker hound, Walker foxhound",
      "English foxhound",
      "redbone",
      "borzoi, Russian wolfhound",
      "Irish wolfhound",
      "Italian greyhound",
      "whippet",
      "Ibizan hound, Ibizan Podenco",
      "Norwegian elkhound, elkhound",
      "otterhound, otter hound",
      "Saluki, gazelle hound",
      "Scottish deerhound, deerhound",
      "Weimaraner",
      "Staffordshire bullterrier, Staffordshire bull terrier",
      "American Staffordshire terrier, Staffordshire terrier, American pit bull terrier, pit bull terrier",
      "Bedlington terrier",
      "Border terrier",
      "Kerry blue terrier",
      "Irish terrier",
      "Norfolk terrier",
      "Norwich terrier",
      "Yorkshire terrier",
      "wire-haired fox terrier",
      "Lakeland terrier",
      "Sealyham terrier, Sealyham",
      "Airedale, Airedale terrier",
      "cairn, cairn terrier",
      "Australian terrier",
      "Dandie Dinmont, Dandie Dinmont terrier",
      "Boston bull, Boston terrier",
      "miniature schnauzer",
      "giant schnauzer",
      "standard schnauzer",
      "Scotch terrier, Scottish terrier, Scottie",
      "Tibetan terrier, chrysanthemum dog",
      "silky terrier, Sydney silky",
      "soft-coated wheaten terrier",
      "West Highland white terrier",
      "Lhasa, Lhasa apso",
      "flat-coated retriever",
      "curly-coated retriever",
      "golden retriever",
      "Labrador retriever",
      "Chesapeake Bay retriever",
      "German short-haired pointer",
      "vizsla, Hungarian pointer",
      "English setter",
      "Irish setter, red setter",
      "Gordon setter",
      "Brittany spaniel",
      "clumber, clumber spaniel",
      "English springer, English springer spaniel",
      "Welsh springer spaniel",
      "cocker spaniel, English cocker spaniel, cocker",
      "Sussex spaniel",
      "Irish water spaniel",
      "kuvasz",
      "schipperke",
      "groenendael",
      "malinois",
      "briard",
      "kelpie",
      "komondor",
      "Old English sheepdog, bobtail",
      "Shetland sheepdog, Shetland sheep dog, Shetland",
      "collie",
      "Border collie",
      "Bouvier des Flandres, Bouviers des Flandres",
      "Rottweiler",
      "German shepherd, German shepherd dog, German police dog, alsatian",
      "Doberman, Doberman pinscher",
      "miniature pinscher",
      "Greater Swiss Mountain dog",
      "Bernese mountain dog",
      "Appenzeller",
      "EntleBucher",
      "boxer",
      "bull mastiff",
      "Tibetan mastiff",
      "French bulldog",
      "Great Dane",
      "Saint Bernard, St Bernard",
      "Eskimo dog, husky",
      "malamute, malemute, Alaskan malamute",
      "Siberian husky",
      "dalmatian, coach dog, carriage dog",
      "affenpinscher, monkey pinscher, monkey dog",
      "basenji",
      "pug, pug-dog",
      "Leonberg",
      "Newfoundland, Newfoundland dog",
      "drum, membranophone, tympan",
      "drumstick",
      "dumbbell",
      "Dutch oven",
      "electric fan, blower",
      "electric guitar",
      "electric locomotive",
      "entertainment center",
      "envelope",
      "espresso maker",
      "face powder",
      "feather boa, boa",
      "file, file cabinet, filing cabinet",
      "fireboat",
      "fire engine, fire truck",
      "fire screen, fireguard",
      "flagpole, flagstaff",
      "flute, transverse flute",
      "folding chair",
      "football helmet",
      "forklift",
      "fountain",
      "fountain pen",
      "four-poster",
      "freight car",
      "French horn, horn",
      "frying pan, frypan, skillet",
      "fur coat",
      "garbage truck, dustcart",
      "gasmask, respirator, gas helmet",
      "gas pump, gasoline pump, petrol pump, island dispenser",
      "goblet",
      "go-kart",
      "golf ball",
      "golfcart, golf cart",
      "gondola",
      "gong, tam-tam",
      "gown",
      "grand piano, grand",
      "greenhouse, nursery, glasshouse",
      "grille, radiator grille",
      "grocery store, grocery, food market, market",
      "guillotine",
      "hair slide",
      "hair spray",
      "half track",
      "hammer",
      "hamper",
      "hand blower, blow dryer, blow drier, hair dryer, hair drier",
      "hand-held computer, hand-held microcomputer",
      "handkerchief, hankie, hanky, hankey",
      "hard disc, hard disk, fixed disk",
      "harmonica, mouth organ, harp, mouth harp",
      "harp",
      "harvester, reaper",
      "hatchet",
      "holster",
      "home theater, home theatre",
      "honeycomb",
      "hook, claw",
      "hoopskirt, crinoline",
      "horizontal bar, high bar",
      "horse cart, horse-cart",
      "hourglass",
      "iPod",
      "iron, smoothing iron",
      "jack-o'-lantern",
      "jean, blue jean, denim",
      "jeep, landrover",
      "jersey, T-shirt, tee shirt",
      "jigsaw puzzle",
      "jinrikisha, ricksha, rickshaw",
      "joystick",
      "kimono",
      "knee pad",
      "knot",
      "lab coat, laboratory coat",
      "ladle",
      "lampshade, lamp shade",
      "laptop, laptop computer",
      "lawn mower, mower",
      "lens cap, lens cover",
      "letter opener, paper knife, paperknife",
      "library",
      "lifeboat",
      "lighter, light, igniter, ignitor",
      "limousine, limo",
      "liner, ocean liner",
      "lipstick, lip rouge",
      "Loafer",
      "lotion",
      "loudspeaker, speaker, speaker unit, loudspeaker system, speaker system",
      "loupe, jeweler's loupe",
      "lumbermill, sawmill",
      "magnetic compass",
      "mailbag, postbag",
      "mailbox, letter box",
      "maillot",
      "maillot, tank suit",
      "manhole cover",
      "maraca",
      "marimba, xylophone",
      "mask",
      "matchstick",
      "maypole",
      "maze, labyrinth",
      "measuring cup",
      "medicine chest, medicine cabinet",
      "megalith, megalithic structure",
      "microphone, mike",
      "microwave, microwave oven",
      "military uniform",
      "milk can",
      "minibus",
      "miniskirt, mini",
      "minivan",
      "missile",
      "mitten",
      "mixing bowl",
      "mobile home, manufactured home",
      "Model T",
      "modem",
      "monastery",
      "monitor",
      "moped",
      "mortar",
      "mortarboard",
      "mosque",
      "mosquito net",
      "motor scooter, scooter",
      "mountain bike, all-terrain bike, off-roader",
      "mountain tent",
      "mouse, computer mouse",
      "mousetrap",
      "moving van",
      "muzzle",
      "nail",
      "neck brace",
      "necklace",
      "nipple",
      "notebook, notebook computer",
      "obelisk",
      "oboe, hautboy, hautbois",
      "ocarina, sweet potato",
      "odometer, hodometer, mileometer, milometer",
      "oil filter",
      "organ, pipe organ",
      "oscilloscope, scope, cathode-ray oscilloscope, CRO",
      "overskirt",
      "oxcart",
      "oxygen mask",
      "packet",
      "paddle, boat paddle",
      "paddlewheel, paddle wheel",
      "padlock",
      "paintbrush",
      "pajama, pyjama, pj's, jammies",
      "palace",
      "panpipe, pandean pipe, syrinx",
      "paper towel",
      "parachute, chute",
      "parallel bars, bars",
      "park bench",
      "parking meter",
      "passenger car, coach, carriage",
      "patio, terrace",
      "pay-phone, pay-station",
      "pedestal, plinth, footstall",
      "pencil box, pencil case",
      "pencil sharpener",
      "perfume, essence",
      "Petri dish",
      "photocopier",
      "pick, plectrum, plectron",
      "pickelhaube",
      "picket fence, paling",
      "pickup, pickup truck",
      "pier",
      "piggy bank, penny bank",
      "pill bottle",
      "pillow",
      "ping-pong ball",
      "pinwheel",
      "pirate, pirate ship",
      "pitcher, ewer",
      "plane, carpenter's plane, woodworking plane",
      "planetarium",
      "plastic bag",
      "plate rack",
      "plow, plough",
      "plunger, plumber's helper",
      "Polaroid camera, Polaroid Land camera",
      "pole",
      "police van, police wagon, paddy wagon, patrol wagon, wagon, black Maria",
      "poncho",
      "pool table, billiard table, snooker table",
      "pop bottle, soda bottle",
      "pot, flowerpot",
      "potter's wheel",
      "power drill",
      "prayer rug, prayer mat",
      "printer",
      "prison, prison house",
      "projectile, missile",
      "projector",
      "puck, hockey puck",
      "punching bag, punch bag, punching ball, punchball",
      "purse",
      "quill, quill pen",
      "quilt, comforter, comfort, puff",
      "racer, race car, racing car",
      "racket, racquet",
      "radiator",
      "radio, wireless",
      "radio telescope, radio reflector",
      "rain barrel",
      "recreational vehicle, RV, R.V.",
      "reel",
      "reflex camera",
      "refrigerator, icebox",
      "remote control, remote",
      "restaurant, eating house, eating place, eatery",
      "revolver, six-gun, six-shooter",
      "rifle",
      "rocking chair, rocker",
      "rotisserie",
      "rubber eraser, rubber, pencil eraser",
      "rugby ball",
      "rule, ruler",
      "running shoe",
      "safe",
      "safety pin",
      "saltshaker, salt shaker",
      "sandal",
      "sarong",
      "sax, saxophone",
      "scabbard",
      "scale, weighing machine",
      "school bus",
      "schooner",
      "scoreboard",
      "screen, CRT screen",
      "screw",
      "screwdriver",
      "seat belt, seatbelt",
      "sewing machine",
      "shield, buckler",
      "shoe shop, shoe-shop, shoe store",
      "shoji",
      "shopping basket",
      "shopping cart",
      "shovel",
      "shower cap",
      "shower curtain",
      "ski",
      "ski mask",
      "sleeping bag",
      "slide rule, slipstick",
      "sliding door",
      "slot, one-armed bandit",
      "snorkel",
      "snowmobile",
      "snowplow, snowplough",
      "soap dispenser",
      "soccer ball",
      "sock",
      "solar dish, solar collector, solar furnace",
      "sombrero",
      "soup bowl",
      "space bar",
      "space heater",
      "space shuttle",
      "spatula",
      "speedboat",
      "spider web, spider's web",
      "spindle",
      "sports car, sport car",
      "spotlight, spot",
      "stage",
      "steam locomotive",
      "steel arch bridge",
      "steel drum",
      "stethoscope",
      "stole",
      "stone wall",
      "stopwatch, stop watch",
      "stove",
      "strainer",
      "streetcar, tram, tramcar, trolley, trolley car",
      "stretcher",
      "studio couch, day bed",
      "stupa, tope",
      "submarine, pigboat, sub, U-boat",
      "suit, suit of clothes",
      "sundial",
      "sunglass",
      "sunglasses, dark glasses, shades",
      "sunscreen, sunblock, sun blocker",
      "suspension bridge",
      "swab, swob, mop",
      "sweatshirt",
      "swimming trunks, bathing trunks",
      "swing",
      "switch, electric switch, electrical switch",
      "syringe",
      "table lamp",
      "tank, army tank, armored combat vehicle, armoured combat vehicle",
      "tape player",
      "teapot",
      "teddy, teddy bear",
      "television, television system",
      "tennis ball",
      "thatch, thatched roof",
      "theater curtain, theatre curtain",
      "thimble",
      "thresher, thrasher, threshing machine",
      "throne",
      "tile roof",
      "toaster",
      "tobacco shop, tobacconist shop, tobacconist",
      "toilet seat",
      "torch",
      "totem pole",
      "tow truck, tow car, wrecker",
      "toyshop",
      "tractor",
      "trailer truck, tractor trailer, trucking rig, rig, articulated lorry, semi",
      "tray",
      "trench coat",
      "tricycle, trike, velocipede",
      "trimaran",
      "tripod",
      "triumphal arch",
      "trolleybus, trolley coach, trackless trolley",
      "trombone",
      "tub, vat",
      "turnstile",
      "typewriter keyboard",
      "umbrella",
      "unicycle, monocycle",
      "upright, upright piano",
      "vacuum, vacuum cleaner",
      "vase",
      "vault",
      "velvet",
      "vending machine",
      "vestment",
      "viaduct",
      "violin, fiddle",
      "volleyball",
      "waffle iron",
      "wall clock",
      "wallet, billfold, notecase, pocketbook",
      "wardrobe, closet, press",
      "warplane, military plane",
      "washbasin, handbasin, washbowl, lavabo, wash-hand basin",
      "washer, automatic washer, washing machine",
      "water bottle",
      "water jug",
      "water tower",
      "whiskey jug",
      "whistle",
      "wig",
      "window screen",
      "window shade",
      "Windsor tie",
      "wine bottle",
      "wing",
      "wok",
      "wooden spoon",
      "wool, woolen, woollen",
      "worm fence, snake fence, snake-rail fence, Virginia fence",
      "wreck",
      "yawl",
      "yurt",
      "web site, website, internet site, site",
      "comic book",
      "crossword puzzle, crossword",
      "street sign",
      "traffic light, traffic signal, stoplight",
      "book jacket, dust cover, dust jacket, dust wrapper",
      "menu",
      "plate",
      "guacamole",
      "consomme",
      "hot pot, hotpot",
      "trifle",
      "ice cream, icecream",
      "ice lolly, lolly, lollipop, popsicle",
      "French loaf",
      "bagel, beigel",
      "pretzel",
      "cheeseburger",
      "hotdog, hot dog, red hot",
      "mashed potato",
      "head cabbage",
      "broccoli",
      "cauliflower",
      "zucchini, courgette",
      "spaghetti squash",
      "acorn squash",
      "butternut squash",
      "cucumber, cuke",
      "artichoke, globe artichoke",
      "bell pepper",
      "cardoon",
      "mushroom",
      "Granny Smith",
      "strawberry",
      "orange",
      "lemon",
      "fig",
      "pineapple, ananas",
      "banana",
      "jackfruit, jak, jack",
      "custard apple",
      "pomegranate",
      "hay",
      "carbonara",
      "chocolate sauce, chocolate syrup",
      "dough",
      "meat loaf, meatloaf",
      "pizza, pizza pie",
      "potpie",
      "burrito",
      "red wine",
      "espresso",
      "cup",
      "eggnog",
      "alp",
      "bubble",
      "cliff, drop, drop-off",
      "coral reef",
      "geyser",
      "lakeside, lakeshore",
      "promontory, headland, head, foreland",
      "sandbar, sand bar",
      "seashore, coast, seacoast, sea-coast",
      "valley, vale",
      "volcano",
      "ballplayer, baseball player",
      "groom, bridegroom",
      "scuba diver",
      "rapeseed",
      "daisy",
      "yellow lady's slipper, yellow lady-slipper, Cypripedium calceolus, Cypripedium parviflorum",
      "corn",
      "acorn",
      "hip, rose hip, rosehip",
      "buckeye, horse chestnut, conker",
      "coral fungus",
      "agaric",
      "gyromitra",
      "stinkhorn, carrion fungus",
      "earthstar",
      "hen-of-the-woods, hen of the woods, Polyporus frondosus, Grifola frondosa",
      "bolete",
      "ear, spike, capitulum",
      "toilet tissue, toilet paper, bathroom tissue",
      "airfield",
      "airplane cabin",
      "airport terminal",
      "alcove",
      "alley",
      "amphitheater",
      "amusement arcade",
      "amusement park",
      "apartment building outdoor",
      "aquarium",
      "aqueduct",
      "arcade",
      "arch",
      "archaelogical excavation",
      "archive",
      "arena hockey",
      "arena performance",
      "arena rodeo",
      "army base",
      "art gallery",
      "art school",
      "art studio",
      "artists loft",
      "assembly line",
      "athletic field outdoor",
      "atrium public",
      "attic",
      "auditorium",
      "auto factory",
      "auto showroom",
      "badlands",
      "bakery shop",
      "balcony exterior",
      "balcony interior",
      "ball pit",
      "ballroom",
      "bamboo forest",
      "bank vault",
      "banquet hall",
      "bar",
      "barn",
      "barndoor",
      "baseball field",
      "basement",
      "basketball court indoor",
      "bathroom",
      "bazaar indoor",
      "bazaar outdoor",
      "beach",
      "beach house",
      "beauty salon",
      "bedchamber",
      "bedroom",
      "beer garden",
      "beer hall",
      "berth",
      "biology laboratory",
      "boardwalk",
      "boat deck",
      "boathouse",
      "bookstore",
      "booth indoor",
      "botanical garden",
      "bow window indoor",
      "bowling alley",
      "boxing ring",
      "bridge",
      "building facade",
      "bullring",
      "burial chamber",
      "bus interior",
      "bus station indoor",
      "butchers shop",
      "butte",
      "cabin outdoor",
      "cafeteria",
      "campsite",
      "campus",
      "canal natural",
      "canal urban",
      "candy store",
      "canyon",
      "car interior",
      "carrousel",
      "castle",
      "catacomb",
      "cemetery",
      "chalet",
      "chemistry lab",
      "childs room",
      "church indoor",
      "church outdoor",
      "classroom",
      "clean room",
      "cliff",
      "closet",
      "clothing store",
      "coast",
      "cockpit",
      "coffee shop",
      "computer room",
      "conference center",
      "conference room",
      "construction site",
      "corn field",
      "corral",
      "corridor",
      "cottage",
      "courthouse"
    ],
    "predict": true,
    "parameters": {
      "mllib": {
        "gpu": true,
        "nclasses": 1365
      },
      "input": {
        "height": 224,
        "width": 224,
        "connector": "image"
      }
    },
    "description": "placeshybrid",
    "type": "supervised",
    "repository": "/opt/models/placeshybrid/",
    "model_stats": {
      "data_mem_test": 1152129720,
      "data_mem_train": 0,
      "params": 139839168,
      "flops": 15471759360
    },
    "mllib": "caffe",
    "name": "placeshybrid"
  }
}
```

For some models (like this one), it can result in quite a long output, so I'm open to the possibility of adding a new separate endpoint (perhaps `/services/<name>/labels` or `/services/<name>/categories`) but that was a bigger code change overall. The way it is in this change is easy to pull out programmatically with something like `jq`:

```
curl -X GET http://localhost:8080/services/placeshybrid | jq '.body.labels[]'
```
Currently the categories/labels are returned in no particular order, just from iterating through the `unordered_map` they were stored in originally.