### PR TITLE
Added new torchlib service param `concurrent_predict`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -960,7 +960,7 @@ if (USE_TENSORRT)
 
     if (NOT TENSORRT_VERSION)
         if (EXISTS "${TRTTESTDIR}/libnvinfer.so.8")
-            set(TENSORRT_VERSION 8.4.3)
+            set(TENSORRT_VERSION v8.6.1)
             message(STATUS "Found TensorRT libraries version 8")
         else()
             message(FATAL_ERROR "No supported TensorRT version found")
@@ -981,10 +981,8 @@ if (USE_TENSORRT)
 
 	set(TRT_PATCHES_PATH ${CMAKE_BINARY_DIR}/patches/trt)
 	set(TRT_PATCHES
-      ${TRT_PATCHES_PATH}/0001-support-for-refinedet.patch
       ${TRT_PATCHES_PATH}/0003-c++14.patch
       ${TRT_PATCHES_PATH}/0009-fix_compil_order.patch
-      ${TRT_PATCHES_PATH}/0010-fix_plugin_detect.patch
       ${TRT_PATCHES_PATH}/0011-fix_plugin_makefile_cub.patch
       )
 
@@ -1201,7 +1199,9 @@ set(COMMON_LINK_LIBS
     ${TORCH_LIB_DEPS}
 )
 if (USE_HDF5)
-    list(APPEND COMMON_LINK_LIBS hdf5_cpp)
+    find_library(HDF5_LIBRARY NAMES hdf5_cpp hdf5_serial_cpp)
+    message(STATUS "HDF5 library at ${HDF5_LIBRARY}")
+    list(APPEND COMMON_LINK_LIBS ${HDF5_LIBRARY})
 endif()
 
 # configure config.cmake for external application
