### PR TITLE
feat: allow returning images in json in base64 format

### DIFF
--- a/src/dto/ddtypes.cc
+++ b/src/dto/ddtypes.cc
@@ -31,6 +31,8 @@ namespace dd
 
       const oatpp::ClassId GpuIdsClass::CLASS_ID("GpuIds");
 
+      const oatpp::ClassId ImageClass::CLASS_ID("Image");
+
       template <>
       const oatpp::ClassId DTOVectorClass<double>::CLASS_ID("vector<double>");
 

--- a/src/dto/predict_out.hpp
+++ b/src/dto/predict_out.hpp
@@ -116,11 +116,24 @@ namespace dd
 
       DTO_FIELD_INFO(vals)
       {
-        info->description = "[Unsupervised] Array containing model output "
-                            "values. Can be in different formats: double, "
-                            "binarized double, booleans, binarized string";
+        info->description
+            = "[Unsupervised] Array containing model output "
+              "values. Can be in different formats: double, "
+              "binarized double, booleans, binarized string, base64 image";
       }
       DTO_FIELD(Any, vals);
+
+      DTO_FIELD_INFO(images)
+      {
+        info->description
+            = "[Unsupervised] Array of images returned by the model";
+      }
+      DTO_FIELD(Vector<DTOImage>, images);
+
+      DTO_FIELD_INFO(imgsize)
+      {
+        info->description = "[Unsupervised] Image size";
+      }
       DTO_FIELD(Object<Dimensions>, imgsize);
 
       DTO_FIELD_INFO(confidences)
@@ -140,6 +153,7 @@ namespace dd
       DTO_FIELD(String, index_uri);
 
     public:
+      // XXX: Legacy & deprecated
       std::vector<cv::Mat> _images; /**<allow to pass images in the DTO */
     };
 

--- a/src/utils/oatpp.cc
+++ b/src/utils/oatpp.cc
@@ -38,6 +38,8 @@ namespace dd
                                    DTO::apiDataDeserialize);
       deser->setDeserializerMethod(DTO::GpuIds::Class::CLASS_ID,
                                    DTO::gpuIdsDeserialize);
+      deser->setDeserializerMethod(DTO::DTOImage::Class::CLASS_ID,
+                                   DTO::imageDeserialize);
       deser->setDeserializerMethod(DTO::DTOVector<double>::Class::CLASS_ID,
                                    DTO::vectorDeserialize<double>);
       deser->setDeserializerMethod(DTO::DTOVector<uint8_t>::Class::CLASS_ID,
@@ -49,6 +51,8 @@ namespace dd
                                DTO::apiDataSerialize);
       ser->setSerializerMethod(DTO::GpuIds::Class::CLASS_ID,
                                DTO::gpuIdsSerialize);
