### PR TITLE
chore: update pytorch to 2.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -856,7 +856,8 @@ if (USE_TORCH)
   set(PYTORCH_PATCHES
     ${PYTORCH_PATCHES_PATH}/pytorch_15_compile.patch
     ${PYTORCH_PATCHES_PATH}/pytorch_113_new_logger.patch
-    ${PYTORCH_PATCHES_PATH}/pytorch_19_use_new_logger.patch
+    ${PYTORCH_PATCHES_PATH}/pytorch_23_use_new_logger.patch
+    ${PYTORCH_PATCHES_PATH}/pytorch_23_cloneable.patch
   )
   if (APPLE)
     list(APPEND PYTORCH_PATCHES ${PYTORCH_PATCHES_PATH}/pytorch_113_apple_includes.patch)
@@ -866,7 +867,7 @@ if (USE_TORCH)
   add_definitions(-DUSE_TORCH)
 
   if (NOT TORCH_LOCATION)
-    set(PYTORCH_COMMIT v2.1.2)
+    set(PYTORCH_COMMIT v2.3.0)
     set(PYTORCH_COMPLETE ${CMAKE_BINARY_DIR}/CMakeFiles/pytorch-complete)
 
     if (APPLE)
@@ -900,7 +901,7 @@ if (USE_TORCH)
         set(PYTORCH_USE_CUDA 1)
       endif()
 
