### PR TITLE
fix(torch): segmentation with test_batch_size > 1

### DIFF
--- a/src/backends/torch/torchlib.cc
+++ b/src/backends/torch/torchlib.cc
@@ -2242,7 +2242,7 @@ namespace dd
             output = torch::softmax(output, 1);
             torch::Tensor target = batch.target.at(0).to(torch::kFloat64);
             torch::Tensor segmap
-                = torch::flatten(torch::argmax(output.squeeze(), 0))
+                = torch::flatten(torch::argmax(output.squeeze(), 1))
                       .contiguous()
                       .to(torch::kFloat64)
                       .to(cpu); // squeeze removes the batch size


### PR DESCRIPTION
`torch::argmax` was done on batch dimension instead of classes dimension.
`segmap` tensor had shape `height*width` instead of `test_batch_size*height*width`.
This resulted in bad metrics and segfaults.
Maybe we should do the same here: https://github.com/jolibrain/deepdetect/blob/master/src/backends/torch/torchlib.cc#L1858