### PR TITLE
feat(torch): add map metrics with arbitrary iou threshold

### DIFF
--- a/src/backends/torch/torchlib.h
+++ b/src/backends/torch/torchlib.h
@@ -90,7 +90,8 @@ namespace dd
                                         const at::Tensor &targ_labels,
                                         const at::Tensor &bboxes_tensor,
                                         const at::Tensor &labels_tensor,
-                                        const at::Tensor &score_tensor);
+                                        const at::Tensor &score_tensor,
+                                        float overlap_threshold);
 
   public:
     unsigned int _nclasses = 0; /**< number of classes*/


### PR DESCRIPTION
TODO
- [x] Finish testing
- [x] Call example
- [ ] add in dd_widgets (later)

## Usage

For example, to request mAP with IoU threshold = 0.9: add `"map-90"` to `parameters.output.measure`.

`"map"` is no longer required if `"map-xx"` is specified, but it is kept for backward compatibility. It corresponds to a default IoU threshold of 0.5.

```bash
# Train call
curl -X GET localhost:8080 -d '{
  "service": "detection",
  "async": true,
  "parameters": {
    "input": {
    },
    "mllib": {
      "gpu": true,
      "gpuid": 2,
      "net": {
        "batch_size": 8,
        "test_batch_size": 4
      },
      "solver": {
        "solver_type": "ADAM"
      },
      "bbox": true
    },
    "output": {
      "measure": [
        "map-50", "map-75", "map-90"
      ],
      "target_repository": ""
    }
  },
  "data": [
    "/opt/platform/data/train.txt",
    "/opt/platform/data/test.txt"
  ]
}'
```

Example measure output:
-  `"map"` is the mean over all thresholds
```json
{
  "measure": {
    "test_id": 0,
    "map": 0.3333333358168602,
    "map-90_1": 0.25,
    "test_name": "test",
    "map-90": 0.25,
    "map_1": 0.3333333432674408,
    "map-50_1": 0.4166666865348816,
    "map-50": 0.4166666716337204
  },
  "measures": [
    {
      "test_id": 0,
      "map": 0.3333333358168602,
      "map-90_1": 0.25,
      "test_name": "test",
      "map-90": 0.25,
      "map_1": 0.3333333432674408,
      "map-50_1": 0.4166666865348816,
      "map-50": 0.4166666716337204
    }
  ]
}
```