-      file(WRITE ${CMAKE_BINARY_DIR}/build_pytorch.sh "set -x\n${CMAKE_COMMAND} -E env PATH=${PROTOBUF_LIB_DIR}:$ENV{PATH} BUILD_CUSTOM_PROTOBUF=0 GLIBCXX_USE_CXX11_ABI=1 BUILD_TEST=0 USE_CUDA=${PYTORCH_USE_CUDA}  BUILD_CAFFE2=1 BUILD_CAFFE2_OPS=1 BUILD_CAFFE2_MOBILE=0 USE_DDLOG=1 USE_TENSORRT=0 CAFFE2_LINK_LOCAL_PROTOBUF=0 \"CMAKE_CXX_FLAGS=-isystem ${SPDLOG_INCLUDE_DIR} -isystem ${PROTOBUF_INCLUDE_DIR}\" \"CMAKE_CUDA_FLAGS=-isystem ${SPDLOG_INCLUDE_DIR} -isystem ${PROTOBUF_INCLUDE_DIR}\" TORCH_CUDA_ARCH_LIST=\"${CUDA_ARCH}\" \"CMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc\" CMAKE_PREFIX_PATH=${PROTOBUF_LIB_DIR}/cmake MAX_JOBS=8 python3 ../pytorch/tools/build_libtorch.py")
+      file(WRITE ${CMAKE_BINARY_DIR}/build_pytorch.sh "set -x\n${CMAKE_COMMAND} -E env PATH=${PROTOBUF_LIB_DIR}:$ENV{PATH} BUILD_CUSTOM_PROTOBUF=0 GLIBCXX_USE_CXX11_ABI=1 BUILD_TEST=0 USE_CUDA=${PYTORCH_USE_CUDA}  BUILD_CAFFE2=1 BUILD_CAFFE2_OPS=1 BUILD_CAFFE2_MOBILE=0 USE_DDLOG=1 USE_TENSORRT=0 CAFFE2_LINK_LOCAL_PROTOBUF=0 \"CMAKE_CXX_FLAGS=-isystem ${SPDLOG_INCLUDE_DIR} -isystem ${PROTOBUF_INCLUDE_DIR} -isystem /usr/lib/x86_64-linux-gnu/openmpi/include\" \"CMAKE_CUDA_FLAGS=-isystem ${SPDLOG_INCLUDE_DIR} -isystem ${PROTOBUF_INCLUDE_DIR} -isystem /usr/lib/x86_64-linux-gnu/openmpi/include\" TORCH_CUDA_ARCH_LIST=\"${CUDA_ARCH}\" \"CMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc\" CMAKE_PREFIX_PATH=${PROTOBUF_LIB_DIR}/cmake MAX_JOBS=8 python3 ../pytorch/tools/build_libtorch.py")
       ExternalProject_Add(
         pytorch
         PREFIX pytorch
@@ -936,7 +937,7 @@ if (USE_TORCH)
 
   # TORCH VISION
   message(STATUS "Configuring Pytorch Vision")
-  set(PYTORCH_VISION_COMMIT "v0.16.2") # 0.16.2 & torch 2.1.2
+  set(PYTORCH_VISION_COMMIT "v0.18.0") # 0.18.0 & torch 2.3.0
   set(PYTORCH_VISION_PATCHES_PATH ${CMAKE_BINARY_DIR}/patches/pytorch/vision)
   # set(PYTORCH_VISION_PATCHES
   #   ${PYTORCH_VISION_PATCHES_PATH}/xxx.patch # add patches here

--- a/patches/pytorch/pytorch_23_cloneable.patch
+++ b/patches/pytorch/pytorch_23_cloneable.patch
@@ -1,0 +1,37 @@
+diff --git a/torch/csrc/api/include/torch/nn/cloneable.h b/torch/csrc/api/include/torch/nn/cloneable.h
+index aaf30d90974..bd41c8d7271 100644
+--- a/torch/csrc/api/include/torch/nn/cloneable.h
++++ b/torch/csrc/api/include/torch/nn/cloneable.h
+@@ -21,7 +21,7 @@ namespace nn {
+ /// because then storing a module would always require templatizing it.
+ template <typename Derived>
+ // NOLINTNEXTLINE(bugprone-exception-escape)
+-class Cloneable : public Module {
++class Cloneable : public virtual Module {
+  public:
+   using Module::Module;
+ 
+@@ -90,7 +90,7 @@ class Cloneable : public Module {
+         clone != nullptr,
+         "Attempted to clone submodule, but it is of a "
+         "different type than the submodule it was to be cloned into");
+-    static_cast<Derived&>(*this) = *clone;
++    static_cast<Derived&>(*this) = std::move(*clone);
+   }
+ };
+ 
+diff --git a/torch/csrc/api/include/torch/nn/module.h b/torch/csrc/api/include/torch/nn/module.h
+index de8d243533a..20d1024ad41 100644
+--- a/torch/csrc/api/include/torch/nn/module.h
++++ b/torch/csrc/api/include/torch/nn/module.h
+@@ -81,10 +81,6 @@ class TORCH_API Module : public std::enable_shared_from_this<Module> {
+   /// The name of the submodule is inferred via RTTI (if possible) the first
+   /// time `.name()` is invoked.
+   Module();
+-  Module(const Module&) = default;
+-  Module& operator=(const Module&) = default;
+-  Module(Module&&) noexcept = default;
+-  Module& operator=(Module&&) noexcept = default;
+ 
+   virtual ~Module() = default;
+ 

--- a/patches/pytorch/pytorch_23_use_new_logger.patch
+++ b/patches/pytorch/pytorch_23_use_new_logger.patch
@@ -1,0 +1,78 @@
+diff --git a/c10/CMakeLists.txt b/c10/CMakeLists.txt
+index 1f742f4c176..324324c110e 100644
+--- a/c10/CMakeLists.txt
++++ b/c10/CMakeLists.txt
+@@ -15,6 +15,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+ # ---[ Configure macro file.
+ set(C10_USE_GFLAGS ${USE_GFLAGS}) # used in cmake_macros.h.in
+ set(C10_USE_GLOG ${USE_GLOG}) # used in cmake_macros.h.in
++set(C10_USE_DDLOG ${USE_DDLOG}) # used in cmake_macros.h.in
+ set(C10_BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS}) # used in cmake_macros.h.in
+ set(C10_USE_NUMA ${USE_NUMA})
+ set(C10_USE_MSVC_STATIC_RUNTIME ${CAFFE2_USE_MSVC_STATIC_RUNTIME})
+diff --git a/c10/macros/cmake_macros.h.in b/c10/macros/cmake_macros.h.in
+index 76c185b5523..bd4d5e72056 100644
+--- a/c10/macros/cmake_macros.h.in
++++ b/c10/macros/cmake_macros.h.in
+@@ -6,6 +6,7 @@
+ 
+ #cmakedefine C10_BUILD_SHARED_LIBS
+ #cmakedefine C10_USE_GLOG
++#cmakedefine C10_USE_DDLOG
+ #cmakedefine C10_USE_GFLAGS
+ #cmakedefine C10_USE_NUMA
+ #cmakedefine C10_USE_MSVC_STATIC_RUNTIME
+diff --git a/c10/util/Logging.cpp b/c10/util/Logging.cpp
+index f4eef35b147..978b0cf5b52 100644
+--- a/c10/util/Logging.cpp
++++ b/c10/util/Logging.cpp
+@@ -209,6 +209,21 @@ C10_DEFINE_int32(v, 0, "Equivalent to glog verbose");
+ C10_DEFINE_bool(logtostderr, false, "Equivalent to glog logtostderr");
+ #endif // !defined(c10_USE_GLOG)
+ 
++#if defined(C10_USE_DDLOG)
++namespace c10 {
++bool InitCaffeLogging(int* argc, char** argv) {
++  return true;
++}
++void UpdateLoggingLevelsFromFlags() {}
++
++} // namespace c10
++
++C10_DEFINE_int(
++    caffe2_log_level,
++    0,
++    "The minimum log level that caffe2 will output.");
++
++#else
+ #ifdef C10_USE_GLOG
+ 
+ // Provide easy access to the above variables, regardless whether GLOG is
+@@ -419,6 +434,7 @@ MessageLogger::~MessageLogger() {
+ } // namespace c10
+ 
+ #endif // !C10_USE_GLOG
++#endif // !C10_USE_DDLOG
+ 
+ namespace c10::detail {
+ namespace {
+diff --git a/c10/util/Logging.h b/c10/util/Logging.h
+index 267dd30966e..b2ac93ad410 100644
+--- a/c10/util/Logging.h
++++ b/c10/util/Logging.h
+@@ -22,11 +22,15 @@
+ #endif // CAFFE2_LOG_THRESHOLD
+ 
+ // Below are different implementations for glog and non-glog cases.
++#ifdef C10_USE_DDLOG
++#include <c10/util/logging_is_dd_log.h>
++#else
+ #ifdef C10_USE_GLOG
+ #include <c10/util/logging_is_google_glog.h>
+ #else // !C10_USE_GLOG
+ #include <c10/util/logging_is_not_google_glog.h>
+ #endif // C10_USE_GLOG
++#endif // C10_USE_DDLOG
+ 
+ C10_DECLARE_int(caffe2_log_level);
+ C10_DECLARE_bool(caffe2_use_fatal_for_enforce);

--- a/src/apidata.h
+++ b/src/apidata.h
@@ -561,7 +561,6 @@ namespace dd
     JDoc *_jd = nullptr;
     JVal *_jv = nullptr;
   };
-
 }
 
 #endif

--- a/src/backends/torch/optim/madgrad.cc
+++ b/src/backends/torch/optim/madgrad.cc
@@ -128,8 +128,7 @@ namespace dd
 
             TORCH_CHECK(!grad.is_sparse(),
                         "Madgrad does not support sparse gradients");
-            auto param_state
-                = state_.find(c10::guts::to_string(p.unsafeGetTensorImpl()));
+            auto param_state = state_.find(p.unsafeGetTensorImpl());
             auto &options = static_cast<MadgradOptions &>(group.options());
 
             // State initialization
@@ -146,15 +145,14 @@ namespace dd
                 state->slow_buffer(torch::empty_like(
                     p.data(), torch::MemoryFormat::Preserve));
                 state->slow_buffer().copy_(p.data());
-                state_[c10::guts::to_string(p.unsafeGetTensorImpl())]
-                    = std::move(state);
+                state_[p.unsafeGetTensorImpl()] = std::move(state);
                 if (options.swa())
                   state->swa_buffer(torch::zeros_like(
                       p.data(), torch::MemoryFormat::Preserve));
               }
 
             auto &state = static_cast<MadgradParamState &>(
-                *state_[c10::guts::to_string(p.unsafeGetTensorImpl())]);
+                *state_[p.unsafeGetTensorImpl()]);
 
             auto &grad_sum_sq = state.grad_sum_sq();
             auto &s = state.s();