+      ser->setSerializerMethod(DTO::DTOImage::Class::CLASS_ID,
+                               DTO::imageSerialize);
       ser->setSerializerMethod(DTO::DTOVector<double>::Class::CLASS_ID,
                                DTO::vectorSerialize<double>);
       ser->setSerializerMethod(DTO::DTOVector<uint8_t>::Class::CLASS_ID,
@@ -190,6 +194,13 @@ namespace dd
             {
               jval.PushBack(dto_gpuid->_ids[i], jdoc.GetAllocator());
             }
+        }
+      else if (polymorph.getValueType() == DTO::DTOImage::Class::getType())
+        {
+          auto dto_img = polymorph.cast<DTO::DTOImage>();
+          std::string img_str
+              = cv_utils::image_to_base64(dto_img->get_img(), dto_img->_ext);
+          jval.SetString(img_str.c_str(), jdoc.GetAllocator());
         }
       else if (polymorph.getValueType()->classId.id
                    == oatpp::data::mapping::type::__class::AbstractVector::

--- a/tests/ut-tensorrtapi.cc
+++ b/tests/ut-tensorrtapi.cc
@@ -271,6 +271,31 @@ TEST(tensorrtapi, service_predict_gan_onnx)
   ASSERT_TRUE(jd["body"]["predictions"][0]["vals"].IsArray());
   ASSERT_EQ(jd["body"]["predictions"][0]["vals"].Size(), 360 * 360 * 3);
 
+  // predict to image
+  jpredictstr
+      = "{\"service\":\"" + sname
+        + "\",\"parameters\":{\"input\":{\"height\":360,"
+          "\"width\":360,\"rgb\":true,\"scale\":0.00392,\"mean\":[0.5,0.5,0.5]"
+          ",\"std\":[0.5,0.5,0.5]},\"output\":{\"image\":true},\"mllib\":{"
+          "\"extract_layer\":\"last\"}},\"data\":[\""
+        + cyclegan_onnx_repo + "horse.jpg\"]}";
+  joutstr = japi.jrender(japi.service_predict(jpredictstr));
+  jd = JDoc();
+  // std::cout << "joutstr=" << joutstr << std::endl;
+  jd.Parse<rapidjson::kParseNanAndInfFlag>(joutstr.c_str());
+  ASSERT_TRUE(!jd.HasParseError());
+  ASSERT_EQ(200, jd["status"]["code"]);
+  ASSERT_TRUE(jd["body"]["predictions"].IsArray());
+  ASSERT_TRUE(jd["body"]["predictions"][0]["images"].IsArray());
+  ASSERT_EQ(jd["body"]["predictions"][0]["images"].Size(), 1);
+  // png image
+  std::string base64_img
+      = jd["body"]["predictions"][0]["images"][0].GetString();
+  // may be small differences between machines, versions of libpng/jpeg?
+  ASSERT_NEAR(base64_img.size(), 388292, 100);
+  // cv::imwrite("onnx_gan_base64.jpg", cv_utils::base64_to_image(base64_img));
+
+  // delete
   ASSERT_TRUE(fileops::file_exists(cyclegan_onnx_repo + "TRTengine_arch"
                                    + get_trt_archi() + "_fp16_bs1"));
 

--- a/tests/ut-torchapi.cc
+++ b/tests/ut-torchapi.cc
@@ -124,6 +124,8 @@ static std::string iterations_ttransformer_cpu = "100";
 static std::string iterations_ttransformer_gpu = "1000";
 
 static std::string iterations_resnet50 = "200";
+/// different values to mitigate failure due to randomness
+static std::string iterations_resnet50_split = "300";
 static std::string iterations_vit = "200";
 static std::string iterations_detection = "200";
 static std::string iterations_deeplabv3 = "200";
@@ -831,7 +833,7 @@ TEST(torchapi, service_train_images_split)
   std::string jtrainstr
       = "{\"service\":\"imgserv\",\"async\":false,\"parameters\":{"
         "\"mllib\":{\"solver\":{\"iterations\":"
-        + iterations_resnet50 + ",\"base_lr\":" + torch_lr
+        + iterations_resnet50_split + ",\"base_lr\":" + torch_lr
         + ",\"iter_size\":4,\"solver_type\":\"ADAM\",\"test_"
           "interval\":200},\"net\":{\"batch_size\":4},\"nclasses\":2,"
           "\"resume\":false},"
@@ -846,7 +848,8 @@ TEST(torchapi, service_train_images_split)
   ASSERT_TRUE(!jd.HasParseError());
   ASSERT_EQ(201, jd["status"]["code"]);
 
-  ASSERT_TRUE(jd["body"]["measure"]["iteration"] == 200) << "iterations";
+  int it_count = std::stoi(iterations_resnet50_split);
+  ASSERT_TRUE(jd["body"]["measure"]["iteration"] == it_count) << "iterations";
   ASSERT_TRUE(jd["body"]["measure"]["train_loss"].GetDouble() <= 3.0)
       << "loss";
 
@@ -862,9 +865,9 @@ TEST(torchapi, service_train_images_split)
         remove(ff.c_str());
     }
   ASSERT_TRUE(!fileops::file_exists(resnet50_train_repo + "checkpoint-"
-                                    + iterations_resnet50 + ".ptw"));
+                                    + iterations_resnet50_split + ".ptw"));
   ASSERT_TRUE(!fileops::file_exists(resnet50_train_repo + "checkpoint-"
-                                    + iterations_resnet50 + ".pt"));
+                                    + iterations_resnet50_split + ".pt"));
   fileops::clear_directory(resnet50_train_repo + "train.lmdb");
   fileops::clear_directory(resnet50_train_repo + "test_0.lmdb");
   fileops::remove_dir(resnet50_train_repo + "train.lmdb");


### PR DESCRIPTION
With `image=true`, a dd predict call will now return base64 encoded images in an `images` field.

Adds `parameters.output.encoding`: an extension characterizing the image encoding, e.g ".png" or ".jpg"