### PR TITLE
Fix graceful exit

### DIFF
--- a/bindings/python/deepdetect/cli/CLI_SPEC.md
+++ b/bindings/python/deepdetect/cli/CLI_SPEC.md
@@ -159,6 +159,9 @@ Shared training options:
   model repository. When explicitly set, the run files are written under
   `<job-dir>/<run-name>/`.
 - `--poll-interval`, `--timeout`: async monitoring controls.
+- `--cancel-timeout`: grace period for asynchronous `pytorch` workers after a
+  cooperative cancellation request. It defaults to 30 seconds and must be
+  positive.
 - `--terminal verbose|live`: choose stdout behavior for async training.
   `verbose` is the default and preserves `--output-format`. `live` uses a
   fixed-size Rich display when stdout is a TTY and falls back to JSONL when it
@@ -221,6 +224,17 @@ bbox line format, class ranges, and numeric bbox values; SegFormer validates
 mask values unless `--skip-mask-validation` is passed. With
 `--dataset-check none`, the CLI emits a skipped dataset-check event and leaves
 dataset validation to the DeepDetect backend.
+
+For asynchronous profiles using the `pytorch` worker backend, the first
+Ctrl-C requests cooperative cancellation so the worker can write its final
+checkpoint. Monitoring continues with a `cancelling` status, and another
+Ctrl-C forces worker process-group termination. If the worker does not finish
+within `--cancel-timeout`, the CLI escalates automatically and reports
+`terminating`. Cooperative and forced shutdown finish as `cancelled` and
+`terminated`, respectively, and return exit code 130. If training finishes
+while cancellation is racing with completion, the run remains `finished` and
+returns zero. Blocking `--sync` training and other backends retain their
+existing interrupt behavior.
 
 ### Agent Observation CLI
 

--- a/bindings/python/deepdetect/cli/external-pytorch-detector-default.yaml
+++ b/bindings/python/deepdetect/cli/external-pytorch-detector-default.yaml
@@ -26,6 +26,7 @@ gpuid: null
 sync: false
 poll_interval: 0.5
 timeout: null
+cancel_timeout: 30
 job_dir: null
 run_name: null
 resume: null

--- a/bindings/python/deepdetect/cli/main.py
+++ b/bindings/python/deepdetect/cli/main.py
@@ -93,6 +93,11 @@ def _add_train_parser(parser: argparse.ArgumentParser) -> None:
     )
     parser.add_argument("--sync", action=argparse.BooleanOptionalAction, default=None)
     parser.add_argument("--timeout", type=float)
+    parser.add_argument(
+        "--cancel-timeout",
+        type=float,
+        help="seconds to wait for a cooperative PyTorch cancellation before forcing it",
+    )
     parser.add_argument("--poll-interval", type=float)
     parser.add_argument("--job-dir", type=Path)
     parser.add_argument("--run-name")

--- a/bindings/python/deepdetect/cli/profiles.py
+++ b/bindings/python/deepdetect/cli/profiles.py
@@ -71,6 +71,7 @@ class ModelProfile:
             "sync": False,
             "poll_interval": 0.5,
             "timeout": None,
+            "cancel_timeout": 30.0,
             "job_dir": None,
             "run_name": None,
             "resume": None,

--- a/bindings/python/deepdetect/cli/segformer-default.yaml
+++ b/bindings/python/deepdetect/cli/segformer-default.yaml
@@ -36,6 +36,7 @@ gpuid: null
 sync: false
 poll_interval: 0.5
 timeout: null
+cancel_timeout: 30
 job_dir: null
 run_name: null
 resume: null

--- a/bindings/python/deepdetect/cli/terminal.py
+++ b/bindings/python/deepdetect/cli/terminal.py
@@ -84,7 +84,11 @@ class LiveTrainingTerminalReporter:
             if isinstance(measure, dict):
                 self._measure = measure
                 self._update_latest_metrics(measure)
-            if self._live is None and not self._ready_to_render():
+            if (
+                self._live is None
+                and self._status not in {"cancelling", "terminating"}
+                and not self._ready_to_render()
+            ):
                 return record
             self._start_or_refresh()
         elif event == "metric":
@@ -153,7 +157,18 @@ class LiveTrainingTerminalReporter:
                 )
             )
         )
-        table.add_row(f"[bold]loss[/] {_format_values(self._loss_values(), empty='pending')}")
+        table.add_row(
+            f"[bold]loss[/] {_format_values(self._loss_values(), empty='pending')}"
+        )
+        if self._status == "cancelling":
+            table.add_row(
+                "[bold yellow]cancel[/] saving a final checkpoint; "
+                "press Ctrl-C again to force termination"
+            )
+        elif self._status == "terminating":
+            table.add_row(
+                "[bold red]cancel[/] forcing worker process-group termination"
+            )
         table.add_row(Rule(style="dim"))
         if self._has_test_progress():
             table.add_row(self._test_progress(Progress, SpinnerColumn, TextColumn, BarColumn))

--- a/bindings/python/deepdetect/cli/torchvision-detector-default.yaml
+++ b/bindings/python/deepdetect/cli/torchvision-detector-default.yaml
@@ -39,6 +39,7 @@ gpuid: null
 sync: false
 poll_interval: 0.5
 timeout: null
+cancel_timeout: 30
 job_dir: null
 run_name: null
 resume: null

--- a/bindings/python/deepdetect/cli/training.py
+++ b/bindings/python/deepdetect/cli/training.py
@@ -56,6 +56,7 @@ def run_train(args: Any) -> int:
         gpuid=parse_gpu_ids(args.gpuid),
         sync=args.sync,
         timeout=args.timeout,
+        cancel_timeout=args.cancel_timeout,
         poll_interval=args.poll_interval,
         job_dir=args.job_dir,
         run_name=args.run_name,
@@ -106,6 +107,7 @@ def run_train(args: Any) -> int:
     if options.get("max_objects") is not None and int(options["max_objects"]) <= 0:
         raise ValueError("max_objects must be positive")
     validate_positive("visdom_port", int(options["visdom_port"]))
+    validate_positive("cancel_timeout", float(options["cancel_timeout"]))
     if int(options["visdom_results_count"]) < 0:
         raise ValueError("visdom_results_count must be non-negative")
     run_name = str(options.get("run_name") or repository_name(Path(options["repository"])))
@@ -216,7 +218,9 @@ def run_train(args: Any) -> int:
                     result_visualizer=result_visualizer,
                     extractor=extractor,
                     timeout=options["timeout"],
+                    cancel_timeout=float(options["cancel_timeout"]),
                     poll_interval=float(options["poll_interval"]),
+                    staged_cancellation=profile.backend == "pytorch",
                 )
             else:
                 _debug("run_train: processing synchronous training result")
@@ -235,16 +239,29 @@ def run_train(args: Any) -> int:
                 )
                 if result_visualizer is not None:
                     result_visualizer.maybe_write({"status": "finished", **result}, events)
+        final_state = final_status.get("status", "finished")
+        final_metadata = {
+            key: final_status[key]
+            for key in (
+                "cancellation_requested_at",
+                "cancellation_reason",
+                "force_requested_at",
+                "force_reason",
+            )
+            if key in final_status
+        }
         writer.emit(
             "run_finished",
             run_id=manifest.data["run_id"],
-            status=final_status.get("status", "finished"),
+            status=final_state,
+            **final_metadata,
         )
         manifest.update(
-            status=final_status.get("status", "finished"),
+            status=final_state,
             last_status=final_status,
+            **final_metadata,
         )
-        return 0
+        return 130 if final_state in {"cancelled", "terminated"} else 0
     finally:
         _debug("run_train: closing sinks and terminal")
         metric_sink.close()
@@ -525,31 +542,30 @@ def monitor_training(
     metric_sink: CompositeMetricSink,
     result_visualizer: TrainingResultVisualizer | None = None,
     timeout: float | None = None,
+    cancel_timeout: float = 30.0,
     poll_interval: float = 0.5,
     extractor: MetricEventExtractor | None = None,
+    staged_cancellation: bool = False,
 ) -> dict[str, Any]:
     started = time.monotonic()
     extractor = extractor or MetricEventExtractor()
     manifest.update(job=job.job, status="running")
