### PR TITLE
Tracing CLIP-based vision models for DeepDetect

### DIFF
--- a/tools/torch/trace_clip.py
+++ b/tools/torch/trace_clip.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+
+
+### REQUIRES PATCHING transformers/models/modeling_clip.py in two places to cast to long:
+# line 177 should be changed to:
+# self.register_buffer("position_ids", torch.arange(self.num_positions).expand((1, -1)).long(), persistent=False)
+# line 187 should be changed to:
+# embeddings = embeddings + self.position_embedding(self.position_ids.long())
+
+
+import torch, transformers, torchvision
+import numpy as np
+from torch import nn
+from transformers import CLIPVisionModelWithProjection, TensorType
+# import torchvision.transforms.v2 as T
+import torchvision.transforms as T
+from torchvision.transforms import InterpolationMode
+from typing import Tuple
+import argparse
+import logging
+
+class CLIPWrapper(nn.Module):
+  def __init__(self, visionmodel):
+    super(CLIPWrapper, self).__init__()
+    self.visionmodel = visionmodel
+    self.visionmodel.eval()
+    # If you prefer to script the wrapper, you can uncomment the following to internally trace the visionmodel's forward method
+    # and also remove torch.jit.script from the self.transforms
+    # self.visionmodel = torch.jit.trace(self.visionmodel.forward, example_kwarg_inputs={'pixel_values': torch.rand([1, 3, 336, 336])})
+
+    self.transforms = torch.jit.script(nn.Sequential(
+      T.ConvertImageDtype(torch.float),
+      T.Resize(size=[336,], interpolation=InterpolationMode.BICUBIC, antialias=True), # Resize to 336 on shortest edge
+      T.CenterCrop([336, 336]), # Center crop a square of 336x336
+      T.Normalize(mean=[0.48145466, 0.4578275, 0.40821073], std=[0.26862954, 0.26130258, 0.27577711])
+    ))
+
+  def forward(self, x: torch.Tensor):
+    with torch.no_grad():
+      x = self.transforms(x)
+      return self.visionmodel(pixel_values=x)[0]
+
+
+parser = argparse.ArgumentParser(description="Trace CLIP-based vision models from pytorch-transformers (only tested on openai/clip-vit-large-patch14-336 and its derivatives)")
+parser.add_argument(
+  '--model',
+  type=str,
+  help="Model to trace",
+  default="openai/clip-vit-large-patch14-336",
+)
+parser.add_argument(
+  '--cache-dir',
+  type=str,
+  help="Cache dir for HuggingFace models. Leave unset to use default",
+  default=None,
+)
+parser.add_argument(
+  '-v', '--verbose',
+  action='store_true',
+  help="Set logging level to INFO",
+)
+parser.add_argument(
+  '-o', '--output-dir',
+  type=str,
+  help="Output directory for traced models",
+  default=".",
+)
+args = parser.parse_args()
+
+if args.verbose:
+  logging.basicConfig(level=logging.INFO)
+
+logging.info(f"pytorch version {torch.__version__}, from {torch.__file__}")
+logging.info(f"transformers version {transformers.__version__}, from {transformers.__file__}")
+logging.info(f"torchvision version {torchvision.__version__}, from {torchvision.__file__}")
+
+
+# use cache dir if you want to specify a custom huggingface cache dir
+visionmodel = CLIPVisionModelWithProjection.from_pretrained(args.model, torchscript=True, cache_dir=args.cache_dir)
+
+model = CLIPWrapper(visionmodel)
+model.eval()
+
+# Uncomment if you prefer to script the wrapper
+# traced_model = torch.jit.script(model, torch.rand([1, 3, 1366, 1024]))
+traced_model = torch.jit.trace(model, torch.rand([1, 3, 1366, 1024]))
+
+outputfilename = f"{os.path.join(args.output_dir, args.model.replace('/', '-'))}.pt"
+logging.info(f"Saving to {outputfilename}")
+torch.jit.save(traced_model, outputfilename)
+logging.info("Done")
+
+# To use in DeepDetect, use something like the following to create the service:
+# curl -X PUT "http://localhost:8080/services/mymodel" -d '{
+#   "mllib":"torch",
+#   "description":"myclipmodel",
+#   "type":"unsupervised",
+#   "parameters":{
+#     "input":{
+#       "connector":"image",
+#       "height":336,
+#       "width":336,
+#       "rgb":true
+#     },
+#     "mllib":{
+#       "concurrent_predict":false
+#     }
+#   },
+#   "model":{
+#     "repository":"/opt/models/myclipmodel/"
+#   }
+# }'
+
+# and something like the following to get the image embedding output:
+# curl -X POST "http://localhost:8080/predict" -d '{
+#   "service":"myclipmodel", 
+#   "parameters":{
+#     "mllib":{
+#       "extract_layer":"last"
+#     }
+#   }, 
+#   "data":["test.jpg"]
+# }'

--- a/tools/torch/trace_clip.py
+++ b/tools/torch/trace_clip.py
@@ -97,7 +97,7 @@ if args.script_wrapper:
   traced_model = torch.jit.script(model, torch.rand([1, 3, 1366, 1024]))
   outputfilename = f"{os.path.join(args.output_dir, args.model.replace('/', '-'))}-scripted.pt"
 else:
-  logging.info(f"Tracing wrapper (underlying transforms will still be traced)")
+  logging.info(f"Tracing wrapper (underlying transforms will still be scripted)")
   traced_model = torch.jit.trace(model, torch.rand([1, 3, 1366, 1024]))
   outputfilename = f"{os.path.join(args.output_dir, args.model.replace('/', '-'))}-traced.pt"
 


### PR DESCRIPTION
Added basic script to trace HuggingFace Transformers models based on https://huggingface.co/openai/clip-vit-large-patch14-336

Note: this does require patching `transformers/models/modeling_clip.py` as noted in the comments. Without the patch, the values are traced to either `CPUFloatType` or `CUDAFloatType` and so the model cannot be used on either type of device interchangeably.