### PR TITLE
feat(torch): add inference visualisation at test time

### DIFF
--- a/src/backends/torch/torchlib.cc
+++ b/src/backends/torch/torchlib.cc
@@ -2014,6 +2014,7 @@ namespace dd
   {
     APIData ad_res;
     APIData ad_bbox;
+    APIData ad_res_bbox;
     APIData ad_out = ad.getobj("parameters").getobj("output");
     int nclasses = _masked_lm ? inputc.vocab_size() : _nclasses;
 
@@ -2159,6 +2160,59 @@ namespace dd
                     ad_bbox_per_iou[iou_thres].add(std::to_string(entry_id),
                                                    vbad);
                   }
+
+                // Raw results
+                APIData bad;
+                // predictions
+                auto bboxes_acc = bboxes_tensor.accessor<float, 2>();
+                auto labels_acc = labels_tensor.accessor<int64_t, 1>();
+                auto score_acc = score_tensor.accessor<float, 1>();
+                std::vector<APIData> pred_vad;
+
+                for (int k = 0; k < labels_tensor.size(0); k++)
+                  {
+                    APIData pred_ad;
+                    pred_ad.add("label", labels_acc[k]);
+                    pred_ad.add("prob", static_cast<double>(score_acc[k]));
+                    APIData bbox_ad;
+                    bbox_ad.add("xmin", static_cast<double>(bboxes_acc[k][0]));
+                    bbox_ad.add("ymin", static_cast<double>(bboxes_acc[k][1]));
+                    bbox_ad.add("xmax", static_cast<double>(bboxes_acc[k][2]));
+                    bbox_ad.add("ymax", static_cast<double>(bboxes_acc[k][3]));
+                    pred_ad.add("bbox", bbox_ad);
+                    pred_vad.push_back(pred_ad);
+                  }
+                bad.add("predictions", pred_vad);
+                // targets
+                auto targ_bboxes_acc = targ_bboxes.accessor<float, 2>();
+                auto targ_labels_acc = targ_labels.accessor<int64_t, 1>();
+                std::vector<APIData> targ_vad;
+
+                for (int k = start; k < stop; k++)
+                  {
+                    APIData targ_ad;
+                    targ_ad.add("label", targ_labels_acc[k]);
+                    APIData bbox_ad;
+                    bbox_ad.add("xmin",
+                                static_cast<double>(targ_bboxes_acc[k][0]));
+                    bbox_ad.add("ymin",
+                                static_cast<double>(targ_bboxes_acc[k][1]));
+                    bbox_ad.add("xmax",
+                                static_cast<double>(targ_bboxes_acc[k][2]));
+                    bbox_ad.add("ymax",
+                                static_cast<double>(targ_bboxes_acc[k][3]));
+                    targ_ad.add("bbox", bbox_ad);
+                    targ_vad.push_back(targ_ad);
+                  }
+                bad.add("targets", targ_vad);
+                // pred image
+                std::vector<cv::Mat> img_vec;
+                img_vec.push_back(torch_utils::tensorToImage(
+                    batch.data.at(0).index(
+                        { torch::indexing::Slice(i, i + 1) }),
+                    /* rgb = */ true));
+                bad.add("image", img_vec);
+                ad_res_bbox.add(std::to_string(entry_id), bad);
                 ++entry_id;
               }
           }
@@ -2340,12 +2394,17 @@ namespace dd
                         ad_bbox_per_iou[iou_thres]);
           }
         ad_res.add("0", ad_bbox);
+        // raw bbox results
+        ad_res.add("raw_bboxes", ad_res_bbox);
       }
     else if (_segmentation)
       ad_res.add("segmentation", true);
     ad_res.add("batch_size",
                entry_id); // here batch_size = tested entries count
     SupervisedOutput::measure(ad_res, ad_out, out, test_id, test_name);
+    SupervisedOutput::create_visuals(
+        ad_res, ad_out, this->_mlmodel._repo + this->_mlmodel._visuals_dir,
+        test_id);
     _module.train();
     return 0;
   }

--- a/src/backends/torch/torchutils.cc
+++ b/src/backends/torch/torchutils.cc
@@ -256,7 +256,7 @@ namespace dd
       torch_utils::copy_weights(jit_module, module, device, logger, strict);
     }
 
-    cv::Mat tensorToImage(torch::Tensor tensor)
+    cv::Mat tensorToImage(torch::Tensor tensor, bool rgb)
     {
       // 4 channels: batch size, chan, width, height
       auto dims = tensor.sizes();
@@ -285,6 +285,13 @@ namespace dd
                 }
             }
         }
+
+      // convert to bgr
+      if (rgb)
+        {
+          cv::cvtColor(vals_mat, vals_mat, cv::COLOR_RGB2BGR);
+        }
+
       return vals_mat;
     }
   }

--- a/src/backends/torch/torchutils.h
+++ b/src/backends/torch/torchutils.h
@@ -158,8 +158,9 @@ namespace dd
 
     /** Converts a tensor to a CV image that can be saved on the disk.
      * XXX(louis) this function is currently debug only, and makes strong
-     * assumptions on the input tensor format. */
-    cv::Mat tensorToImage(torch::Tensor tensor);
+     * assumptions on the input tensor format.
+     * \param rgb wether the tensor image is rgb */
+    cv::Mat tensorToImage(torch::Tensor tensor, bool rgb = false);
   }
 }
 #endif

--- a/src/mlmodel.h
+++ b/src/mlmodel.h
@@ -181,6 +181,7 @@ namespace dd
     std::string _corresp; /**< file name of the class correspondences (e.g.
                              house / 23) */
     std::string _best_model_filename = "/best_model.txt";
+    std::string _visuals_dir = "/visuals";
 
 #ifdef USE_SIMSEARCH
 #ifdef USE_ANNOY


### PR DESCRIPTION
This is a draft for visualization during training on the DeepDetect platform. This PR adds saving images with predictions at test time, for detection models only. Some points are left for discussion:
- How do we select the images? For large test sets it's impractical to generate visuals for the whole test set. Suggestions:
    - always the same images from the beginning of the test set
    - random images
    - best / worst metrics (would require to change things in the supervisedoutputconnector)
    - a random subset in a fixed part of the test set
- What confidence threshold should we use to filter boxes?
- how we display class name / confidence...

![image1](https://user-images.githubusercontent.com/15674552/228279093-d3c083ab-f24e-491f-949f-337b45f38208.jpg)