@@ -1238,8 +1238,8 @@ endif()
 file(GLOB_RECURSE ALL_SOURCE_FILES src/*.cpp src/*.hpp src/*.h src/*.c tests/*.cc src/*.cc)
 list(FILTER ALL_SOURCE_FILES EXCLUDE REGEX "^${CMAKE_SOURCE_DIR}/src/ext/.*$")
 
-
-find_program(CLANG_FORMAT_BIN clang-format-10 clang-format)
+# ubuntu 20: clang-format-10, ubuntu 22: clang-format 14
+find_program(CLANG_FORMAT_BIN NAMES clang-format clang-format-14 clang-format-10)
 add_custom_target(
         clang-format
         COMMAND ${CLANG_FORMAT_BIN}

--- a/ci/devel-trt.Dockerfile
+++ b/ci/devel-trt.Dockerfile
@@ -1,17 +1,12 @@
 # syntax = docker/dockerfile:1.0-experimental
 
-ARG DD_UBUNTU_VERSION=20.04
-ARG DD_CUDA_VERSION=11.8
+ARG DD_UBUNTU_VERSION=22.04
+ARG DD_CUDA_VERSION=12.1
 ARG DD_CUDNN_VERSION=8
-ARG DD_TENSORRT_VERSION=8.5.3+cuda11.8
+ARG DD_TENSORRT_VERSION=8.6.1+cuda12.1
 
 # FROM nvidia/cuda:${DD_CUDA_VERSION}-cudnn${DD_CUDNN_VERSION}-devel-ubuntu${DD_UBUNTU_VERSION}
-# TODO(sileht): tensorrt is not yet in ubuntu20.04 nvidia machine learning repository
-# https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/
-# https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu2004/x86_64/
-# We temporary use another docker image just to build tensorrt
-
-FROM nvcr.io/nvidia/tensorrt:22.12-py3 AS build
+FROM nvcr.io/nvidia/tensorrt:23.05-py3 AS build
 
 ARG DD_UBUNTU_VERSION
 ARG DD_CUDA_VERSION
@@ -24,13 +19,11 @@ RUN echo CUDNN_VERSION=${DD_CUDNN_VERSION} >> /image-info
 RUN echo TENSORRT_VERSION=${DD_TENSORRT_VERSION} >> /image-info
 
 RUN export DEBIAN_FRONTEND=noninteractive && \
-    apt-get update -y && apt-get install -y python-dev apt-transport-https ca-certificates gnupg software-properties-common wget curl
-RUN curl https://apt.kitware.com/keys/kitware-archive-latest.asc | apt-key add -
-RUN apt-add-repository 'deb https://apt.kitware.com/ubuntu/ focal main'
+    apt-get update -y && apt-get install -y apt-transport-https ca-certificates gnupg software-properties-common wget curl
 
 # python2 pycompile + docker-buildkit is a bit buggy, it's slow as hell, so disable it for dev
 # bug closed as won't fix as python2 is eol: https://github.com/docker/for-linux/issues/502
-RUN cp /bin/true /usr/bin/pycompile
+# RUN cp /bin/true /usr/bin/pycompile
 
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update -y && apt-get install -y \
@@ -38,14 +31,13 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     ccache \
     automake \
     rsync \
-    clang-format-10 \
+    clang-format-14 \
     build-essential \
     openjdk-8-jdk \
     pkg-config \
     cmake \
     zip \
-    g++ \
-    gcc-7 g++-7 \
+    gcc-11 g++-11 \
     zlib1g-dev \
     libgoogle-glog-dev \
     libgflags-dev \
@@ -77,20 +69,11 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     libmapbox-variant-dev \
     autoconf \
     libtool-bin \
-    python-numpy \
-    python-yaml \
-    python-typing \
     swig \
     curl \
     unzip \
     python-setuptools \
-    python-dev \
-    python3-dev \
-    python3-pip \
     tox \
-    python-six \
-    python-enum34 \
-    python3-yaml \
     unzip \
     libgoogle-perftools-dev \
     curl \
@@ -101,12 +84,8 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     util-linux \
     libgstreamer1.0-dev
 
-RUN for url in \
-        https://github.com/bazelbuild/bazel/releases/download/0.24.1/bazel_0.24.1-linux-x86_64.deb \
-        ; do curl -L -s -o /tmp/p.deb $url && dpkg -i /tmp/p.deb && rm -rf /tmp/p.deb; done
-
 RUN python3 -m pip install --upgrade pip
-RUN python3 -m pip install torch==1.13.1
+RUN python3 -m pip install torch==2.0.1
 
 WORKDIR /tmp
 

--- a/ci/devel.Dockerfile
+++ b/ci/devel.Dockerfile
@@ -102,7 +102,7 @@ RUN for url in \
         ; do curl -L -s -o /tmp/p.deb $url && dpkg -i /tmp/p.deb && rm -rf /tmp/p.deb; done
 
 RUN python3 -m pip install --upgrade pip
-RUN python3 -m pip install torch==1.11.0 torchvision==0.12.0
+RUN python3 -m pip install torch==2.0.1 torchvision==0.15.2 onnx
 
 RUN apt clean -y
 ADD ci/gitconfig /etc/gitconfig

--- a/docs/api.md
+++ b/docs/api.md
@@ -1119,12 +1119,13 @@ test_batch_size | int  | yes      | N/A     | Prediction batch size (the server 
 - Torch
 
 Parameter     | Type   | Optional | Default | Description
----------     | ----   | -------- | ------- | -----------
+---------     | ----   | -------- |---------| -----------
 gpu           | bool   | yes      | false   | Whether to use GPU
-gpuid         | int or array | yes | 0      | GPU id, use single int for single GPU, `-1` for using all GPUs, and array e.g. `[1,3]` for selecting among multiple GPUs
+gpuid         | int or array | yes | 0       | GPU id, use single int for single GPU, `-1` for using all GPUs, and array e.g. `[1,3]` for selecting among multiple GPUs
 extract_layer | string | yes      | ""      | Returns tensor values from intermediate layers. In bert models "hidden_state" allows to extract raw hidden_states values to return as output. If set to 'last', simply returns the tensor values from last layer.
-forward_method | string | yes | "" | Executes a custom function from within a traced/JIT model, instead of the standard forward()
-multi_label | bool | yes | false | Model outputs an independent score for each class
+forward_method | string | yes | ""      | Executes a custom function from within a traced/JIT model, instead of the standard forward()
+multi_label | bool | yes | false   | Model outputs an independent score for each class
+concurrent_predict | bool | yes | true    | Enable/disable concurrent predict for the model
 
 
 - XGBoost

--- a/src/backends/tensorrt/tensorrtlib.h
+++ b/src/backends/tensorrt/tensorrtlib.h
@@ -146,9 +146,12 @@ namespace dd
 
     bool _TRTContextReady = false;
 
-    int _inputIndex;
-    int _outputIndex0;
-    int _outputIndex1;
+    std::string _inputName;
+    int _inputIndex = 0;
+    std::string _outputName0;
+    int _outputIndex0 = 1;
+    std::string _outputName1;
+    int _outputIndex1 = 2;
 
     bool _first_predict
         = true; // do some cuda allocations only at first predict

--- a/src/backends/torch/llogging.h
+++ b/src/backends/torch/llogging.h
@@ -84,7 +84,8 @@ private:
 #ifdef CAFFE_THROW_ON_ERROR
 #include <sstream>
 #define SSTR(x)                                                               \
-  dynamic_cast<std::ostringstream &>((std::ostringstream() << std::dec << x)) \
+  dynamic_cast<std::ostringstream &&>(                                        \
+      (std::ostringstream() << std::dec << x))                                \
       .str()
 class CaffeErrorException : public std::exception
 {
@@ -135,9 +136,12 @@ static std::ostream nullstream(0);
 /* #endif */
 #endif
 
+// XXX: support for clang-format 10 on ubuntu 20.04
+// clang-format off
 #define CHECK_NOTNULL(x)                                                      \
   ((x) == NULL ? LOG(FATAL) << "Check  notnull: " #x << ' ',                  \
-   (x) : (x)) // NOLINT(*)
+   (x)         : (x)) // NOLINT(*)
+// clang-format on
 
 #ifdef NDEBUG
 #define DCHECK(x)                                                             \

