### PR TITLE
feat: recompose action to recreate an image from a GAN + crop

### DIFF
--- a/src/apidata.cc
+++ b/src/apidata.cc
@@ -21,6 +21,8 @@
 
 #include "apidata.h"
 
+#include "utils/utils.hpp"
+
 namespace dd
 {
   /*- visitor_vad -*/
@@ -244,4 +246,11 @@ namespace dd
       }
   }
 
+  std::string APIData::toJSONString() const
+  {
+    JDoc jd;
+    jd.SetObject();
+    toJDoc(jd);
+    return dd_utils::jrender(jd);
+  }
 }

--- a/src/apidata.h
+++ b/src/apidata.h
@@ -286,6 +286,11 @@ namespace dd
     void toJVal(JDoc &jd, JVal &jv) const;
 
     /**
+     * \brief converts APIData to json string
+     */
+    std::string toJSONString() const;
+
+    /**
      * \brief converts APIData to oat++ DTO
      */
     template <typename T> inline oatpp::Object<T> createSharedDTO() const

--- a/src/backends/tensorrt/tensorrtlib.h
+++ b/src/backends/tensorrt/tensorrtlib.h
@@ -20,11 +20,11 @@
 #ifndef TENSORRTLIB_H
 #define TENSORRTLIB_H
 
-#include "tensorrtmodel.h"
-#include "apidata.h"
 #include "NvCaffeParser.h"
 #include "NvInfer.h"
 
+#include "apidata.h"
+#include "tensorrtmodel.h"
 #include "error_recorder.hpp"
 
 namespace dd
@@ -127,6 +127,7 @@ namespace dd
         _template; /**< template for models that require specific treatment */
 
     //!< The TensorRT engine used to run the network
+    std::shared_ptr<TRTErrorRecorder> _error_recorder = nullptr;
     std::shared_ptr<nvinfer1::IInt8Calibrator> _calibrator = nullptr;
     std::shared_ptr<nvinfer1::ICudaEngine> _engine = nullptr;
     std::shared_ptr<nvinfer1::IBuilder> _builder = nullptr;

--- a/src/chain.cc
+++ b/src/chain.cc
@@ -96,7 +96,7 @@ namespace dd
             for (auto p : *body->predictions)
               {
                 std::string uri = p->uri;
-                p->uri = model_name.c_str();
+                p->uri = model_name;
                 other_models_out.insert(
                     std::pair<std::string, oatpp::Object<DTO::Prediction>>(uri,
                                                                            p));
@@ -123,7 +123,7 @@ namespace dd
             for (auto p : *out_body->predictions)
               {
                 std::string uri = p->uri;
-                p->uri = action_id.c_str();
+                p->uri = action_id;
                 other_models_out.insert(
                     std::pair<std::string, oatpp::Object<DTO::Prediction>>(uri,
                                                                            p));

--- a/src/chain_actions.h
+++ b/src/chain_actions.h
@@ -88,6 +88,15 @@ namespace dd
       return std::to_string(std::hash<std::string>{}(str));
     }
 
+    /** Apply an action to a model output.
+     * \param model_out Output of the previous model.
+     * \param cdata Chain data object containing all the output of previous
+     * models and actions. This method should add the action result to cdata
+     * using the `add_action_data()` method. If the action creates data that
+     * should appear in the result, they are stored in the "output" field. If
+     * the action creates data that should be used by the next model, they are
+     * stored in other fields, as handled in `services.h:chain_service()`.
+     * */
     void apply(APIData &model_out, ChainData &cdata);
 
     std::string _action_id;
@@ -123,6 +132,24 @@ namespace dd
     }
 
     ~ImgsRotateAction()
+    {
+    }
+
+    void apply(APIData &model_out, ChainData &cdata);
+  };
+
+  /** Recompose origin image with inference result, for example in crop + GAN
+   * pipeline */
+  class ImgsCropRecomposeAction : public ChainAction
+  {
+  public:
+    ImgsCropRecomposeAction(oatpp::Object<DTO::ChainCall> call_dto,
+                            const std::shared_ptr<spdlog::logger> chain_logger)
+        : ChainAction(call_dto, chain_logger)
+    {
+    }
+
+    ~ImgsCropRecomposeAction()
     {
     }
 
@@ -206,6 +233,9 @@ namespace dd
     oatpp::Object<DTO::ChainCall> _call_dto;
   };
 
