### PR TITLE
fix(torch): add measures to output event when training not done

### DIFF
--- a/src/backends/torch/torchlib.cc
+++ b/src/backends/torch/torchlib.cc
@@ -1291,11 +1291,8 @@ namespace dd
                       }
                   }
 
-                if (elapsed_it == iterations)
-                  {
-                    out.add("measure", meas_out.getobj("measure"));
-                    out.add("measures", meas_out.getv("measures"));
-                  }
+                out.add("measure", meas_out.getobj("measure"));
+                out.add("measures", meas_out.getv("measures"));
               }
 
             train_loss = 0;


### PR DESCRIPTION
an empty metrics field breaks the platform, and metrics field remains empty when the training is stopped early

## TODO

- [x] check that it solves the problem on the platform