### PR TITLE
Swagger api doc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,6 +248,11 @@ add_custom_target(
     DEPENDS ${CMAKE_BINARY_DIR}/src/caffe.pb.h ${CMAKE_BINARY_DIR}/src/caffe.pb.cc
 )
 
+# read documentation
+file(
+    READ "${CMAKE_SOURCE_DIR}/docs/api_swagger.md"
+    API_DOC
+)
 
 # dependency on Eigen for confusion matrix fast computation
 if (USE_TF)
@@ -1392,6 +1397,10 @@ endif()
 configure_file (
   "${PROJECT_SOURCE_DIR}/src/dd_config.h.in"
   "${PROJECT_BINARY_DIR}/dd_config.h"
+)
+configure_file (
+  "${PROJECT_SOURCE_DIR}/src/dd_config.cc.in"
+  "${PROJECT_BINARY_DIR}/dd_config.cc"
 )
 
 # status

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ curl -X GET https://docker.jolibrain.com/v2/deepdetect_cpu/tags/list
 - templates for the most useful neural architectures (e.g. Googlenet, Alexnet, ResNet, convnet, character-based convnet, mlp, logistic regression, SSD, DeepLab, PSPNet, U-Net, CRNN, ShuffleNet, SqueezeNet, MobileNet, RefineDet, VOVNet, ...)
 - support for sparse features and computations on both GPU and CPU
 - built-in similarity indexing and search of predicted features, images, objects and probability distributions