--- a/src/backends/torch/native/native_wrapper.h
+++ b/src/backends/torch/native/native_wrapper.h
@@ -39,19 +39,22 @@ namespace dd
   public:
     TModule _module;
 
+    // XXX: support of clang-format-10 on ubuntu 20.04
+    // clang-format off
     template <typename... Args>
-    NativeModuleWrapper(Args &&... args) : _module(args...)
+    NativeModuleWrapper(Args &&...args) : _module(args...)
     {
       _clone_function
           = [args = std::make_tuple(std::forward<Args>(args)...)]() {
               return dd_utils::apply(
-                  [](auto &&... args) {
+                  [](auto &&...args) {
                     return new NativeModuleWrapper<TModule>(args...);
                   },
                   std::move(args));
             };
       this->register_module("wrapped", _module);
     }
+    // clang-format on
 
     std::shared_ptr<torch::nn::Module>
     clone(const c10::optional<torch::Device> &device

--- a/src/backends/torch/torchlib.h
+++ b/src/backends/torch/torchlib.h
@@ -112,9 +112,17 @@ namespace dd
     bool _segmentation = false;   /**< select segmentation type problem */
     bool _ctc = false;            /**< select OCR type problem */
     bool _multi_label = false;    /**< whether model outputs multiple labels */
+    bool _concurrent_predict = true; /**< allow concurrent predicts */
     std::string _loss = "";       /**< selected loss*/
     double _reg_weight
         = 1; /**< for detection models, weight for bbox regression loss. */
+
+    std::mutex
+        _net_mutex; /**< mutex around net, e.g. no concurrent predict calls as
+                         it can use more gpu memory than initially expected.
+                         Use batches instead.
+                         This is only used if concurrent_predict is
+                         disabled. */
 
     APIData _template_params; /**< template parameters, for recurrent and
                                  native models*/

--- a/src/dto/mllib.hpp
+++ b/src/dto/mllib.hpp
@@ -183,6 +183,13 @@ namespace dd
       }
       DTO_FIELD(Boolean, multi_label) = false;
 
+      DTO_FIELD_INFO(concurrent_predict)
+      {
+        info->description
+            = "Enable/disable concurrent predict for the model";
+      }
+      DTO_FIELD(Boolean, concurrent_predict) = true;
+
       // Libtorch predict options
       DTO_FIELD_INFO(forward_method)
       {

--- a/src/utils/utils.hpp
+++ b/src/utils/utils.hpp
@@ -24,6 +24,7 @@
 
 #include <fstream>
 #include <vector>
+#include <algorithm>
 
 namespace dd
 {

--- a/tests/ut-chain.cc
+++ b/tests/ut-chain.cc
@@ -49,7 +49,7 @@ static std::string caffe_ocr_repo = "../examples/caffe/multiword_ocr";
 static std::string caffe_faces_detect_repo = "../examples/caffe/faces_512";
 static std::string caffe_age_repo = "../examples/caffe/age_real";
 
-static std::string trt_detect_repo = "../examples/trt/faces_512/";
+static std::string trt_detect_repo = "../examples/trt/yolox_onnx_trt_nowrap/";
 static std::string trt_gan_repo
     = "../examples/trt/cyclegan_resnet_attn_onnx_trt";
 
@@ -372,18 +372,18 @@ TEST(chain, chain_trt_detection_gan)
   JsonAPI japi;
   std::string detect_sname = "detect";
   std::string jstr
-      = "{\"mllib\":\"tensorrt\",\"description\":\"imagenet\","
+      = "{\"mllib\":\"tensorrt\",\"description\":\"yolox\","
         "\"type\":\"supervised\",\"model\":{\"repository\":\""
         + trt_detect_repo
         + "\"},\"parameters\":{\"input\":{\"connector\":"
-          "\"image\",\"height\":512,\"width\":512},\"mllib\":{\"datatype\":"
-          "\"fp32\",\"maxBatchSize\":1,\"maxWorkspaceSize\":256,\"gpuid\":0}}"
-          "}";
+          "\"image\",\"height\":640,\"width\":640},\"mllib\":{"
+          "\"maxBatchSize\":2,\"maxWorkspaceSize\":256,\"gpuid\":0,"
+          "\"template\":\"yolox\",\"nclasses\":81,\"datatype\":\"fp16\"}}}";
   std::string joutstr = japi.jrender(japi.service_create(detect_sname, jstr));
   ASSERT_EQ(created_str, joutstr);
 
   std::string gan_sname = "gan";
-  jstr = "{\"mllib\":\"tensorrt\",\"description\":\"squeezenet\",\"type\":"
+  jstr = "{\"mllib\":\"tensorrt\",\"description\":\"gan\",\"type\":"
          "\"supervised\",\"model\":{\"repository\":\""
          + trt_gan_repo
          + "\"},\"parameters\":{\"input\":{\"connector\":\"image\",\"height\":"


### PR DESCRIPTION
Added new torchlib service param `concurrent_predict` (default true) to help manage GPU memory if multiple external API callers are in use and memory management cannot be done externally.

This is in reference to [this conversation](https://matrix.to/#/!rkhGyFNrjfeCIXnDnS:gitter.im/$iKc-UQ33lWc3JOKXpzVWWGYGZkGjKCXeREijK0h3NKE?via=gitter.im&via=matrix.org) around torch concurrent predict calls and GPU memory usage management.