### PR TITLE
fix(chain): DTO chain returns nothing 

### DIFF
--- a/src/services.h
+++ b/src/services.h
@@ -1213,7 +1213,8 @@ namespace dd
               size_t npred_classes
                   = pred->classes != nullptr ? pred->classes->size() : 0;
               classes_size += npred_classes;
-              vals_size += static_cast<int>(pred->vals != nullptr);
+              vals_size += static_cast<int>(pred->vals != nullptr)
+                           + static_cast<int>(pred->images->size());
 
               if (chain_pos == 0) // first call's response contains uniformized
                                   // top level URIs.


### PR DESCRIPTION
When used with linked application, if the return type is "image", the chain fails with "no results from prediction"