+- auto-generated documentation based on [Swagger](https://swagger.io/)
 
 
 ## Machine Learning functionalities per library

--- a/docs/api_swagger.md
+++ b/docs/api_swagger.md
@@ -1,0 +1,312 @@
+# Introduction
+
+Welcome to the DeepDetect API!
+
+DeepDetect is a Machine Learning server. At this stage, it provides a flexible API to train deep neural networks and gradient boosted trees, and use them where they are needed, in both development and production.
+
+## Principles
+
+The Open Source software provides a server, an API, and the underlying Machine Learning procedures for training statistical models. The REST API defines a set of resources and options in order to access and command the server over a network.
+
+### Architecture
+
+The software defines a very simple flow, from data to the statistical model and the final application. The main elements and vocabulary are in that order:
+
+* `data` or `dataset`: images, numerical data, or text
+* `input connector`: entry point for data into DeepDetect. Specialized versions handle different data types (e.g. images, text, CSV, ...)
+* `model`: repository that holds all the files necessary for building and usage of a statistical model such as a neural net
+* `service`: the central holder of models and connectors, living in memory and servicing the machine learning capabilities through the API. While the `model` can be held permanently on disk, a `service` is spawn around it and destroyed at will
+* `mllib`: the machine learning library used for operations, two are supported at the moment, Caffe, Caffe2, XGBoost, Dlib, NCNN and Tensorflow, more are on the way
+* `training`: the computational phase that uses a dataset to build a statistical model with predictive abilities on statistically relevant data
+* `prediction`: the computational phase that uses a trained statistical model in order to make a guess about one or more samples of data
+* `output connector`: the DeepDetect output, that supports templates so that the output can be easily customized by the user in order to fit in the final application
+
+### API Principles
+
+The main idea behind the API is that it allows users to spawn Machine Learning `services`, each serving its own purpose, and to interact with them.
+
+The REST API builds around four resources:
+
+* `/info`: yields the general information about the server and the services currently being active on it
+* `/services`: yields access to creation and destruction of Machine Learning services.
+* `/train`: controls the resources for the potentially long computational phase of building the statistical model from a `dataset`
+* `/predict`: takes data in, and uses a trained statistical model to make predictions over some properties of the data
+
+Each of the resources are detailed below, along with their options and examples to be tested on the command line.
+
+# Train
+
+Trains a statistical model from a dataset, the model can be further used for prediction
+
+The DeepDetect server supports both blocking and asynchronous training calls. Training is often a very computational operation that can last for days in some cases.
+
+Blocking calls block the communication with the server, and returns results once completed. They are not well suited to most machine learning tasks.
+
+Asynchronous calls run the training in the background as a separate thread (`PUT /train`). Status of the training job can be consulted live with by calling on the server (`GET /train`). The final report on an asynchronous training job is consumed by the first `GET /train` call after completion of the job. After that, the job is definitely destroyed.
+
+<div class="alert alert-primary mx-2" style="width: 58%">
+⚠️ Asynchronous training calls are the default, use of blocking calls is useful for testing and debugging
+</div>
+
+<div class="alert alert-danger mx-2" style="width: 58%">
+⚠️ The current integration of the Caffe back-end for deep learning does not allow making predictions while training. However, two different services can train and predict at the same time.
+</div>
+
+# Predict
+
+Makes predictions from data out of an existing statistical model. If `measure` is specified, the prediction expects a supervised dataset and produces accuracy measures as output, otherwise it is prediction for every of the input samples.
+
+# Connectors
+
+The DeepDetect API supports the control of input and output connectors.
+
+* `input connectors` are parametrized with the `input` JSON object
+
+> input connector:
+
+```json
+"parameters":{
+   "input":{
+
+  }
+}
+```
+
+* `output connectors` are parametrized with the `output` JSON object
+
+> output connector:
+
+```json
+"parameters":{
+   "output":{
+
+  }
+}
+```
+
+<div class="alert alert-primary mx-2" style="width: 58%">
+⚠️ Connectors are defined at service creation but their options can be modified in `train` and `predict` calls as needed.
+</div>
+
+## Input connectors
+The `connector` field defines its type:
+
+* `image` instantiates the image input connector
+* `csv` instantiates the input connector for CSV files
+* `txt` instantiates the input connector for text files
+
+Input connectors work almost the same during both the training and prediction phases. But the training phase usually deals with large masses of data, and therefore the connectors above are optimized to automate some tasks, typically building and preprocessing the dataset at training time.
+
+## Output connectors
+
+The output connector controls the output formats for supervised and unsupervised models.
+
+Its two main features are the control of the number of predictions per URI, and the output templating, which allows for custom output and seamless integration in external applications. Other options modulates the output format.
+
+The variables that are usable in the output template format are those from the standard JSON output. See the [output template](#output-templates) dedicated section for more details and examples.
+
+# Output Templates
+
+> example of a custom output template:
+
+```
+status={{#status}}{{code}}{{/status}}\n{{#body}}{{#predictions}}*{{uri}}:\n{{#classes}}{{cat}}->{{prob}}\n{{/classes}}{{/predictions}}{{/body}}
+```
+
+> turn the standard JSON output of a predict call into a custom string output
+
+```shell
+curl -X POST "http://localhost:8080/predict" -d "{\"service\":\"imageserv\",\"parameters\":{\"mllib\":{\"gpu\":true},\"input\":{\"width\":224,\"height\":224},\"output\":{\"best\":3,\"template\":\"status={{#status}}{{code}}{{/status}}\n{{#body}}{{#predictions}}*{{uri}}:\n{{#classes}}{{cat}}->{{prob}}\n{{/classes}}{{/predictions}}{{/body}}\"}},\"data\":[\"ambulance.jpg\"]}"
+```
+
+> yields:
+
+```
+status=200
+*ambulance.jpg:
+n02701002 ambulance->0.993358
+n03977966 police van, police wagon, paddy wagon, patrol wagon, wagon, black Maria->0.00642457
+n03769881 minibus->9.11523e-05
+```
+> instead of:
+
+```json
+{"status":{"code":200,"msg":"OK"},"head":{"method":"/predict","time":28.0,"service":"imageserv"},"body":{"predictions":{"uri":"ambulance.jpg","classes":[{"prob":0.993358314037323,"cat":"n02701002 ambulance"},{"prob":0.006424566265195608,"cat":"n03977966 police van, police wagon, paddy wagon, patrol wagon, wagon, black Maria"},{"prob":0.00009115227294387296,"cat":"n03769881 minibus"}]}}}
+```
+
+The DeepDetect server and API allow you to ease the connection to your applications through output templates. Output templates are an easy way to customize the output of the `/predict` calls. Take variables from the standard JSON output and reuse their values in the format of your choice.
+
+Instead of decoding the standard JSON output of the DeepDetect server, the API allows to transmit output templates in the [Mustache](https://mustache.github.io/) [format](https://mustache.github.io/mustache.5.html). No more glue code, the server does the job for you! See examples below.
+
+Parameter    | Type   | Optional | Default                        | Description
+---------    | ----   | -------- | -------                        | -----------
+template     | string | yes      | empty                          | Output template in Mustache format
+network      | object | yes      | empty                          | Output network parameters for pushing the output into another listening software
+
+- Network object
+
+Parameter    | Type   | Optional | Default                        | Description
+---------    | ----   | -------- | -------                        | -----------
+url          | string | no       | N/A                            | URL of the remote service to connect to (e.g http://localhost:9200)
+http_method  | string | yes      | POST                           | HTTP connecting method, from "POST", "PUT", etc...
+content_type | string | yes      | Content-Type: application/json | Content type HTTP header string
+
+Using Mustache, you can turn the JSON into anything, from XML to specialized formats, with application to indexing into search engines, post-processing, UI rendering, etc...
+
+# Model Templates
+
+> Example of a 3-layer MLP with 512 hidden units in each layer and PReLU activations:
+
+```json
+{"parameters":{"mllib":{"template":"mlp","nclasses":9,"layers":[512,512,512],"activation":"PReLU","nclasses":9}}}
+```
+
+> Example of GoogleNet for 1000 classes of images:
+
+```json
+{"parameters":{"input":{"connector":"image","width":224,"height":224},"mllib":{"template":"googlenet","nclasses":1000}}}
+```
+
+The DeepDetect server and API come with a set of Machine Learning model templates.
+
+At the moment templates are available for [Caffe](https://caffe.berkeleyvision.org/) and [Pytorch](https://pytorch.org/) backends. They include some of the most powerful deep neural net architectures for image classification, and other customizable classic and useful architectures.
+
+## Neural network templates
+
+All models below are used by passing their id to the `mllib/template` parameter in `PUT /services` calls:
+
+### Pytorch
+
+#### Native models
+
+- LSTM-like models (including autoencoder): `recurrent`
+- NBEATS model: `nbeats`
+- Vision transformer: `vit` and `visformer`
+- Transformer-based timeseries models: `ttransformer`
+- [TorchVision image classification models](https://pytorch.org/vision/0.8/models.html):
+	- `resnet18`
+	- `resnet34`
+	- `resnet50`
+	- `resnet101`
+	- `resnet152`
+	- `resnext50_32x4d`
+	- `resnext101_32x8d`
+	- `wideresnet50_2`
+	- `wideresnet101_2`
+	- `alexnet`
+	- `vgg11`
+	- `vgg13`
+	- `vgg16`
+	- `vgg19`
+	- `vgg11bn`
+	- `vgg13bn`
+	- `vgg16bn`
+	- `vgg19bn`
+	- `mobilenetv2`
+	- `densenet121`
+	- `densenet169`
+	- `densenet201`
+	- `densenet161`
+	- `mnasnet0_5`
+	- `mnasnet0_75`
+	- `mnasnet1_0`
+	- `mnasnet1_3`
+	- `shufflenetv2_x0_5`
+	- `shufflenetv2_x1_0`
+	- `shufflenetv2_x1_5`
+	- `shufflenetv2_x2_0`
+	- `squeezenet1_0`
+	- `squeezenet1_1`
+
+#### Traced models
+
+These templates require an external traced model to work:
+
+- Language models:
+	- `bert`
+	- `gpt2`
+- Detection models:
+	- `fasterrcnn`
+	- `retinanet`
+    - `yolox`
+- Segmentation models:
+    - `segformer`
+
+## Parameters
+
+Model instantiation parameters for recurrent template (applies to all backends supporting templates):
+
+Parameter       | Template  | Type            | Default                      | Description
+---------       | --------- | ------          | ---------------------------- | -----------
+layers          | recurrent | array of string | []                           | ["L50","L50"] means 2 layers of LSTMs with hidden size of 50. ["L100","L100", "T", "L300"] means an lstm autoencoder with encoder composed of 2 LSTM layers of hidden size 100 and decoder is one LSTM layer of hidden size 300
+
+### Pytorch
+
+Template parameters for native templates (nbeats/ttransformer):
+
+Parameter       | Template  | Type            | Default                      | Description
+---------       | --------- | ------          | ---------------------------- | -----------
+template_params.stackdef | nbeats    | array of string | ["t2","s","g3","b3","h10" ] | default means: trend stack with theta = 2, seasonal stack with theta maxed , generic stack with theta = 3, 3 blocks per stacks, hidden unit size of 10 everywhere
+template_params.vit_flavor | vit | string | vit_base_patch16 | Vision transformer architecture, from smaller to larger: vit_tiny_patch16, vit_small_patch16, vit_base_patch32, vit_base_patch16, vit_large_patch16, vit_large_patch32, vit_huge_patch16, vit_huge_patch32
+template_params.visformer_flavor | visformer | visformer_tiny | Visformer architecture, from visformer_tiny or visformer_small
+template_params.realformer | vit | bool | false | Whether to use the 'realformer' residual among attention heads
+template_params.positional_encoding.type | ttransformer | string | "sincos" | Positional encoding "sincos for original frequential encoding, "naive" for simple enumeration
+template_params.positional_encoding.learn | ttransformer | bool | false | learn or not positional encoding (starting from above value)
+template_params.positional_encoding.dropout | ttransformer | float | 0.1 | value of dropout in positional encodin
+template_params.embed.layers | ttransformer | int | 3 | Number of layers of MLP value embedder
+template_params.embed.activation | ttransformer | string | relu | "relu", "gelu" or "siren" : activation type of MLP embedder
+template_params.embed.dim | ttransformer | int | 32 | size of embedding for MLP embedder (per timestep) (embed.dim must be divisible by encoder.heads)
+template_params.embed.type | ttransformer | string | step | "step" embeds every step separately, "serie" embeds every serie separately, "all" embeds all timesteps of all serie at once (needs a lot of memory")
+template_params.embed.dropout | ttransformer | float | 0.1 | value of dropout in MLP embedder
+template_params.encoder.heads | ttransformer | int | 8 | number of heads for transformer encoder (embed.dim must be divisible by encoder.heads)
+template_params.encoder.layers | ttransformer | int | 1 | number of layers in transformer encoder
+template_params.encoder.hidden_dim | ttransformer | int | input_dim * embed.dim | internal dim of feedfoward net in encoder layer
+template_params.encoder.activation | ttransformer | string | relu | "relu" or "gelu"
+template_params.encoder.dropout | ttransformer | float | 0.1 | dropout value for encoder stack
+template_params.decoder.type | ttransformer | string | simple | simple is a MLP, "transformer" is attention based decoder
+template_params.decoder.heads | ttransformer | int | 8 | number of heads for transformer decoder (if any)
+template_params.decoder.layers | ttransformer | int | 1 | number of layers of decoder
+template_params.decoder.dropout | ttransformer | float | 0.1 | dropout value for decoder stack
+template_params.autoreg | ttransformer | bool | false | false for nbeats style decoding, ie gives a window of prediction at one, true for autoregressive, ie predicts value one after the others then use previsouly predicted values as a context
+
+# Errors
+
+The DeepDetect API uses the following error HTTP and associated custom error codes when applicable:
+
+
+HTTP Status Code | Meaning
+---------------- | -------
+400              | Bad Request -- Malformed syntax in request or JSON body
+403              | Forbidden -- The requested resource or method cannot be accessed
+404              | Not Found -- The requested resource, service or model does not exist
+409              | Conflict -- The requested method cannot be processed due to a conflict
+500              | Internal Server Error -- Other errors, including internal Machine Learning libraries errors
+
+DeepDetect Error Code | Meaning
+--------------------- | -------
+1000                  | Unknown Library -- The requested Machine Learning library is unknown
+1001                  | No Data -- Empty data provided
+1002                  | Service Not Found -- Machine Learning service not found
+1003                  | Job Not Found -- Training job not found
+1004                  | Input Connector Not Found -- Unknown or incompatible input connector and service
+1005                  | Service Input Bad Request -- Any service error from input connector
+1006                  | Service Bad Request -- Any bad parameter request error from Machine Learning library
+1007                  | Internal ML Library Error -- Internal Machine Learning library error
+1008                  | Train Predict Conflict -- Algorithm does not support prediction while training
+1009                  | Output Connector Network Error -- Output connector has failed to connect to external software via network
+
+# Examples
+
+See the <a href="https://deepdetect.com/overview/examples/">Examples</a> page, and the <a href="https://deepdetect.com/overview/faq/">FAQ</a> for tips and tricks.
+
+Examples include:
+
+* Text: neural networks, from words or low-level characters
+* Images: neural networks, visual search
+* Generic Data: neural networks, gradient boosted trees, sparse data, ...
+
+Demos include:
+
+* Image classification User Interface, https://github.com/beniz/deepdetect/tree/master/demo/imgdetect
+* Visual search, https://github.com/beniz/deepdetect/tree/master/demo/imgsearch
+* Integration with Elasticsearch, https://deepdetect.com/tutorials/es-image-classifier

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,7 @@
 set_source_files_properties(
   ${CMAKE_BINARY_DIR}/src/caffe.pb.cc
   ${CMAKE_BINARY_DIR}/src/caffe.pb.h
+  ${CMAKE_BINARY_DIR}/dd_config.cc
   PROPERTIES GENERATED TRUE)
 set_source_files_properties(
   ${CMAKE_BINARY_DIR}/src/caffe.pb.cc
@@ -23,7 +24,7 @@ set(ddetect_SOURCES deepdetect.h deepdetect.cc mllibstrategy.h mlmodel.h
     svminputfileconn.h svminputfileconn.cc txtinputfileconn.h
     txtinputfileconn.cc apidata.h apidata.cc chain_actions.h chain_actions.cc
     service_stats.h service_stats.cc chain.h chain.cc resources.cc ext/rmustache/mustache.h ext/rmustache/mustache.cc
-    utils/oatpp.cc dto/ddtypes.cc utils/db.cpp utils/db_lmdb.cpp ${CMAKE_BINARY_DIR}/src/caffe.pb.cc)
+    utils/oatpp.cc dto/ddtypes.cc utils/db.cpp utils/db_lmdb.cpp ${CMAKE_BINARY_DIR}/src/caffe.pb.cc ${CMAKE_BINARY_DIR}/dd_config.cc)
 
 if (USE_JSON_API)
   list(APPEND ddetect_SOURCES jsonapi.h jsonapi.cc)
@@ -32,7 +33,7 @@ if (USE_HTTP_SERVER)
   list(APPEND ddetect_SOURCES httpjsonapi.cc httpjsonapi.h)
 endif()
 if (USE_HTTP_SERVER_OATPP)
-  list(APPEND ddetect_SOURCES oatppjsonapi.cc oatppjsonapi.h http/app_component.hpp http/swagger_component.hpp http/controller.hpp http/error_handler.hpp http/error_handler.cpp http/access_log.cpp)
+  list(APPEND ddetect_SOURCES oatppjsonapi.cc oatppjsonapi.h http/app_component.hpp http/swagger_component.hpp http/controller.hpp http/error_handler.hpp http/error_handler.cpp http/access_log.cpp http/documentation.cc)
 endif()
 if (USE_HTTP_SERVER OR USE_HTTP_SERVER_OATPP)
   list(APPEND ddetect_SOURCES http/flags.h)

--- a/src/dd_config.cc.in
+++ b/src/dd_config.cc.in
@@ -1,0 +1,6 @@
+#include "dd_config.h"
+
+std::string GET_API_DOC() {
+    static std::string API_DOC = R"apidocumentation(@API_DOC@)apidocumentation";
+    return API_DOC;
+}

--- a/src/dd_config.h.in
+++ b/src/dd_config.h.in
@@ -1,6 +1,8 @@
 #ifndef DD_CONFIG_H
 #define DD_CONFIG_H
 
+#include <string>
+
 #define BUILD_TYPE "@BUILD_TYPE@"
 #define GIT_VERSION "@GIT_VERSION@"
 #define GIT_BRANCH "@GIT_BRANCH@"
@@ -19,5 +21,8 @@
   "OPENCV_VERSION=@OpenCV_VERSION@ "                                          \
   "CUDA_VERSION=@CUDA_VERSION_STRING@ CUDNN_VERSION=@CUDNN_VERSION@ "         \
   "CUDA_ARCH=@CUDA_ARCH@ TENSORRT_VERSION=@TENSORRT_VERSION@"
+
+// Swagger documentation
+std::string GET_API_DOC();
 
 #endif

--- a/src/http/controller.hpp
+++ b/src/http/controller.hpp
@@ -39,6 +39,7 @@
 #include "dto/service_create.hpp"
 #include "dto/stream.hpp"
 #include "dto/resource.hpp"
+#include "documentation.hpp"
 
 #include OATPP_CODEGEN_BEGIN(ApiController)
 
@@ -64,7 +65,8 @@ public:
 
   ENDPOINT_INFO(get_info)
   {
-    info->summary = "Retrieve server information";
+    info->summary = "Returns general information about the deepdetect server, "
+                    "including the list of existing services.";
     info->addResponse<Object<dd::DTO::InfoResponse>>(Status::CODE_200,
                                                      "application/json");
   }
@@ -100,7 +102,7 @@ public:
 
   ENDPOINT_INFO(get_service)
   {
-    info->summary = "Retrieve a service detail";
+    info->summary = "Returns information on an existing service";
   }
   ENDPOINT("GET", "services/{service-name}", get_service,
            PATH(oatpp::String, service_name, "service-name"),
@@ -138,7 +140,7 @@ public:
 
   ENDPOINT_INFO(create_service)
   {
-    info->summary = "Create a service";
+    info->summary = "Create a new machine learning service";
     info->addConsumes<Object<dd::DTO::ServiceCreate>>("application/json");
   }
   ENDPOINT("POST", "services/{service-name}", create_service,
@@ -164,6 +166,13 @@ public:
   ENDPOINT_INFO(delete_service)
   {
     info->summary = "Delete a service";
+    info->queryParams.add("clear", String::Class::getType()).description
+        = "`full`, `lib`, `mem`, `dir` or `index`. `full` clears the model "
+          "and service repository, `lib` removes model files only according "
+          "to the behavior specified by the service's ML library, `mem` "
+          "removes the service from memory without affecting the files, `dir` "
+          "removes the whole directory, `index` removes the index when using "
+          "similarity search. default=`mem`";
   }
   ENDPOINT("DELETE", "services/{service-name}", delete_service,
            PATH(oatpp::String, service_name, "service-name"),
@@ -199,7 +208,9 @@ public:
 
   ENDPOINT_INFO(post_train)
   {
-    info->summary = "Do a training";
+    info->summary
+        = "Launches a blocking or asynchronous training job from a service.";
+    info->body.description = dd::GET_TRAIN_PARAMETERS();
   }
   ENDPOINT("POST", "train", post_train, BODY_STRING(oatpp::String, train_data))
   {
@@ -219,7 +230,7 @@ public:
   }
   ENDPOINT_INFO(delete_train)
   {
-    info->summary = "Delete a training";
+    info->summary = "Stop and delete a training job";
   }
   ENDPOINT("DELETE", "train", delete_train, QUERIES(QueryParams, queryParams))
   {
@@ -230,7 +241,8 @@ public:
 
   ENDPOINT_INFO(create_chain)
   {
-    info->summary = "Run a chain";
+    info->summary = "Run a chain call, that allows to call multiple models "
+                    "sequentially";
   }
   ENDPOINT("POST", "chain/{chain-name}", create_chain,
            PATH(oatpp::String, chain_name, "chain-name"),

--- a/src/http/documentation.cc
+++ b/src/http/documentation.cc
@@ -1,0 +1,189 @@
+#include "documentation.hpp"
+
+namespace dd
+{
+  // TODO This will be obsolete once training params will use DTO
+  std::string GET_TRAIN_PARAMETERS()
+  {
+    static std::string TRAIN_PARAMS = R"trainparams(
+Documentation source: [documentation.cc](https://github.com/jolibrain/deepdetect/blob/master/src/http/documentation.cc)
+
+Parameter | Type   | Optional | Default | Description
+--------- | ----   | -------- | ------- | -----------
+service   | string | No       | N/A     | service resource identifier
+async     | bool   | No       | true    | whether to start a non-blocking training call
+data      | object | yes      | empty   | input dataset for training, in some cases can be handled by the input connectors, in general non optional though
+
+## Output connector
+
+Parameter         | Type   | Optional | Default | Description
+---------         | ----   | -------- | ------- | -----------
+best              | int    | yes      | 1       | Number of top predictions returned by data URI (supervised)
+measure           | array  | yes      | empty   | Output measures requested, from `acc`: accuracy, `acc-k`: top-k accuracy, replace k with number (e.g. `acc-5`), `f1`: f1, precision and recall, `mcll`: multi-class log loss, `auc`: area under the curve, `cmdiag`: diagonal of confusion matrix (requires `f1`), `cmfull`: full confusion matrix (requires `f1`), `mcc`: Matthews correlation coefficient, `eucll`: euclidean distance (e.g. for regression tasks),`l1`: l1 distance (e.g. for regression tasks), `percent`: mean relative error in percent,  `kl`: KL_divergence, `js`: JS divergence, `was`: Wasserstein, `ks`: Kolmogorov Smirnov, `dc`: distance correlation, `r2`: R2, `deltas`: delta scores, 'raw': ouput raw results, in case of predict call, this requires a special deploy.prototxt that is a test network (to have ground truth)
+target_repository | string | yes      | empty   | target directory to which to copy the best model files once training has completed
+
+Problem type | Default | Possible values | Description
+------------ | ------- | --------------- | -----------
+timeserie    |   L1    | L1, L2, mase, mape, smape, mase, owa, mae, mse; L1_all, L2_all, mase_all, mape_all, smape_all, mase_all, owa_all, mae_all, mse_all | L1: mean error, L2: mean squared error, mase : mean absolute scaled error, mape: mean absolute percentage error, smape: symetric mean absolute percentage error, owa: overall weighted average, mae: mean absolute error, mse: mean squarred error; ; versions with "\_all" also show metrics per dimension/serie, and not only average.
+
+## Machine learning libraries
+
+Parameter     | Type           | Optional | Default        | Description
+---------     | ----           | -------- | -------        | -----------
+gpu           | bool           | yes      | false          | Whether to use GPU
+gpuid         | int or array   | yes      | 0              | GPU id, use single int for single GPU, `-1` for using all GPUs, and array e.g. `[1,3]` for selecting among multiple GPUs
+resume        | bool           | yes      | false          | Whether to resume training from .solverstate and .caffemodel files
+class_weights | array of float | yes      | 1.0 everywhere | Whether to weight some classes more / less than others, e.g. [1.0,0.1,1.0]
+ignore_label  | int            | yes      | N/A            | A single label to be ignored by the loss (i.e. no gradients)
+timesteps     | int            | yes      | N/A            | Number of timesteps for recurrence ('csvts', `ctc` OCR) models (in case of csvts, used only at train time)
+offset        | int            | yes      | N/A            | Offset beween start point of sequences with connector `cvsts`, defining the overlap of input series. For [0, n] steps a timestep of t and an offset of k, series [0..t-1], [k..t+k-1], [2k, 2k+t-1] ... will be cosntructed. If some elements at the end could not be taken using this, it will add a final [n-t+1..n] sequence (used only at train time).
+freeze_traced   | bool   | yes      | false   | Freeze the traced part of the net during finetuning (e.g. for classification)
+retain_graph	| bool	 | yes	    | false   | Whether to use `retain_graph` with torch autograd
+template        | string | yes      | ""      | e.g. "bert", "gpt2", "recurrent", "nbeats", "vit", "visformer", "ttransformer", "resnet50", ... All templates are listed in the [Model Templates](#model-templates) section.
+template_params | dict   | yes      | template dependent | Model parameter for templates. All parameters are listed in the [Model Templates](#model-templates) section.
+regression | bool            | yes                      | false   | Whether the model is a regressor
+timesteps     | int            | yes      | N/A            | Number of timesteps for time models (LSTM/NBEATS...) : this sets the length of sequences that will be given for learning, every timestep contains inputs and outputs as defined by the csv/csvts connector
+forecast_timesteps      | int            | yes      | N/A       | for nbeats model, this gives the length of the forecast
+backcast_timesteps      | int            | yes      | N/A       | for nbeats model, this gives the length of the backcast
+datatype      | string | yes       | fp32 | Datatype used at prediction time, possible values are "fp16" (only if inference is done on GPU) , "fp32" and "fp64" (double)
+dataloader_threads | int | yes | 1 | How many threads should be used to load data. 0 means no prefetch.
+
+### Solver
+
+Parameter            | Type         | Optional | Default | Description
+---------            | ----         | -------- | ------- | -----------
+iterations           | int          | yes      | N/A     | Max number of solver's iterations
+snapshot             | int          | yes      | N/A     | Iterations between model snapshots
+snapshot_prefix      | string       | yes      | empty   | Prefix to snapshot file, supports repository
+solver_type          | string       | yes      | SGD     | from "SGD", "ADAGRAD", "NESTEROV", "RMSPROP", "ADADELTA", "ADAM",  "AMSGRAD",  "RANGER", "RANGER_PLUS", "ADAMW", "SGDW", "AMSGRADW" (\*W version for decoupled weight decay, RANGER_PLUS is ranger + adabelief + centralized_gradient)
+clip                 | bool         | yes      | false (true if RANGER\* selected) | gradients with absolute value greater than clip_value will be clipped to below values
+clip_value           | real         | yes      | 5.0     | gradients with absolute value greater than clip_value will be clipped to this value
+clip_norm            | real         | yes      | 100.0   | gradients with euclidean norm greater than clip_norm will be clipped to this value
+adabelief            | bool         | yes      | false   | adabelief mod for ADAM https://arxiv.org/abs/2010.07468
+gradient_centralization | bool         | yes      | false   | centralized gradient mod for ADAM ie https://arxiv.org/abs/2004.01461v2
+beta1         | real   | yes      | 0.9     | for RANGER\* : beta1 param
+beta2         | real   | yes      | 0.999   | for RANGER\* : beta2 param
+weight_decay  | real   | yes      | 0.0     | for RANGER\* : weight decay
+rectified     | bool   | yes      | true    | for RANGER\* : enable/disable rectified ADAM
+lookahead     | bool   | yes      | true    | for RANGER\* and MADGRAD : enable/disable lookahead
+lookahead_steps | int  | yes      | 6       | for RANGER\* and MADGRAD : if lookahead enabled, number of steps
+lookahead_alpha | real | yes      | 0.5     | for RANGER\* and MADGRAD : if lookahead enables, alpha param
+adabelief     | bool   | yes      | false for RANGER, true for RANGER_PLUS   | for RANGER\* : enable/disable adabelief
+gradient_centralization | bool | yes | false for RANGER, true for RANGER_PLUS| for RANGER\* : enable/disable gradient centralization
+sam           | bool   | yes      | false   | Sharpness Aware Minimization (https://arxiv.org/abs/2010.01412)
+sam_rho       | real   | yes      | 0.05    | neighborhood size for SAM (see above)
+swa           | bool   | yes      | false   | SWA https://arxiv.org/abs/1803.05407 , implemented  only for  RANGER / RANGER_PLUS / MADGRAD  solver types.
+test_interval        | int          | yes      | N/A     | Number of iterations between testing phases
+test_initialization  | bool         | true     | N/A     | Whether to start training by testing the network
+lr_policy            | string       | yes      | N/A     | learning rate policy ("step", "inv", "fixed", "sgdr", ...)
+base_lr              | real         | yes      | N/A     | Initial learning rate
+warmup_lr            | real         | yes      | N/A     | warmup starting learning rate (linearly goes to base_lr)
+warmup_iter          | int          | yes      | 0       | number of warmup iterations
+gamma                | real         | yes      | N/A     | Learning rate drop factor
+stepsize             | int          | yes      | N/A     | Number of iterations between the dropping of the learning rate
+stepvalue            | array of int | yes      | N/A     | Iterations at which a learning rate change takes place, with `multistep` `lr_policy`
+momentum             | real         | yes      | N/A     | Learning momentum
+period               | int          | yes      | -1      | N/A | Period in number of iterations with SGDR, best to use ncycles instead
+ncycles              | int          | yes      | 1       | Number of restart cycles with SGDR
+weight_decay         | real         | yes      | N/A     | Weight decay
+power                | real         | yes      | N/A     | Power applicable to some learning rate policies
+iter_size            | int          | yes      | 1       | Number of passes (iter_size * batch_size) at every iteration
+rand_skip            | int          | yes      | 0       | Max number of images to skip when resuming training (only with segmentation or multilabel and Caffe backend)
+lookahead            | bool         | yes      | false   | weither to use lookahead strategy from  https://arxiv.org/abs/1907.08610v1
+lookahead_steps      | int          | yes      | 6       | number of lookahead steps for lookahead strategy
+lookahead_alpha      | real         | yes      | 0.5     | size of step towards full lookahead
+decoupled_wd_periods | int          | yes      | 4       | number of search periods for SGDW ADAMW AMSGRADW (periods end with a restart)
+decoupled_wd_mult    | real         | yes      | 2.0     | muliplier of period for SGDW ADAMW AMSGRADW
+lr_dropout           | real         | yes      | 1.0     | learning rate dropout, as in https://arxiv.org/abs/1912.00144 1.0 means no dropout, 0.0 means no learning at all (this value is the probability of keeping computed value and not putting zero)
+
+Note: most of the default values for the parameters above are to be found in the Caffe files describing a given neural network architecture, or within Caffe library, therefore regarded as N/A at DeepDetect level.
+
+### Net
+
+Parameter       | Type | Optional | Default | Description
+---------       | ---- | -------- | ------- | -----------
+batch_size      | int  | yes      | N/A     | Training batch size
+test_batch_size | int  | yes      | N/A     | Testing batch size
+
+### Data augmentation
+
+Noise (images only):
+
+Parameter      | Type   | Optional | Default | Description
+---------      | ----   | -------- | ------- | -----------
+prob           | double | yes      | 0.0     | Probability of each effect occurence
+all_effects    | bool   | yes      | false   | Apply all effects below, randomly
+decolorize     | bool   | yes      | N/A     | Whether to decolorize image
+hist_eq        | bool   | yes      | N/A     | Whether to equalize histogram
+inverse        | bool   | yes      | N/A     | Whether to inverse image
+gauss_blur     | bool   | yes      | N/A     | Whether to apply Gaussian blur
+posterize      | bool   | yes      | N/A     | Whether to posterize image
+erode          | bool   | yes      | N/A     | Whether to erode image
+saltpepper     | bool   | yes      | N/A     | Whether to apply salt & pepper effect to image
+clahe          | bool   | yes      | N/A     | Whether to apply CLAHE
+convert_to_hsv | bool   | yes      | N/A     | Whether to convert to HSV
+convert_to_lab | bool   | yes      | N/A     | Whether to convert to LAB
+
+Distort (images only):
+
+Parameter       | Type   | Optional | Default | Description
+---------       | ----   | -------- | ------- | -----------
+prob            | double | yes      | 0.0     | Probability of each effect occurence
+all_effects     | bool   | yes      | false   | Apply all effects below, randomly
+brightness      | bool   | yes      | N/A     | Whether to distort image brightness
+contrast        | bool   | yes      | N/A     | Whether to distort image contrast
+saturation      | bool   | yes      | N/A     | Whether to distort image saturation
+HUE             | bool   | yes      | N/A     | Whether to distort image HUE
+random ordering | bool   | yes      | N/A     | Whether to randomly reorder the image channels
+
+Geometry (images only):
+
+Parameter        | Type   | Optional | Default  | Description
+---------        | ----   | -------- | -------  | -----------
+prob             | double | yes      | 0.0      | Probability of each effect occurence
+all_effects      | bool   | yes      | false    | Apply all effects below, randomly
+persp_horizontal | bool   | yes      | true     | Whether to distort the perspective horizontally
+persp_vertical   | bool   | yes      | true     | Whether to distort the perspective vertically
+zoom_out         | bool   | yes      | true     | distance change, look further away
+zoom_in          | bool   | yes      | true     | distance changee, look from closer by
+zoom_factor      | float  | yes      | 0.25     | 0.25 means that image can be \*1.25 or /1.25
+persp_factor     | float  | yes      | 0.25     | 0.25 means that new image corners  be in \*1.25 or 0.75
+pad_mode         | string | yes      | mirrored | filling around image, from `mirrored` / `constant` (black) / `repeat_nearest`
+
+
+### XGBoost
+
+Parameter     | Type   | Optional | Default                | Description
+---------     | ----   | -------- | -------                | -----------
+objective     | string | yes      | multi:softprob         | objective function, among multi:softprob, binary:logistic, reg:linear, reg:logistic
+booster       | string | yes      | gbtree                 | which booster to use, gbtree or gblinear
+num_feature   | int    | yes      | set by xgbbost         | maximum dimension of the feature
+eval_metric   | string | yes      | according to objective | evaluation metric internal to xgboost
+base_score    | double | yes      | 0.5                    | initial prediction score, global bias
+seed          | int    | yes      | 0                      | random number seed
+iterations    | int    | no       | N/A                    | number of boosting iterations
+test_interval | int    | yes      | 1                      | number of iterations between each testing pass
+save_period   | int    | yes      | 0                      | number of iterations between model saving to disk
+
+Booster_params:
+
+Parameter        | Type   | Optional | Default | Description
+---------        | ----   | -------- | ------- | -----------
+eta              | double | yes      | 0.3     | step size shrinkage
+gamma            | double | yes      | 0       | minimum loss reduction
+max_depth        | int    | yes      | 6       | maximum depth of a tree
+min_child_weight | int    | yes      | 1       | minimum sum of instance weight
+max_delta_step   | int    | yes      | 0       | maximum delta step
+subsample        | double | yes      | 1.0     | subsample ratio of traning instance
+colsample        | double | yes      | 1.0     | subsample ratio of columns when contructing each tree
+lambda           | double | yes      | 1.0     | L2 regularization term on weights
+alpha            | double | yes      | 0.0     | L1 regularization term on weights
+lambda_bias      | double | yes      | 0.0     | L2 regularization for linear booster
+tree_method      | string | yes      | auto    | tree construction algorithm, from auto, exact, approx
+scale_pos_weight | double | yes      | 1.0     | control the balance of positive and negative weights
+
+For more details on all XGBoost parameters see the dedicated page at https://github.com/dmlc/xgboost/blob/master/doc/parameter.md
+        )trainparams";
+    return TRAIN_PARAMS;
+  }
+}

--- a/src/http/documentation.hpp
+++ b/src/http/documentation.hpp
@@ -1,0 +1,11 @@
+#ifndef DD_HTPP_DOCUMENTATION
+#define DD_HTPP_DOCUMENTATION
+
+#include <string>
+
+namespace dd
+{
+  std::string GET_TRAIN_PARAMETERS();
+}
+
+#endif // DD_HTPP_DOCUMENTATION

--- a/src/http/swagger_component.hpp
+++ b/src/http/swagger_component.hpp
@@ -44,8 +44,8 @@ public:
 
     std::ostringstream version;
     version << GIT_VERSION << " (" << BUILD_TYPE << ")";
-    builder.setTitle("DeepDetect")
-        .setDescription("DeepDetect REST API")
+    builder.setTitle("DeepDetect API Documentation")
+        .setDescription(GET_API_DOC())
         .setVersion(version.str().c_str())
         .setContactName("Jolibrain")
         .setContactUrl("https://deepdetect.com/")


### PR DESCRIPTION
Swagger documentation is served by the DeepDetect server at `host:port/swagger/ui`

Open API json is also served by the server at `host:port/api-docs/oas-3.0.0.json`. It can be used to serve documentation as a separate page, for example with Fast API.

To serve the documentation as a static page, the required files are:
```
/api-docs/oas-3.0.0.json
/swagger/favicon-16x16.png
/swagger/ui
/swagger/swagger-ui.css
/swagger/swagger-ui-bundle.js
/swagger/swagger-ui-standalone-preset.js
```