@@ -225,7 +223,7 @@ namespace dd
         for (auto &p : group.params())
           {
             auto &state = static_cast<MadgradParamState &>(
-                *state_[c10::guts::to_string(p.unsafeGetTensorImpl())]);
+                *state_[p.unsafeGetTensorImpl()]);
             auto &swa_buf = state.swa_buffer();
 
             auto tmp = torch::empty_like(p.data());

--- a/src/backends/torch/optim/radam.cc
+++ b/src/backends/torch/optim/radam.cc
@@ -119,8 +119,7 @@ namespace dd
             auto grad = p.grad();
             TORCH_CHECK(
                 !grad.is_sparse(), "RAdam does not support sparse gradients" /*, please consider SparseRAdam instead*/);
-            auto param_state
-                = state_.find(c10::guts::to_string(p.unsafeGetTensorImpl()));
+            auto param_state = state_.find(p.unsafeGetTensorImpl());
             auto &options = static_cast<RAdamOptions &>(group.options());
 
             // State initialization
@@ -134,12 +133,11 @@ namespace dd
                 // Exponential moving average of squared gradient values
                 state->exp_avg_sq(
                     torch::zeros_like(p, torch::MemoryFormat::Preserve));
-                state_[c10::guts::to_string(p.unsafeGetTensorImpl())]
-                    = std::move(state);
+                state_[p.unsafeGetTensorImpl()] = std::move(state);
               }
 
             auto &state = static_cast<RAdamParamState &>(
-                *state_[c10::guts::to_string(p.unsafeGetTensorImpl())]);
+                *state_[p.unsafeGetTensorImpl()]);
             auto &exp_avg = state.exp_avg();
             auto &exp_avg_sq = state.exp_avg_sq();
 