+  /** Add an action type to DeepDetect chains. The action transforms the output
+   * of a model. This output can then be used by another model or embedded in
+   * the API result. */
 #define CHAIN_ACTION(ActionName, ActionType)                                  \
   namespace                                                                   \
   {                                                                           \

--- a/src/dd_types.h
+++ b/src/dd_types.h
@@ -23,6 +23,7 @@
 #define DDTYPES_H
 
 #include <exception>
+
 class RapidjsonException : public std::exception
 {
 public:

--- a/src/dto/predict_out.hpp
+++ b/src/dto/predict_out.hpp
@@ -128,7 +128,7 @@ namespace dd
         info->description
             = "[Unsupervised] Array of images returned by the model";
       }
-      DTO_FIELD(Vector<DTOImage>, images);
+      DTO_FIELD(Vector<DTOImage>, images) = Vector<DTOImage>::createShared();
 
       DTO_FIELD_INFO(imgsize)
       {

--- a/src/jsonapi.cc
+++ b/src/jsonapi.cc
@@ -349,30 +349,15 @@ namespace dd
     return jd;
   }
 
+  // XXX: legacy methods, remove in favor of dd_utils::jrender?
   std::string JsonAPI::jrender(const JDoc &jst) const
   {
-    rapidjson::StringBuffer buffer;
-    rapidjson::Writer<rapidjson::StringBuffer, rapidjson::UTF8<>,
-                      rapidjson::UTF8<>, rapidjson::CrtAllocator,
-                      rapidjson::kWriteNanAndInfFlag>
-        writer(buffer);
-    bool done = jst.Accept(writer);
-    if (!done)
-      throw DataConversionException("JSON rendering failed");
-    return buffer.GetString();
+    return dd_utils::jrender(jst);
   }
 
   std::string JsonAPI::jrender(const JVal &jval) const
   {
-    rapidjson::StringBuffer buffer;
-    rapidjson::Writer<rapidjson::StringBuffer, rapidjson::UTF8<>,
-                      rapidjson::UTF8<>, rapidjson::CrtAllocator,
-                      rapidjson::kWriteNanAndInfFlag>
-        writer(buffer);
-    bool done = jval.Accept(writer);
-    if (!done)
-      throw DataConversionException("JSON rendering failed");
-    return buffer.GetString();
+    return dd_utils::jrender(jval);
   }
 
   JDoc JsonAPI::info(const std::string &jstr) const

--- a/src/utils/oatpp.cc
+++ b/src/utils/oatpp.cc
@@ -23,6 +23,7 @@
 #include <iostream>
 
 #include "dto/ddtypes.hpp"
+#include "utils/utils.hpp"
 
 namespace dd
 {
@@ -293,6 +294,14 @@ namespace dd
           throw std::runtime_error("dtoToJVal: \"" + type_name
                                    + "\": type not recognised");
         }
+    }
+
+    std::string dtoToJSONString(const oatpp::Void &polymorph, bool ignore_null)
+    {
+      JDoc jd;
+      jd.SetObject();
+      dtoToJDoc(polymorph, jd, ignore_null);
+      return dd_utils::jrender(jd);
     }
   }
 }

--- a/src/utils/oatpp.hpp
+++ b/src/utils/oatpp.hpp
@@ -69,6 +69,9 @@ namespace dd
                    bool ignore_null = true);
     void dtoToJVal(const oatpp::Void &polymorph, JDoc &jdoc, JVal &jval,
                    bool ignore_null = true);
+
+    std::string dtoToJSONString(const oatpp::Void &polymorph,
+                                bool ignore_null = true);
   }
 }
 

--- a/src/utils/utils.hpp
+++ b/src/utils/utils.hpp
@@ -27,6 +27,13 @@
 #include <algorithm>
 
 #include <boost/lexical_cast.hpp>