-    while True:
-        _debug(f"monitor_training: polling job {job.job}")
-        output_parameters: dict[str, Any] = {
-            "measure_hist": True,
-            "max_hist_points": 10000,
-        }
-        if result_visualizer is not None:
-            output_parameters["test_predictions"] = True
-        status = job.status(output_parameters=output_parameters)
-        state = str(status.get("status", "")).lower()
-        measure = status.get("measure") if isinstance(status.get("measure"), dict) else {}
-        _debug(
-            "monitor_training: status=%s iteration=%s train_loss=%s"
-            % (
-                state,
-                measure.get("iteration"),
-                measure.get("train_loss"),
-            )
-        )
+    latest_status: dict[str, Any] = {}
+    cancellation_started: float | None = None
+    cancellation_requested_at: float | None = None
+    cancellation_reason: str | None = None
+    force_requested_at: float | None = None
+    force_reason: str | None = None
+
+    def cancellation_status(state: str) -> dict[str, Any]:
+        status = dict(latest_status)
+        status["status"] = state
+        status["job"] = job.job
+        status.setdefault("measure", {})
+        return status
+
+    def emit_cancellation_state(state: str, message: str) -> None:
+        status = cancellation_status(state)
         writer.emit(
             "training_status",
             run_id=manifest.data["run_id"],
@@ -558,23 +574,128 @@ def monitor_training(
             time=status.get("time"),
             measure=status.get("measure", {}),
             measures=status.get("measures"),
+            message=message,
+            cancellation_reason=cancellation_reason,
+            force_reason=force_reason,
         )
-        events = write_metric_events(
-            status,
-            writer=writer,
-            manifest=manifest,
-            metric_sink=metric_sink,
-            extractor=extractor,
+        manifest.update(
+            status=state,
+            last_status=status,
+            cancellation_requested_at=cancellation_requested_at,
+            cancellation_reason=cancellation_reason,
+            **(
+                {
+                    "force_requested_at": force_requested_at,
+                    "force_reason": force_reason,
+                }
+                if force_reason is not None
+                else {}
+            ),
         )
-        if result_visualizer is not None:
-            result_visualizer.maybe_write(status, events)
-        manifest.update(status=state or "running", last_status=status)
-        if state in deepdetect.TrainingJob._TERMINAL:
-            if state != "finished":
-                raise RuntimeError(f"training ended with status {state!r}")
-            return status
-        if timeout is not None and time.monotonic() - started >= timeout:
-            job.cancel()
-            manifest.update(status="cancelled")
-            raise TimeoutError(f"training job {job.job} timed out and was cancelled")
-        time.sleep(poll_interval)
+
+    def request_cooperative_cancellation(reason: str) -> None:
+        nonlocal cancellation_started
+        nonlocal cancellation_requested_at
+        nonlocal cancellation_reason
+        cancellation_started = time.monotonic()
+        cancellation_requested_at = time.time()
+        cancellation_reason = reason
+        job.cancel(wait=False)
+        emit_cancellation_state(
+            "cancelling",
+            "cooperative cancellation requested; press Ctrl-C again to force termination",
+        )
+
+    def request_forced_cancellation(reason: str) -> None:
+        nonlocal force_requested_at
+        nonlocal force_reason
+        force_requested_at = time.time()
+        force_reason = reason
+        emit_cancellation_state(
+            "terminating",
+            "forcing PyTorch worker process-group termination",
+        )
+        job.cancel(wait=False, force=True)
+
+    while True:
+        try:
+            if (
+                cancellation_started is not None
+                and force_reason is None
+                and time.monotonic() - cancellation_started >= cancel_timeout
+            ):
+                request_forced_cancellation("cancel_timeout")
+
+            _debug(f"monitor_training: polling job {job.job}")
+            output_parameters: dict[str, Any] = {
+                "measure_hist": True,
+                "max_hist_points": 10000,
+            }
+            if result_visualizer is not None:
+                output_parameters["test_predictions"] = True
+            status = job.status(output_parameters=output_parameters)
+            latest_status = status
+            state = str(status.get("status", "")).lower()
+            measure = (
+                status.get("measure") if isinstance(status.get("measure"), dict) else {}
+            )
+            _debug(
+                "monitor_training: status=%s iteration=%s train_loss=%s"
+                % (
+                    state,
+                    measure.get("iteration"),
+                    measure.get("train_loss"),
+                )
+            )
+            writer.emit(
+                "training_status",
+                run_id=manifest.data["run_id"],
+                job=job.job,
+                status=state,
+                time=status.get("time"),
+                measure=status.get("measure", {}),
+                measures=status.get("measures"),
+            )
+            events = write_metric_events(
+                status,
+                writer=writer,
+                manifest=manifest,
+                metric_sink=metric_sink,
+                extractor=extractor,
+            )
+            if result_visualizer is not None:
+                result_visualizer.maybe_write(status, events)
+            manifest.update(status=state or "running", last_status=status)
+            if state in deepdetect.TrainingJob._TERMINAL:
+                if state not in {"finished", "cancelled", "terminated"}:
+                    raise RuntimeError(f"training ended with status {state!r}")
+                if cancellation_reason is not None:
+                    status["cancellation_requested_at"] = cancellation_requested_at
+                    status["cancellation_reason"] = cancellation_reason
+                if force_reason is not None:
+                    status["force_requested_at"] = force_requested_at
+                    status["force_reason"] = force_reason
+                return status
+            if (
+                timeout is not None
+                and cancellation_started is None
+                and time.monotonic() - started >= timeout
+            ):
+                if not staged_cancellation:
+                    job.cancel()
+                    manifest.update(status="cancelled")
+                    raise TimeoutError(
+                        f"training job {job.job} timed out and was cancelled"
+                    )
+                request_cooperative_cancellation("training_timeout")
+            time.sleep(poll_interval)
+        except KeyboardInterrupt:
+            if not staged_cancellation:
+                raise
+            if cancellation_started is None:
+                try:
+                    request_cooperative_cancellation("keyboard_interrupt")
+                except KeyboardInterrupt:
+                    request_forced_cancellation("second_keyboard_interrupt")
+            elif force_reason is None:
+                request_forced_cancellation("second_keyboard_interrupt")

--- a/bindings/python/deepdetect/cli/vitpose-default.yaml
+++ b/bindings/python/deepdetect/cli/vitpose-default.yaml
@@ -51,6 +51,7 @@ gpuid: null
 sync: false
 poll_interval: 0.5
 timeout: null
+cancel_timeout: 30
 job_dir: null
 run_name: null
 resume: null

--- a/bindings/python/deepdetect/cli/yolox-default.yaml
+++ b/bindings/python/deepdetect/cli/yolox-default.yaml
@@ -37,6 +37,7 @@ gpuid: null
 sync: false
 poll_interval: 0.5
 timeout: null
+cancel_timeout: 30
 job_dir: null
 run_name: null
 resume: null

--- a/bindings/python/deepdetect/client.py
+++ b/bindings/python/deepdetect/client.py
@@ -345,7 +345,12 @@ class TrainingJob:
                 raise TimeoutError(f"training job {self.job} did not finish in time")
             time.sleep(poll_interval)
 
-    def cancel(self) -> None:
+    def cancel(self, *, wait: bool = True, force: bool = False) -> None:
         self.service._active()
-        request = _json({"service": self.service.name, "job": self.job})
+        payload: dict[str, Any] = {"service": self.service.name, "job": self.job}
+        if wait is not True:
+            payload["wait"] = wait
+        if force is not False:
+            payload["force"] = force
+        request = _json(payload)
         _checked(self.service._client._runtime.cancel_training(request))

--- a/bindings/python/deepdetect/pytorch_worker/builtin/vision/detection/common.py
+++ b/bindings/python/deepdetect/pytorch_worker/builtin/vision/detection/common.py
@@ -4,6 +4,7 @@ import math
 import os
 import random
 import sys
+import tempfile
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -933,10 +934,42 @@ def save_checkpoint(
         "iteration": iteration,
         "optimizer_state": optimizer.state_dict(),
     }
-    torch.save(model_payload, context.artifact_path(f"checkpoint-{iteration}.pt"))
-    torch.save(model_payload, context.artifact_path("checkpoint-latest.pt"))
-    torch.save(solver_payload, context.artifact_path(f"solver-{iteration}.pt"))
-    torch.save(solver_payload, context.artifact_path("solver-latest.pt"))
+    _atomic_torch_save(
+        torch,
+        model_payload,
+        context.artifact_path(f"checkpoint-{iteration}.pt"),
+    )
+    _atomic_torch_save(
+        torch,
+        model_payload,
+        context.artifact_path("checkpoint-latest.pt"),
+    )
+    _atomic_torch_save(
+        torch,
+        solver_payload,
+        context.artifact_path(f"solver-{iteration}.pt"),
+    )
+    _atomic_torch_save(
+        torch,
+        solver_payload,
+        context.artifact_path("solver-latest.pt"),
+    )
+
+
+def _atomic_torch_save(torch: Any, payload: Any, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        delete=False,
+    ) as temporary:
+        temporary_path = Path(temporary.name)
+    try:
+        torch.save(payload, temporary_path)
+        os.replace(temporary_path, path)
+    finally:
+        temporary_path.unlink(missing_ok=True)
 
 
 def request_dict(params: dict[str, Any]) -> dict[str, Any]:

--- a/bindings/python/deepdetect/pytorch_worker/dummy_worker.py
+++ b/bindings/python/deepdetect/pytorch_worker/dummy_worker.py
@@ -38,9 +38,10 @@ class DeepDetectWorker(DeepDetectWorkerBase):
         iterations = int(solver.get("iterations", 5))
         iterations = max(1, min(iterations, 1000000))
         learning_rate = float(solver.get("base_lr", 0.001))
+        ignore_cancellation = bool(mllib.get("ignore_cancellation", False))
 
         for iteration in range(1, iterations + 1):
-            if cancellation.requested:
+            if cancellation.requested and not ignore_cancellation:
                 reporter.status(
                     phase="cancelled",
                     iteration=iteration - 1,

--- a/bindings/python/tests/test_cli.py
+++ b/bindings/python/tests/test_cli.py
@@ -1,7 +1,15 @@
+import errno
 import io
 import json
+import os
+import pty
 import re
+import signal
+import subprocess
 import sys
+import textwrap
+import threading
+import time
 from types import SimpleNamespace
 from pathlib import Path
 
@@ -88,6 +96,10 @@ class FakeRuntime:
             },
             body=status.get("body", {}),
         )
+
+    def cancel_training(self, request):
+        self.calls.append(("cancel", json.loads(request)))
+        return response()
 
     def predict(self, request):
         request = json.loads(request)
@@ -221,6 +233,7 @@ def test_default_example_configs_load():
     assert sam2["service_mllib"]["sam2"]["variant"] == "tiny"
     assert sam2["service_mllib"]["sam2"]["automatic"]["max_masks"] == 0
     assert vitpose["mllib"]["data_source"] == "connector_tensor_pull"
+    assert vitpose["cancel_timeout"] == 30
     assert vitpose["dataset_check"] == "full"
 
 
@@ -379,6 +392,635 @@ def test_train_torchvision_detector_uses_pytorch_backend_without_weights(
         if line.strip()
     ]
     assert "run_finished" in {event["event"] for event in events}
+
+
+@pytest.mark.parametrize(
+    ("terminal", "live"),
+    [("verbose", False), ("live", True)],
+)
+def test_pytorch_train_first_ctrl_c_cancels_cooperatively(
+    monkeypatch, tmp_path, capsys, terminal, live
+):
+    class FakeLiveReporter:
+        instances = []
+
+        def __init__(self, *, total_iterations, gpu_ids=None):
+            self.events = []
+            self.closed = False
+            FakeLiveReporter.instances.append(self)
+
+        def emit(self, event, **payload):
+            record = {"event": event, "timestamp": 1.0, **payload}
+            self.events.append(record)
+            return record
+
+        def close(self):
+            self.closed = True
+
+    runtime = FakeRuntime()
+    runtime.statuses = [
+        {
+            "status": "running",
+            "body": {"measure": {"iteration": 4, "train_loss": 1.25}},
+        },
+        {
+            "status": "cancelled",
+            "body": {"measure": {"iteration": 4, "train_loss": 1.25}},
+        },
+    ]
+    monkeypatch.setattr(
+        training.deepdetect, "DeepDetect", lambda: DeepDetect(_runtime=runtime)
+    )
+    sleep_calls = 0
+
+    def interrupt_once(_interval):
+        nonlocal sleep_calls
+        sleep_calls += 1
+        if sleep_calls == 1:
+            raise KeyboardInterrupt
+
+    monkeypatch.setattr(training.time, "sleep", interrupt_once)
+    monkeypatch.setattr(training.sys.stdout, "isatty", lambda: live)
+    if live:
+        monkeypatch.setattr(training, "LiveTrainingTerminalReporter", FakeLiveReporter)
+    _weights, train, test = write_training_files(tmp_path)
+    run_root = tmp_path / "runs"
+
+    code = cli.main(
+        [
+            "train",
+            "torchvision-detector",
+            "--train-data",
+            str(train),
+            "--test-data",
+            str(test),
+            "--repository",
+            str(tmp_path / "repo"),
+            "--job-dir",
+            str(run_root),
+            "--run-name",
+            f"cancel-{terminal}",
+            "--iterations",
+            "100",
+            "--dataset-check",
+            "none",
+            "--terminal",
+            terminal,
+        ]
+    )
+
+    assert code == 130
+    assert (
+        "cancel",
+        {"service": "python-torchvision-detector-train", "job": 7, "wait": False},
+    ) in runtime.calls
+    manifest = json.loads(
+        (run_root / f"cancel-{terminal}" / "run.json").read_text(encoding="utf-8")
+    )
+    assert manifest["status"] == "cancelled"
+    assert manifest["cancellation_reason"] == "keyboard_interrupt"
+    assert manifest["last_status"]["measure"]["train_loss"] == 1.25
+    if live:
+        events = FakeLiveReporter.instances[0].events
+        assert FakeLiveReporter.instances[0].closed is True
+    else:
+        events = [
+            json.loads(line)
+            for line in capsys.readouterr().out.splitlines()
+            if line.strip()
+        ]
+    cancelling = [
+        event
+        for event in events
+        if event["event"] == "training_status" and event.get("status") == "cancelling"
+    ]
+    assert cancelling
+    assert cancelling[0]["measure"]["train_loss"] == 1.25
+    assert "press Ctrl-C again" in cancelling[0]["message"]
+    assert events[-1]["event"] == "run_finished"
+    assert events[-1]["status"] == "cancelled"
+
+
+def test_live_pytorch_subprocess_sigint_exits_130_with_valid_checkpoint(tmp_path):
+    script = tmp_path / "run_training.py"
+    script.write_text(
+        textwrap.dedent(
+            """
+            import json
+            import signal
+            import sys
+            from pathlib import Path
+
+            from deepdetect import DeepDetect
+            from deepdetect.cli import main as cli
+            from deepdetect.cli import training
+            from deepdetect.pytorch_worker.builtin.vision.detection.common import (
+                _atomic_torch_save,
+            )
+
+
+            def response(code=200, *, head=None, body=None):
+                value = {"status": {"code": code, "msg": "OK"}}
+                if head is not None:
+                    value["head"] = head
+                if body is not None:
+                    value["body"] = body
+                return json.dumps(value)
+
+
+            class Runtime:
+                def __init__(self):
+                    self.cancelled = False
+                    self.repository = None
+
+                def build_info(self):
+                    return json.dumps({"version": "test", "cuda": False})
+
+                def create_service(self, _name, request):
+                    self.repository = Path(json.loads(request)["model"]["repository"])
+                    return response(201)
+
+                def set_log_level(self, _level):
+                    return response()
+
+                def set_service_log_level(self, _name, _level):
+                    return response()
+
+                def train(self, _request):
+                    return response(201, head={"job": 7, "status": "running"})
+
+                def training_status(self, _request):
+                    state = "cancelled" if self.cancelled else "running"
+                    return response(
+                        head={"job": 7, "status": state, "time": 1.0},
+                        body={"measure": {"iteration": 4, "train_loss": 1.25}},
+                    )
+
+                def cancel_training(self, _request):
+                    class FakeTorch:
+                        @staticmethod
+                        def save(_payload, path):
+                            path.write_bytes(b"valid-checkpoint")
+
+                    _atomic_torch_save(
+                        FakeTorch,
+                        {"iteration": 4},
+                        self.repository / "checkpoint-latest.pt",
+                    )
+                    self.cancelled = True
+                    return response()
+
+                def delete_service(self, _name, _request):
+                    return response()
+
+
+            signal.signal(signal.SIGINT, signal.default_int_handler)
+            runtime = Runtime()
+            training.deepdetect.DeepDetect = lambda: DeepDetect(_runtime=runtime)
+            raise SystemExit(cli.main(sys.argv[1:]))
+            """
+        ),
+        encoding="utf-8",
+    )
+    _weights, train, test = write_training_files(tmp_path)
+    repository = tmp_path / "subprocess-repo"
+    source_python = str(Path(cli_package_file).resolve().parents[2])
+    environment = dict(os.environ)
+    environment["PYTHONPATH"] = os.pathsep.join(
+        [source_python, environment.get("PYTHONPATH", "")]
+    ).rstrip(os.pathsep)
+    master_fd, slave_fd = pty.openpty()
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            str(script),
+            "train",
+            "torchvision-detector",
+            "--train-data",
+            str(train),
+            "--test-data",
+            str(test),
+            "--repository",
+            str(repository),
+            "--iterations",
+            "100",
+            "--dataset-check",
+            "none",
+            "--terminal",
+            "live",
+        ],
+        stdout=slave_fd,
+        stderr=subprocess.PIPE,
+        env=environment,
+    )
+    os.close(slave_fd)
+
+    def drain_live_output() -> None:
+        while True:
+            try:
+                if not os.read(master_fd, 65536):
+                    return
+            except OSError as error:
+                if error.errno in {errno.EBADF, errno.EIO}:
+                    return
+                raise
+
+    drain_thread = threading.Thread(target=drain_live_output, daemon=True)
+    drain_thread.start()
+    try:
+        manifest_path = repository / "run.json"
+        deadline = time.monotonic() + 10.0
+        while time.monotonic() < deadline:
+            try:
+                manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+                last_status = manifest.get("last_status", {})
+                if (
+                    manifest["status"] == "running"
+                    and last_status.get("status") == "running"
+                    and last_status.get("measure", {}).get("train_loss") == 1.25
+                ):
+                    break
+            except (FileNotFoundError, json.JSONDecodeError):
+                pass
+            time.sleep(0.02)
+        else:
+            raise AssertionError("subprocess training did not emit a running status")
+
+        process.send_signal(signal.SIGINT)
+        assert process.wait(timeout=10.0) == 130
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        assert manifest["status"] == "cancelled"
+        assert manifest["cancellation_reason"] == "keyboard_interrupt"
+        assert (repository / "checkpoint-latest.pt").read_bytes() == (
+            b"valid-checkpoint"
+        )
+    finally:
+        if process.poll() is None:
+            process.kill()
+            process.wait(timeout=5.0)
+        drain_thread.join(timeout=5.0)
+        os.close(master_fd)
+
+
+def test_pytorch_train_second_ctrl_c_forces_termination(monkeypatch, tmp_path, capsys):
+    runtime = FakeRuntime()
+    runtime.statuses = [
+        {
+            "status": "running",
+            "body": {"measure": {"iteration": 3, "train_loss": 2.0}},
+        },
+        {
+            "status": "cancelling",
+            "body": {"measure": {"iteration": 3, "train_loss": 2.0}},
+        },
+        {
+            "status": "terminated",
+            "body": {"measure": {"iteration": 3, "train_loss": 2.0}},
+        },
+    ]
+    monkeypatch.setattr(
+        training.deepdetect, "DeepDetect", lambda: DeepDetect(_runtime=runtime)
+    )
+    sleep_calls = 0
+
+    def interrupt_twice(_interval):
+        nonlocal sleep_calls
+        sleep_calls += 1
+        if sleep_calls <= 2:
+            raise KeyboardInterrupt
+
+    monkeypatch.setattr(training.time, "sleep", interrupt_twice)
+    _weights, train, test = write_training_files(tmp_path)
+    run_root = tmp_path / "runs"
+
+    code = cli.main(
+        [
+            "train",
+            "torchvision-detector",
+            "--train-data",
+            str(train),
+            "--test-data",
+            str(test),
+            "--repository",
+            str(tmp_path / "repo"),
+            "--job-dir",
+            str(run_root),
+            "--run-name",
+            "forced-cancel",
+            "--iterations",
+            "100",
+            "--dataset-check",
+            "none",
+        ]
+    )
+
+    assert code == 130
+    cancel_calls = [call for call in runtime.calls if call[0] == "cancel"]
+    assert cancel_calls == [
+        (
+            "cancel",
+            {
+                "service": "python-torchvision-detector-train",
+                "job": 7,
+                "wait": False,
+            },
+        ),
+        (
+            "cancel",
+            {
+                "service": "python-torchvision-detector-train",
+                "job": 7,
+                "wait": False,
+                "force": True,
+            },
+        ),
+    ]
+    assert runtime.calls[-1] == (
+        "delete",
+        "python-torchvision-detector-train",
+        {},
+    )
+    manifest = json.loads(
+        (run_root / "forced-cancel" / "run.json").read_text(encoding="utf-8")
+    )
+    assert manifest["status"] == "terminated"
+    assert manifest["cancellation_reason"] == "keyboard_interrupt"
+    assert manifest["force_reason"] == "second_keyboard_interrupt"
+    events = [
+        json.loads(line)
+        for line in capsys.readouterr().out.splitlines()
+        if line.strip()
+    ]
+    assert "terminating" in {
+        event.get("status") for event in events if event["event"] == "training_status"
+    }
+
+
+def test_pytorch_train_cancel_timeout_forces_termination(monkeypatch, tmp_path, capsys):
+    runtime = FakeRuntime()
+    runtime.statuses = [
+        {"status": "running", "body": {"measure": {"iteration": 1}}},
+        {"status": "terminated", "body": {"measure": {"iteration": 1}}},
+    ]
+    monkeypatch.setattr(
+        training.deepdetect, "DeepDetect", lambda: DeepDetect(_runtime=runtime)
+    )
+    ticks = iter([0.0, 1.0, 3.0])
+    monkeypatch.setattr(training.time, "monotonic", lambda: next(ticks))
+    sleep_calls = 0
+
+    def interrupt_once(_interval):
+        nonlocal sleep_calls
+        sleep_calls += 1
+        if sleep_calls == 1:
+            raise KeyboardInterrupt
+
+    monkeypatch.setattr(training.time, "sleep", interrupt_once)
+    _weights, train, test = write_training_files(tmp_path)
+    run_root = tmp_path / "runs"
+
+    code = cli.main(
+        [
+            "train",
+            "torchvision-detector",
+            "--train-data",
+            str(train),
+            "--test-data",
+            str(test),
+            "--repository",
+            str(tmp_path / "repo"),
+            "--job-dir",
+            str(run_root),
+            "--run-name",
+            "cancel-timeout",
+            "--iterations",
+            "100",
+            "--dataset-check",
+            "none",
+            "--cancel-timeout",
+            "1",
+        ]
+    )
+
+    assert code == 130
+    force_call = [
+        call for call in runtime.calls if call[0] == "cancel" and call[1].get("force")
+    ]
+    assert len(force_call) == 1
+    manifest = json.loads(
+        (run_root / "cancel-timeout" / "run.json").read_text(encoding="utf-8")
+    )
+    assert manifest["status"] == "terminated"
+    assert manifest["force_reason"] == "cancel_timeout"
+    capsys.readouterr()
+
+
+def test_pytorch_training_timeout_reuses_staged_cancellation(
+    monkeypatch, tmp_path, capsys
+):
+    runtime = FakeRuntime()
+    runtime.statuses = [
+        {"status": "running", "body": {"measure": {"iteration": 1}}},
+        {"status": "terminated", "body": {"measure": {"iteration": 1}}},
+    ]
+    monkeypatch.setattr(
+        training.deepdetect, "DeepDetect", lambda: DeepDetect(_runtime=runtime)
+    )
+    ticks = iter([0.0, 2.0, 3.0, 5.0])
+    monkeypatch.setattr(training.time, "monotonic", lambda: next(ticks))
+    monkeypatch.setattr(training.time, "sleep", lambda _interval: None)
+    _weights, train, test = write_training_files(tmp_path)
+    run_root = tmp_path / "runs"
+
+    code = cli.main(
+        [
+            "train",
+            "torchvision-detector",
+            "--train-data",
+            str(train),
+            "--test-data",
+            str(test),
+            "--repository",
+            str(tmp_path / "repo"),
+            "--job-dir",
+            str(run_root),
+            "--run-name",
+            "training-timeout",
+            "--iterations",
+            "100",
+            "--dataset-check",
+            "none",
+            "--timeout",
+            "1",
+            "--cancel-timeout",
+            "1",
+        ]
+    )
+
+    assert code == 130
+    manifest = json.loads(
+        (run_root / "training-timeout" / "run.json").read_text(encoding="utf-8")
+    )
+    assert manifest["status"] == "terminated"
+    assert manifest["cancellation_reason"] == "training_timeout"
+    assert manifest["force_reason"] == "cancel_timeout"
+    capsys.readouterr()
+
+
+def test_pytorch_train_finish_race_after_ctrl_c_returns_success(
+    monkeypatch, tmp_path, capsys
+):
+    runtime = FakeRuntime()
+    runtime.statuses = [
+        {"status": "running", "body": {"measure": {"iteration": 1}}},
+        {"status": "finished", "body": {"measure": {"iteration": 2}}},
+    ]
+    monkeypatch.setattr(
+        training.deepdetect, "DeepDetect", lambda: DeepDetect(_runtime=runtime)
+    )
+    sleep_calls = 0
+
+    def interrupt_once(_interval):
+        nonlocal sleep_calls
+        sleep_calls += 1
+        if sleep_calls == 1:
+            raise KeyboardInterrupt
+
+    monkeypatch.setattr(training.time, "sleep", interrupt_once)
+    _weights, train, test = write_training_files(tmp_path)
+    run_root = tmp_path / "runs"
+
+    code = cli.main(
+        [
+            "train",
+            "torchvision-detector",
+            "--train-data",
+            str(train),
+            "--test-data",
+            str(test),
+            "--repository",
+            str(tmp_path / "repo"),
+            "--job-dir",
+            str(run_root),
+            "--run-name",
+            "finish-race",
+            "--iterations",
+            "2",
+            "--dataset-check",
+            "none",
+        ]
+    )
+
+    assert code == 0
+    manifest = json.loads(
+        (run_root / "finish-race" / "run.json").read_text(encoding="utf-8")
+    )
+    assert manifest["status"] == "finished"
+    assert manifest["cancellation_reason"] == "keyboard_interrupt"
+    events = [
+        json.loads(line)
+        for line in capsys.readouterr().out.splitlines()
+        if line.strip()
+    ]
+    assert events[-1]["status"] == "finished"
+
+
+def test_train_cancel_timeout_cli_overrides_yaml(monkeypatch, tmp_path, capsys):
+    runtime = FakeRuntime()
+    runtime.statuses = [
+        {
+            "status": "finished",
+            "body": {"measure": {"iteration": 1, "train_loss": 1.0}},
+        }
+    ]
+    monkeypatch.setattr(
+        training.deepdetect, "DeepDetect", lambda: DeepDetect(_runtime=runtime)
+    )
+    _weights, train, test = write_training_files(tmp_path)
+    repository = tmp_path / "repo"
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("cancel_timeout: 17\n", encoding="utf-8")
+
+    code = cli.main(
+        [
+            "train",
+            "torchvision-detector",
+            "--config",
+            str(cfg),
+            "--train-data",
+            str(train),
+            "--test-data",
+            str(test),
+            "--repository",
+            str(repository),
+            "--iterations",
+            "1",
+            "--dataset-check",
+            "none",
+            "--cancel-timeout",
+            "4",
+        ]
+    )
+
+    assert code == 0
+    assert config.load_config(repository / "config.yaml")["cancel_timeout"] == 4.0
+    capsys.readouterr()
+
+
+def test_train_cancel_timeout_must_be_positive(tmp_path, capsys):
+    _weights, train, test = write_training_files(tmp_path)
+
+    code = cli.main(
+        [
+            "train",
+            "torchvision-detector",
+            "--train-data",
+            str(train),
+            "--test-data",
+            str(test),
+            "--repository",
+            str(tmp_path / "repo"),
+            "--dataset-check",
+            "none",
+            "--cancel-timeout",
+            "0",
+        ]
+    )
+
+    assert code != 0
+    assert "cancel_timeout must be positive" in capsys.readouterr().err
+
+
+def test_sync_pytorch_training_remains_blocking(monkeypatch, tmp_path, capsys):
+    runtime = FakeRuntime()
+    monkeypatch.setattr(
+        training.deepdetect, "DeepDetect", lambda: DeepDetect(_runtime=runtime)
+    )
+    _weights, train, test = write_training_files(tmp_path)
+
+    code = cli.main(
+        [
+            "train",
+            "torchvision-detector",
+            "--train-data",
+            str(train),
+            "--test-data",
+            str(test),
+            "--repository",
+            str(tmp_path / "repo"),
+            "--iterations",
+            "1",
+            "--dataset-check",
+            "none",
+            "--sync",
+        ]
+    )
+
+    assert code == 0
+    train_call = next(call for call in runtime.calls if call[0] == "train")
+    assert train_call[1]["async"] is False
+    assert not any(call[0] == "cancel" for call in runtime.calls)
+    capsys.readouterr()
 
 
 def test_train_external_pytorch_detector_passes_entrypoint_from_yaml(
@@ -1568,6 +2210,24 @@ def test_live_training_terminal_reporter_renders_sink_warning():
     output = stream.getvalue()
     assert "warning" in output
     assert "VisdomResultSink: transient prediction failure" in output
+
+
+def test_live_training_terminal_reporter_explains_staged_cancellation():
+    for state, message in (
+        ("cancelling", "press Ctrl-C again to force termination"),
+        ("terminating", "forcing worker process-group termination"),
+    ):
+        stream = io.StringIO()
+        reporter = LiveTrainingTerminalReporter(
+            total_iterations=10,
+            gpu_monitor=None,
+            stream=stream,
+            force_terminal=True,
+        )
+        reporter.emit("training_status", status=state, measure={})
+        reporter.close()
+
+        assert message in strip_ansi(stream.getvalue())
 
 
 def test_explicit_run_name_collision_fails_before_training(

--- a/bindings/python/tests/test_client.py
+++ b/bindings/python/tests/test_client.py
@@ -191,6 +191,29 @@ def test_job_wait_and_cancel(monkeypatch):
     assert runtime.calls[-1] == ("cancel", {"service": "classifier", "job": 7})
 
 
+def test_job_cancel_supports_nonblocking_and_force_requests():
+    runtime, _, service = make_service()
+    job = TrainingJob(service, 7)
+
+    job.cancel(wait=False)
+    assert runtime.calls[-1] == (
+        "cancel",
+        {"service": "classifier", "job": 7, "wait": False},
+    )
+
+    job.cancel(wait=False, force=True)
+    assert runtime.calls[-1] == (
+        "cancel",
+        {"service": "classifier", "job": 7, "wait": False, "force": True},
+    )
+
+    job.cancel(force=True)
+    assert runtime.calls[-1] == (
+        "cancel",
+        {"service": "classifier", "job": 7, "force": True},
+    )
+
+
 def test_job_status_accepts_output_parameters():
     runtime, _, service = make_service()
     runtime.statuses = ["running"]

--- a/bindings/python/tests/test_pytorch_worker_runtime.py
+++ b/bindings/python/tests/test_pytorch_worker_runtime.py
@@ -31,6 +31,7 @@ from deepdetect.pytorch_worker.builtin.vision.detection.base import (
 from deepdetect.pytorch_worker.builtin.vision.detection.common import (
     DetectionListDataset,
     DetectionTensorBatchDataset,
+    _atomic_torch_save,
     make_loader,
 )
 from deepdetect.pytorch_worker.builtin.vision.detection.training import (
@@ -54,6 +55,27 @@ from deepdetect.pytorch_worker.templates.train_worker import (
 from deepdetect.pytorch_worker.builtin.vision.detection.reference_torch_detector import (
     DeepDetectWorker as ReferenceTorchDetectorWorker,
 )
+
+
+def test_detector_atomic_checkpoint_preserves_previous_file_on_interruption(tmp_path):
+    final_path = tmp_path / "checkpoint-latest.pt"
+    final_path.write_bytes(b"previous-checkpoint")
+
+    class InterruptedTorch:
+        saved_path = None
+
+        @classmethod
+        def save(cls, _payload, path):
+            cls.saved_path = path
+            path.write_bytes(b"incomplete-checkpoint")
+            raise KeyboardInterrupt
+
+    with pytest.raises(KeyboardInterrupt):
+        _atomic_torch_save(InterruptedTorch, {"iteration": 2}, final_path)
+
+    assert InterruptedTorch.saved_path.parent == final_path.parent
+    assert final_path.read_bytes() == b"previous-checkpoint"
+    assert list(tmp_path.glob(".checkpoint-latest.pt.*.tmp")) == []
 
 
 class MemorySocket:

--- a/bindings/python/tests/test_vitpose_worker.py
+++ b/bindings/python/tests/test_vitpose_worker.py
@@ -35,7 +35,7 @@ from coco_keypoints_to_dd import (
     format_deepdetect_topdown_line,
 )
 from vitpose_worker.assignment import hungarian_assign
-from vitpose_worker.checkpoint import load_model_checkpoint
+from vitpose_worker.checkpoint import _atomic_torch_save, load_model_checkpoint
 from vitpose_worker.config import worker_config_from_mllib
 from vitpose_worker.decode import decode_topdown_outputs
 from vitpose_worker.losses import PoseLossConfig, slot_pose_losses, topdown_pose_losses
@@ -43,6 +43,27 @@ from vitpose_worker.model import ViTPoseModelConfig, ViTPoseSlots, ViTPoseTopDow
 from vitpose_worker.targets import PoseTargetConfig, build_batch_targets
 from vitpose_worker.worker_impl import ConnectorBatchPrefetcher, DeepDetectWorker
 from vitpose_worker.worker_impl import PoseTrainOptions, PoseTrainRequest
+
+
+def test_vitpose_atomic_checkpoint_preserves_previous_file_on_interruption(tmp_path):
+    final_path = tmp_path / "solver-latest.pt"
+    final_path.write_bytes(b"previous-solver")
+
+    class InterruptedTorch:
+        saved_path = None
+
+        @classmethod
+        def save(cls, _payload, path):
+            cls.saved_path = path
+            path.write_bytes(b"incomplete-solver")
+            raise KeyboardInterrupt
+
+    with pytest.raises(KeyboardInterrupt):
+        _atomic_torch_save(InterruptedTorch, {"iteration": 2}, final_path)
+
+    assert InterruptedTorch.saved_path.parent == final_path.parent
+    assert final_path.read_bytes() == b"previous-solver"
+    assert list(tmp_path.glob(".solver-latest.pt.*.tmp")) == []
 
 
 def test_hungarian_assignment_is_permutation_invariant():

--- a/docs/api.md
+++ b/docs/api.md
@@ -758,7 +758,7 @@ parameters.output.max_hist_points | int    | yes      | 10000   | max number of 
 ```shell
 curl -X DELETE "http://localhost:8080/train?service=imageserv&job=1"
 
-{"status":{"code":200,"msg":"OK"},"head":{"time":196.0,"status":"terminated","method":"/train","job":1}}
+{"status":{"code":200,"msg":"OK"},"head":{"time":196.0,"status":"cancelled","method":"/train","job":1}}
 ```
 ```python
 from dd_client import DD
@@ -769,7 +769,9 @@ dd.set_return_format(dd.RETURN_PYTHON)
 dd.delete_train('imageserv',job=1)
 ```
 
-Kills a training job running asynchronously
+Cooperatively cancels a training job running asynchronously. Nonblocking
+requests expose `cancelling` and `terminating` states through training status
+polls. PyTorch force requests terminate the worker process group.
 
 ### HTTP Request
 
@@ -781,6 +783,8 @@ Parameter | Type | Optional | Default | Description
 --------- | ---- | -------- | ------- | -----------
 service | string | no | N/A | name of the service the training job is running on
 job | int | no | N/A | job identifier
+wait | bool | yes | true | wait for cancellation to finish before returning
+force | bool | yes | false | force PyTorch worker process-group termination
 
 
 # Predict

--- a/docs/python_library_spec.md
+++ b/docs/python_library_spec.md
@@ -93,7 +93,11 @@ Blocking training returns the API `body`. Asynchronous training returns a
 the API `head` with fields from the API `body`. `wait()` returns on
 `finished`, `error`, `terminated`, or `cancelled`, and raises `TimeoutError`
 when its deadline expires. Cancellation is administrative and returns
-`None`.
+`None`. `job.cancel()` keeps its blocking cooperative behavior. Use
+`job.cancel(wait=False)` to request cancellation while continuing to poll
+`cancelling` status, and `job.cancel(wait=False, force=True)` to request
+bounded PyTorch worker process-group termination. Forced jobs finish as
+`terminated`; cooperative workers finish as `cancelled`.
 
 ## Inputs
 

--- a/extern/pytorch_workers/vitpose/vitpose_worker/checkpoint.py
+++ b/extern/pytorch_workers/vitpose/vitpose_worker/checkpoint.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -102,10 +104,34 @@ def save_checkpoint(
         "iteration": int(iteration),
         "optimizer_state": optimizer.state_dict(),
     }
-    torch.save(model_payload, repository / f"checkpoint-{iteration}.pt")
-    torch.save(model_payload, repository / "checkpoint-latest.pt")
-    torch.save(solver_payload, repository / f"solver-{iteration}.pt")
-    torch.save(solver_payload, repository / "solver-latest.pt")
+    _atomic_torch_save(
+        torch,
+        model_payload,
+        repository / f"checkpoint-{iteration}.pt",
+    )
+    _atomic_torch_save(torch, model_payload, repository / "checkpoint-latest.pt")
+    _atomic_torch_save(
+        torch,
+        solver_payload,
+        repository / f"solver-{iteration}.pt",
+    )
+    _atomic_torch_save(torch, solver_payload, repository / "solver-latest.pt")
+
+
+def _atomic_torch_save(torch: Any, payload: Any, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        delete=False,
+    ) as temporary:
+        temporary_path = Path(temporary.name)
+    try:
+        torch.save(payload, temporary_path)
+        os.replace(temporary_path, path)
+    finally:
+        temporary_path.unlink(missing_ok=True)
 
 
 def _state_dict(payload: Any) -> dict[str, Any]:

--- a/src/backends/pytorch_worker/pytorchworkerlib.cc
+++ b/src/backends/pytorch_worker/pytorchworkerlib.cc
@@ -288,7 +288,6 @@ namespace dd
     try
       {
         APIData params = request_params(train_request(ad));
-        this->_tjob_running.store(true);
         debug_log("train: sending train_start");
         _worker->request("train_start", params);
         debug_log("train: train_start acknowledged");
@@ -298,6 +297,14 @@ namespace dd
         int status = 1;
         while (!finished)
           {
+            if (this->_tjob_force_stop.load())
+              {
+                debug_log("train: force-terminating worker process group");
+                _worker->terminate();
+                finished = true;
+                status = static_cast<int>(TrainingJobResult::terminated);
+                break;
+              }
             if (!this->_tjob_running.load() && !cancel_sent)
               {
                 APIData cancel_params;
@@ -419,7 +426,14 @@ namespace dd
         std::string state = payload.IsObject() && payload.HasMember("status")
                                 ? json_string(payload["status"], "finished")
                                 : "finished";
-        status = state == "finished" ? 0 : 1;
+        if (state == "finished")
+          status = static_cast<int>(TrainingJobResult::finished);
+        else if (state == "cancelled")
+          status = static_cast<int>(TrainingJobResult::cancelled);
+        else if (state == "terminated")
+          status = static_cast<int>(TrainingJobResult::terminated);
+        else
+          status = static_cast<int>(TrainingJobResult::error);
         this->collect_measures(out);
       }
   }

--- a/src/dto/info.hpp
+++ b/src/dto/info.hpp
@@ -83,8 +83,9 @@ namespace dd
 
       DTO_FIELD_INFO(status)
       {
-        info->description = "status of the job, one of: \"not started\", "
-                            "\"running\", \"finished\"";
+        info->description
+            = "status of the job, one of: \"running\", \"cancelling\", "
+              "\"terminating\", \"finished\"";
       }
       DTO_FIELD(String, status);
     };

--- a/src/jsonapi.cc
+++ b/src/jsonapi.cc
@@ -1244,7 +1244,9 @@ namespace dd
       }
     jtrain.AddMember("head", jhead, jtrain.GetAllocator());
     jtrain.AddMember("body", jout, jtrain.GetAllocator());
-    if (train_status == "finished" || train_status == "running")
+    if (train_status == "finished" || train_status == "running"
+        || train_status == "cancelling" || train_status == "terminating"
+        || train_status == "cancelled" || train_status == "terminated")
       {
         std::string mrepo
             = out.getobj("model").get("repository").get<std::string>();

--- a/src/mllibstrategy.h
+++ b/src/mllibstrategy.h
@@ -34,6 +34,14 @@
 
 namespace dd
 {
+  enum class TrainingJobResult : int
+  {
+    finished = 0,
+    error = 1,
+    cancelled = 2,
+    terminated = 3
+  };
+
   /**
    * \brief ML library bad parameter exception
    */
@@ -87,7 +95,8 @@ namespace dd
     /**
      * \brief constructor from model
      */
-    MLLib(const TMLModel &mlmodel) : _mlmodel(mlmodel), _tjob_running(false)
+    MLLib(const TMLModel &mlmodel)
+        : _mlmodel(mlmodel), _tjob_running(false), _tjob_force_stop(false)
     {
     }
 
@@ -99,7 +108,8 @@ namespace dd
           _mlmodel(mll._mlmodel), _meas(mll._meas),
           _meas_per_iter(mll._meas_per_iter),
           _status_payloads(mll._status_payloads), _stats(mll._stats),
-          _tjob_running(mll._tjob_running.load()), _logger(mll._logger),
+          _tjob_running(mll._tjob_running.load()),
+          _tjob_force_stop(mll._tjob_force_stop.load()), _logger(mll._logger),
           _model_gflops(mll._model_gflops), _model_params(mll._model_params),
           _mem_used_train(mll._mem_used_train),
           _mem_used_test(mll._mem_used_test)
@@ -420,6 +430,9 @@ namespace dd
     std::atomic<bool> _tjob_running = {
       false
     }; /**< whether a training job is running with this lib instance. */
+    std::atomic<bool> _tjob_force_stop = {
+      false
+    }; /**< whether the training thread must terminate an external worker. */
 
     std::shared_ptr<spdlog::logger> _logger; /**< mllib logger. */
 

--- a/src/mlservice.h
+++ b/src/mlservice.h
@@ -79,17 +79,55 @@ namespace dd
   /**
    * \brief training job
    */
+  enum class TrainingJobState
+  {
+    running,
+    cancelling,
+    terminating
+  };
+
+  inline const char *training_job_state_name(TrainingJobState state)
+  {
+    switch (state)
+      {
+      case TrainingJobState::cancelling:
+        return "cancelling";
+      case TrainingJobState::terminating:
+        return "terminating";
+      case TrainingJobState::running:
+      default:
+        return "running";
+      }
+  }
+
+  inline const char *training_job_result_name(int result)
+  {
+    switch (static_cast<TrainingJobResult>(result))
+      {
+      case TrainingJobResult::finished:
+        return "finished";
+      case TrainingJobResult::cancelled:
+        return "cancelled";
+      case TrainingJobResult::terminated:
+        return "terminated";
+      case TrainingJobResult::error:
+      default:
+        return "error";
+      }
+  }
+
   class tjob
   {
   public:
     tjob(std::future<int> &&ft,
          const std::chrono::time_point<std::chrono::system_clock> &tstart)
-        : _ft(std::move(ft)), _tstart(tstart), _status(1)
+        : _ft(std::move(ft)), _tstart(tstart),
+          _state(TrainingJobState::running)
     {
     }
     tjob(tjob &&tj)
         : _ft(std::move(tj._ft)), _tstart(std::move(tj._tstart)),
-          _status(std::move(tj._status))
+          _state(tj._state)
     {
     }
     ~tjob()
@@ -98,9 +136,8 @@ namespace dd
 
     std::future<int> _ft; /**< training job output status upon termination. */
     std::chrono::time_point<std::chrono::system_clock>
-        _tstart; /**< date at which the training job has started*/
-    int _status
-        = 0; /**< 0: not started, 1: running, 2: finished or terminated */
+        _tstart;             /**< date at which the training job has started*/
+    TrainingJobState _state; /**< running, cancelling, or terminating. */
   };
 
   /**
@@ -186,10 +223,10 @@ namespace dd
         {
           std::future_status status
               = (*hit).second._ft.wait_for(std::chrono::seconds(0));
-          if (status == std::future_status::timeout
-              && (*hit).second._status
-                     == 1) // process is running, terminate it
+          if (status == std::future_status::timeout)
             {
+              (*hit).second._state = TrainingJobState::terminating;
+              this->_tjob_force_stop.store(true);
               this->_tjob_running.store(false);
               (*hit).second._ft.wait();
               auto ohit = _training_out.find((*hit).first);
@@ -261,26 +298,21 @@ namespace dd
             {
               APIData jad;
               jad.add("job", (*hit).first);
-              int jstatus = (*hit).second._status;
-              if (jstatus == 0)
-                jad.add("status", std::string("not started"));
-              else if (jstatus == 1)
+              std::future_status future_status
+                  = (*hit).second._ft.wait_for(std::chrono::seconds(0));
+              if (future_status == std::future_status::timeout)
                 {
-                  jad.add("status", std::string("running"));
-                  std::future_status status
-                      = (*hit).second._ft.wait_for(std::chrono::seconds(0));
-                  if (status == std::future_status::timeout)
-                    {
-                      this->collect_measures(jad);
-                      std::chrono::time_point<std::chrono::system_clock> trun
-                          = std::chrono::system_clock::now();
-                      jad.add("time",
-                              std::chrono::duration_cast<std::chrono::seconds>(
-                                  trun - (*hit).second._tstart)
-                                  .count());
-                    }
+                  jad.add("status", std::string(training_job_state_name(
+                                        (*hit).second._state)));
+                  this->collect_measures(jad);
+                  std::chrono::time_point<std::chrono::system_clock> trun
+                      = std::chrono::system_clock::now();
+                  jad.add("time",
+                          std::chrono::duration_cast<std::chrono::seconds>(
+                              trun - (*hit).second._tstart)
+                              .count());
                 }
-              else if (jstatus == 2)
+              else
                 jad.add("status", std::string("finished"));
               serv_dto->jobs->push_back(jad);
               ++hit;
@@ -329,6 +361,8 @@ namespace dd
           ++_tjobs_counter;
           int local_tcounter = _tjobs_counter;
           this->_has_predict = false;
+          this->_tjob_force_stop.store(false);
+          this->_tjob_running.store(true);
           _training_jobs.emplace(
               local_tcounter,
               std::move(tjob(
@@ -350,6 +384,8 @@ namespace dd
         }
       else
         {
+          this->_tjob_force_stop.store(false);
+          this->_tjob_running.store(true);
           boost::unique_lock<boost::shared_mutex> lock(
               _train_or_predict_mutex);
           this->_has_predict = false;
@@ -385,7 +421,8 @@ namespace dd
               = (*hit).second._ft.wait_for(std::chrono::seconds(secs));
           if (status == std::future_status::timeout)
             {
-              out.add("status", std::string("running"));
+              out.add("status", std::string(training_job_state_name(
+                                    (*hit).second._state)));
               APIData jmrepo;
               jmrepo.add("repository", this->_mlmodel._repo);
               out.add("model", jmrepo);
@@ -430,13 +467,12 @@ namespace dd
                       (*ohit).second); // get async process output object
                   _training_out.erase(ohit);
                 }
-              if (st == 0)
+              const std::string result_status = training_job_result_name(st);
+              out.add("status", result_status);
+              if (st == static_cast<int>(TrainingJobResult::finished))
                 {
-                  out.add("status", std::string("finished"));
                   this->_has_predict = true;
                 }
-              else
-                out.add("status", std::string("unknown error"));
               // this->collect_measures(out); // XXX: beware if there was a
               // queue, since the job has finished, there might be a new one
               // running.
@@ -478,33 +514,39 @@ namespace dd
     int training_job_delete(const APIData &ad, APIData &out)
     {
       int j = ad.get("job").get<int>();
+      const bool wait = !ad.has("wait") || ad.get("wait").get<bool>();
+      const bool force = ad.has("force") && ad.get("force").get<bool>();
       std::lock_guard<std::mutex> lock(_tjobs_mutex);
       std::unordered_map<int, tjob>::iterator hit;
       if ((hit = _training_jobs.find(j)) != _training_jobs.end())
         {
           std::future_status status
               = (*hit).second._ft.wait_for(std::chrono::seconds(0));
-          if (status == std::future_status::timeout
-              && (*hit).second._status
-                     == 1) // process is running, terminate it
+          if (status == std::future_status::timeout)
             {
-              this->_tjob_running.store(false); // signals the process
-              (*hit).second._ft.wait(); // XXX: default timeout in case the
-                                        // process does not return ?
-              out.add("status", std::string("terminated"));
+              (*hit).second._state = force ? TrainingJobState::terminating
+                                           : TrainingJobState::cancelling;
+              if (force)
+                this->_tjob_force_stop.store(true);
+              this->_tjob_running.store(false);
+              out.add("status", std::string(training_job_state_name(
+                                    (*hit).second._state)));
+              if (!wait)
+                return 0;
+
+              (*hit).second._ft.wait();
+              const int result = (*hit).second._ft.get();
+              out.add("status", std::string(training_job_result_name(result)));
               std::chrono::time_point<std::chrono::system_clock> trun
                   = std::chrono::system_clock::now();
               out.add("time", std::chrono::duration_cast<std::chrono::seconds>(
                                   trun - (*hit).second._tstart)
                                   .count());
-              _training_jobs.erase(hit);
-              auto ohit = _training_out.find((*hit).first);
+              const int job_id = (*hit).first;
+              auto ohit = _training_out.find(job_id);
               if (ohit != _training_out.end())
                 _training_out.erase(ohit);
-            }
-          else if ((*hit).second._status == 0)
-            {
-              out.add("status", std::string("not started"));
+              _training_jobs.erase(hit);
             }
           return 0;
         }

--- a/tests/ut-pytorch-worker-api.cc
+++ b/tests/ut-pytorch-worker-api.cc
@@ -11,10 +11,12 @@
 #include <gtest/gtest.h>
 #include <rapidjson/document.h>
 
+#include <cerrno>
 #include <chrono>
 #include <cstdlib>
 #include <fstream>
 #include <filesystem>
+#include <set>
 #include <sstream>
 #include <string>
 #include <sys/wait.h>
@@ -70,6 +72,18 @@ namespace
   {
     cleanup_repo(repo);
     std::filesystem::create_directories(repo);
+  }
+
+  std::set<std::string> worker_socket_dirs()
+  {
+    std::set<std::string> paths;
+    for (const auto &entry : std::filesystem::directory_iterator("/tmp"))
+      {
+        const std::string name = entry.path().filename().string();
+        if (name.rfind("dd-pytorch-worker-", 0) == 0)
+          paths.insert(entry.path().string());
+      }
+    return paths;
   }
 
   bool python_has_torchvision()
@@ -377,7 +391,8 @@ namespace
           return status;
         const std::string train_status = status["head"]["status"].GetString();
         if (train_status == "finished" || train_status == "unknown error"
-            || train_status == "error")
+            || train_status == "error" || train_status == "cancelled"
+            || train_status == "terminated")
           return status;
         std::this_thread::sleep_for(std::chrono::milliseconds(50));
       }
@@ -1391,8 +1406,95 @@ TEST(pytorchworkerapi, async_train_can_be_cancelled)
   ASSERT_TRUE(cancelled.HasMember("head")) << japi.jrender(cancelled);
   ASSERT_TRUE(cancelled["head"].HasMember("status"))
       << japi.jrender(cancelled);
-  ASSERT_STREQ("terminated", cancelled["head"]["status"].GetString())
+  ASSERT_STREQ("cancelled", cancelled["head"]["status"].GetString())
       << japi.jrender(cancelled);
+
+  ASSERT_EQ(ok_str, japi.jrender(japi.service_delete(service, "")));
+  cleanup_repo(repo);
+}
+
+TEST(pytorchworkerapi, async_train_nonblocking_cancel_can_be_polled)
+{
+  configure_pythonpath();
+  JsonAPI japi;
+  const std::string service = "pytorchworker_nonblocking_cancel";
+  const std::string repo = repo_path(service);
+  prepare_repo(repo);
+
+  ASSERT_EQ(created_str,
+            japi.jrender(japi.service_create(service, create_request(repo))));
+
+  JDoc train = japi.service_train(train_request(service, 1000000, true));
+  ASSERT_EQ(201, status_code(train)) << japi.jrender(train);
+  const int job = train["head"]["job"].GetInt();
+  poll_until_running(japi, service, job);
+
+  const auto started = std::chrono::steady_clock::now();
+  const std::string delete_request = "{\"service\":\"" + service
+                                     + "\",\"job\":" + std::to_string(job)
+                                     + ",\"wait\":false}";
+  JDoc cancelling = japi.service_train_delete(delete_request);
+  const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+      std::chrono::steady_clock::now() - started);
+  ASSERT_EQ(200, status_code(cancelling)) << japi.jrender(cancelling);
+  ASSERT_STREQ("cancelling", cancelling["head"]["status"].GetString())
+      << japi.jrender(cancelling);
+  ASSERT_LT(elapsed.count(), 500);
+
+  JDoc cancelled = poll_until_terminal(japi, service, job);
+  ASSERT_STREQ("cancelled", cancelled["head"]["status"].GetString())
+      << japi.jrender(cancelled);
+
+  ASSERT_EQ(ok_str, japi.jrender(japi.service_delete(service, "")));
+  cleanup_repo(repo);
+}
+
+TEST(pytorchworkerapi, async_train_force_terminates_uncooperative_worker)
+{
+  configure_pythonpath();
+  JsonAPI japi;
+  const std::set<std::string> socket_dirs_before = worker_socket_dirs();
+  const std::string service = "pytorchworker_force_cancel";
+  const std::string repo = repo_path(service);
+  prepare_repo(repo);
+
+  ASSERT_EQ(
+      created_str,
+      japi.jrender(japi.service_create(
+          service, create_request(repo, ",\"ignore_cancellation\":true"))));
+
+  JDoc train = japi.service_train(train_request(service, 1000000, true));
+  ASSERT_EQ(201, status_code(train)) << japi.jrender(train);
+  const int job = train["head"]["job"].GetInt();
+  poll_until_running(japi, service, job);
+
+  const std::string cancel_request = "{\"service\":\"" + service
+                                     + "\",\"job\":" + std::to_string(job)
+                                     + ",\"wait\":false}";
+  JDoc cancelling = japi.service_train_delete(cancel_request);
+  ASSERT_EQ(200, status_code(cancelling)) << japi.jrender(cancelling);
+  ASSERT_STREQ("cancelling", cancelling["head"]["status"].GetString())
+      << japi.jrender(cancelling);
+
+  const auto started = std::chrono::steady_clock::now();
+  const std::string force_request = "{\"service\":\"" + service
+                                    + "\",\"job\":" + std::to_string(job)
+                                    + ",\"wait\":false,\"force\":true}";
+  JDoc terminating = japi.service_train_delete(force_request);
+  ASSERT_EQ(200, status_code(terminating)) << japi.jrender(terminating);
+  ASSERT_STREQ("terminating", terminating["head"]["status"].GetString())
+      << japi.jrender(terminating);
+
+  JDoc terminated = poll_until_terminal(japi, service, job);
+  const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+      std::chrono::steady_clock::now() - started);
+  ASSERT_STREQ("terminated", terminated["head"]["status"].GetString())
+      << japi.jrender(terminated);
+  ASSERT_LT(elapsed.count(), 3000);
+  ASSERT_EQ(socket_dirs_before, worker_socket_dirs());
+  errno = 0;
+  ASSERT_EQ(-1, ::waitpid(-1, nullptr, WNOHANG));
+  ASSERT_EQ(ECHILD, errno);
 
   ASSERT_EQ(ok_str, japi.jrender(japi.service_delete(service, "")));
   cleanup_repo(repo);


### PR DESCRIPTION
This PR brings a graceful exit to the deepdetect cli, including with pytorch workers. A first Ctrl-C triggers the exit, with a 30 seconds or a second Ctrl-C call to explicitely terminate all async jobs. A checkpoint is saved upon the first Ctrl-C call.