--- a/src/backends/torch/optim/ranger.cc
+++ b/src/backends/torch/optim/ranger.cc
@@ -186,8 +186,7 @@ namespace dd
 
             TORCH_CHECK(!grad.is_sparse(),
                         "Ranger does not support sparse gradients");
-            auto param_state
-                = state_.find(c10::guts::to_string(p.unsafeGetTensorImpl()));
+            auto param_state = state_.find(p.unsafeGetTensorImpl());
             auto &options = static_cast<RangerOptions &>(group.options());
 
             // State initialization
@@ -204,15 +203,14 @@ namespace dd
                 state->slow_buffer(
                     torch::empty_like(p, torch::MemoryFormat::Preserve));
                 state->slow_buffer().copy_(p.data());
-                state_[c10::guts::to_string(p.unsafeGetTensorImpl())]
-                    = std::move(state);
+                state_[p.unsafeGetTensorImpl()] = std::move(state);
                 if (options.swa())
                   state->swa_buffer(torch::zeros_like(
                       p.data(), torch::MemoryFormat::Preserve));
               }
 
             auto &state = static_cast<RangerParamState &>(
-                *state_[c10::guts::to_string(p.unsafeGetTensorImpl())]);
+                *state_[p.unsafeGetTensorImpl()]);
             auto &exp_avg = state.exp_avg();
             auto &exp_avg_sq = state.exp_avg_sq();
 
@@ -350,7 +348,7 @@ namespace dd
         for (auto &p : group.params())
           {
             auto &state = static_cast<RangerParamState &>(
-                *state_[c10::guts::to_string(p.unsafeGetTensorImpl())]);
+                *state_[p.unsafeGetTensorImpl()]);
             auto &swa_buf = state.swa_buffer();
 
             auto tmp = torch::empty_like(p.data());


### PR DESCRIPTION
<!>
- Added hard coded system mpi includes because they were not found by CMake -> maybe there's an other way around ?
- torch::nn::Cloneable is no longer a virtual class, which breaks most native modules in dede. I chose to revert the change with a patch, which might not be the best solution long-term wise