+#include <rapidjson/allocators.h>
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/reader.h>
+#include <rapidjson/writer.h>
+
+#include "apidata.h"
+#include "dd_types.h"
 
 namespace dd
 {
@@ -80,6 +87,32 @@ namespace dd
       return start == std::string::npos || end == std::string::npos
                  ? ""
                  : item.substr(start, end - start + 1);
+    }
+
+    inline std::string jrender(const JDoc &jst)
+    {
+      rapidjson::StringBuffer buffer;
+      rapidjson::Writer<rapidjson::StringBuffer, rapidjson::UTF8<>,
+                        rapidjson::UTF8<>, rapidjson::CrtAllocator,
+                        rapidjson::kWriteNanAndInfFlag>
+          writer(buffer);
+      bool done = jst.Accept(writer);
+      if (!done)
+        throw DataConversionException("JSON rendering failed");
+      return buffer.GetString();
+    }
+
+    inline std::string jrender(const JVal &jval)
+    {
+      rapidjson::StringBuffer buffer;
+      rapidjson::Writer<rapidjson::StringBuffer, rapidjson::UTF8<>,
+                        rapidjson::UTF8<>, rapidjson::CrtAllocator,
+                        rapidjson::kWriteNanAndInfFlag>
+          writer(buffer);
+      bool done = jval.Accept(writer);
+      if (!done)
+        throw DataConversionException("JSON rendering failed");
+      return buffer.GetString();
     }
 
     inline bool iequals(const std::string &a, const std::string &b)


### PR DESCRIPTION
Adds a "recompose" action at the end of a chain to replace a part of an image (determined by a detection model) with a transformed version created by a generative model.

Example: Given 2 services "detection" and "gan"
```bash
curl -X POST localhost:8080/chain -d '{
  "chain": {
    "name": "chain",
    "calls": [
      {
        "service": "detection",
        "parameters": {
          "input": {
            "keep_orig": true,
            "cuda": true
          },
          "output": {
            "bbox": true,
            "best_bbox": 2
          }
        },
        "data": [
          "examples/trt/cyclegan_resnet_attn_onnx_trt/horse_1024.jpg"
        ]
      },
      {
        "id": "crop",
        "action": {
          "type": "crop",
          "parameters": {
            "fixed_width": 360,
            "fixed_height": 360
          }
        }
      },
      {
        "service": "gan",
        "parent_id": "crop",
        "parameters": {
          "input": {
            "cuda": true
          },
          "mllib": {
            "extract_layer": "last"
          },
          "output": {
            "image": true
          }
        }
      },
      {
        "id": "recompose",
        "action": {
          "type": "recompose",
          "parameters": {
            "save_img": true,
            "save_path": "."
          }
        }
      }
    ]
  }
}'
```
These are options that you can change:
- On the detection call
  - `keep_orig=true` to keep original image size
  - `cuda=true` so that preprocessing will be using opencv cuda
  - `best_bbox=2`: recompose action can manage multiple crops
- On the GAN call
  - `image=true` is *required*
- On the recompose action
  - `save_img=true` & `save_path="."` are debug options to save the recomposed image on the server side, you do not need to include them in the call.

Output
```json
{                                                                                                                                                                                                           
  "status": {                                                                                                                                                                                               
    "code": 200,                                                                                                                                                                                            
    "msg": "OK"                                                                                                                                                                                             
  },
  "head": {
    "method": "/chain",
    "time": 3011
  },
  "body": {
    "predictions": [
      {
        "images": [],
        "classes": [
          {
            "class_id": "8635193368570945251",
            "cat": "18",
            "prob": 0.9306421279907227,
            "gan": {
              "classes": [],
              "images": [
                "<base64 encoded image>"
              ]
            },
            "bbox": {
              "xmin": 334.0142822265625,
              "ymin": 5.5608296394348145,
              "xmax": 1021.8338012695312,
              "ymax": 919.8924560546875
            }
          },
          {
            "class_id": "18070901992019112847",
            "cat": "20",
            "prob": 0.4800424873828888,
            "gan": {
              "last": true,
              "classes": [],
              "images": [
                "<base64 encoded image>"
              ]
            },
            "bbox": {
              "xmin": 18.50065040588379,
              "ymin": 117.07843017578125,
              "xmax": 49.29962921142578,
              "ymax": 169.6492156982422
            },
            "last": true
          }
        ],
        "recompose": {
          "classes": [],
          "images": [
            "<base64 encoded image>"
          ]
        },
        "uri": "0"
      }
    ]
  }
}
```

(Also fixes a tensorrt "error" when destroying a service)